### PR TITLE
Proposed changes to httpd conf template for bad bot blocking via u/a

### DIFF
--- a/sites/template.linux/httpd-{sitename}.conf
+++ b/sites/template.linux/httpd-{sitename}.conf
@@ -18,7 +18,12 @@
 		# Friendly URLs
 		<IfModule mod_rewrite.c>
 			RewriteEngine	On
-			RewriteRule  ^robots\.txt$ /robots.php [NC,L]
+# block emergent bots (Humans touch here)
+                        Include /usr/local/aspen-discovery/sites/{sitename]/conf/badbots.conf
+# block known bad bots (Aspen canonical - no touchy)
+                        Include /usr/local/aspen-discovery/sites/{sitename]/conf/markscommittedbadbots.conf
+
+                        RewriteRule  ^robots\.txt$ /robots.php [NC,L]
 			RewriteRule  ^sitemapindex\.xml$ /sitemapindex.php [NC,L]
 			RewriteRule  ^grouped_work_site_map(.+)$ /sitemaps/grouped_work_site_map$1 [NC,L]
 


### PR DESCRIPTION
Proposal only - no need to merge (unless you like it...)

This patch is a proposal for a potential syntax to block known bad bots. 

The first line includes a file (that we'll need aspen to install) that can contain site specific, emergent bots to detect and send to 403.

The second include is a file that we would maintain to block known bad bots that bother every Aspen for central distribution to All aspens, no matter if they are hosted by us or not.