### PR TITLE
Reconcile GPL version number between license.txt and readme.txt

### DIFF
--- a/README.TXT
+++ b/README.TXT
@@ -7,7 +7,7 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU General Public License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ============================================================================
-All code is covered by the GNU General Public License version 2
+All code is covered by the GNU General Public License version 3
 
 All contributors to the code may be found at: https://github.com/Aspen-Discovery/aspen-discovery/graphs/contributors. We thank all of our contributors for their hard work. 
 


### PR DESCRIPTION
license.txt cites the GPL v3 license, this file references GPL v2, they should match up.