### PR TITLE
Fix searches that fail because of special characters

### DIFF
--- a/code/web/interface/themes/responsive/Record/view-subjects.tpl
+++ b/code/web/interface/themes/responsive/Record/view-subjects.tpl
@@ -6,7 +6,7 @@
 				{foreach from=$lcSubjects item=subject name=loop}
 					{foreach from=$subject item=subjectPart name=subloop}
 						{if empty($smarty.foreach.subloop.first)} -- {/if}
-						<a href="/Search/Results?lookfor=%22{$subjectPart.search|escape:"url"}%22&amp;searchIndex=Subject">{$subjectPart.title|escape}</a>
+						<a href="/Search/Results?lookfor=%22{$subjectPart.title|escape:"url"}%22&amp;searchIndex=Subject">{$subjectPart.title|escape}</a>
 					{/foreach}
 					<br>
 			{/foreach}
@@ -21,7 +21,7 @@
 				{foreach from=$bisacSubjects item=subject name=loop}
 					{foreach from=$subject item=subjectPart name=subloop}
 						{if empty($smarty.foreach.subloop.first)} -- {/if}
-						<a href="/Search/Results?lookfor=%22{$subjectPart.search|escape:"url"}%22&amp;searchIndex=Subject">{$subjectPart.title|escape}</a>
+						<a href="/Search/Results?lookfor=%22{$subjectPart.title|escape:"url"}%22&amp;searchIndex=Subject">{$subjectPart.title|escape}</a>
 					{/foreach}
 					<br>
 				{/foreach}
@@ -36,7 +36,7 @@
 				{foreach from=$oclcFastSubjects item=subject name=loop}
 					{foreach from=$subject item=subjectPart name=subloop}
 						{if empty($smarty.foreach.subloop.first)} -- {/if}
-						<a href="/Search/Results?lookfor=%22{$subjectPart.search|escape:"url"}%22&amp;searchIndex=Subject">{$subjectPart.title|escape}</a>
+						<a href="/Search/Results?lookfor=%22{$subjectPart.title|escape:"url"}%22&amp;searchIndex=Subject">{$subjectPart.title|escape}</a>
 					{/foreach}
 					<br>
 				{/foreach}
@@ -51,7 +51,7 @@
 				{foreach from=$localSubjects item=subject name=loop}
 					{foreach from=$subject item=subjectPart name=subloop}
 						{if empty($smarty.foreach.subloop.first)} -- {/if}
-						<a href="/Search/Results?lookfor=%22{$subjectPart.search|escape:"url"}%22&amp;searchIndex=Subject">{$subjectPart.title|escape}</a>
+						<a href="/Search/Results?lookfor=%22{$subjectPart.title|escape:"url"}%22&amp;searchIndex=Subject">{$subjectPart.title|escape}</a>
 					{/foreach}
 					<br>
 				{/foreach}
@@ -66,7 +66,7 @@
 				{foreach from=$otherSubjects item=subject name=loop}
 					{foreach from=$subject item=subjectPart name=subloop}
 						{if empty($smarty.foreach.subloop.first)} -- {/if}
-						<a href="/Search/Results?lookfor=%22{$subjectPart.search|escape:"url"}%22&amp;searchIndex=Subject">{$subjectPart.title|escape}</a>
+						<a href="/Search/Results?lookfor=%22{$subjectPart.title|escape:"url"}%22&amp;searchIndex=Subject">{$subjectPart.title|escape}</a>
 					{/foreach}
 					<br>
 				{/foreach}

--- a/code/web/release_notes/24.07.00.MD
+++ b/code/web/release_notes/24.07.00.MD
@@ -24,6 +24,9 @@
 // katherine
 ### General Updates
 - In offline mode, don't show buttons like Add a Review and Add to List that prompt a login. (Ticket 132443) (*KP*)
+- 
+### Searching Updates
+- Fixed bugs with searches that included special characters, especially subject searches. (Tickets 124011, 125190, 126636, 125764, 125718, 96412, 126604, 127927, 129569, 125996, 127927, 104133, 122594, 106178, 121322, 104134) (*KP*)
 
 // alexander
 ### Summon Updates

