### PR TITLE
Fix for Chrome/Edge Browse Category bug

### DIFF
--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -11009,6 +11009,10 @@ AspenDiscovery.Browse = (function(){
 						$("#browse-category-feed .swiper-wrapper > .swiper-slide:not(.swiper-slide-visible) a").prop("tabindex", "-1");
 						$("#browse-category-feed .swiper-wrapper > .swiper-slide-visible a").removeProp("tabindex");
 					});
+					// Prevent accidental cover selection when the user clicks too fast
+					$(".swiper").on("mousedown", function (e) {
+						e.preventDefault();
+					});
 				}
 			}).fail(function(){
 				AspenDiscovery.ajaxFail();

--- a/code/web/interface/themes/responsive/js/aspen/browse.js
+++ b/code/web/interface/themes/responsive/js/aspen/browse.js
@@ -342,6 +342,10 @@ AspenDiscovery.Browse = (function(){
 						$("#browse-category-feed .swiper-wrapper > .swiper-slide:not(.swiper-slide-visible) a").prop("tabindex", "-1");
 						$("#browse-category-feed .swiper-wrapper > .swiper-slide-visible a").removeProp("tabindex");
 					});
+					// Prevent accidental cover selection when the user clicks too fast
+					$(".swiper").on("mousedown", function (e) {
+						e.preventDefault();
+					});
 				}
 			}).fail(function(){
 				AspenDiscovery.ajaxFail();


### PR DESCRIPTION
- In Edge and Chrome only, if the user clicked too fast on the arrow Accessible Browse Categories arrows, all the covers in that category would get selected because it was getting detected as a double click. This fixes that problem and you can still select covers and tabbing still works.  I tested in Edge, Chrome, and Firefox.
- No release notes update since this a QA fix relating to a different browse category bug. 