### PR TITLE
Fix browse category tab order keyboard navigation

### DIFF
--- a/code/web/interface/themes/responsive/Search/browse-sub-category-tab.tpl
+++ b/code/web/interface/themes/responsive/Search/browse-sub-category-tab.tpl
@@ -9,6 +9,9 @@
         {foreach from=$subCategories item=subCategory}
 		    <div id="tabpanel-{$subCategory.textId}" role="tabpanel" aria-labelledby="browse-sub-category-tab-{$subCategory.textId}" {if $subCategory@iteration != 1}class="is-hidden"{/if}>
 			    <div class="swiper {if $subCategory@iteration == 1}swiper-first{/if} swiper-sub-browse-category-{$subCategory.textId}" id="swiper-sub-{$subCategory.textId}">
+					<div class="swiper-navigation-container">
+						<div class="swiper-button-prev"></div>
+					</div>
 				    <div class="swiper-wrapper" id="swiper-sub-browse-category-{$subCategory.textId}">
 					    {if $subCategory@iteration == 1 && !empty($subCategory.initialResults)}
 						    <div class="swiper-slide" id="swiper-loading-{$subCategory.textId}" style="height: 200px">
@@ -26,9 +29,6 @@
 							    <i class="fas fa-lg fa-spinner fa-spin"></i>
 						    </div>
                         {/if}
-				    </div>
-				    <div class="swiper-navigation-container">
-				        <div class="swiper-button-prev"></div>
 				    </div>
 				    <div class="swiper-navigation-container">
 				        <div class="swiper-button-next"></div>

--- a/code/web/interface/themes/responsive/Search/home.tpl
+++ b/code/web/interface/themes/responsive/Search/home.tpl
@@ -15,6 +15,9 @@
 		            </div>
 	            {else}
 		            <div class="swiper swiper-first swiper-browse-category-{$browseCategory.textId}" id="swiper-{$browseCategory.textId}">
+						<div class="swiper-navigation-container">
+							<div class="swiper-button-prev"></div>
+						</div>
 			            <div class="swiper-wrapper" id="swiper-browse-category-{$browseCategory.textId}">
 				            <div class="swiper-slide" id="swiper-loading-{$browseCategory.textId}" style="height: 200px">
 					            <i class="fas fa-lg fa-spinner fa-spin"></i>
@@ -22,9 +25,6 @@
 	                       {literal} <script type="text/javascript">
 					            setTimeout(() => AspenDiscovery.Browse.initializeBrowseCategorySwiper({/literal}'{$browseCategory.textId}'{literal}), 1000)
 	                        </script>{/literal}
