### PR TITLE
Only strip by author's name from titles

### DIFF
--- a/code/reindexer/src/org/aspen_discovery/grouping/GroupedWork.java
+++ b/code/reindexer/src/org/aspen_discovery/grouping/GroupedWork.java
@@ -207,8 +207,8 @@ public class GroupedWork implements Cloneable {
 		return groupingTitle;
 	}
 
-	private static final Pattern commonSubtitlesSimplePattern = Pattern.compile("\\b(by\\s\\w+\\s\\w+|a novel of .*|stories|an autobiography|a biography|a memoir in books|poems|the movie|large print|the graphic novel|graphic novel|magazine|audio cd|book club kit|with illustrations|book \\d+|the original classic edition|classic edition|a novel|large type edition|novel)$");
-	private static final Pattern commonSubtitlesComplexPattern = Pattern.compile("\\b((a|una|an)\\s(.*)novel(a|la)?|a(.*)memoir|a(.*)mystery|a(.*)thriller|by\\s\\w+\\s\\w+|an? .* story|a .*\\s?book|[\\w\\s]+series book \\d+|[\\w\\s]+serie libro \\d+|the[\\w\\s]+chronicles book \\d+|[\\w\\s]+trilogy book \\d+|^novel|[\\w\\s]+series|.+\\sbook\\s\\d+)$");
+	private static final Pattern commonSubtitlesSimplePattern = Pattern.compile("\\b(a novel of .*|stories|an autobiography|a biography|a memoir in books|poems|the movie|large print|the graphic novel|graphic novel|magazine|audio cd|book club kit|with illustrations|book \\d+|the original classic edition|classic edition|a novel|large type edition|novel)$");
+	private static final Pattern commonSubtitlesComplexPattern = Pattern.compile("\\b((a|una|an)\\s(.*)novel(a|la)?|a(.*)memoir|a(.*)mystery|a(.*)thriller|an? .* story|a .*\\s?book|[\\w\\s]+series book \\d+|[\\w\\s]+serie libro \\d+|the[\\w\\s]+chronicles book \\d+|[\\w\\s]+trilogy book \\d+|^novel|[\\w\\s]+series|.+\\sbook\\s\\d+)$");
 	private String removeCommonSubtitles(String groupingTitle) {
 		boolean changeMade = true;
 		while (changeMade){
@@ -325,6 +325,25 @@ public class GroupedWork implements Cloneable {
 		return title;
 	}
 
+	private static final Pattern authorStatementPattern = Pattern.compile("\\b(by\\s\\w+\\s\\w+)");
+	private void removeTitleAuthorStatement() {
+		if (!this.fullTitle.isEmpty() && !this.author.isEmpty()) {
+			Matcher authorStatementMatcher = authorStatementPattern.matcher(this.fullTitle);
+			if (authorStatementMatcher.find() && authorStatementMatcher.hitEnd()) {
+				String[] authorNames = this.author.split("(,\\s|\\s)");
+				String match = authorStatementMatcher.group();
+				String newTitle = this.fullTitle;
+				for (String authorName : authorNames) {
+					if (match.contains(authorName)) {
+						newTitle = authorStatementMatcher.replaceFirst("");
+						break;
+					}
+				}
+				this.fullTitle = newTitle.trim();
+			}
+		}
+	}
+
 	public String getAuthor() {
 		return author;
 	}
@@ -332,6 +351,7 @@ public class GroupedWork implements Cloneable {
 	public void setAuthor(String author) {
 		originalAuthorName = author;
 		this.author = normalizeAuthor(author);
+		removeTitleAuthorStatement();
 	}
 
 	private static final Pattern validCategories = Pattern.compile("^(book|music|movie|other|comic)$");

--- a/code/web/release_notes/24.07.00.MD
+++ b/code/web/release_notes/24.07.00.MD
@@ -75,6 +75,9 @@
 ### CloudLibrary Updates
 - Fixed bug where CloudLibrary showed available books as On Order. (Tickets 133182, 131721, 130690, 127870) (*KP*)
 
+### Indexing Updates
+- For title grouping, only strip 'by' clauses when 'by' is followed by the author's name. (Tickets 111195, 120017, 127241) (*KP*) 
+
 // alexander
 ### Summon Updates
 - Adjustments to code in Summon getFacetSet function to correct a bug. Individual facet filters can now be unchecked and the filter unset by clicking the checkbox. (*AB*)


### PR DESCRIPTION
- Instead of removing any phrase in the title that is "by" followed by two words, now "by..." is only removed if at least one of the following words is part of the author's name and it's at the end of the title.  So "by Bram Stoker" would be removed from "Dracula by Bram Stoker" but "Death by Vanilla Latte" stays "Death by Vanilla Latte".
- Updated release notes.