### PR TITLE
Change step name to refer to Quay.io, not Docker Hub

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
-      - name: Log in to Docker Hub
+      - name: Log in to Quay.io
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
           registry: quay.io
@@ -158,7 +158,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
-      - name: Log in to Docker Hub
+      - name: Log in to Quay.io
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
           registry: quay.io

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
-      - name: Log in to Docker Hub
+      - name: Log in to Quay.io
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
           registry: quay.io


### PR DESCRIPTION
In the GitHub actions, there is a step named "Log in to Docker" but it actually logs into Quay.io The name for this step should be updated to reflect what it actually does.