### PR TITLE
If catalog is offline, don't show buttons that prompt a login

### DIFF
--- a/code/web/RecordDrivers/Axis360RecordDriver.php
+++ b/code/web/RecordDrivers/Axis360RecordDriver.php
@@ -201,7 +201,10 @@ class Axis360RecordDriver extends GroupedWorkSubDriver {
 				$loadDefaultActions = count($this->_actions) == 0;
 			}
 
-			if ($loadDefaultActions) {
+            //Check if catalog is offline and login for eResources should be allowed for offline
+            global $offlineMode;
+            global $loginAllowedWhileOffline;
+            if ($loadDefaultActions && (!$offlineMode || $loginAllowedWhileOffline)) {
 				if ($isAvailable) {
 					$this->_actions[] = [
 						'title' => translate([

--- a/code/web/RecordDrivers/Axis360RecordDriver.php
+++ b/code/web/RecordDrivers/Axis360RecordDriver.php
@@ -201,10 +201,10 @@ class Axis360RecordDriver extends GroupedWorkSubDriver {
 				$loadDefaultActions = count($this->_actions) == 0;
 			}
 
-            //Check if catalog is offline and login for eResources should be allowed for offline
-            global $offlineMode;
-            global $loginAllowedWhileOffline;
-            if ($loadDefaultActions && (!$offlineMode || $loginAllowedWhileOffline)) {
+			//Check if catalog is offline and login for eResources should be allowed for offline
+			global $offlineMode;
+			global $loginAllowedWhileOffline;
+			if ($loadDefaultActions && (!$offlineMode || $loginAllowedWhileOffline)) {
 				if ($isAvailable) {
 					$this->_actions[] = [
 						'title' => translate([

--- a/code/web/RecordDrivers/CloudLibraryRecordDriver.php
+++ b/code/web/RecordDrivers/CloudLibraryRecordDriver.php
@@ -182,7 +182,10 @@ class CloudLibraryRecordDriver extends MarcRecordDriver {
 				$loadDefaultActions = count($this->_actions) == 0;
 			}
 
-			if ($loadDefaultActions) {
+            //Check if catalog is offline and login for eResources should be allowed for offline
+            global $offlineMode;
+            global $loginAllowedWhileOffline;
+            if ($loadDefaultActions && (!$offlineMode || $loginAllowedWhileOffline)) {
 				if ($isAvailable) {
 					$userId = UserAccount::getActiveUserId();
 					if ($userId == false) {

--- a/code/web/RecordDrivers/CloudLibraryRecordDriver.php
+++ b/code/web/RecordDrivers/CloudLibraryRecordDriver.php
@@ -182,10 +182,10 @@ class CloudLibraryRecordDriver extends MarcRecordDriver {
 				$loadDefaultActions = count($this->_actions) == 0;
 			}
 
-            //Check if catalog is offline and login for eResources should be allowed for offline
-            global $offlineMode;
-            global $loginAllowedWhileOffline;
-            if ($loadDefaultActions && (!$offlineMode || $loginAllowedWhileOffline)) {
+			//Check if catalog is offline and login for eResources should be allowed for offline
+			global $offlineMode;
+			global $loginAllowedWhileOffline;
+			if ($loadDefaultActions && (!$offlineMode || $loginAllowedWhileOffline)) {
 				if ($isAvailable) {
 					$userId = UserAccount::getActiveUserId();
 					if ($userId == false) {

--- a/code/web/RecordDrivers/EbscohostRecordDriver.php
+++ b/code/web/RecordDrivers/EbscohostRecordDriver.php
@@ -596,16 +596,16 @@ class EbscohostRecordDriver extends RecordInterface {
 	public function getRecordActions() {
 		if ($this->_actions === null) {
 			$this->_actions = [];
-            $this->_actions[] = [
-                'title' => translate([
-                    'text' => 'Access Online',
-                    'isPublicFacing' => true,
-                ]),
-                'url' => '/EBSCOhost/AccessOnline?id=' . $this->getUniqueID(),
-                'requireLogin' => true,
-                'type' => 'ebscohost_access_online',
-            ];
-        }
+			$this->_actions[] = [
+				'title' => translate([
+					'text' => 'Access Online',
+					'isPublicFacing' => true,
+				]),
+				'url' => '/EBSCOhost/AccessOnline?id=' . $this->getUniqueID(),
+				'requireLogin' => true,
+				'type' => 'ebscohost_access_online',
+			];
+		}
 		return $this->_actions;
 	}
 }

--- a/code/web/RecordDrivers/EbscohostRecordDriver.php
+++ b/code/web/RecordDrivers/EbscohostRecordDriver.php
@@ -596,16 +596,16 @@ class EbscohostRecordDriver extends RecordInterface {
 	public function getRecordActions() {
 		if ($this->_actions === null) {
 			$this->_actions = [];
-			$this->_actions[] = [
-				'title' => translate([
-					'text' => 'Access Online',
-					'isPublicFacing' => true,
-				]),
-				'url' => '/EBSCOhost/AccessOnline?id=' . $this->getUniqueID(),
-				'requireLogin' => true,
-				'type' => 'ebscohost_access_online',
-			];
-		}
+            $this->_actions[] = [
+                'title' => translate([
+                    'text' => 'Access Online',
+                    'isPublicFacing' => true,
+                ]),
+                'url' => '/EBSCOhost/AccessOnline?id=' . $this->getUniqueID(),
+                'requireLogin' => true,
+                'type' => 'ebscohost_access_online',
+            ];
+        }
 		return $this->_actions;
 	}
 }

--- a/code/web/RecordDrivers/HooplaRecordDriver.php
+++ b/code/web/RecordDrivers/HooplaRecordDriver.php
@@ -238,7 +238,10 @@ class HooplaRecordDriver extends GroupedWorkSubDriver {
 				$loadDefaultActions = count($this->_actions) == 0;
 			}
 
-			if ($loadDefaultActions) {
+            //Check if catalog is offline and login for eResources should be allowed for offline
+            global $offlineMode;
+            global $loginAllowedWhileOffline;
+            if ($loadDefaultActions && (!$offlineMode || $loginAllowedWhileOffline)) {
 				/** @var Library $searchLibrary */
 				$searchLibrary = Library::getSearchLibrary();
 				if ($searchLibrary->hooplaLibraryID > 0) { // Library is enabled for Hoopla patron action integration

--- a/code/web/RecordDrivers/HooplaRecordDriver.php
+++ b/code/web/RecordDrivers/HooplaRecordDriver.php
@@ -238,10 +238,10 @@ class HooplaRecordDriver extends GroupedWorkSubDriver {
 				$loadDefaultActions = count($this->_actions) == 0;
 			}
 
-            //Check if catalog is offline and login for eResources should be allowed for offline
-            global $offlineMode;
-            global $loginAllowedWhileOffline;
-            if ($loadDefaultActions && (!$offlineMode || $loginAllowedWhileOffline)) {
+			//Check if catalog is offline and login for eResources should be allowed for offline
+			global $offlineMode;
+			global $loginAllowedWhileOffline;
+			if ($loadDefaultActions && (!$offlineMode || $loginAllowedWhileOffline)) {
 				/** @var Library $searchLibrary */
 				$searchLibrary = Library::getSearchLibrary();
 				if ($searchLibrary->hooplaLibraryID > 0) { // Library is enabled for Hoopla patron action integration

--- a/code/web/RecordDrivers/OverDriveRecordDriver.php
+++ b/code/web/RecordDrivers/OverDriveRecordDriver.php
@@ -844,10 +844,10 @@ class OverDriveRecordDriver extends GroupedWorkSubDriver {
 			require_once ROOT_DIR . '/Drivers/OverDriveDriver.php';
 			$overDriveDriver = OverDriveDriver::getOverDriveDriver();
 			$readerName = $overDriveDriver->getReaderName();
-            //Check if catalog is offline and login for eResources should be allowed for offline
-            global $offlineMode;
-            global $loginAllowedWhileOffline;
-            //Show link to OverDrive record when the catalog is offline and can't do logins
+			//Check if catalog is offline and login for eResources should be allowed for offline
+			global $offlineMode;
+			global $loginAllowedWhileOffline;
+			//Show link to OverDrive record when the catalog is offline and can't do logins
 			if (!$overDriveDriver->isCirculationEnabled() || ($offlineMode && !$loginAllowedWhileOffline)) {
 				$overDriveMetadata = $this->getOverDriveMetaData();
 				$crossRefId = $overDriveMetadata->getDecodedRawData()->crossRefId;
@@ -873,7 +873,7 @@ class OverDriveRecordDriver extends GroupedWorkSubDriver {
 					$loadDefaultActions = count($this->_actions) == 0;
 				}
 
-                if ($loadDefaultActions && (!$offlineMode || $loginAllowedWhileOffline)) {
+				if ($loadDefaultActions && (!$offlineMode || $loginAllowedWhileOffline)) {
 					if ($isAvailable) {
 						$this->_actions[] = [
 							'title' => translate([

--- a/code/web/RecordDrivers/OverDriveRecordDriver.php
+++ b/code/web/RecordDrivers/OverDriveRecordDriver.php
@@ -844,7 +844,11 @@ class OverDriveRecordDriver extends GroupedWorkSubDriver {
 			require_once ROOT_DIR . '/Drivers/OverDriveDriver.php';
 			$overDriveDriver = OverDriveDriver::getOverDriveDriver();
 			$readerName = $overDriveDriver->getReaderName();
-			if (!$overDriveDriver->isCirculationEnabled()) {
+            //Check if catalog is offline and login for eResources should be allowed for offline
+            global $offlineMode;
+            global $loginAllowedWhileOffline;
+            //Show link to OverDrive record when the catalog is offline and can't do logins
+			if (!$overDriveDriver->isCirculationEnabled() || ($offlineMode && !$loginAllowedWhileOffline)) {
 				$overDriveMetadata = $this->getOverDriveMetaData();
 				$crossRefId = $overDriveMetadata->getDecodedRawData()->crossRefId;
 				$productUrl = $overDriveDriver->getProductUrl($crossRefId);
@@ -869,7 +873,7 @@ class OverDriveRecordDriver extends GroupedWorkSubDriver {
 					$loadDefaultActions = count($this->_actions) == 0;
 				}
 
-				if ($loadDefaultActions) {
+                if ($loadDefaultActions && (!$offlineMode || $loginAllowedWhileOffline)) {
 					if ($isAvailable) {
 						$this->_actions[] = [
 							'title' => translate([

--- a/code/web/RecordDrivers/PalaceProjectRecordDriver.php
+++ b/code/web/RecordDrivers/PalaceProjectRecordDriver.php
@@ -209,8 +209,10 @@ class PalaceProjectRecordDriver extends GroupedWorkSubDriver {
 				$this->_actions = array_merge($this->_actions, $user->getCirculatedRecordActions('palace_project', $this->id));
 				$loadDefaultActions = count($this->_actions) == 0;
 			}
-
-			if ($loadDefaultActions) {
+            //Check if catalog is offline and login for eResources should be allowed for offline
+            global $offlineMode;
+            global $loginAllowedWhileOffline;
+			if ($loadDefaultActions && (!$offlineMode || $loginAllowedWhileOffline)) {
 				if (!empty($this->palaceProjectRawMetadata)) {
 					foreach ($this->palaceProjectRawMetadata->links as $link) {
 						if ($link->rel == 'http://opds-spec.org/acquisition/borrow') {

--- a/code/web/RecordDrivers/PalaceProjectRecordDriver.php
+++ b/code/web/RecordDrivers/PalaceProjectRecordDriver.php
@@ -209,9 +209,9 @@ class PalaceProjectRecordDriver extends GroupedWorkSubDriver {
 				$this->_actions = array_merge($this->_actions, $user->getCirculatedRecordActions('palace_project', $this->id));
 				$loadDefaultActions = count($this->_actions) == 0;
 			}
-            //Check if catalog is offline and login for eResources should be allowed for offline
-            global $offlineMode;
-            global $loginAllowedWhileOffline;
+			//Check if catalog is offline and login for eResources should be allowed for offline
+			global $offlineMode;
+			global $loginAllowedWhileOffline;
 			if ($loadDefaultActions && (!$offlineMode || $loginAllowedWhileOffline)) {
 				if (!empty($this->palaceProjectRawMetadata)) {
 					foreach ($this->palaceProjectRawMetadata->links as $link) {

--- a/code/web/interface/themes/responsive/Assabet/event.tpl
+++ b/code/web/interface/themes/responsive/Assabet/event.tpl
@@ -101,13 +101,13 @@
 						{else}
 							<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-register btn-wrap" target="_blank" style="width:70%" aria-label="{translate text="Registration Information" isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})"><i class="fas fa-external-link-alt" role="presentation"></i> {translate text="Registration Information" isPublicFacing=true}</a>
 						{/if}
-						{if empty($offline)}
+						{if empty($offline) || $enableEContentWhileOffline}
 							<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'assabet');"
 							  class="btn btn-sm btn-action btn-wrap addToYourEventsBtn"
 							  style="width:70%">{translate text="Add to Your Events" isPublicFacing=true}</a>
 						{/if}
 					</div>
-				{elseif empty($offline)}
+				{elseif empty($offline) || $enableEContentWhileOffline}
 					<a class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:70%" onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'assabet');">{translate text="Add to Your Events" isPublicFacing=true}</a>
 				{/if}
 			{/if}

--- a/code/web/interface/themes/responsive/Assabet/event.tpl
+++ b/code/web/interface/themes/responsive/Assabet/event.tpl
@@ -101,9 +101,13 @@
 						{else}
 							<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-register btn-wrap" target="_blank" style="width:70%" aria-label="{translate text="Registration Information" isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})"><i class="fas fa-external-link-alt" role="presentation"></i> {translate text="Registration Information" isPublicFacing=true}</a>
 						{/if}
-						<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'assabet');" class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:70%">{translate text="Add to Your Events" isPublicFacing=true}</a>
+						{if empty($offline)}
+							<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'assabet');"
+							  class="btn btn-sm btn-action btn-wrap addToYourEventsBtn"
+							  style="width:70%">{translate text="Add to Your Events" isPublicFacing=true}</a>
+						{/if}
 					</div>
-				{else}
+				{elseif empty($offline)}
 					<a class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:70%" onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'assabet');">{translate text="Add to Your Events" isPublicFacing=true}</a>
 				{/if}
 			{/if}

--- a/code/web/interface/themes/responsive/Author/home.tpl
+++ b/code/web/interface/themes/responsive/Author/home.tpl
@@ -39,10 +39,10 @@
 		{if !empty($pageLinks.all)}<div class="text-center">{$pageLinks.all}</div>{/if}
 	{/if}
 
-	{if !empty($showSearchTools) && !$showSearchToolsAtTop}
+	{if !empty($showSearchTools) && !$showSearchToolsAtTop && (empty($offline) || $enableEContentWhileOffline)}
 		<div class="well small">
 			<strong>{translate text='Search Tools' isPublicFacing=true} </strong> &nbsp;
-			<a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a> &nbsp;
+			{if !empty($rssLink)}<a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a> &nbsp;{/if}
 			<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
 		</div>
 	{/if}

--- a/code/web/interface/themes/responsive/Communico/event.tpl
+++ b/code/web/interface/themes/responsive/Communico/event.tpl
@@ -101,11 +101,11 @@
 						{else}
 							<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-register btn-wrap" target="_blank" style="width:100%" aria-label="{translate text="Registration Information" isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})"><i class="fas fa-external-link-alt" role="presentation"></i> {translate text="Registration Information" isPublicFacing=true}</a>
 						{/if}
-						{if empty($offline)}
+						{if empty($offline) || $enableEContentWhileOffline}
 							<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'communico');" class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>
 						{/if}
 					</div>
-				{else empty($offline)}
+				{else empty($offline) || $enableEContentWhileOffline}
 					<a class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:70%" onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'communico');">{translate text="Add to Your Events" isPublicFacing=true}</a>
 				{/if}
 			{/if}

--- a/code/web/interface/themes/responsive/Communico/event.tpl
+++ b/code/web/interface/themes/responsive/Communico/event.tpl
@@ -101,9 +101,11 @@
 						{else}
 							<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-register btn-wrap" target="_blank" style="width:100%" aria-label="{translate text="Registration Information" isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})"><i class="fas fa-external-link-alt" role="presentation"></i> {translate text="Registration Information" isPublicFacing=true}</a>
 						{/if}
-						<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'communico');" class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>
+						{if empty($offline)}
+							<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'communico');" class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>
+						{/if}
 					</div>
-				{else}
+				{else empty($offline)}
 					<a class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:70%" onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'communico');">{translate text="Add to Your Events" isPublicFacing=true}</a>
 				{/if}
 			{/if}

--- a/code/web/interface/themes/responsive/CourseReserves/list-none.tpl
+++ b/code/web/interface/themes/responsive/CourseReserves/list-none.tpl
@@ -51,12 +51,14 @@
 				<strong>{translate text='Search Tools' isPublicFacing=true} </strong>
 				{if !empty($showSearchTools)}
 					<a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a>
-					<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
-					{if !empty($enableSavedSearches)}
-						{if !empty($savedSearch)}
-							<a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text="Remove Saved Search" isPublicFacing=true}</a>
-						{else}
-							<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a>
+					{if empty($offline)}
+						<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
+						{if !empty($enableSavedSearches)}
+							{if !empty($savedSearch)}
+								<a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text="Remove Saved Search" isPublicFacing=true}</a>
+							{else}
+								<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a>
+							{/if}
 						{/if}
 					{/if}
 					{*<a href="{$excelLink|escape}">{translate text='Export To CSV' isPublicFacing=true}</a>*}

--- a/code/web/interface/themes/responsive/CourseReserves/list-none.tpl
+++ b/code/web/interface/themes/responsive/CourseReserves/list-none.tpl
@@ -51,7 +51,7 @@
 				<strong>{translate text='Search Tools' isPublicFacing=true} </strong>
 				{if !empty($showSearchTools)}
 					<a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a>
-					{if empty($offline)}
+					{if empty($offline) || $enableEContentWhileOffline}
 						<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
 						{if !empty($enableSavedSearches)}
 							{if !empty($savedSearch)}

--- a/code/web/interface/themes/responsive/CourseReserves/list.tpl
+++ b/code/web/interface/themes/responsive/CourseReserves/list.tpl
@@ -74,12 +74,14 @@
 		<strong>{translate text='Search Tools' isPublicFacing=true} </strong>
 		{if !empty($showSearchTools)}
 			<a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a>
-			<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
-			{if !empty($enableSavedSearches)}
-				{if !empty($savedSearch)}
-					<a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text="Remove Saved Search" isPublicFacing=true}</a>
-				{else}
-					<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a>
+			{if empty($offline)}
+				<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
+				{if !empty($enableSavedSearches)}
+					{if !empty($savedSearch)}
+						<a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text="Remove Saved Search" isPublicFacing=true}</a>
+					{else}
+						<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a>
+					{/if}
 				{/if}
 			{/if}
 			{*<a href="{$excelLink|escape}">{translate text='Export To CSV' isPublicFacing=true}</a>*}

--- a/code/web/interface/themes/responsive/CourseReserves/list.tpl
+++ b/code/web/interface/themes/responsive/CourseReserves/list.tpl
@@ -74,7 +74,7 @@
 		<strong>{translate text='Search Tools' isPublicFacing=true} </strong>
 		{if !empty($showSearchTools)}
 			<a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a>
-			{if empty($offline)}
+			{if empty($offline) || $enableEContentWhileOffline}
 				<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
 				{if !empty($enableSavedSearches)}
 					{if !empty($savedSearch)}

--- a/code/web/interface/themes/responsive/EBSCO/list.tpl
+++ b/code/web/interface/themes/responsive/EBSCO/list.tpl
@@ -30,7 +30,7 @@
 		<div class="search_tools well small">
 			<strong>{translate text='Search Tools' isPublicFacing=true} </strong>
 			<a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a>
-			{if empty($offline)}
+			{if empty($offline) || $enableEContentWhileOffline}
 				<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true); ">{translate text='Email this Search' isPublicFacing=true}</a>
 				{if !empty($enableSavedSearches)}
 					{if !empty($savedSearch)}

--- a/code/web/interface/themes/responsive/EBSCO/list.tpl
+++ b/code/web/interface/themes/responsive/EBSCO/list.tpl
@@ -30,12 +30,14 @@
 		<div class="search_tools well small">
 			<strong>{translate text='Search Tools' isPublicFacing=true} </strong>
 			<a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a>
-			<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true); ">{translate text='Email this Search' isPublicFacing=true}</a>
-			{if !empty($enableSavedSearches)}
-				{if !empty($savedSearch)}
-					<a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text="Remove Saved Search" isPublicFacing=true}</a>
-				{else}
-					<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a>
+			{if empty($offline)}
+				<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true); ">{translate text='Email this Search' isPublicFacing=true}</a>
+				{if !empty($enableSavedSearches)}
+					{if !empty($savedSearch)}
+						<a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text="Remove Saved Search" isPublicFacing=true}</a>
+					{else}
+						<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a>
+					{/if}
 				{/if}
 			{/if}
 			{*<a href="{$excelLink|escape}">{translate text='Export To CSV' isPublicFacing=true}</a>*}

--- a/code/web/interface/themes/responsive/EBSCO/result-tools-horizontal.tpl
+++ b/code/web/interface/themes/responsive/EBSCO/result-tools-horizontal.tpl
@@ -8,7 +8,7 @@
 						<a href="{if !empty($summUrl)}{$summUrl}{else}{$recordDriver->getLinkUrl()}{/if}" class="btn btn-sm btn-tools" onclick="AspenDiscovery.EBSCO.trackEdsUsage('{$recordDriver->getPermanentId()}')" target="_blank" aria-label="{translate text="More Info" isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})"><i class="fas fa-external-link-alt" role="presentation"></i> {translate text="More Info" isPublicFacing=true}</a>
 					</div>
 				{/if}
-				{if $showFavorites == 1 && empty($offline)}
+				{if $showFavorites == 1 && (empty($offline) || $enableEContentWhileOffline)}
 					<div class="btn-group btn-group-sm">
 						<button onclick="return AspenDiscovery.Account.showSaveToListForm(this, 'EbscoEds', '{$recordDriver->getPermanentId()|escape}');" class="btn btn-sm btn-tools addToListBtn">{translate text="Add to List" isPublicFacing=true}</button>
 					</div>

--- a/code/web/interface/themes/responsive/EBSCO/result-tools-horizontal.tpl
+++ b/code/web/interface/themes/responsive/EBSCO/result-tools-horizontal.tpl
@@ -8,7 +8,7 @@
 						<a href="{if !empty($summUrl)}{$summUrl}{else}{$recordDriver->getLinkUrl()}{/if}" class="btn btn-sm btn-tools" onclick="AspenDiscovery.EBSCO.trackEdsUsage('{$recordDriver->getPermanentId()}')" target="_blank" aria-label="{translate text="More Info" isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})"><i class="fas fa-external-link-alt" role="presentation"></i> {translate text="More Info" isPublicFacing=true}</a>
 					</div>
 				{/if}
-				{if $showFavorites == 1}
+				{if $showFavorites == 1 && empty($offline)}
 					<div class="btn-group btn-group-sm">
 						<button onclick="return AspenDiscovery.Account.showSaveToListForm(this, 'EbscoEds', '{$recordDriver->getPermanentId()|escape}');" class="btn btn-sm btn-tools addToListBtn">{translate text="Add to List" isPublicFacing=true}</button>
 					</div>

--- a/code/web/interface/themes/responsive/EBSCOhost/list.tpl
+++ b/code/web/interface/themes/responsive/EBSCOhost/list.tpl
@@ -30,7 +30,7 @@
 		<div class="search_tools well small">
 			<strong>{translate text='Search Tools' isPublicFacing=true} </strong>
 			{if !empty($rssLink)}<a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a>{/if}
-			{if empty($offline)}
+			{if empty($offline) || $enableEContentWhileOffline}
 				<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true); ">{translate text='Email this Search' isPublicFacing=true}</a>
 				{if !empty($enableSavedSearches)}
 					{if !empty($savedSearch)}

--- a/code/web/interface/themes/responsive/EBSCOhost/list.tpl
+++ b/code/web/interface/themes/responsive/EBSCOhost/list.tpl
@@ -30,12 +30,14 @@
 		<div class="search_tools well small">
 			<strong>{translate text='Search Tools' isPublicFacing=true} </strong>
 			{if !empty($rssLink)}<a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a>{/if}
-			<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true); ">{translate text='Email this Search' isPublicFacing=true}</a>
-			{if !empty($enableSavedSearches)}
-				{if !empty($savedSearch)}
-					<a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text="Remove Saved Search" isPublicFacing=true}</a>
-				{else}
-					<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a>
+			{if empty($offline)}
+				<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true); ">{translate text='Email this Search' isPublicFacing=true}</a>
+				{if !empty($enableSavedSearches)}
+					{if !empty($savedSearch)}
+						<a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text="Remove Saved Search" isPublicFacing=true}</a>
+					{else}
+						<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a>
+					{/if}
 				{/if}
 			{/if}
 			{*<a href="{$excelLink|escape}">{translate text='Export To CSV' isPublicFacing=true}</a>*}

--- a/code/web/interface/themes/responsive/EBSCOhost/result-tools-horizontal.tpl
+++ b/code/web/interface/themes/responsive/EBSCOhost/result-tools-horizontal.tpl
@@ -8,7 +8,7 @@
 						<a href="{if !empty($summUrl)}{$summUrl}{else}{$recordDriver->getLinkUrl()}{/if}" class="btn btn-sm btn-tools" onclick="AspenDiscovery.EBSCO.trackEdsUsage('{$recordDriver->getPermanentId()}')" target="_blank" aria-label="{translate text="More Info" isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})"><i class="fas fa-external-link-alt" role="presentation"></i> {translate text="More Info" isPublicFacing=true}</a>
 					</div>
 				{/if}
-				{if $showFavorites == 1 && empty($offline)}
+				{if $showFavorites == 1 && (empty($offline) || $enableEContentWhileOffline)}
 					<div class="btn-group btn-group-sm">
 						<button onclick="return AspenDiscovery.Account.showSaveToListForm(this, 'Ebscohost', '{$recordDriver->getPermanentId()|escape}');" class="btn btn-sm btn-tools addToListBtn">{translate text="Add to List" isPublicFacing=true}</button>
 					</div>

--- a/code/web/interface/themes/responsive/EBSCOhost/result-tools-horizontal.tpl
+++ b/code/web/interface/themes/responsive/EBSCOhost/result-tools-horizontal.tpl
@@ -8,7 +8,7 @@
 						<a href="{if !empty($summUrl)}{$summUrl}{else}{$recordDriver->getLinkUrl()}{/if}" class="btn btn-sm btn-tools" onclick="AspenDiscovery.EBSCO.trackEdsUsage('{$recordDriver->getPermanentId()}')" target="_blank" aria-label="{translate text="More Info" isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})"><i class="fas fa-external-link-alt" role="presentation"></i> {translate text="More Info" isPublicFacing=true}</a>
 					</div>
 				{/if}
-				{if $showFavorites == 1}
+				{if $showFavorites == 1 && empty($offline)}
 					<div class="btn-group btn-group-sm">
 						<button onclick="return AspenDiscovery.Account.showSaveToListForm(this, 'Ebscohost', '{$recordDriver->getPermanentId()|escape}');" class="btn btn-sm btn-tools addToListBtn">{translate text="Add to List" isPublicFacing=true}</button>
 					</div>

--- a/code/web/interface/themes/responsive/Events/list-none.tpl
+++ b/code/web/interface/themes/responsive/Events/list-none.tpl
@@ -62,7 +62,7 @@
 			<strong>{translate text='Search Tools' isPublicFacing=true} </strong>
 			{if !empty($showSearchTools)}
 				<a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a>
-				{if empty($offline)}
+				{if empty($offline) || $enableEContentWhileOffline}
 					<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
 					{if !empty($enableSavedSearches)}
 						{if !empty($savedSearch)}

--- a/code/web/interface/themes/responsive/Events/list-none.tpl
+++ b/code/web/interface/themes/responsive/Events/list-none.tpl
@@ -62,12 +62,14 @@
 			<strong>{translate text='Search Tools' isPublicFacing=true} </strong>
 			{if !empty($showSearchTools)}
 				<a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a>
-				<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
-				{if !empty($enableSavedSearches)}
-					{if !empty($savedSearch)}
-						<a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text="Remove Saved Search" isPublicFacing=true}</a>
-					{else}
-						<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a>
+				{if empty($offline)}
+					<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
+					{if !empty($enableSavedSearches)}
+						{if !empty($savedSearch)}
+							<a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text="Remove Saved Search" isPublicFacing=true}</a>
+						{else}
+							<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a>
+						{/if}
 					{/if}
 				{/if}
 				{*<a href="{$excelLink|escape}">{translate text='Export To CSV' isPublicFacing=true}</a>*}

--- a/code/web/interface/themes/responsive/Events/list.tpl
+++ b/code/web/interface/themes/responsive/Events/list.tpl
@@ -72,7 +72,7 @@
 		<strong>{translate text='Search Tools' isPublicFacing=true} </strong>
 		{if !empty($showSearchTools)}
 			<a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a>
-		{if empty($offline)}
+		{if empty($offline) || $enableEContentWhileOffline}
 				<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
 				{if !empty($enableSavedSearches)}
 					{if !empty($savedSearch)}

--- a/code/web/interface/themes/responsive/Events/list.tpl
+++ b/code/web/interface/themes/responsive/Events/list.tpl
@@ -72,12 +72,14 @@
 		<strong>{translate text='Search Tools' isPublicFacing=true} </strong>
 		{if !empty($showSearchTools)}
 			<a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a>
-			<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
-			{if !empty($enableSavedSearches)}
-				{if !empty($savedSearch)}
-					<a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text="Remove Saved Search" isPublicFacing=true}</a>
-				{else}
-					<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a>
+		{if empty($offline)}
+				<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
+				{if !empty($enableSavedSearches)}
+					{if !empty($savedSearch)}
+						<a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text="Remove Saved Search" isPublicFacing=true}</a>
+					{else}
+						<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a>
+					{/if}
 				{/if}
 			{/if}
 			{*<a href="{$excelLink|escape}">{translate text='Export To CSV' isPublicFacing=true}</a>*}

--- a/code/web/interface/themes/responsive/Genealogy/list.tpl
+++ b/code/web/interface/themes/responsive/Genealogy/list.tpl
@@ -52,12 +52,14 @@
 		<div class="search_tools well small">
 			<strong>{translate text='Search Tools' isPublicFacing=true} </strong>
 			<a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a>
-			<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true); ">{translate text='Email this Search' isPublicFacing=true}</a>
-			{if !empty($enableSavedSearches)}
-				{if !empty($savedSearch)}
-					<a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text="Remove Saved Search" isPublicFacing=true}</a>
-				{else}
-					<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a>
+			{if empty($offline)}
+				<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true); ">{translate text='Email this Search' isPublicFacing=true}</a>
+				{if !empty($enableSavedSearches)}
+					{if !empty($savedSearch)}
+						<a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text="Remove Saved Search" isPublicFacing=true}</a>
+					{else}
+						<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a>
+					{/if}
 				{/if}
 			{/if}
 			{if !empty($excelLink)}<a href="{$excelLink|escape}">{translate text='Export To CSV' isPublicFacing=true}</a>{/if}

--- a/code/web/interface/themes/responsive/Genealogy/list.tpl
+++ b/code/web/interface/themes/responsive/Genealogy/list.tpl
@@ -52,7 +52,7 @@
 		<div class="search_tools well small">
 			<strong>{translate text='Search Tools' isPublicFacing=true} </strong>
 			<a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a>
-			{if empty($offline)}
+			{if empty($offline) || $enableEContentWhileOffline}
 				<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true); ">{translate text='Email this Search' isPublicFacing=true}</a>
 				{if !empty($enableSavedSearches)}
 					{if !empty($savedSearch)}

--- a/code/web/interface/themes/responsive/Genealogy/result-tools-horizontal.tpl
+++ b/code/web/interface/themes/responsive/Genealogy/result-tools-horizontal.tpl
@@ -8,7 +8,7 @@
 						<a href="{if !empty($summUrl)}{$summUrl}{else}{$recordDriver->getLinkUrl()}{/if}" class="btn btn-sm btn-tools">{translate text="More Info" isPublicFacing=true}</a>
 					</div>
 				{/if}
-				{if $showFavorites == 1 && empty($offline)}
+				{if $showFavorites == 1 && (empty($offline) || $enableEContentWhileOffline)}
 					<div class="btn-group btn-group-sm">
 						<button onclick="return AspenDiscovery.Account.showSaveToListForm(this, 'Genealogy', '{$recordDriver->getPermanentId()|escape}');" class="btn btn-sm btn-tools addToListBtn">{translate text="Add to List" isPublicFacing=true}</button>
 					</div>

--- a/code/web/interface/themes/responsive/Genealogy/result-tools-horizontal.tpl
+++ b/code/web/interface/themes/responsive/Genealogy/result-tools-horizontal.tpl
@@ -8,7 +8,7 @@
 						<a href="{if !empty($summUrl)}{$summUrl}{else}{$recordDriver->getLinkUrl()}{/if}" class="btn btn-sm btn-tools">{translate text="More Info" isPublicFacing=true}</a>
 					</div>
 				{/if}
-				{if $showFavorites == 1}
+				{if $showFavorites == 1 && empty($offline)}
 					<div class="btn-group btn-group-sm">
 						<button onclick="return AspenDiscovery.Account.showSaveToListForm(this, 'Genealogy', '{$recordDriver->getPermanentId()|escape}');" class="btn btn-sm btn-tools addToListBtn">{translate text="Add to List" isPublicFacing=true}</button>
 					</div>

--- a/code/web/interface/themes/responsive/GroupedWork/result-tools-horizontal.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/result-tools-horizontal.tpl
@@ -17,14 +17,16 @@
 				{if $showMoreInfo !== false}
 					<a href="{if !empty($summUrl)}{$summUrl}{else}{$recordDriver->getMoreInfoLinkUrl()}{/if}" class="btn btn-sm btn-tools" aria-label="{translate text="More Info for %1% record %2%" 1=$summTitle|escapeCSS 2=$recordDriver->getPermanentId() isPublicFacing=true inAttribute=true}">{translate text="More Info" isPublicFacing=true}</a>
 				{/if}
-				{if $showComments == 1}
-					{* Hide Review Button for xs views in Search Results & User Lists *}
-					<button id="userreviewlink{$recordDriver->getPermanentId()}" class="resultAction btn btn-sm btn-tools{if $module == 'Search' || ($action == 'MyList' && $module == 'MyAccount')} hidden-xs{/if}" onclick="return AspenDiscovery.GroupedWork.showReviewForm(this, '{$recordDriver->getPermanentId()}')" onkeypress="return AspenDiscovery.GroupedWork.showReviewForm(this, '{$recordDriver->getPermanentId()}')">
-						{translate text='Add a Review' isPublicFacing=true}
-					</button>
-				{/if}
-				{if $showFavorites == 1}
-					<button onclick="return AspenDiscovery.Account.showSaveToListForm(this, 'GroupedWork', '{$recordDriver->getPermanentId()|escape}');" onkeypress="return AspenDiscovery.Account.showSaveToListForm(this, 'GroupedWork', '{$recordDriver->getPermanentId()|escape}');" class="btn btn-sm btn-tools addToListBtn">{translate text="Add to List" isPublicFacing=true}</button>
+				{if empty($offline)}
+					{if $showComments == 1}
+						{* Hide Review Button for xs views in Search Results & User Lists *}
+						<button id="userreviewlink{$recordDriver->getPermanentId()}" class="resultAction btn btn-sm btn-tools{if $module == 'Search' || ($action == 'MyList' && $module == 'MyAccount')} hidden-xs{/if}" onclick="return AspenDiscovery.GroupedWork.showReviewForm(this, '{$recordDriver->getPermanentId()}')" onkeypress="return AspenDiscovery.GroupedWork.showReviewForm(this, '{$recordDriver->getPermanentId()}')">
+							{translate text='Add a Review' isPublicFacing=true}
+						</button>
+					{/if}
+					{if $showFavorites == 1}
+						<button onclick="return AspenDiscovery.Account.showSaveToListForm(this, 'GroupedWork', '{$recordDriver->getPermanentId()|escape}');" onkeypress="return AspenDiscovery.Account.showSaveToListForm(this, 'GroupedWork', '{$recordDriver->getPermanentId()|escape}');" class="btn btn-sm btn-tools addToListBtn">{translate text="Add to List" isPublicFacing=true}</button>
+					{/if}
 				{/if}
 				{if !empty($loggedIn) && $module == 'Search' && in_array('Manually Group and Ungroup Works', $userPermissions)}
 					<button onclick="return AspenDiscovery.GroupedWork.getGroupWithSearchForm(this, '{$recordDriver->getPermanentId()}', '{$searchId}', '{$page}')" onkeypress="return AspenDiscovery.GroupedWork.getGroupWithSearchForm(this, '{$recordDriver->getPermanentId()}', '{$searchId}', '{$page}')" class="btn btn-sm btn-tools">{translate text='Group With' isAdminFacing=true}</button>

--- a/code/web/interface/themes/responsive/GroupedWork/result-tools-horizontal.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/result-tools-horizontal.tpl
@@ -17,7 +17,7 @@
 				{if $showMoreInfo !== false}
 					<a href="{if !empty($summUrl)}{$summUrl}{else}{$recordDriver->getMoreInfoLinkUrl()}{/if}" class="btn btn-sm btn-tools" aria-label="{translate text="More Info for %1% record %2%" 1=$summTitle|escapeCSS 2=$recordDriver->getPermanentId() isPublicFacing=true inAttribute=true}">{translate text="More Info" isPublicFacing=true}</a>
 				{/if}
-				{if empty($offline)}
+				{if empty($offline) || $enableEContentWhileOffline}
 					{if $showComments == 1}
 						{* Hide Review Button for xs views in Search Results & User Lists *}
 						<button id="userreviewlink{$recordDriver->getPermanentId()}" class="resultAction btn btn-sm btn-tools{if $module == 'Search' || ($action == 'MyList' && $module == 'MyAccount')} hidden-xs{/if}" onclick="return AspenDiscovery.GroupedWork.showReviewForm(this, '{$recordDriver->getPermanentId()}')" onkeypress="return AspenDiscovery.GroupedWork.showReviewForm(this, '{$recordDriver->getPermanentId()}')">

--- a/code/web/interface/themes/responsive/GroupedWork/result-tools.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/result-tools.tpl
@@ -1,5 +1,5 @@
 {strip}
-	{if $showFavorites == 1}
+	{if $showFavorites == 1 && empty($offline)}
 		<div class="text-center row">
 			<div class="col-xs-12">
 				<span onclick="return AspenDiscovery.Account.showSaveToListForm(this, 'GroupedWork', '{$recordDriver->getPermanentId()|escape}');" class="btn btn-sm addtolistlink addToListBtn">{translate text="Add to List" isPublicFacing=true}</span>

--- a/code/web/interface/themes/responsive/GroupedWork/result-tools.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/result-tools.tpl
@@ -1,5 +1,5 @@
 {strip}
-	{if $showFavorites == 1 && empty($offline)}
+	{if $showFavorites == 1 && (empty($offline) || $enableEContentWhileOffline)}
 		<div class="text-center row">
 			<div class="col-xs-12">
 				<span onclick="return AspenDiscovery.Account.showSaveToListForm(this, 'GroupedWork', '{$recordDriver->getPermanentId()|escape}');" class="btn btn-sm addtolistlink addToListBtn">{translate text="Add to List" isPublicFacing=true}</span>

--- a/code/web/interface/themes/responsive/LibraryMarket/event.tpl
+++ b/code/web/interface/themes/responsive/LibraryMarket/event.tpl
@@ -66,10 +66,12 @@
 							{else}
 								<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-register btn-wrap" target="_blank" style="width:70%" aria-label="{translate text="Go To Your Events" isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})"><i class="fas fa-external-link-alt" role="presentation"></i> {translate text="Registration Information" isPublicFacing=true}</a>
 							{/if}
-							<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap">{translate text="Go To Your Events" isPublicFacing=true}</a>
+							{if empty($offline)}
+								<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap">{translate text="Go To Your Events" isPublicFacing=true}</a>
+							{/if}
 						</div>
 						<br>
-					{else}
+					{elseif empty($offline)}
 						<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap">{translate text="In Your Events" isPublicFacing=true}</a>
 					{/if}
 				{else}
@@ -81,9 +83,11 @@
 							{else}
 								<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-register btn-wrap" target="_blank" style="width:70%" aria-label="{translate text="Registration Information" isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})"><i class="fas fa-external-link-alt" role="presentation"></i> {translate text="Registration Information" isPublicFacing=true}</a>
 							{/if}
-							<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'library_market');" class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:70%">{translate text="Add to Your Events" isPublicFacing=true}</a>
+							{if empty($offline)}
+								<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'library_market');" class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:70%">{translate text="Add to Your Events" isPublicFacing=true}</a>
+							{/if}
 						</div>
-					{else}
+					{elseif empty($offline)}
 						<a class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:70%" onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'library_market');">{translate text="Add to Your Events" isPublicFacing=true}</a>
 					{/if}
 				{/if}

--- a/code/web/interface/themes/responsive/LibraryMarket/event.tpl
+++ b/code/web/interface/themes/responsive/LibraryMarket/event.tpl
@@ -66,12 +66,12 @@
 							{else}
 								<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-register btn-wrap" target="_blank" style="width:70%" aria-label="{translate text="Go To Your Events" isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})"><i class="fas fa-external-link-alt" role="presentation"></i> {translate text="Registration Information" isPublicFacing=true}</a>
 							{/if}
-							{if empty($offline)}
+							{if empty($offline) || $enableEContentWhileOffline}
 								<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap">{translate text="Go To Your Events" isPublicFacing=true}</a>
 							{/if}
 						</div>
 						<br>
-					{elseif empty($offline)}
+					{elseif empty($offline) || $enableEContentWhileOffline}
 						<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap">{translate text="In Your Events" isPublicFacing=true}</a>
 					{/if}
 				{else}
@@ -83,11 +83,11 @@
 							{else}
 								<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-register btn-wrap" target="_blank" style="width:70%" aria-label="{translate text="Registration Information" isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})"><i class="fas fa-external-link-alt" role="presentation"></i> {translate text="Registration Information" isPublicFacing=true}</a>
 							{/if}
-							{if empty($offline)}
+							{if empty($offline) || $enableEContentWhileOffline}
 								<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'library_market');" class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:70%">{translate text="Add to Your Events" isPublicFacing=true}</a>
 							{/if}
 						</div>
-					{elseif empty($offline)}
+					{elseif empty($offline) || $enableEContentWhileOffline}
 						<a class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:70%" onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'library_market');">{translate text="Add to Your Events" isPublicFacing=true}</a>
 					{/if}
 				{/if}

--- a/code/web/interface/themes/responsive/Lists/list-none.tpl
+++ b/code/web/interface/themes/responsive/Lists/list-none.tpl
@@ -51,7 +51,7 @@
 				<strong>{translate text='Search Tools' isPublicFacing=true} </strong>
 				{if !empty($showSearchTools)}
 					<a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a>
-					{if empty($offline)}
+					{if empty($offline) || $enableEContentWhileOffline}
 						<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
 						{if !empty($enableSavedSearches)}
 							{if !empty($savedSearch)}

--- a/code/web/interface/themes/responsive/Lists/list-none.tpl
+++ b/code/web/interface/themes/responsive/Lists/list-none.tpl
@@ -51,12 +51,14 @@
 				<strong>{translate text='Search Tools' isPublicFacing=true} </strong>
 				{if !empty($showSearchTools)}
 					<a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a>
-					<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
-					{if !empty($enableSavedSearches)}
-						{if !empty($savedSearch)}
-							<a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text="Remove Saved Search" isPublicFacing=true}</a>
-						{else}
-							<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a>
+					{if empty($offline)}
+						<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
+						{if !empty($enableSavedSearches)}
+							{if !empty($savedSearch)}
+								<a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text="Remove Saved Search" isPublicFacing=true}</a>
+							{else}
+								<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a>
+							{/if}
 						{/if}
 					{/if}
 					{if !empty($excelLink)}<a href="{$excelLink|escape}">{translate text='Export To CSV' isPublicFacing=true}</a>{/if}

--- a/code/web/interface/themes/responsive/Lists/list.tpl
+++ b/code/web/interface/themes/responsive/Lists/list.tpl
@@ -74,7 +74,7 @@
 		<strong>{translate text='Search Tools' isPublicFacing=true} </strong>
 		{if !empty($showSearchTools)}
 			<a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a>
-			{if empty($offline)}
+			{if empty($offline) || $enableEContentWhileOffline}
 				<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
 				{if !empty($enableSavedSearches)}
 					{if !empty($savedSearch)}

--- a/code/web/interface/themes/responsive/Lists/list.tpl
+++ b/code/web/interface/themes/responsive/Lists/list.tpl
@@ -74,12 +74,14 @@
 		<strong>{translate text='Search Tools' isPublicFacing=true} </strong>
 		{if !empty($showSearchTools)}
 			<a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a>
-			<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
-			{if !empty($enableSavedSearches)}
-				{if !empty($savedSearch)}
-					<a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text="Remove Saved Search" isPublicFacing=true}</a>
-				{else}
-					<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a>
+			{if empty($offline)}
+				<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
+				{if !empty($enableSavedSearches)}
+					{if !empty($savedSearch)}
+						<a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text="Remove Saved Search" isPublicFacing=true}</a>
+					{else}
+						<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a>
+					{/if}
 				{/if}
 			{/if}
 			{if !empty($excelLink)}<a href="{$excelLink|escape}">{translate text='Export To CSV' isPublicFacing=true}</a>{/if}

--- a/code/web/interface/themes/responsive/OpenArchives/list-none.tpl
+++ b/code/web/interface/themes/responsive/OpenArchives/list-none.tpl
@@ -62,7 +62,7 @@
 			<strong>{translate text='Search Tools' isPublicFacing=true} </strong>
 			{if !empty($showSearchTools)}
 				<a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a>
-				{if empty($offline)}
+				{if empty($offline) || $enableEContentWhileOffline}
 					<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
 					{if !empty($enableSavedSearches)}
 						{if !empty($savedSearch)}

--- a/code/web/interface/themes/responsive/OpenArchives/list-none.tpl
+++ b/code/web/interface/themes/responsive/OpenArchives/list-none.tpl
@@ -62,12 +62,14 @@
 			<strong>{translate text='Search Tools' isPublicFacing=true} </strong>
 			{if !empty($showSearchTools)}
 				<a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a>
-				<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
-				{if !empty($enableSavedSearches)}
-					{if !empty($savedSearch)}
-						<a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text="Remove Saved Search" isPublicFacing=true}</a>
-					{else}
-						<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a>
+				{if empty($offline)}
+					<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
+					{if !empty($enableSavedSearches)}
+						{if !empty($savedSearch)}
+							<a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text="Remove Saved Search" isPublicFacing=true}</a>
+						{else}
+							<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a>
+						{/if}
 					{/if}
 				{/if}
 				{*<a href="{$excelLink|escape}">{translate text='Export To CSV' isPublicFacing=true}</a>*}

--- a/code/web/interface/themes/responsive/OpenArchives/list.tpl
+++ b/code/web/interface/themes/responsive/OpenArchives/list.tpl
@@ -77,7 +77,7 @@
 		<strong>{translate text='Search Tools' isPublicFacing=true} </strong>
 		{if !empty($showSearchTools)}
 			<a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a>
-			{if empty($offline)}
+			{if empty($offline) || $enableEContentWhileOffline}
 				<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
 				{if !empty($enableSavedSearches)}
 					{if !empty($savedSearch)}

--- a/code/web/interface/themes/responsive/OpenArchives/list.tpl
+++ b/code/web/interface/themes/responsive/OpenArchives/list.tpl
@@ -77,12 +77,14 @@
 		<strong>{translate text='Search Tools' isPublicFacing=true} </strong>
 		{if !empty($showSearchTools)}
 			<a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a>
-			<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
-			{if !empty($enableSavedSearches)}
-				{if !empty($savedSearch)}
-					<a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text="Remove Saved Search" isPublicFacing=true}</a>
-				{else}
-					<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a>
+			{if empty($offline)}
+				<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
+				{if !empty($enableSavedSearches)}
+					{if !empty($savedSearch)}
+						<a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text="Remove Saved Search" isPublicFacing=true}</a>
+					{else}
+						<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a>
+					{/if}
 				{/if}
 			{/if}
 			{*<a href="{$excelLink|escape}">{translate text='Export To CSV' isPublicFacing=true}</a>*}

--- a/code/web/interface/themes/responsive/OpenArchives/result-tools-horizontal.tpl
+++ b/code/web/interface/themes/responsive/OpenArchives/result-tools-horizontal.tpl
@@ -8,7 +8,7 @@
 						<a href="{$openArchiveUrl}" class="btn btn-sm btn-tools" target="_blank" aria-label="{translate text='More Info' isPublicFacing=true} ({translate text='opens in new window' isPublicFacing=true})">{translate text="More Info" isPublicFacing=true}</a>
 					</div>
 				{/if}
-				{if $showFavorites == 1}
+				{if $showFavorites == 1 && empty($offline)}
 					<div class="btn-group btn-group-sm">
 						<button onclick="return AspenDiscovery.Account.showSaveToListForm(this, 'OpenArchives', '{$id|escape}');" class="btn btn-sm btn-tools addToListBtn">{translate text="Add to List" isPublicFacing=true}</button>
 					</div>

--- a/code/web/interface/themes/responsive/OpenArchives/result-tools-horizontal.tpl
+++ b/code/web/interface/themes/responsive/OpenArchives/result-tools-horizontal.tpl
@@ -8,7 +8,7 @@
 						<a href="{$openArchiveUrl}" class="btn btn-sm btn-tools" target="_blank" aria-label="{translate text='More Info' isPublicFacing=true} ({translate text='opens in new window' isPublicFacing=true})">{translate text="More Info" isPublicFacing=true}</a>
 					</div>
 				{/if}
-				{if $showFavorites == 1 && empty($offline)}
+				{if $showFavorites == 1 && (empty($offline) || $enableEContentWhileOffline)}
 					<div class="btn-group btn-group-sm">
 						<button onclick="return AspenDiscovery.Account.showSaveToListForm(this, 'OpenArchives', '{$id|escape}');" class="btn btn-sm btn-tools addToListBtn">{translate text="Add to List" isPublicFacing=true}</button>
 					</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/Events/assabet_result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Events/assabet_result.tpl
@@ -85,11 +85,13 @@
 									{else}
 										<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-register btn-wrap" target="_blank" style="width:100%"aria-label="{translate text="Registration Information" isPublicFacing=true inAttribute=true} ({translate text='opens in new window' isPublicFacing=true inAttribute=true})"><i class="fas fa-external-link-alt" role="presentation"></i> {translate text="Registration Information" isPublicFacing=true}</a>
 									{/if}
-									<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'assabet');" class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>
+									{if empty($offline)}
+										<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'assabet');" class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>
+									{/if}
 								</div>
 							</div>
 							<br>
