### PR TITLE
Plane #141: Fix display of 'small' covers in collection spotlights

### DIFF
--- a/code/web/interface/themes/responsive/CollectionSpotlight/horizontalCarousel.tpl
+++ b/code/web/interface/themes/responsive/CollectionSpotlight/horizontalCarousel.tpl
@@ -1,4 +1,4 @@
-<div role="tabpanel" aria-labelledby="spotlightTab{$list->id}" id="tab-{$wrapperId}"{if !empty($display) && $display == 'false'} style="display:none"{/if} class="titleScroller tab-pane{if !empty($active)} active{/if}{if !empty($collectionSpotlight) && $collectionSpotlight->coverSize == 'medium'} mediumScroller{/if}{if !empty($collectionSpotlight) && $collectionSpotlight->showRatings} scrollerWithRatings{/if}">
+<div role="tabpanel" aria-labelledby="spotlightTab{$list->id}" id="tab-{$wrapperId}"{if !empty($display) && $display == 'false'} style="display:none"{/if} class="titleScroller tab-pane{if !empty($active)} active{/if}{if !empty($collectionSpotlight) && $collectionSpotlight->coverSize == 'medium'} mediumScroller{/if}{if !empty($collectionSpotlight) && $collectionSpotlight->coverSize == 'small'} smallScroller{/if}{if !empty($collectionSpotlight) && $collectionSpotlight->showRatings} scrollerWithRatings{/if}">
 {if !empty($showCollectionSpotlightTitle)}
 	<div id="tab-{$wrapperId}Header" class="titleScrollerHeader">
 		{if !empty($showCollectionSpotlightTitle) && !empty($scrollerTitle)}
@@ -7,7 +7,7 @@
 	</div>
 {/if}
 <div class="jcarousel-wrapper horizontalCarouselSpotlightWrapper">
-	<div class="jcarousel horizontalCarouselSpotlight {if $collectionSpotlight->coverSize == 'medium'}mediumScroller{/if}" id="collectionSpotlightCarousel{$list->id}">
+	<div class="jcarousel horizontalCarouselSpotlight {if $collectionSpotlight->coverSize == 'medium'}mediumScroller{/if}{if $collectionSpotlight->coverSize == 'small'}smallScroller{/if}" id="collectionSpotlightCarousel{$list->id}">
 		<div class="loading">{translate text="Loading carousel items..." isPublicFacing=true }</div>
 	</div>
 

--- a/code/web/interface/themes/responsive/css-rtl/main.css
+++ b/code/web/interface/themes/responsive/css-rtl/main.css
@@ -9627,6 +9627,9 @@ a.browse-thumbnail.active {
   right: 0;
   left: 0;
 }
+.horizontalCarouselSpotlightWrapper .smallScroller .scrollerTitleCover {
+  width: auto;
+}
 .moreLikeThisWrapper li.carouselTitleWrapper,
 .seriesWrapper li.carouselTitleWrapper {
   width: 140px !important;

--- a/code/web/interface/themes/responsive/css-rtl/main.css
+++ b/code/web/interface/themes/responsive/css-rtl/main.css
@@ -9630,6 +9630,9 @@ a.browse-thumbnail.active {
 .horizontalCarouselSpotlightWrapper .smallScroller .scrollerTitleCover {
   width: auto;
 }
+.horizontalCarouselSpotlightWrapper .smallScroller .carouselScrollerTitle .carouselScrollerTitleImage {
+  height: 140px;
+}
 .moreLikeThisWrapper li.carouselTitleWrapper,
 .seriesWrapper li.carouselTitleWrapper {
   width: 140px !important;

--- a/code/web/interface/themes/responsive/css-rtl/title-scroller.less
+++ b/code/web/interface/themes/responsive/css-rtl/title-scroller.less
@@ -125,6 +125,9 @@
     .scrollerTitleCover{
       width: auto;
     }
+    .carouselScrollerTitle .carouselScrollerTitleImage {
+      height: 140px;
+    }
   }
 }
 

--- a/code/web/interface/themes/responsive/css-rtl/title-scroller.less
+++ b/code/web/interface/themes/responsive/css-rtl/title-scroller.less
@@ -121,6 +121,11 @@
     right: 0;
     left: 0;
   }
