### PR TITLE
Translate Kindle/OverDrive message

### DIFF
--- a/code/web/Drivers/OverDriveDriver.php
+++ b/code/web/Drivers/OverDriveDriver.php
@@ -1295,7 +1295,14 @@ class OverDriveDriver extends AbstractEContentDriver {
 				'isPublicFacing' => true,
 			]);
 			if (isset($response->message)) {
-				$cancelHoldResult['message'] .= "  {$response->message}";
+				if ($response->message == "An unmapped error has occurred. '7'") {
+					$cancelHoldResult['message'] .= "  " . translate([
+							'text' => "An unmapped error has occurred. '7'",
+							'isPublicFacing' => true,
+						]);
+				} else {
+					$cancelHoldResult['message'] .= "  {$response->message}";
+				}
 			}
 
 			// Result for API or app use
@@ -1308,7 +1315,14 @@ class OverDriveDriver extends AbstractEContentDriver {
 				'isPublicFacing' => true,
 			]);
 			if (isset($response->message)) {
-				$cancelHoldResult['api']['message'] .= "  {$response->message}";
+				if ($response->message == "An unmapped error has occurred. '7'") {
+					$cancelHoldResult['api']['message'] .= "  " . translate([
+							'text' => "An unmapped error has occurred. '7'",
+							'isPublicFacing' => true,
+						]);
+				} else {
+					$cancelHoldResult['api']['message'] .= "  {$response->message}";
+				}
 			}
 
 			$this->incrementStat('numApiErrors');

--- a/code/web/release_notes/24.06.01.MD
+++ b/code/web/release_notes/24.06.01.MD
@@ -2,6 +2,10 @@
 ### Other Updates
 - Update bot blocking files. (*MDN*)
 
+### OverDrive Updates
+- Error message when returning Kindle books is now translatable. (Tickets 133671, 133815, 133663, 133982) (*KP*)
+
 ## This release includes code contributions from
 - ByWater Solutions
   - Mark Noble (MDN)
+  - Katherine Perdue (KP)


### PR DESCRIPTION
-Translated error message when you try to return an OverDrive book that has been transferred to Kindle.
-Updated release notes.