-						{else}
+						{elseif empty($offline)}
 							<div class="btn-toolbar">
 								<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'assabet');" class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>
 							</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/Events/assabet_result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Events/assabet_result.tpl
@@ -85,13 +85,13 @@
 									{else}
 										<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-register btn-wrap" target="_blank" style="width:100%"aria-label="{translate text="Registration Information" isPublicFacing=true inAttribute=true} ({translate text='opens in new window' isPublicFacing=true inAttribute=true})"><i class="fas fa-external-link-alt" role="presentation"></i> {translate text="Registration Information" isPublicFacing=true}</a>
 									{/if}
-									{if empty($offline)}
+									{if empty($offline) || $enableEContentWhileOffline}
 										<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'assabet');" class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>
 									{/if}
 								</div>
 							</div>
 							<br>
-						{elseif empty($offline)}
+						{elseif empty($offline) || $enableEContentWhileOffline}
 							<div class="btn-toolbar">
 								<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'assabet');" class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>
 							</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/Events/communico_result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Events/communico_result.tpl
@@ -85,11 +85,13 @@
 									{else}
 										<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-register btn-wrap" target="_blank" style="width:100%"aria-label="{translate text="Registration Information" isPublicFacing=true inAttribute=true} ({translate text='opens in new window' isPublicFacing=true inAttribute=true})"><i class="fas fa-external-link-alt" role="presentation"></i> {translate text="Registration Information" isPublicFacing=true}</a>
 									{/if}