-			            </div>
-			            <div class="swiper-navigation-container">
-				            <div class="swiper-button-prev"></div>
 			            </div>
 			            <div class="swiper-navigation-container">
 				            <div class="swiper-button-next"></div>

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -10981,7 +10981,7 @@ AspenDiscovery.Browse = (function(){
 				}else {
 					var resultsTabPanel = document.getElementById('swiper-browse-category-' + categoryTextId) ;
 					resultsTabPanel.innerHTML = "";
-					new Swiper('.swiper-browse-category-' + categoryTextId, {
+					var browseSwiper = new Swiper('.swiper-browse-category-' + categoryTextId, {
 						slidesPerView: 5,
 						spaceBetween: 20,
 						direction: 'horizontal',
@@ -11001,6 +11001,13 @@ AspenDiscovery.Browse = (function(){
 							enabled: true,
 							slides: Object.values(data.records),
 						}
+					});
+					// Fix keyboard navigation
+					$("#browse-category-feed .swiper-wrapper > .swiper-slide:not(.swiper-slide-visible) a").prop("tabindex", "-1");
+					$("#browse-category-feed .swiper-wrapper > .swiper-slide-visible a").removeProp("tabindex");
+					browseSwiper.on('slideChangeTransitionEnd', function () {
+						$("#browse-category-feed .swiper-wrapper > .swiper-slide:not(.swiper-slide-visible) a").prop("tabindex", "-1");
+						$("#browse-category-feed .swiper-wrapper > .swiper-slide-visible a").removeProp("tabindex");
 					});
 				}
 			}).fail(function(){
@@ -11160,7 +11167,7 @@ AspenDiscovery.Browse = (function(){
 				}else{
 					var resultsTabPanel = document.getElementById('swiper-sub-browse-category-' + subCategoryTextId) ;
 					resultsTabPanel.innerHTML = "";
-					new Swiper('.swiper-sub-browse-category-' + subCategoryTextId, {
+					var browseSwiper = new Swiper('.swiper-sub-browse-category-' + subCategoryTextId, {
 						slidesPerView: 5,
 						spaceBetween: 20,
 						direction: 'horizontal',
@@ -11180,6 +11187,13 @@ AspenDiscovery.Browse = (function(){
 							enabled: true,
 							slides: Object.values(data.records),
 						}
+					});
+					// Fix keyboard navigation
+					$("#browse-category-feed .swiper-wrapper > .swiper-slide:not(.swiper-slide-visible) a").prop("tabindex", "-1");
+					$("#browse-category-feed .swiper-wrapper > .swiper-slide-visible a").removeProp("tabindex");
+					browseSwiper.on('slideChangeTransitionEnd', function () {
+						$("#browse-category-feed .swiper-wrapper > .swiper-slide:not(.swiper-slide-visible) a").prop("tabindex", "-1");
+						$("#browse-category-feed .swiper-wrapper > .swiper-slide-visible a").removeProp("tabindex");
 					});
 
 				}

--- a/code/web/interface/themes/responsive/js/aspen/browse.js
+++ b/code/web/interface/themes/responsive/js/aspen/browse.js
@@ -314,7 +314,7 @@ AspenDiscovery.Browse = (function(){
 				}else {
 					var resultsTabPanel = document.getElementById('swiper-browse-category-' + categoryTextId) ;
 					resultsTabPanel.innerHTML = "";
-					new Swiper('.swiper-browse-category-' + categoryTextId, {
+					var browseSwiper = new Swiper('.swiper-browse-category-' + categoryTextId, {
 						slidesPerView: 5,
 						spaceBetween: 20,
 						direction: 'horizontal',
@@ -334,6 +334,13 @@ AspenDiscovery.Browse = (function(){
 							enabled: true,
 							slides: Object.values(data.records),
 						}
+					});
+					// Fix keyboard navigation
+					$("#browse-category-feed .swiper-wrapper > .swiper-slide:not(.swiper-slide-visible) a").prop("tabindex", "-1");
+					$("#browse-category-feed .swiper-wrapper > .swiper-slide-visible a").removeProp("tabindex");
+					browseSwiper.on('slideChangeTransitionEnd', function () {
+						$("#browse-category-feed .swiper-wrapper > .swiper-slide:not(.swiper-slide-visible) a").prop("tabindex", "-1");
+						$("#browse-category-feed .swiper-wrapper > .swiper-slide-visible a").removeProp("tabindex");
 					});
 				}
 			}).fail(function(){
@@ -493,7 +500,7 @@ AspenDiscovery.Browse = (function(){
 				}else{
 					var resultsTabPanel = document.getElementById('swiper-sub-browse-category-' + subCategoryTextId) ;
 					resultsTabPanel.innerHTML = "";
-					new Swiper('.swiper-sub-browse-category-' + subCategoryTextId, {
+					var browseSwiper = new Swiper('.swiper-sub-browse-category-' + subCategoryTextId, {
 						slidesPerView: 5,
 						spaceBetween: 20,
 						direction: 'horizontal',
@@ -513,6 +520,13 @@ AspenDiscovery.Browse = (function(){
 							enabled: true,
 							slides: Object.values(data.records),
 						}
+					});
+					// Fix keyboard navigation
+					$("#browse-category-feed .swiper-wrapper > .swiper-slide:not(.swiper-slide-visible) a").prop("tabindex", "-1");
+					$("#browse-category-feed .swiper-wrapper > .swiper-slide-visible a").removeProp("tabindex");
+					browseSwiper.on('slideChangeTransitionEnd', function () {
+						$("#browse-category-feed .swiper-wrapper > .swiper-slide:not(.swiper-slide-visible) a").prop("tabindex", "-1");
+						$("#browse-category-feed .swiper-wrapper > .swiper-slide-visible a").removeProp("tabindex");
 					});
 
 				}

--- a/code/web/release_notes/24.06.00.MD
+++ b/code/web/release_notes/24.06.00.MD
@@ -191,6 +191,7 @@
 
 ### Theme Updates
 - Added a new browse category display mode designed to be more accessible. (*KK*)
+- Fixed keyboard navigation problem with accessible browse categories.(Ticket 133620)(*KP*)
 
 <div markdown="1" class="settings">
 


### PR DESCRIPTION
This relates to ticket 133620. Tabbing through accessible browse categories on the homepage went to the next book off the screen instead of to the Next button, which caused Next to move. This change adds tabindex="-1" to the hidden books that are off the screen so that they won't get focus. It also moves the Previous button so that the tab order is now Previous -> Book Cover 1-5 -> Next instead of Book Cover 1-5 -> Previous -> Next. I have tested in Firefox, Edge, and Chrome.

Sorry for any confusion when I accidentally deleted this pull request a moment ago.