### PR TITLE
Change Spotlight title when changing title of only tab

### DIFF
--- a/code/web/release_notes/24.07.00.MD
+++ b/code/web/release_notes/24.07.00.MD
@@ -24,7 +24,10 @@
 // katherine
 ### General Updates
 - In offline mode, don't show buttons like Add a Review and Add to List that prompt a login. (Ticket 132443) (*KP*)
-- 
+
+### Collection Spotlight Updates
+- When replacing an existing tab on a Collection Spotlight, changing the title of the tab now also changes the title of the spotlight if it's the only tab. (*KP*) 
+
 ### Searching Updates
 - Fixed bugs with searches that included special characters, especially subject searches. (Tickets 124011, 125190, 126636, 125764, 125718, 96412, 126604, 127927, 129569, 125996, 127927, 104133, 122594, 106178, 121322, 104134) (*KP*)
 

--- a/code/web/services/Admin/CreateCollectionSpotlight.php
+++ b/code/web/services/Admin/CreateCollectionSpotlight.php
@@ -115,6 +115,11 @@ class Admin_CreateCollectionSpotlight extends Action {
 					$spotlightList->sourceCourseReserveId = $sourceId;
 					$spotlightList->source = 'CourseReserve';
 				}
+                $listCount = $collectionSpotlight->getNumLists();
+                if ($listCount == 1) {
+                    $collectionSpotlight->name = $spotlightName;
+                    $collectionSpotlight->update();
+                }
 				$spotlightList->name = $spotlightName;
 				$spotlightList->update();
 			}


### PR DESCRIPTION
When replacing a Spotlight tab with a new search there's an option to rename the tab.  But if there's only one tab, it makes sense to rename the whole Spotlight.