-									<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'communico');" class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>
+							        {if empty($offline)}
+									    <a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'communico');" class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>
+									{/if}
 								</div>
 							</div>
 							<br>
-						{else}
+						{elseif empty($offline)}
 							<div class="btn-toolbar">
 								<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'communico');" class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>
 							</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/Events/communico_result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Events/communico_result.tpl
@@ -85,13 +85,13 @@
 									{else}
 										<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-register btn-wrap" target="_blank" style="width:100%"aria-label="{translate text="Registration Information" isPublicFacing=true inAttribute=true} ({translate text='opens in new window' isPublicFacing=true inAttribute=true})"><i class="fas fa-external-link-alt" role="presentation"></i> {translate text="Registration Information" isPublicFacing=true}</a>
 									{/if}
-							        {if empty($offline)}
+							        {if empty($offline) || $enableEContentWhileOffline}
 									    <a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'communico');" class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>
 									{/if}
 								</div>
 							</div>
 							<br>
-						{elseif empty($offline)}
+						{elseif empty($offline) || $enableEContentWhileOffline}
 							<div class="btn-toolbar">
 								<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'communico');" class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>
 							</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/Events/library_calendar_result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Events/library_calendar_result.tpl
@@ -76,13 +76,13 @@
 									{else}
 										<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-register btn-wrap" target="_blank" style="width:100%"aria-label="{translate text="Registration Information" isPublicFacing=true inAttribute=true} ({translate text='opens in new window' isPublicFacing=true inAttribute=true})"><i class="fas fa-external-link-alt" role="presentation"></i> {translate text="Registration Information" isPublicFacing=true}</a>
 									{/if}