+  .smallScroller {
+    .scrollerTitleCover{
+      width: auto;
+    }
+  }
 }
 
 .moreLikeThisWrapper,.seriesWrapper {

--- a/code/web/interface/themes/responsive/css/main.css
+++ b/code/web/interface/themes/responsive/css/main.css
@@ -9810,6 +9810,9 @@ a.browse-thumbnail.active {
 .horizontalCarouselSpotlightWrapper .smallScroller .scrollerTitleCover {
   width: auto;
 }
+.horizontalCarouselSpotlightWrapper .smallScroller .carouselScrollerTitle .carouselScrollerTitleImage {
+  height: 140px;
+}
 .moreLikeThisWrapper li.carouselTitleWrapper,
 .seriesWrapper li.carouselTitleWrapper {
   width: 140px !important;

--- a/code/web/interface/themes/responsive/css/main.css
+++ b/code/web/interface/themes/responsive/css/main.css
@@ -9807,6 +9807,9 @@ a.browse-thumbnail.active {
   left: 0;
   right: 0;
 }
+.horizontalCarouselSpotlightWrapper .smallScroller .scrollerTitleCover {
+  width: auto;
+}
 .moreLikeThisWrapper li.carouselTitleWrapper,
 .seriesWrapper li.carouselTitleWrapper {
   width: 140px !important;

--- a/code/web/interface/themes/responsive/css/title-scroller.less
+++ b/code/web/interface/themes/responsive/css/title-scroller.less
@@ -121,6 +121,11 @@
     left: 0;
     right: 0;
   }
+  .smallScroller {
+    .scrollerTitleCover {
+      width: auto;
+    }
+  }
 }
 
 .moreLikeThisWrapper,.seriesWrapper {

--- a/code/web/interface/themes/responsive/css/title-scroller.less
+++ b/code/web/interface/themes/responsive/css/title-scroller.less
@@ -125,6 +125,9 @@
     .scrollerTitleCover {
       width: auto;
     }
+    .carouselScrollerTitle .carouselScrollerTitleImage{
+      height: 140px;
+    }
   }
 }
 

--- a/code/web/release_notes/24.06.00.MD
+++ b/code/web/release_notes/24.06.00.MD
@@ -128,6 +128,11 @@
 - Added new Documentation links to several settings pages (*MKD*)
 - Updates to default user roles: removed testing roles and a couple uncommonly used roles; updated role titles (*MKD*)
 
+
+//Pedro - PTFS
+### Other Updates
+- Fix display of 'small' covers in collection spotlights | PLANE #141 (*PA*)
+
 ## This release includes code contributions from
 - ByWater Solutions
   - Mark Noble (MDN)
@@ -135,3 +140,6 @@
   - Kodi Lein (KL)
   - Liz Rea (LR)
   - Morgan Daigneault (MKD)
+
+- PTFS-Europe
+  - Pedro Amorim (PA)


### PR DESCRIPTION
Test plan

1) Perform a search
2) Scroll down to the bottom of the page. Click 'Create Spotlight'.
3) Enter name, click 'Create Spotlight'
4) Click "Edit" at the top.
5) Set 'The cover size to use when showing the display' to 'Small' and access the spotlight i.e.:     http://localhost:8083/API/SearchAPI?method=getCollectionSpotlight&id=2
6) Before the patches: Notice the title covers are distorted and the carousel controls don't match the height of the title covers.
7) After the patches: Notice the title covers are presented with the original aspect ratio and the carousel controls match the new (shorter) height of the title covers