### PR TITLE
Fix replacing Spotlight tabs with a new search

### DIFF
--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -12757,8 +12757,13 @@ AspenDiscovery.CollectionSpotlights = (function(){
 					}
 				});
 				document.getElementById("collectionSpotlightListId").value = "-1.0";
+				if (listCount == 1) {
+					var $onlyValidOption = $("#collectionSpotlightListId").find("option").filter(function () {
+						return this["hidden"] == false && this['disabled'] == false;
+					});
+					$onlyValidOption.prop("selected", true);
+				}
 			});
-
 		},
 	};
 }(AspenDiscovery.CollectionSpotlights || {}));

--- a/code/web/interface/themes/responsive/js/aspen/collection-spotlights.js
+++ b/code/web/interface/themes/responsive/js/aspen/collection-spotlights.js
@@ -81,8 +81,13 @@ AspenDiscovery.CollectionSpotlights = (function(){
 					}
 				});
 				document.getElementById("collectionSpotlightListId").value = "-1.0";
+				if (listCount == 1) {
+					var $onlyValidOption = $("#collectionSpotlightListId").find("option").filter(function () {
+						return this["hidden"] == false && this['disabled'] == false;
+					});
+					$onlyValidOption.prop("selected", true);
+				}
 			});
-
 		},
 	};
 }(AspenDiscovery.CollectionSpotlights || {}));

--- a/code/web/release_notes/24.06.00.MD
+++ b/code/web/release_notes/24.06.00.MD
@@ -35,7 +35,8 @@
 - Fix display of 'small' covers in collection spotlights (*PA*)
 - Fixed issue in collection spotlights 'Tabbed display' that prevented switching tabs when the display type was one of the following: 'Single Title', 'Single Title with next button' and 'Text Only List'
 - Fixed issue in collection spotlights 'Drop Down List' that prevented switching list using the dropdown list.
-- Fixed issue in collection spotlights that prevented the active tab from having the correct 'active' style appliedm in 'Tabbed display'
+- Fixed issue in collection spotlights that prevented the active tab from having the correct 'active' style applied in 'Tabbed display'
+- Fixed issue with replacing spotlight tabs with a new search (Ticket 133171) (*KP*)
 
 ### Database Cleanup
 - Remove requirement for unsaved searches to be two days old before deletion. They are now deleted each time the cron runs, In keeping with GDPR.

--- a/code/web/services/Admin/CreateCollectionSpotlight.php
+++ b/code/web/services/Admin/CreateCollectionSpotlight.php
@@ -23,7 +23,7 @@ class Admin_CreateCollectionSpotlight extends Action {
 			$replaceExisting = isset($_REQUEST['replaceExisting']) ? $_REQUEST['replaceExisting'] : '';
 			$replaceIds = isset($_REQUEST['collectionSpotlightListId']) ? $_REQUEST['collectionSpotlightListId'] : '';
 			$replaceListIds = explode(".", $replaceIds);
-			$replaceListId = $replaceListIds[0];
+			$replaceListId = isset($replaceListIds[1]) ? $replaceListIds[1] : '';
 
 			if ($existingSpotlightId == -1) {
 				$collectionSpotlight = new CollectionSpotlight();


### PR DESCRIPTION
This is related to Ticket 133171: "Replace existing spotlight with current search" not updating tabbed spotlights.  The problem happened when doing a search, choosing Create Spotlight from search tools, then choosing to replace an existing spotlight.  If the spotlight only had one tab, it wasn't replaced at all.  If it had more than one, then no matter which tab the user picked, the first tab was the one that would be replaced.  I've tested this in Firefox, Edge, and Chrome with single and multi-tabbed spotlights.