-							        {if empty($offline)}
+							        {if empty($offline) || $enableEContentWhileOffline}
 									    <a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'library_market');" class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>
 									{/if}
 								</div>
 							</div>
 							<br>
-						{elseif empty($offline)}
+						{elseif empty($offline) || $enableEContentWhileOffline}
 							<div class="btn-toolbar">
 								<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'library_market');" class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>
 							</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/Events/library_calendar_result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Events/library_calendar_result.tpl
@@ -76,11 +76,13 @@
 									{else}
 										<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-register btn-wrap" target="_blank" style="width:100%"aria-label="{translate text="Registration Information" isPublicFacing=true inAttribute=true} ({translate text='opens in new window' isPublicFacing=true inAttribute=true})"><i class="fas fa-external-link-alt" role="presentation"></i> {translate text="Registration Information" isPublicFacing=true}</a>
 									{/if}
-									<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'library_market');" class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>
+							        {if empty($offline)}
+									    <a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'library_market');" class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>
+									{/if}
 								</div>
 							</div>
 							<br>
-						{else}
+						{elseif empty($offline)}
 							<div class="btn-toolbar">
 								<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'library_market');" class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>
 							</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/Events/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Events/listEntry.tpl
@@ -60,7 +60,7 @@
 							{if $recordDriver->isRegistrationRequired()}
 								<div class="btn-group btn-group-vertical btn-block">
 									<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-register btn-wrap" target="_blank" style="width:100%"aria-label="{translate text="Registration Information" isPublicFacing=true inAttribute=true} ({translate text='opens in new window' isPublicFacing=true inAttribute=true})"><i class="fas fa-external-link-alt" role="presentation"></i> {translate text="Registration Information" isPublicFacing=true}</a>
