### PR TITLE
Target Audience & Manga vs Manga Graphic Novels 

### DIFF
--- a/code/java_shared_libraries/src/com/turning_leaf_technologies/indexing/BaseIndexingSettings.java
+++ b/code/java_shared_libraries/src/com/turning_leaf_technologies/indexing/BaseIndexingSettings.java
@@ -163,17 +163,17 @@ public class BaseIndexingSettings {
 			for (File curFile : defaultTranslationMapFiles) {
 				String mapName = curFile.getName().replace(".properties", "");
 				mapName = mapName.replace("_map", "");
-				if (mapName.startsWith("format")) {
+				/*if (mapName.startsWith("format")) {*/
 					translationMaps.put(mapName, loadSystemTranslationMap(curFile, logEntry));
-				}
+				/*}*/
 			}
 			if (serverTranslationMapFiles != null) {
 				for (File curFile : serverTranslationMapFiles) {
 					String mapName = curFile.getName().replace(".properties", "");
 					mapName = mapName.replace("_map", "");
-					if (mapName.startsWith("format")) {
+					/*if (mapName.startsWith("format")) {*/
 						translationMaps.put(mapName, loadSystemTranslationMap(curFile, logEntry));
-					}
+					/*}*/
 				}
 			}
 		}
@@ -210,9 +210,6 @@ public class BaseIndexingSettings {
 	}
 
 	public boolean hasTranslation(String mapName, String value) {
-		if (value == null) {
-			return false;
-		}
 		HashMap<String, String> translationMap = translationMaps.get(mapName);
 		if (translationMap != null){
 			return translationMap.containsKey(value.toLowerCase());
@@ -263,7 +260,7 @@ public class BaseIndexingSettings {
 		return translatedValue;
 	}
 
-	LinkedHashSet<String> translateCollection(String mapName, Set<String> values, String identifier, BaseIndexingLogEntry logEntry, Logger logger, boolean logUnableToTranslateWarnings) {
+	public LinkedHashSet<String> translateCollection(String mapName, Set<String> values, String identifier, BaseIndexingLogEntry logEntry, Logger logger, boolean logUnableToTranslateWarnings) {
 		LinkedHashSet<String> translatedCollection = new LinkedHashSet<>();
 		for (String value : values){
 			String translatedValue = translateValue(mapName, value, identifier, logEntry, logger, logUnableToTranslateWarnings);

--- a/code/java_shared_libraries/src/com/turning_leaf_technologies/indexing/BaseIndexingSettings.java
+++ b/code/java_shared_libraries/src/com/turning_leaf_technologies/indexing/BaseIndexingSettings.java
@@ -210,6 +210,9 @@ public class BaseIndexingSettings {
 	}
 
 	public boolean hasTranslation(String mapName, String value) {
+		if (value == null) {
+			return false;
+		}
 		HashMap<String, String> translationMap = translationMaps.get(mapName);
 		if (translationMap != null){
 			return translationMap.containsKey(value.toLowerCase());

--- a/code/reindexer/src/org/aspen_discovery/format_classification/MarcRecordFormatClassifier.java
+++ b/code/reindexer/src/org/aspen_discovery/format_classification/MarcRecordFormatClassifier.java
@@ -332,7 +332,7 @@ public class MarcRecordFormatClassifier {
 							result.add("BoardBook");
 						}else if (subfieldData.contains("pop-up")) {
 							result.add("Pop-UpBook");
-						}else if (subfieldData.startsWith("manga graphic novel")) {
+						}else if (subfieldData.startsWith("manga graphic novel") || subfieldData.equals("manga")) {
 							result.add("Manga");
 						}else if (subfieldData.contains("graphic novel")) {
 							boolean okToAdd = false;

--- a/code/reindexer/src/org/aspen_discovery/reindexer/MarcRecordProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/MarcRecordProcessor.java
@@ -653,13 +653,13 @@ abstract class MarcRecordProcessor {
 			targetAudiences.add(unknownAudienceLabel);
 		}
 
-		LinkedHashSet<String> translatedAudiences = indexer.translateSystemCollection("target_audience", targetAudiences, identifier);
+		LinkedHashSet<String> translatedAudiences = settings.translateCollection("target_audience", targetAudiences, identifier, indexer.getLogEntry(), logger, true);
 		if (!unknownAudienceLabel.equals("Unknown") && translatedAudiences.contains("Unknown")){
 			translatedAudiences.remove("Unknown");
 			translatedAudiences.add(unknownAudienceLabel);
 		}
 		groupedWork.addTargetAudiences(translatedAudiences);
-		LinkedHashSet<String> translatedAudiencesFull = indexer.translateSystemCollection("target_audience_full", targetAudiences, identifier);
+		LinkedHashSet<String> translatedAudiencesFull = settings.translateCollection("target_audience_full", targetAudiences, identifier, indexer.getLogEntry(), logger, true);
 		if (!unknownAudienceLabel.equals("Unknown") && translatedAudiencesFull.contains("Unknown")){
 			translatedAudiencesFull.remove("Unknown");
 			translatedAudiencesFull.add(unknownAudienceLabel);

--- a/code/web/release_notes/24.06.00.MD
+++ b/code/web/release_notes/24.06.00.MD
@@ -45,6 +45,9 @@
 ### Searching Updates
 - Fixed issue where multiselect facets were not allowing multiple values to be selected when searching (Tickets 131841, 131923) (*KL, MDN*)
 
+### Indexing Updates
+- Add format match on 655a where if it equals "manga" the format "Manga" will be added (*KL*)
+- Fixed issue where target audiences were not being mapped with the correct translation map values (Ticket 131935) (*KL*)
 
 //other
 


### PR DESCRIPTION
Fix issue where target audiences were not being mapped using the correct translation maps
Add match for graphic novels where 655a equals "manga" we will add "Manga" as a format
Updated release notes