### PR TITLE
Summon facet uncheck fix

### DIFF
--- a/code/web/release_notes/24.06.00.MD
+++ b/code/web/release_notes/24.06.00.MD
@@ -10,12 +10,40 @@
 - Updated the minimum iOS version to 16, users with older versions will no longer receive app updates or be able to download the app. (*KK*)
 
 ## Aspen Discovery Updates
-//mark
+
+### Accessibility Updates
+- Libby lending period options are now select elements to make them keyboard accessible and easily indicate selected values. (*KK*)
+
+### Aspen Discovery Support Updates
+- Added additional fields in the "Submit Ticket" form to make it easier to share important information when making those submissions. (*KK*)
+
+### Aspen LiDA Administration Updates
+- In Branded App Settings, added an option to allow users to log in without being prompted to select a location at login using their home location. (Ticket 125816) (*KK*)
+
+<div markdown="1" class="settings">
+
+#### New Settings
+- Aspen LiDA > Branded App Settings > Use User Home Location When Logging In
+</div>
+
 ### CARL.X Updates
 - When processing records to reload, force the record to be updated from Carl.X during the indexing process. (*MDN*)
 
+### Collection Spotlight Updates
+- Fix display of 'small' covers in collection spotlights (*PA*)
+- Fixed issue in collection spotlights 'Tabbed display' that prevented switching tabs when the display type was one of the following: 'Single Title', 'Single Title with next button' and 'Text Only List'
+- Fixed issue in collection spotlights 'Drop Down List' that prevented switching list using the dropdown list.
+- Fixed issue in collection spotlights that prevented the active tab from having the correct 'active' style appliedm in 'Tabbed display'
+
+### Database Cleanup
+- Remove requirement for unsaved searches to be two days old before deletion. They are now deleted each time the cron runs, In keeping with GDPR.
+
+### EDS Updates
+- Add toggle for defaulting "Full Text" Limiter on/off (Ticket 129247) (*KL*)
+
 ### Events Updates
 - Correct multi-select facets so multiple values can be selected when searching events. (*KL, MDN*) 
+- Removed copy events facet group for now pending other events changes (*KP*)
 
 ### Evergreen Updates
 - When processing records to reload, force the record to be updated from Evergreen during the indexing process. (*MDN*)
@@ -30,6 +58,8 @@
 - Add information to the log if a translation map value cannot be parsed as a regular expression. (*MDN*)
 - Corrections for loading formats and grouping when using Mat Type from Sierra. (Ticket 130819) (*MDN*)
 - Combine default format maps into a single file. (*MDN*)
+- Add format match on 655a where if it equals "manga" the format "Manga" will be added (*KL*)
+- Fixed issue where target audiences were not being mapped with the correct translation map values (Ticket 131935) (*KL*)
 
 <div markdown="1" class="settings">
 
@@ -49,12 +79,20 @@
 ### Koha Updates
 - When a user has opted out of auto-renewal, do not show auto-renewal message even if the title is otherwise eligible for auto-renewal.  (Ticket 131789) (*MDN*)
 - When processing records to reload, force the record to be updated from Koha during the indexing process. (*MDN*)
+- Remove any OPACUserCss configurations added in Koha when web scraping. (*JOM*)
+
+### Location Updates
+- Fixed a bug where updating coordinates required two saves to properly store the values from the Google API. (*KK*)
 
 ### OverDrive Updates
 - Show when a record has been ungrouped from other works within staff view and allow them to be regrouped. (*MDN*) 
 
 ### Polaris Updates
 - When processing records to reload, force the record to be updated from Polaris during the indexing process. (*MDN*)
+- Correct typo within indexing logs. (*MG*)
+
+### Searching Updates
+- Fixed issue where multiselect facets were not allowing multiple values to be selected when searching (Tickets 131841, 131923) (*KL, MDN*)
 
 ### Sierra Updates
 - When processing records to reload, force the record to be updated from Sierra during the indexing process. (*MDN*)
@@ -89,6 +127,18 @@
 
 </div>
 