-									{if empty($offline)}
+									{if empty($offline) || $enableEContentWhileOffline}
 										<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', '{$eventVendor}');" class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>
 									{/if}
 								</div>
@@ -68,7 +68,7 @@
 									<i class="fas fa-external-link-alt" role="presentation"></i>
 									{translate text="Add to Your Events and Register" isPublicFacing=true}
 								</a>*}
-							{elseif empty($offline)}
+							{elseif empty($offline) || $enableEContentWhileOffline}
 								<a class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:100%" onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', '{$eventVendor}');">{translate text="Add to Your Events" isPublicFacing=true}</a>
 							{/if}
 						{/if}

--- a/code/web/interface/themes/responsive/RecordDrivers/Events/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Events/listEntry.tpl
@@ -60,13 +60,15 @@
 							{if $recordDriver->isRegistrationRequired()}
 								<div class="btn-group btn-group-vertical btn-block">
 									<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-register btn-wrap" target="_blank" style="width:100%"aria-label="{translate text="Registration Information" isPublicFacing=true inAttribute=true} ({translate text='opens in new window' isPublicFacing=true inAttribute=true})"><i class="fas fa-external-link-alt" role="presentation"></i> {translate text="Registration Information" isPublicFacing=true}</a>
-									<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', '{$eventVendor}');" class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>
+									{if empty($offline)}
+										<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', '{$eventVendor}');" class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>
+									{/if}
 								</div>
 								{*<a class="btn btn-sm btn-action btn-wrap" style="width:100%" onclick="return AspenDiscovery.Account.saveEventReg(this, 'Events', '{$recordDriver->getUniqueID()|escape}');">
 									<i class="fas fa-external-link-alt" role="presentation"></i>
 									{translate text="Add to Your Events and Register" isPublicFacing=true}
 								</a>*}
