### PR TITLE
Quick Poll Quick Fix

### DIFF
--- a/code/web/interface/themes/responsive/WebBuilder/quickPoll.tpl
+++ b/code/web/interface/themes/responsive/WebBuilder/quickPoll.tpl
@@ -32,6 +32,11 @@
 	    {/if}
 		<form id="quickPoll{$id}" class="form-horizontal" role="form" action="/WebBuilder/SubmitQuickPoll"  onsubmit="setFormSubmitting();" method="post">
 			<input type="hidden" name="id" id="id" value="{$id}">
+			{if !empty($patronIdCheck)}
+				<input type="hidden" name="patronIdCheck" id="patronIdCheck" value={$patronIdCheck|escape}>
+			{else}
+				<input type="hidden" name="patronIdCheck" id="patronIdCheck" value=0>
+			{/if}
 			<div id="pollOptions">
 				{foreach from=$pollOptions item=$pollOption}
 					{include file="WebBuilder/quickPollOption.tpl"}

--- a/code/web/release_notes/24.05.00.MD
+++ b/code/web/release_notes/24.05.00.MD
@@ -158,6 +158,7 @@
 - For Libby, Boundless, Palace Project, and CloudLibrary holds, set cancelable to true, allowing cancellation in Aspen LiDA. (*KK*)
 - In the record's details display, the button 'More info'/'Access online' has been re-adapted according to the size of the screen. (Ticket 106632) (*LM*)
 - Added a toggle that allows/disallows masquerading using a username (Ticket 130373) (*KL*)
+- Fix issue where if a user is doing a quick poll that requires logging in, opens a new tab, signs out in that tab and another user logs in - the new user won't be able to submit the poll that is still open in the other tab (*KL*)
 
 <div markdown="1" class="settings">
 

--- a/code/web/services/WebBuilder/QuickPoll.php
+++ b/code/web/services/WebBuilder/QuickPoll.php
@@ -25,6 +25,7 @@ class WebBuilder_QuickPoll extends Action {
 
 		if (!UserAccount::isLoggedIn()) {
 			if (!$this->quickPoll->requireLogin) {
+				$interface->assign('patronIdCheck', 0);
 				require_once ROOT_DIR . '/sys/Enrichment/RecaptchaSetting.php';
 				$recaptcha = new RecaptchaSetting();
 				if ($recaptcha->find(true) && !empty($recaptcha->publicKey)) {
@@ -39,7 +40,11 @@ class WebBuilder_QuickPoll extends Action {
 				$myAccountAction->launch();
 				exit();
 			}
+		}  else {
+			$userId = UserAccount::getActiveUserId();
+			$interface->assign('patronIdCheck', $userId);
 		}
+
 		require_once ROOT_DIR . '/sys/Parsedown/AspenParsedown.php';
 		$parsedown = AspenParsedown::instance();
 		$parsedown->setBreaksEnabled(true);

--- a/code/web/services/WebBuilder/SubmitQuickPoll.php
+++ b/code/web/services/WebBuilder/SubmitQuickPoll.php
@@ -45,6 +45,15 @@ class WebBuilder_SubmitQuickPoll extends Action {
 					]);
 					$processQuickPoll = false;
 				}
+			} else if ($this->quickPoll->requireLogin) { //this should only happen in rare cases involving multiple tabs being opened with different patrons on each tab
+				$user = UserAccount::getLoggedInUser();
+				if ($_REQUEST['patronIdCheck'] != 0 && $_REQUEST['patronIdCheck'] != $user->id){
+					$submissionErrors[] = translate([
+						'text' => 'Wrong account credentials, please try again.',
+						'isPublicFacing' => true,
+					]);
+					$processQuickPoll = false;
+				}
 			}
 
 			if ($processQuickPoll) {


### PR DESCRIPTION
Fix issue where if a user is doing a quick poll that requires logging in, opens a new tab, signs out in that tab and another user logs in - the new user won't be able to submit the poll that is still open in the other tab 
Updated release notes