+### Summon Updates
+- Limited Summon Search results to those within the library's own subscription. (*AB / JOM*)
+- Added limit filters for Summon Search - search by whether record is scholarly and whether it is peer reviewed. (*AB / JOM*)
+- Added control over whether images available from the API are used in a Summon Search or whether Aspen created covers only should be used - impacts load speed. (*AB*)
+
+<div markdown="1" class="settings">
+
+#### New Settings
+- Primary Configuration > Library Systems > Summon > Show Available Covers in Summon
+
+</div>
+
 ### System Updates
 - Add automated blocking of some poorly behaved bots within apache configuration files. (*MDN, LR*)
 - Track requests by User Agent. (*MDN*)
@@ -106,34 +156,6 @@
 
 </div>
 
-### Other Updates
-- Update escaping of facet values so that translatable facet values can be translated in translation mode. (Tickets 130428, 130798) (*MDN*)
-- Fix translation mode for Export to CSV buttons in the Admin interface. (*MDN*)
-- Increase Patron Type field length in user table to 50 characters to match ptype table. (Ticket 132568) (*MDN*)
-- Add Accessibility Note (532 Field) to the Notes section when viewing a MARC record. (Ticket 132244) (*MDN*)
-- Display the full language rather than language code in More Details of a full record. (Ticket 132727) (*MDN*)
-- Correctly update database when covers are reloaded and uploaded. (*MDN*)
-- Cleanup code in Grouped Work AJAX code. (*MDN*)
-
-//kirstien
-### Accessibility Updates
-- Libby lending period options are now select elements to make them keyboard accessible and easily indicate selected values. (*KK*)
-
-### Aspen Discovery Support Updates
-- Added additional fields in the Submit Ticket form to make it easier to share important information when making those submissions. (*KK*) 
-
-### Aspen LiDA Administration Updates
-- In Branded App Settings, added an option to allow users to log in without being prompted to select a location at login using their home location. (Ticket 125816) (*KK*)
-
-<div markdown="1" class="settings">
-
-#### New Settings
-- Aspen LiDA > Branded App Settings > Use User Home Location When Logging In
-</div>
-
-### Location Updates
-- Fixed a bug where updating coordinates required two saves to properly store the values from the Google API. (*KK*)
-
 ### Theme Updates
 - Added a new browse category display mode designed to be more accessible. (*KK*)
 
@@ -143,63 +165,18 @@
 - Theme & Layout > Themes > Browse Categories > Use Accessible Layout
 </div>
 
-//kodi
-### EDS Updates
-- Add toggle for defaulting "Full Text" Limiter on/off (Ticket 129247) (*KL*)
-
-### Searching Updates
-- Fixed issue where multiselect facets were not allowing multiple values to be selected when searching (Tickets 131841, 131923) (*KL, MDN*)
-
-### Indexing Updates
-- Add format match on 655a where if it equals "manga" the format "Manga" will be added (*KL*)
-- Fixed issue where target audiences were not being mapped with the correct translation map values (Ticket 131935) (*KL*)
-
-//katherine
-### Events Updates
-- Removed copy events facet group for now pending other events changes (*KP*) 
-
-//morgan 
 ### Other Updates
+- Update escaping of facet values so that translatable facet values can be translated in translation mode. (Tickets 130428, 130798) (*MDN*)
+- Fix translation mode for Export to CSV buttons in the Admin interface. (*MDN*)
+- Increase Patron Type field length in user table to 50 characters to match ptype table. (Ticket 132568) (*MDN*)
+- Add Accessibility Note (532 Field) to the Notes section when viewing a MARC record. (Ticket 132244) (*MDN*)
+- Display the full language rather than language code in More Details of a full record. (Ticket 132727) (*MDN*)
+- Correctly update database when covers are reloaded and uploaded. (*MDN*)
+- Cleanup code in Grouped Work AJAX code. (*MDN*)
 - Added new Documentation links to several settings pages (*MKD*)
 - Updates to default user roles: removed testing roles and a couple uncommonly used roles; updated role titles (*MKD*)