-							{else}
+							{elseif empty($offline)}
 								<a class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:100%" onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', '{$eventVendor}');">{translate text="Add to Your Events" isPublicFacing=true}</a>
 							{/if}
 						{/if}

--- a/code/web/interface/themes/responsive/RecordDrivers/Events/springshare_libcal_result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Events/springshare_libcal_result.tpl
@@ -95,13 +95,13 @@
 									{else}
 										<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-register btn-wrap" target="_blank" style="width:100%"aria-label="{translate text="Registration Information" isPublicFacing=true inAttribute=true} ({translate text='opens in new window' isPublicFacing=true inAttribute=true})"><i class="fas fa-external-link-alt" role="presentation"></i> {translate text="Registration Information" isPublicFacing=true}</a>
 									{/if}
-									{if empty($offline)}
+									{if empty($offline) || $enableEContentWhileOffline}
 										<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'springshare');" class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>
 									{/if}
 								</div>
 							</div>
 							<br>
-						{elseif empty($offline)}
+						{elseif empty($offline) || $enableEContentWhileOffline}
 							<div class="btn-toolbar">
 								<div class="btn-group btn-group-vertical btn-block">
 									<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'springshare');" class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>

--- a/code/web/interface/themes/responsive/RecordDrivers/Events/springshare_libcal_result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Events/springshare_libcal_result.tpl
@@ -95,11 +95,13 @@
 									{else}
 										<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-register btn-wrap" target="_blank" style="width:100%"aria-label="{translate text="Registration Information" isPublicFacing=true inAttribute=true} ({translate text='opens in new window' isPublicFacing=true inAttribute=true})"><i class="fas fa-external-link-alt" role="presentation"></i> {translate text="Registration Information" isPublicFacing=true}</a>
 									{/if}
-									<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'springshare');" class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>
+									{if empty($offline)}
+										<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'springshare');" class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>
+									{/if}
 								</div>
 							</div>
 							<br>
-						{else}
+						{elseif empty($offline)}
 							<div class="btn-toolbar">
 								<div class="btn-group btn-group-vertical btn-block">
 									<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'springshare');" class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>

--- a/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/browse_result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/browse_result.tpl
@@ -30,7 +30,7 @@
 			</a>
 			{if !empty($showRatings) && $browseCategoryRatingsMode != 0}
 				<div class="browse-rating{if $browseCategoryRatingsMode == 2} rater{/if}"
-				{if $browseCategoryRatingsMode == 1} onclick="return AspenDiscovery.GroupedWork.showReviewForm(this, '{$summId}');" onkeypress="return AspenDiscovery.GroupedWork.showReviewForm(this, '{$summId}');" style="cursor: pointer" title="{translate text="Write a Review" inAttribute=true isPublicFacing=true}" role="button" tabindex="0" {/if}
+				{if $browseCategoryRatingsMode == 1 && empty($offline)} onclick="return AspenDiscovery.GroupedWork.showReviewForm(this, '{$summId}');" onkeypress="return AspenDiscovery.GroupedWork.showReviewForm(this, '{$summId}');" style="cursor: pointer" title="{translate text="Write a Review" inAttribute=true isPublicFacing=true}" role="button" tabindex="0" {/if}
 				{if $browseCategoryRatingsMode == 2}
 					{* AJAX rater data fields *}
 					{*{if !empty($ratingData.user)}data-user_rating="{$ratingData.user}" {/if}*}{* Don't show user ratings in browse results because the results get cached so shouldn't be particular to a single user.*}

--- a/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/browse_result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/browse_result.tpl
@@ -30,7 +30,7 @@
 			</a>
 			{if !empty($showRatings) && $browseCategoryRatingsMode != 0}
 				<div class="browse-rating{if $browseCategoryRatingsMode == 2} rater{/if}"
-				{if $browseCategoryRatingsMode == 1 && empty($offline)} onclick="return AspenDiscovery.GroupedWork.showReviewForm(this, '{$summId}');" onkeypress="return AspenDiscovery.GroupedWork.showReviewForm(this, '{$summId}');" style="cursor: pointer" title="{translate text="Write a Review" inAttribute=true isPublicFacing=true}" role="button" tabindex="0" {/if}
+				{if $browseCategoryRatingsMode == 1 && (empty($offline) || $enableEContentWhileOffline)} onclick="return AspenDiscovery.GroupedWork.showReviewForm(this, '{$summId}');" onkeypress="return AspenDiscovery.GroupedWork.showReviewForm(this, '{$summId}');" style="cursor: pointer" title="{translate text="Write a Review" inAttribute=true isPublicFacing=true}" role="button" tabindex="0" {/if}
 				{if $browseCategoryRatingsMode == 2}
 					{* AJAX rater data fields *}
 					{*{if !empty($ratingData.user)}data-user_rating="{$ratingData.user}" {/if}*}{* Don't show user ratings in browse results because the results get cached so shouldn't be particular to a single user.*}

--- a/code/web/interface/themes/responsive/Search/list-none.tpl
+++ b/code/web/interface/themes/responsive/Search/list-none.tpl
@@ -135,7 +135,7 @@
 				<strong>{translate text='Search Tools' isPublicFacing=true} </strong>
 				{if !empty($showSearchTools)}
 					<a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a>
-					{if empty($offline)}
+					{if empty($offline) || $enableEContentWhileOffline}
 						<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
 						{if !empty($enableSavedSearches)}
 							{if !empty($savedSearch)}

--- a/code/web/interface/themes/responsive/Search/list-none.tpl
+++ b/code/web/interface/themes/responsive/Search/list-none.tpl
@@ -110,7 +110,7 @@
 			<div id='dplaSearchResultsPlaceholder'></div>
 		{/if}
 
-		{if $displayMaterialsRequest}
+		{if $displayMaterialsRequest && empty($offline)}
 			{if $materialRequestType == 1}
 				<div class="materialsRequestLink">
 					<h2>{translate text="Didn't find it?" isPublicFacing=true}</h2>
@@ -135,12 +135,14 @@
 				<strong>{translate text='Search Tools' isPublicFacing=true} </strong>
 				{if !empty($showSearchTools)}
 					<a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a>
-					<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
-					{if !empty($enableSavedSearches)}
-						{if !empty($savedSearch)}
-							<a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text="Remove Saved Search" isPublicFacing=true}</a>
-						{else}
-							<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a>
+					{if empty($offline)}
+						<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
+						{if !empty($enableSavedSearches)}
+							{if !empty($savedSearch)}
+								<a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text="Remove Saved Search" isPublicFacing=true}</a>
+							{else}
+								<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a>
+							{/if}
 						{/if}
 					{/if}
 					{if !empty($excelLink)}<a href="{$excelLink|escape}">{translate text='Export To CSV' isPublicFacing=true}</a>{/if}

--- a/code/web/interface/themes/responsive/Search/list.tpl
+++ b/code/web/interface/themes/responsive/Search/list.tpl
@@ -61,7 +61,6 @@
 		<div class="clearer"></div>
 	</div>
 	{* End Listing Options *}
-
 	{if !empty($placard)}
 		{include file="Search/placard.tpl"}
 	{/if}
@@ -101,7 +100,7 @@
 		<div id='dplaSearchResultsPlaceholder'></div>
 	{/if}
 
-	{if $displayMaterialsRequest}
+	{if $displayMaterialsRequest && empty($offline)}
 		{if $materialRequestType == 1}
 			<div class="materialsRequestLink">
 				<h2>{translate text="Didn't find it?" isPublicFacing=true}</h2>
@@ -131,12 +130,14 @@
 			<strong>{translate text='Search Tools' isPublicFacing=true} </strong>
 			{if !empty($showSearchTools)}
 				<a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a>
-				<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
-				{if !empty($enableSavedSearches)}
-					{if !empty($savedSearch)}
-						<a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text="Remove Saved Search" isPublicFacing=true}</a>
-					{else}
-						<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a>
+				{if empty($offline)}
+					<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
+					{if !empty($enableSavedSearches)}
+						{if !empty($savedSearch)}
+							<a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text="Remove Saved Search" isPublicFacing=true}</a>
+						{else}
+							<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a>
+						{/if}
 					{/if}
 				{/if}
 				{if !empty($excelLink)}<a href="{$excelLink|escape}">{translate text='Export To CSV' isPublicFacing=true}</a>{/if}

--- a/code/web/interface/themes/responsive/Search/list.tpl
+++ b/code/web/interface/themes/responsive/Search/list.tpl
@@ -130,7 +130,7 @@
 			<strong>{translate text='Search Tools' isPublicFacing=true} </strong>
 			{if !empty($showSearchTools)}
 				<a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a>
-				{if empty($offline)}
+				{if empty($offline) || $enableEContentWhileOffline}
 					<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
 					{if !empty($enableSavedSearches)}
 						{if !empty($savedSearch)}

--- a/code/web/interface/themes/responsive/Search/search-toolbar-no-display-mode.tpl
+++ b/code/web/interface/themes/responsive/Search/search-toolbar-no-display-mode.tpl
@@ -25,7 +25,7 @@
 			                <button data-toggle="dropdown" class="btn btn-sm btn-default dropdown-toggle" type="button" id="dropdownSearchToolsBtn"><i class="fas fa-toolbox"></i> {translate text='Search Tools' isPublicFacing=true} <span class="caret"></span></button>
 			                <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownSearchToolsBtn">
 			                    {if !empty($showSearchTools)}
-				                    {if !empty($enableSavedSearches) && empty($offline)}
+				                    {if !empty($enableSavedSearches) && (empty($offline) || $enableEContentWhileOffline)}
 					                    {if !empty($savedSearch)}
 					                        <li><a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text='Remove Saved Search' isPublicFacing=true}</a></li>
 					                    {else}

--- a/code/web/interface/themes/responsive/Search/search-toolbar-no-display-mode.tpl
+++ b/code/web/interface/themes/responsive/Search/search-toolbar-no-display-mode.tpl
@@ -25,15 +25,19 @@
 			                <button data-toggle="dropdown" class="btn btn-sm btn-default dropdown-toggle" type="button" id="dropdownSearchToolsBtn"><i class="fas fa-toolbox"></i> {translate text='Search Tools' isPublicFacing=true} <span class="caret"></span></button>
 			                <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownSearchToolsBtn">
 			                    {if !empty($showSearchTools)}
-				                    {if !empty($enableSavedSearches) && (empty($offline) || $enableEContentWhileOffline)}
-					                    {if !empty($savedSearch)}
-					                        <li><a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text='Remove Saved Search' isPublicFacing=true}</a></li>
-					                    {else}
-					                        <li><a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a></li>
-					                    {/if}
-				                    {/if}
-			                    <li><a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a></li>
-			                    <li><a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a></li>
+									{if empty($offline) || $enableEContentWhileOffline}
+										{if !empty($enableSavedSearches)}
+											{if !empty($savedSearch)}
+												<li><a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text='Remove Saved Search' isPublicFacing=true}</a></li>
+											{else}
+												<li><a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a></li>
+											{/if}
+										{/if}
+										<li><a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a></li>
+									{/if}
+									{if !empty($rssLink)}
+			                    		<li><a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a></li>
+									{/if}
 			                    {if !empty($excelLink)}<li><a href="{$excelLink|escape}">{translate text='Export To CSV' isPublicFacing=true}</a></li>{/if}
                                 {if !empty($risLink)}<li><a href="{$risLink|escape}">{translate text="Export To RIS" isPublicFacing=true}</a></li>{/if}
 			                    {/if}
