### PR TITLE
Fix CloudLibrary so that books don't always show as On Order

### DIFF
--- a/code/cloud_library_export/src/com/turning_leaf_technologies/cloud_library/CloudLibraryAvailabilityType.java
+++ b/code/cloud_library_export/src/com/turning_leaf_technologies/cloud_library/CloudLibraryAvailabilityType.java
@@ -1,7 +1,7 @@
 package com.turning_leaf_technologies.cloud_library;
 
 class CloudLibraryAvailabilityType {
-	private int availabilityType;
+	private int availabilityType = 1;
 
 	private String rawResponse = "";
 

--- a/code/web/release_notes/24.07.00.MD
+++ b/code/web/release_notes/24.07.00.MD
@@ -43,6 +43,9 @@
 ### OverDrive Updates
 - Error message when returning Kindle books is now translatable. (Tickets 133671, 133815, 133663, 133982) (*KP*)
 
+### CloudLibrary Updates
+- Fixed bug where CloudLibrary showed available books as On Order. (Tickets 133182, 131721, 130690, 127870) (*KP*)
+
 // alexander
 ### Summon Updates
 - Adjustments to code in Summon getFacetSet function to correct a bug. Individual facet filters can now be unchecked and the filter unset by clicking the checkbox. (*AB*)


### PR DESCRIPTION
- Set default value of 1 for AvailabilityType, since CloudLibrary frequently doesn't send an AvailabilityType at all.  This should still get set to 0 if the AvailabilityType is "PREPUB".  I tested that books that are not on order no longer show as on order and that checked out books show as checked out, but I wasn't able to test that books that really are on order still show up that way.
- Updated release notes.