### PR TITLE
Merge javascript relative fix

### DIFF
--- a/code/web/interface/themes/responsive/js/merge_javascript.php
+++ b/code/web/interface/themes/responsive/js/merge_javascript.php
@@ -1,16 +1,16 @@
 <?php
 header('Content-type: text/plain');
 date_default_timezone_set('America/Denver');
-$mergeListFile = fopen("./javascript_files.txt", 'r');
-$mergedFile = fopen("./aspen.js", 'w');
+$mergeListFile = fopen(__DIR__ . "/javascript_files.txt", 'r');
+$mergedFile = fopen(__DIR__ . "/aspen.js", 'w');
 while (($fileToMerge = fgets($mergeListFile)) !== false){
 	$fileToMerge = trim($fileToMerge);
 	if (strpos($fileToMerge, '#') !== 0){
-		if (file_exists($fileToMerge)){
-			fwrite($mergedFile, file_get_contents($fileToMerge, true));
+	    if (file_exists(__DIR__ . '/' . $fileToMerge)){
+		    fwrite($mergedFile, file_get_contents(__DIR__ . '/' . $fileToMerge, true));
 			fwrite($mergedFile, "\r\n");
 		}else{
-			echo("$fileToMerge does not exist\r\n");
+		    echo("$fileToMerge does not exist\r\n");
 		}
 	}
 }

--- a/code/web/release_notes/24.06.00.MD
+++ b/code/web/release_notes/24.06.00.MD
@@ -138,6 +138,10 @@
 ### Other Updates
 - Fix display of 'small' covers in collection spotlights (*PA*)
 
+//Jacob - PTFS
+### Other Updates
+- Updated the merge_javascript.php script to be relative to the location of the file, not the location the script was ran from (*JOM*)
+
 ## This release includes code contributions from
 - ByWater Solutions
   - Mark Noble (MDN)
@@ -148,3 +152,4 @@
 
 - PTFS-Europe
   - Pedro Amorim (PA)
+  - Jacob O'Mara (JOM)


### PR DESCRIPTION
This PR changes the merge_javascript script to instead call other files relative to the location of the script and not relative to the location the script was called from.

To test:

Make a change to the js files.
Notice the merge_javascript script will only work if executing the script from the containing folder and will fail otherwise.
Apply patch
Notice the script will work regardless of where you run it from
Check the JS files are agglomerated correctly