@@ -52,7 +56,7 @@
 	</div>
 	<div class="row visible-sm visible-xs">
 		<div class="col-sm-12">
-            <button type="button" class="btn btn-default btn-sm" onclick="return AspenDiscovery.Account.showSearchToolbar('{$displayMode}', '{$showCovers}', '{$rssLink|escape}', '{if !empty($excelLink)}{$excelLink|escape}{/if}', '{if !empty($risLink)}{$risLink|escape}{/if}', '{$searchId}', [{foreach from=$sortList item=sortData key=sortLabel}{ldelim}'desc': '{$sortData.desc}','selected': '{$sortData.selected}', 'sortUrl': '{$sortData.sortUrl|escape}'{rdelim},{/foreach}]);">
+            <button type="button" class="btn btn-default btn-sm" onclick="return AspenDiscovery.Account.showSearchToolbar('{$displayMode}', '{$showCovers}', '{if !empty($rssLink)}{$rssLink|escape}{/if}', '{if !empty($excelLink)}{$excelLink|escape}{/if}', '{if !empty($risLink)}{$risLink|escape}{/if}', '{$searchId}', [{foreach from=$sortList item=sortData key=sortLabel}{ldelim}'desc': '{$sortData.desc}','selected': '{$sortData.selected}', 'sortUrl': '{$sortData.sortUrl|escape}'{rdelim},{/foreach}]);">
               <i class="fas fa-toolbox"></i> {translate text='Search Tools' isPublicFacing=true}
             </button>
 		</div>

--- a/code/web/interface/themes/responsive/Search/search-toolbar-no-display-mode.tpl
+++ b/code/web/interface/themes/responsive/Search/search-toolbar-no-display-mode.tpl
@@ -25,7 +25,7 @@
 			                <button data-toggle="dropdown" class="btn btn-sm btn-default dropdown-toggle" type="button" id="dropdownSearchToolsBtn"><i class="fas fa-toolbox"></i> {translate text='Search Tools' isPublicFacing=true} <span class="caret"></span></button>
 			                <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownSearchToolsBtn">
 			                    {if !empty($showSearchTools)}
-				                    {if !empty($enableSavedSearches)}
+				                    {if !empty($enableSavedSearches) && empty($offline)}
 					                    {if !empty($savedSearch)}
 					                        <li><a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text='Remove Saved Search' isPublicFacing=true}</a></li>
 					                    {else}

--- a/code/web/interface/themes/responsive/Search/search-toolbar-popup.tpl
+++ b/code/web/interface/themes/responsive/Search/search-toolbar-popup.tpl
@@ -38,7 +38,7 @@
 			<div class="form-group">
 			    <div class="col-xs-12">
 				    {if !empty($showSearchTools)}
-						{if empty($offline)}
+						{if empty($offline) || $enableEContentWhileOffline}
 							{if !empty($enableSavedSearches)}
 								{if !empty($savedSearch)}
 									<a href="/MyAccount/SaveSearch?delete={$searchId}" class="btn btn-default btn-block">{translate text='Remove Saved Search' isPublicFacing=true}</a>

--- a/code/web/interface/themes/responsive/Search/search-toolbar-popup.tpl
+++ b/code/web/interface/themes/responsive/Search/search-toolbar-popup.tpl
@@ -38,14 +38,16 @@
 			<div class="form-group">
 			    <div class="col-xs-12">
 				    {if !empty($showSearchTools)}
-				        {if !empty($enableSavedSearches)}
-				            {if !empty($savedSearch)}
-				            	<a href="/MyAccount/SaveSearch?delete={$searchId}" class="btn btn-default btn-block">{translate text='Remove Saved Search' isPublicFacing=true}</a>
-				            {else}
-				            	<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')" class="btn btn-default btn-block">{translate text='Save Search' isPublicFacing=true}</a>
-				            {/if}
-				        {/if}
-			            <a href="#" onclick="return AspenDiscovery.Account.showEmailSearchForm();" class="btn btn-default btn-block">{translate text='Email this Search' isPublicFacing=true}</a>
+						{if empty($offline)}
+							{if !empty($enableSavedSearches)}
+								{if !empty($savedSearch)}
+									<a href="/MyAccount/SaveSearch?delete={$searchId}" class="btn btn-default btn-block">{translate text='Remove Saved Search' isPublicFacing=true}</a>
+								{else}
+									<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')" class="btn btn-default btn-block">{translate text='Save Search' isPublicFacing=true}</a>
+								{/if}
+							{/if}
+							<a href="#" onclick="return AspenDiscovery.Account.showEmailSearchForm();" class="btn btn-default btn-block">{translate text='Email this Search' isPublicFacing=true}</a>
+						{/if}
 			            <a href="{$rssLink|escape}" class="btn btn-default btn-block">{translate text='Get RSS Feed' isPublicFacing=true}</a>
 			            {if !empty($excelLink)}<a href="{$excelLink|escape}" class="btn btn-default btn-block">{translate text='Export To CSV' isPublicFacing=true}</a>{/if}
                         {if !empty($risLink)}<a href="{$risLink|escape}" class="btn btn-default btn-block">{translate text="Export To RIS" isPublicFacing=true}</a>{/if}

--- a/code/web/interface/themes/responsive/Search/search-toolbar.tpl
+++ b/code/web/interface/themes/responsive/Search/search-toolbar.tpl
@@ -33,7 +33,7 @@
 			                <button data-toggle="dropdown" class="btn btn-sm btn-default dropdown-toggle" type="button" id="dropdownSearchToolsBtn"><i class="fas fa-toolbox"></i> {translate text='Search Tools' isPublicFacing=true} <span class="caret"></span></button>
 			                <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownSearchToolsBtn">
 			                    {if !empty($showSearchTools)}
-				                    {if !empty($enableSavedSearches) && empty($offline)}
+				                    {if !empty($enableSavedSearches) && (empty($offline) || $enableEContentWhileOffline)}
 					                    {if !empty($savedSearch)}
 					                        <li><a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text='Remove Saved Search' isPublicFacing=true}</a></li>
 					                    {else}

--- a/code/web/interface/themes/responsive/Search/search-toolbar.tpl
+++ b/code/web/interface/themes/responsive/Search/search-toolbar.tpl
@@ -33,15 +33,19 @@
 			                <button data-toggle="dropdown" class="btn btn-sm btn-default dropdown-toggle" type="button" id="dropdownSearchToolsBtn"><i class="fas fa-toolbox"></i> {translate text='Search Tools' isPublicFacing=true} <span class="caret"></span></button>
 			                <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownSearchToolsBtn">
 			                    {if !empty($showSearchTools)}
-				                    {if !empty($enableSavedSearches) && (empty($offline) || $enableEContentWhileOffline)}
-					                    {if !empty($savedSearch)}
-					                        <li><a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text='Remove Saved Search' isPublicFacing=true}</a></li>
-					                    {else}
-					                        <li><a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a></li>
-					                    {/if}
-				                    {/if}
-			                    <li><a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a></li>
-			                    <li><a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a></li>
+									{if empty($offline) || $enableEContentWhileOffline}
+										{if !empty($enableSavedSearches)}
+											{if !empty($savedSearch)}
+												<li><a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text='Remove Saved Search' isPublicFacing=true}</a></li>
+											{else}
+												<li><a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a></li>
+											{/if}
+										{/if}
+										<li><a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a></li>
+									{/if}
+								{if !empty($rssLink)}
+									<li><a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a></li>
+								{/if}
 			                    {if !empty($excelLink)}<li><a href="{$excelLink|escape}">{translate text='Export To CSV' isPublicFacing=true}</a></li>{/if}
                                 {if !empty($risLink)}<li><a href="{$risLink|escape}">{translate text="Export To RIS" isPublicFacing=true}</a></li>{/if}
 			                    {/if}
@@ -60,7 +64,7 @@
 	</div>
 	<div class="row visible-sm visible-xs">
 		<div class="col-sm-12">
-            <button type="button" class="btn btn-default btn-sm" onclick="return AspenDiscovery.Account.showSearchToolbar('{$displayMode}', '{$showCovers}', '{$rssLink|escape}', '{if !empty($excelLink)}{$excelLink|escape}{/if}', '{if !empty($risLink)}{$risLink|escape}{/if}', '{$searchId}', [{foreach from=$sortList item=sortData key=sortLabel}{ldelim}'desc': '{$sortData.desc}','selected': '{$sortData.selected}', 'sortUrl': '{$sortData.sortUrl|escape}'{rdelim},{/foreach}]);">
+            <button type="button" class="btn btn-default btn-sm" onclick="return AspenDiscovery.Account.showSearchToolbar('{$displayMode}', '{$showCovers}', '{if !empty($rssLink)}{$rssLink|escape}{/if}', '{if !empty($excelLink)}{$excelLink|escape}{/if}', '{if !empty($risLink)}{$risLink|escape}{/if}', '{$searchId}', [{foreach from=$sortList item=sortData key=sortLabel}{ldelim}'desc': '{$sortData.desc}','selected': '{$sortData.selected}', 'sortUrl': '{$sortData.sortUrl|escape}'{rdelim},{/foreach}]);">
               <i class="fas fa-toolbox"></i> {translate text='Search Tools' isPublicFacing=true}
             </button>
 		</div>

--- a/code/web/interface/themes/responsive/Search/search-toolbar.tpl
+++ b/code/web/interface/themes/responsive/Search/search-toolbar.tpl
@@ -33,7 +33,7 @@
 			                <button data-toggle="dropdown" class="btn btn-sm btn-default dropdown-toggle" type="button" id="dropdownSearchToolsBtn"><i class="fas fa-toolbox"></i> {translate text='Search Tools' isPublicFacing=true} <span class="caret"></span></button>
 			                <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownSearchToolsBtn">
 			                    {if !empty($showSearchTools)}
-				                    {if !empty($enableSavedSearches)}
+				                    {if !empty($enableSavedSearches) && empty($offline)}
 					                    {if !empty($savedSearch)}
 					                        <li><a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text='Remove Saved Search' isPublicFacing=true}</a></li>
 					                    {else}

--- a/code/web/interface/themes/responsive/Springshare/event.tpl
+++ b/code/web/interface/themes/responsive/Springshare/event.tpl
@@ -104,11 +104,11 @@
 						{else}
 							<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-register btn-wrap" target="_blank" style="width:100%" aria-label="{translate text="Registration Information" isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})"><i class="fas fa-external-link-alt" role="presentation"></i> {translate text="Registration Information" isPublicFacing=true}</a>
 						{/if}
-						{if empty($offline)}
+						{if empty($offline) || $enableEContentWhileOffline}
 							<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'springshare');" class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:70%">{translate text="Add to Your Events" isPublicFacing=true}</a>
 						{/if}
 					</div>
-				{elseif empty($offline)}
+				{elseif empty($offline) || $enableEContentWhileOffline}
 					<a class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:70%" onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'springshare');">{translate text="Add to Your Events" isPublicFacing=true}</a>
 				{/if}
 			{/if}

--- a/code/web/interface/themes/responsive/Springshare/event.tpl
+++ b/code/web/interface/themes/responsive/Springshare/event.tpl
@@ -104,9 +104,11 @@
 						{else}
 							<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-register btn-wrap" target="_blank" style="width:100%" aria-label="{translate text="Registration Information" isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})"><i class="fas fa-external-link-alt" role="presentation"></i> {translate text="Registration Information" isPublicFacing=true}</a>
 						{/if}