--- a/code/web/sys/SolrConnector/Solr.php
+++ b/code/web/sys/SolrConnector/Solr.php
@@ -652,7 +652,14 @@ abstract class Solr {
 			$cleanedQuery = str_replace(':', ' ', $lookfor);
 			$cleanedQuery = str_replace('“', '"', $cleanedQuery);
 			$cleanedQuery = str_replace('”', '"', $cleanedQuery);
-			$cleanedQuery = str_replace('--', ' ', $cleanedQuery);
+            // Fix for date ranges
+            $cleanedQuery = preg_replace("/([0-9a-zA-Z])([-.])([0-9a-zA-Z])/", "$1 $3", $cleanedQuery);
+            // Fix for ordinal numbers
+            $cleanedQuery = preg_replace("/([0-9])([a-zA-Z])/", "$1 $2", $cleanedQuery);
+			$cleanedQuery = str_replace('-', '\-', $cleanedQuery);
+			$cleanedQuery = str_replace('–', '\-\-', $cleanedQuery);
+            $cleanedQuery = str_replace('+', '\+', $cleanedQuery);
+            $cleanedQuery = str_replace('?', '\?', $cleanedQuery);
 			require_once ROOT_DIR . '/sys/Utils/StringUtils.php';
 			$noTrailingPunctuation = StringUtils::removeTrailingPunctuation($cleanedQuery);
 
@@ -723,6 +730,10 @@ abstract class Solr {
 			// except that we'll try to do the "one phrase" in quotes if possible.
 			$cleanedQuery = str_replace('“', '"', $lookfor);
 			$cleanedQuery = str_replace('”', '"', $cleanedQuery);
+            $cleanedQuery = str_replace('+', '\+', $cleanedQuery);
+            $cleanedQuery = str_replace('?', '\?', $cleanedQuery);
+            // Fix for ordinal numbers
+            $cleanedQuery = preg_replace("/([0-9])([a-zA-Z])/", "$1 $2", $cleanedQuery);
 			if (strlen($cleanedQuery) > 0 && $cleanedQuery[0] == '(') {
 				$onephrase = $cleanedQuery;
 			} else {
@@ -1729,11 +1740,10 @@ abstract class Solr {
 					$newWords[count($newWords) - 1] .= ' ' . trim($words[$i]) . ' ' . trim($words[$i + 1]);
 					$i = $i + 1;
 				}
-			} elseif ($words[$i] != '--') { //The -- word shows up with subject searches.  It causes other errors so don't tokenize it.
-				//If we are tokenizing, remove any punctuation
-				$tmpWord = preg_replace('/[[:punct:]]/', '', $words[$i]);
-				if (strlen($tmpWord) > 0) {
-					$newWords[] = trim($tmpWord);
+			} else {
+				// Previously we removed -- and any punctuation at this step, but this was causing problems
+				if (strlen($words[$i]) > 0) {
+					$newWords[] = trim($words[$i]);
 				}
 			}
 		}

--- a/sites/default/conf/groupedWorksSearchSpecs2.yaml
+++ b/sites/default/conf/groupedWorksSearchSpecs2.yaml
@@ -358,6 +358,8 @@ KeywordProper:
       - [onephrase, 10]
     - topic_proper:
       - [onephrase, 500]
+    - subject_proper:
+      - [ onephrase, 100 ]
     - geographic_proper:
       - [onephrase, 300]
     - genre_proper:


### PR DESCRIPTION
Searches that included hyphens, apostrophes, ampersands, question marks, and words that contained both letters and numbers were failing, especially when in quotation marks.  These searches should work now.  This covers tickets: 124011, 125190, 126636, 125764, 125718, 96412, 126604, 127927, 129569, 125996, 127927, 104133, 122594, 106178, 121322, and 104134.

Some example searches that this change fixes are: "World War, 1939-1945 -- Fiction.", "Bush Brothers & Company -- History.", "Chi's Sweet Home", Rejection++(+Psychology+)+--++Religious+++aspects++--++Christianity, K-Ming Chang gods of want, "Economic history -- 21st century.", Did Ye Hear Mammy Died? O'Reilly, Kevin the unicorn: why can't we be bestie-corns?

There are still some things that this change does not fix.  There are lingering issues with apostrophes in titles when the search is in quotes, especially if it's a subtitle, that seems to be a different problem.  It also does not address tickets 129323 or 124077 because they have more to do with preferred search results rather than failing searches.  