### PR TITLE
Make checkAllowRenewals pass the patron's library ID

### DIFF
--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -585,7 +585,7 @@ class Koha extends AbstractIlsDriver {
 			$eligibleForRenewal = 0;
 			$willAutoRenew = 0;
 			$library = $patron->getHomeLibrary();
-			$allowRenewals = $this->checkAllowRenewals($curRow['issue_id']);
+			$allowRenewals = $this->checkAllowRenewals($curRow['issue_id'], $patron->getHomeLocationCode());
 			$timer->logTime("Load check allow renewals for checkout");
 			if ($allowRenewals['success']) {
 				$eligibleForRenewal = $allowRenewals['allows_renewal'] ? 1 : 0;
@@ -7610,7 +7610,7 @@ class Koha extends AbstractIlsDriver {
 		}
 	}
 
-	public function checkAllowRenewals($issueId) {
+	public function checkAllowRenewals($issueId, $patronLibraryId) {
 		$result = [
 			'success' => false,
 			'error' => null,
@@ -7631,9 +7631,10 @@ class Koha extends AbstractIlsDriver {
 				'Cache-Control: no-cache',
 				'Content-Type: application/json;charset=UTF-8',
 				'Host: ' . preg_replace('~http[s]?://~', '', $this->getWebServiceURL()),
+				'x-koha-library: ' . $patronLibraryId,
 			], true);
 
-			$apiUrl = $this->getWebServiceURL() . "/api/v1/checkouts/" . $issueId . "/allows_renewal/";
+			$apiUrl = $this->getWebServiceURL() . "/api/v1/checkouts/" . $issueId . "/allows_renewal";
 
 			$response = $this->apiCurlWrapper->curlSendPage($apiUrl, 'GET');
 			//ExternalRequestLogEntry::logRequest('koha.checkouts_allowRenewals', 'GET', $apiUrl, $this->apiCurlWrapper->getHeaders(), "", $this->apiCurlWrapper->getResponseCode(), $response, []);


### PR DESCRIPTION
Koha's API for renewability will pick the logged in user home branch for calculating renewability. So depending on the home branch for the logged in user, the results it will return.

In order to properly replicate OPAC behavior, Aspen should override the 'current' branch, by passing the `x-koha-library` header, which was designed for this specific purpose. And it should override using the patron's home branch.

That's what this patch does:

Add a new parameter to the `checkAllowRenewals` method so it can be passed the library id.
Use the new parameter to build the `x-koha-library` header.
Retrieve the home library ID from the DB, the same way Aspen already does for other bits, and pass it to `checkAllowRenewals`.