-						<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'springshare');" class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:70%">{translate text="Add to Your Events" isPublicFacing=true}</a>
+						{if empty($offline)}
+							<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'springshare');" class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:70%">{translate text="Add to Your Events" isPublicFacing=true}</a>
+						{/if}
 					</div>
-				{else}
+				{elseif empty($offline)}
 					<a class="btn btn-sm btn-action btn-wrap addToYourEventsBtn" style="width:70%" onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}', 'springshare');">{translate text="Add to Your Events" isPublicFacing=true}</a>
 				{/if}
 			{/if}

--- a/code/web/interface/themes/responsive/Summon/list.tpl
+++ b/code/web/interface/themes/responsive/Summon/list.tpl
@@ -66,7 +66,7 @@
 	{if $showSearchTools || ($loggedIn && count($userPermissions) > 0)}
 	<div class="search_tools well small">
 		<strong>{translate text='Search Tools' isPublicFacing=true} </strong>
-		{if !empty($showSearchTools)}
+		{if !empty($showSearchTools) && empty($offline)}
 			<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
 			{if !empty($enableSavedSearches)}
 				{if !empty($savedSearch)}

--- a/code/web/interface/themes/responsive/Summon/list.tpl
+++ b/code/web/interface/themes/responsive/Summon/list.tpl
@@ -66,7 +66,7 @@
 	{if $showSearchTools || ($loggedIn && count($userPermissions) > 0)}
 	<div class="search_tools well small">
 		<strong>{translate text='Search Tools' isPublicFacing=true} </strong>
-		{if !empty($showSearchTools) && empty($offline)}
+		{if !empty($showSearchTools) && (empty($offline) || $enableEContentWhileOffline)}
 			<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
 			{if !empty($enableSavedSearches)}
 				{if !empty($savedSearch)}

--- a/code/web/interface/themes/responsive/Summon/result-tools-horizontal.tpl
+++ b/code/web/interface/themes/responsive/Summon/result-tools-horizontal.tpl
@@ -8,7 +8,7 @@
 						<a href="{if !empty($summUrl)}{$summUrl}{else}{$recordDriver->getLinkUrl()}{/if}" class="btn btn-sm btn-tools" onclick="AspenDiscovery.Summon.trackSummonUsage('{$recordDriver->getPermanentId()}')" target="_blank" aria-label="{translate text='More Info' isPublicFacing=true} ({translate text='opens in new window' isPublicFacing=true})"><i class="fas fa-external-link-alt" role="presentation"></i> {translate text="More Info" isPublicFacing=true}</a>
 					</div>
 				{/if}
-				{if $showFavorites == 1 && empty($offline)}
+				{if $showFavorites == 1 && empty($offline) || $enableEContentWhileOffline}
 					<div class="btn-group btn-group-sm">
 						<button onclick="return AspenDiscovery.Account.showSaveToListForm(this, 'Summon', '{$recordDriver->getPermanentId()|escape}');" class="btn btn-sm btn-tools addToListBtn">{translate text="Add to List" isPublicFacing=true}</button>
 					</div>

--- a/code/web/interface/themes/responsive/Summon/result-tools-horizontal.tpl
+++ b/code/web/interface/themes/responsive/Summon/result-tools-horizontal.tpl
@@ -8,7 +8,7 @@
 						<a href="{if !empty($summUrl)}{$summUrl}{else}{$recordDriver->getLinkUrl()}{/if}" class="btn btn-sm btn-tools" onclick="AspenDiscovery.Summon.trackSummonUsage('{$recordDriver->getPermanentId()}')" target="_blank" aria-label="{translate text='More Info' isPublicFacing=true} ({translate text='opens in new window' isPublicFacing=true})"><i class="fas fa-external-link-alt" role="presentation"></i> {translate text="More Info" isPublicFacing=true}</a>
 					</div>
 				{/if}
-				{if $showFavorites == 1}
+				{if $showFavorites == 1 && empty($offline)}
 					<div class="btn-group btn-group-sm">
 						<button onclick="return AspenDiscovery.Account.showSaveToListForm(this, 'Summon', '{$recordDriver->getPermanentId()|escape}');" class="btn btn-sm btn-tools addToListBtn">{translate text="Add to List" isPublicFacing=true}</button>
 					</div>

--- a/code/web/interface/themes/responsive/Websites/list-none.tpl
+++ b/code/web/interface/themes/responsive/Websites/list-none.tpl
@@ -62,12 +62,14 @@
 			<strong>{translate text='Search Tools' isPublicFacing=true} </strong>
 			{if !empty($showSearchTools)}
 				<a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a>
-				<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
-				{if !empty($enableSavedSearches)}
-					{if !empty($savedSearch)}
-						<a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text="Remove Saved Search" isPublicFacing=true}</a>
-					{else}
-						<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a>
+				{if empty($offline)}
+					<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
+					{if !empty($enableSavedSearches)}
+						{if !empty($savedSearch)}
+							<a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text="Remove Saved Search" isPublicFacing=true}</a>
+						{else}
+							<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a>
+						{/if}
 					{/if}
 				{/if}
 				{*{if !empty($excelLink)}

--- a/code/web/interface/themes/responsive/Websites/list-none.tpl
+++ b/code/web/interface/themes/responsive/Websites/list-none.tpl
@@ -62,7 +62,7 @@
 			<strong>{translate text='Search Tools' isPublicFacing=true} </strong>
 			{if !empty($showSearchTools)}
 				<a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a>
-				{if empty($offline)}
+				{if empty($offline) || $enableEContentWhileOffline}
 					<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
 					{if !empty($enableSavedSearches)}
 						{if !empty($savedSearch)}

--- a/code/web/interface/themes/responsive/Websites/list.tpl
+++ b/code/web/interface/themes/responsive/Websites/list.tpl
@@ -71,13 +71,17 @@
 	<div class="search_tools well small">
 		<strong>{translate text='Search Tools' isPublicFacing=true} </strong>
 		{if !empty($showSearchTools)}
-			<a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a>
-			<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
-			{if !empty($enableSavedSearches)}
-				{if !empty($savedSearch)}
-					<a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text="Remove Saved Search" isPublicFacing=true}</a>
-				{else}
-					<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a>
+			{if !empty($rssLink)}
+				<a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a>
+			{/if}
+			{if empty($offline) || $enableEContentWhileOffline}
+				<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
+				{if !empty($enableSavedSearches)}
+					{if !empty($savedSearch)}
+						<a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text="Remove Saved Search" isPublicFacing=true}</a>
+					{else}
+						<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a>
+					{/if}
 				{/if}
 			{/if}
 		{*<a href="{$excelLink|escape}">{translate text='Export To CSV' isPublicFacing=true}</a>*}

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -7538,28 +7538,22 @@ AspenDiscovery.Account = (function () {
 		},
 
 		regInfoModal: function (trigger, source, id, vendor, regLink) {
-			if (Globals.loggedIn) {
-				var url = Globals.path + "/MyAccount/AJAX";
-				var params = {
-					'method': 'eventRegistrationModal',
-					sourceId: id,
-					source: source,
-					regLink: regLink,
-					vendor: vendor
-				};
-				// noinspection JSUnresolvedFunction
-				$.getJSON(url, params, function (data) {
-					if (data.success) {
-						AspenDiscovery.showMessageWithButtons(data.title, data.body, data.buttons, false);
-					} else {
-						AspenDiscovery.showMessage("Error", data.message);
-					}
-				}).fail(AspenDiscovery.ajaxFail);
-			}else {
-				AspenDiscovery.Account.ajaxLogin(null, function () {
-					return AspenDiscovery.Account.regInfoModal(trigger, source, id, vendor, regLink);
-				}, false);
-			}
+			var url = Globals.path + "/MyAccount/AJAX";
+			var params = {
+				'method': 'eventRegistrationModal',
+				sourceId: id,
+				source: source,
+				regLink: regLink,
+				vendor: vendor
+			};
+			// noinspection JSUnresolvedFunction
+			$.getJSON(url, params, function (data) {
+				if (data.success) {
+					AspenDiscovery.showMessageWithButtons(data.title, data.body, data.buttons, false);
+				} else {
+					AspenDiscovery.showMessage("Error", data.message);
+				}
+			}).fail(AspenDiscovery.ajaxFail);
 			return false;
 		},
 

--- a/code/web/interface/themes/responsive/js/aspen/account.js
+++ b/code/web/interface/themes/responsive/js/aspen/account.js
@@ -2041,28 +2041,22 @@ AspenDiscovery.Account = (function () {
 		},
 
 		regInfoModal: function (trigger, source, id, vendor, regLink) {
-			if (Globals.loggedIn) {
-				var url = Globals.path + "/MyAccount/AJAX";
-				var params = {
-					'method': 'eventRegistrationModal',
-					sourceId: id,
-					source: source,
-					regLink: regLink,
-					vendor: vendor
-				};
-				// noinspection JSUnresolvedFunction
-				$.getJSON(url, params, function (data) {
-					if (data.success) {
-						AspenDiscovery.showMessageWithButtons(data.title, data.body, data.buttons, false);
-					} else {
-						AspenDiscovery.showMessage("Error", data.message);
-					}
-				}).fail(AspenDiscovery.ajaxFail);
-			}else {
-				AspenDiscovery.Account.ajaxLogin(null, function () {
-					return AspenDiscovery.Account.regInfoModal(trigger, source, id, vendor, regLink);
-				}, false);
-			}
+			var url = Globals.path + "/MyAccount/AJAX";
+			var params = {
+				'method': 'eventRegistrationModal',
+				sourceId: id,
+				source: source,
+				regLink: regLink,
+				vendor: vendor
+			};
+			// noinspection JSUnresolvedFunction
+			$.getJSON(url, params, function (data) {
+				if (data.success) {
+					AspenDiscovery.showMessageWithButtons(data.title, data.body, data.buttons, false);
+				} else {
+					AspenDiscovery.showMessage("Error", data.message);
+				}
+			}).fail(AspenDiscovery.ajaxFail);
 			return false;
 		},
 

--- a/code/web/release_notes/24.07.00.MD
+++ b/code/web/release_notes/24.07.00.MD
@@ -9,6 +9,8 @@
 // kodi
 
 // katherine
+### General Updates
+- In offline mode, don't show buttons like Add a Review and Add to List that prompt a login. (Ticket 132443) (*KP*)
 
 // alexander
 

--- a/code/web/services/GroupedWork/AJAX.php
+++ b/code/web/services/GroupedWork/AJAX.php
@@ -521,7 +521,8 @@ class GroupedWork_AJAX extends JSON_Action {
 				'text' => "More Info",
 				'isPublicFacing' => true,
 			]) . "</button></a>";
-		if(!$showFavorites) {
+        global $offlineMode;
+		if(!$showFavorites || $offlineMode) {
 			$buttons = "<a href='$url'><button class='modal-buttons btn btn-primary'>" . translate([
 					'text' => 'More Info',
 					'isPublicFacing' => true,


### PR DESCRIPTION
In offline mode, eContent logins are not enabled, buttons won't show up if they would prompt the user to login, since logins won't work when the catalog is offline.  The buttons that won't show are:
- Add to List
- Add a Review
- Add to your Events
- Save Search
- Email this Search
- Materials Request
- Check out buttons for Palace Project, Hoopla, Boundless, Cloudlibrary, Libby/Overdrive

Additional behavior:
- For Libby/Overdrive only, instead of a checkout button, there should be an Access Online button instead that goes to the Overdrive page (I'm not sure if we want it to work this way or not?)
- Events Registration button is not hidden - instead it no longer asks for a login since there wasn't any reason to require a login for this.