### PR TITLE
Message "old PIN provided is incorrect" should be translatable

### DIFF
--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -4753,7 +4753,10 @@ class Koha extends AbstractIlsDriver {
 		if ($patron->cat_password != $oldPin) {
 			return [
 				'success' => false,
-				'message' => "The old PIN provided is incorrect.",
+				'message' => translate([
+					'text' => 'The old PIN provided is incorrect.',
+					'isPublicFacing' => true,
+				])
 			];
 		}
 		$result = [

--- a/code/web/Drivers/Polaris.php
+++ b/code/web/Drivers/Polaris.php
@@ -1671,7 +1671,10 @@ class Polaris extends AbstractIlsDriver {
 		if ($patron->ils_password != $oldPin && $patron->cat_password != $oldPin) {
 			return [
 				'success' => false,
-				'message' => "The old PIN provided is incorrect.",
+				'message' => translate([
+					'text' => 'The old PIN provided is incorrect.',
+					'isPublicFacing' => true,
+				]),
 			];
 		}
 		$result = [

--- a/code/web/Drivers/Sierra.php
+++ b/code/web/Drivers/Sierra.php
@@ -1807,7 +1807,10 @@ class Sierra extends Millennium {
 		if ($patron->getPasswordOrPin() != $oldPin) {
 			return [
 				'success' => false,
-				'message' => "The old PIN provided is incorrect.",
+				'message' => translate([
+					'text' => 'The old PIN provided is incorrect.',
+					'isPublicFacing' => true,
+				]),
 			];
 		}
 		/** @noinspection PhpArrayIndexImmediatelyRewrittenInspection */

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -13311,7 +13311,9 @@ AspenDiscovery.OverDrive = (function(){
 					url: ajaxUrl,
 					cache: false,
 					success: function(data){
-						AspenDiscovery.showMessage("Title Returned", data.message, data.success);
+						AspenDiscovery.showMessage(
+							data.success ? 'Title Returned' : 'Error Returning Title', data.message, data.success
+						);
 						if (data.success){
 							$(".overdrive_checkout_" + overDriveId).hide();
 							AspenDiscovery.Account.loadMenuData();

--- a/code/web/interface/themes/responsive/js/aspen/overdrive.js
+++ b/code/web/interface/themes/responsive/js/aspen/overdrive.js
@@ -294,7 +294,9 @@ AspenDiscovery.OverDrive = (function(){
 					url: ajaxUrl,
 					cache: false,
 					success: function(data){
-						AspenDiscovery.showMessage("Title Returned", data.message, data.success);
+						AspenDiscovery.showMessage(
+							data.success ? 'Title Returned' : 'Unable to Return Title', data.message, data.success
+						);
 						if (data.success){
 							$(".overdrive_checkout_" + overDriveId).hide();
 							AspenDiscovery.Account.loadMenuData();

--- a/code/web/release_notes/24.07.00.MD
+++ b/code/web/release_notes/24.07.00.MD
@@ -55,6 +55,7 @@
 ### General Updates
 - In offline mode, don't show buttons like Add a Review and Add to List that prompt a login. (Ticket 132443) (*KP*)
 - 'Return to List' returns submissions from the correct custom form or quick poll and the submissions page now prompts users to pick a form/poll. (Ticket 118583) (*KP*)
+- 'Old PIN provided is incorrect' message is now translatable. (Ticket 123151) (*KP*)
 
 ### Collection Spotlight Updates
 - When replacing an existing tab on a Collection Spotlight, changing the title of the tab now also changes the title of the spotlight if it's the only tab. (*KP*) 

--- a/code/web/services/WebBuilder/CustomFormSubmissions.php
+++ b/code/web/services/WebBuilder/CustomFormSubmissions.php
@@ -66,7 +66,7 @@ class WebBuilder_CustomFormSubmissions extends ObjectEditor {
 	}
 
 	function showReturnToList(): bool {
-		return false;
+		return true;
 	}
 
 	function getObjectStructure($context = ''): array {


### PR DESCRIPTION
- Made message translatable.
- Updated release notes.
- This is for ticket 123151, which has been closed already.  I couldn't actually get this error message to show up and it looks to me like it may only show for Polaris or possibly not at all, since the ticket says the problem is not happening anymore.