-
-//alexander
-### Summon Updates
-- Limited Summon Search results to those within the library's own subscription. (*AB / JOM*)
-- Added limit filters for Summon Search - search by whether record is scholarly and whether it is peer reviewed. (*AB / JOM*)
-- Added control over whether images available from the API are used in a Summon Search or whether Aspen created covers only should be used - impacts load speed. (*AB*)
-
-<div markdown="1" class="settings">
-
-#### New Settings
-- Primary Configuration > Library Systems > Summon > Show Available Covers in Summon
-
-</div>
-
-//mikeg
-### Polaris Updates
-- Correct typo within indexing logs. (*MG*)
-
-//other
-
-//Pedro - PTFS
-### Other Updates
-- Fix display of 'small' covers in collection spotlights (*PA*)
-- Fixed issue in collection spotlights 'Tabbed display' that prevented switching tabs when the display type was one of the following: 'Single Title', 'Single Title with next button' and 'Text Only List'
-- Fixed issue in collection spotlights 'Drop Down List' that prevented switching list using the dropdown list.
-- Fixed issue in collection spotlights that prevented the active tab from having the correct 'active' style appliedm in 'Tabbed display'
-
-//Jacob - PTFS
-### Koha Updates
-- Remove any OPACUserCss configurations added in Koha when web scraping. (*JOM*)
-
-### Other Updates
 - Updated the merge_javascript.php script to be relative to the location of the file, not the location the script was run from. (*JOM*)
 - Amend typo in previous database updates (*JOM*)
-
-//Alexander Blanchard - PTFS - Europe
-### Database Cleanup
-- Remove requirement for unsaved searches to be two days old before deletion. They are now deleted each time the cron runs, In keeping with GDPR. 
 
 ## This release includes code contributions from
 - ByWater Solutions
@@ -216,4 +193,4 @@
   - Jacob O'Mara (JOM)
 
 - Main Library Alliance
-  - Mike Gurgurev (MG)
+  - Mike Grgurev (MG)

--- a/code/web/release_notes/24.07.00.MD
+++ b/code/web/release_notes/24.07.00.MD
@@ -1,0 +1,31 @@
+## Aspen LiDA Updates
+- 
+
+## Aspen Discovery Updates
+// mark
+
+// kirstien
+
+// kodi
+
+// katherine
+
+// alexander
+
+// jacob
+
+// pedro
+
+// other
+
+## This release includes code contributions from
+- ByWater Solutions
+  - Mark Noble (MDN)
+  - Kirstin Kroeger (KK)
+  - Kodi Lein (KL)
+  - Katherine Perdue (KP)
+
+- PTFS-Europe
+  - Pedro Amorim (PA)
+  - Alexander Blanchard (AB)
+  - Jacob O'Mara (JOM)

--- a/code/web/sys/DBMaintenance/version_updates/24.07.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/24.07.00.php
@@ -1,0 +1,30 @@
+<?php
+
+function getUpdates24_07_00(): array {
+	$curTime = time();
+	return [
+		/*'name' => [
+			 'title' => '',
+			 'description' => '',
+			 'continueOnError' => false,
+			 'sql' => [
+				 ''
+			 ]
+		 ], //name*/
+
+		//mark - ByWater
+
+
+		//kirstien - ByWater
+
+
+		//kodi - ByWater
+
+		//katherine - ByWater
+
+		//other
+
+
+
+	];
+}


### PR DESCRIPTION
Adjust code to allow Summon facet filters to be unchecked if they are clicked why $isApplied is true

TEST PLAN:
Before applying patch:

Carry out a Summon Search as usual
1.Apply one of the facets
1.Notice that the page reloads and the number of results reflects the chosen filter
3.Click the same filter again, notice the page reloads but the filter is still checked and applied
4.Click the red minus in the Applied Filters section for the filter you wish to remove
5.Notice that the page reloads and the filter has now been removed
APPLY PATCH:

1.Carry out a Summon Search and apply an filter as above
2.Click the same (checked) filter
3.Notice that the page reloads and the filter is now removed.