### PR TITLE
Add supporting company to new site install

### DIFF
--- a/code/web/release_notes/24.07.00.MD
+++ b/code/web/release_notes/24.07.00.MD
@@ -93,6 +93,10 @@
 - Add a utility to generate a site template to aid in migrating servers. (*MDN*)
 - Update updateSitePermissions scripts to include all directories. (*MDN*)
 
+// Chloe PTFS-Europe
+### Other Updates
+- Add the ability to change the supporting company name on site creation. (*CZ*)
+
 ## This release includes code contributions from
 - ByWater Solutions
   - Mark Noble (MDN)
@@ -106,6 +110,7 @@
 - PTFS-Europe
   - Pedro Amorim (PA)
   - Alexander Blanchard (AB)
+  - Chloe Zermatten (CZ)
 
 - Theke Solutions
   - Lucas Montoya (LM)

--- a/install/createSite.php
+++ b/install/createSite.php
@@ -34,6 +34,7 @@ if (count($_SERVER['argv']) > 1){
 		$variables = [
 			'sitename' => $sitename,
 			'cleanSitename' => $cleanSitename,
+			'supportingCompany' => $configArray['Site']['supportingCompany'],
 			'library' => $configArray['Site']['sitename'],
 			'title' => $configArray['Site']['title'],
 			'url' => $configArray['Site']['url'],
@@ -90,6 +91,11 @@ if (!$foundConfig) {
 	$variables['library'] = '';
 	while (empty($variables['library'])) {
 		$variables['library'] = readline("Enter the library or consortium name, e.g., Aspen Public Library > ");
+	}
+
+	$variables['supportingCompany'] = readline("Enter the name of the supporting company (default: ByWater Solutions) > ");
+	if (empty($variables['supportingCompany'])) {
+		$variables['supportingCompany'] = "ByWater Solutions";
 	}
 
 	$variables['title'] = '';
@@ -314,6 +320,10 @@ exec("$mysqlConnectionCommand {$variables['aspenDBName']} < $installDir/install/
 $aspen_db = new PDO("mysql:dbname={$variables['aspenDBName']};host={$variables['aspenDBHost']}",$variables['aspenDBUser'],$variables['aspenDBPwd']);
 $updateUserStmt = $aspen_db->prepare("UPDATE user set cat_password=" . $aspen_db->quote($variables['aspenAdminPwd']) . ", password=" . $aspen_db->quote($variables['aspenAdminPwd']) . " where username = 'aspen_admin'");
 $updateUserStmt->execute();
+
+//Assign supportingCompany in the db
+$postSupportingCompanyStmt = $aspen_db->prepare("UPDATE system_variables set supportingCompany=" . $aspen_db->quote($variables['supportingCompany']));
+$postSupportingCompanyStmt->execute();
 
 if ($variables['ils'] == 'Koha'){
 	// Attempt to get the system's temp directory

--- a/install/createSiteTemplate.ini
+++ b/install/createSiteTemplate.ini
@@ -19,6 +19,8 @@ solrPort = 8080
 ils =
 ; timezone of the library (e.g. America/Los_Angeles, check http://www.php.net/manual/en/timezones.php)
 timezone =
+; name of the supporting company (is set to ByWater Solutions by default)
+supportingCompany =
 
 [Aspen]
 ; Database host for Aspen


### PR DESCRIPTION
**Description**:

This patch adds the options to set the name of the supporting company when creating a new site. The user will be prompted to either accept the default (ByWater Solutions), or input their own preferred company name. It also adds the supporting company to the template options for createSiteTemplate.ini.

**Test plan**:

to test without templating:

- cd into the install folder
- run `php createSite.php` and follow the prompts (note that the aspen database credentials must be correct. Also, the aspen database name given here must be unique)
- open your aspen database host, and navigate to the database which you have just created
- open the system_variables table
- check that there is only one row within this table
- also check that the value stored under supportingCompany matches the one entered while creating the site

to test with templating:

- cd into the install folder
- create a copy of createSiteTemplate.ini and fill in the variables (note that the aspen database credentials must be correct. Also, the aspen database name given here must be unique)
- run `php createSite.php createSiteTemplateCopy.ini`
- open your aspen database host, and navigate to the database which you have just created
- open the system_variables table
- check that there is only one row within this table
- also check that the value stored under supportingCompany matches the one value you assigned to supportingCompany in createSiteTemplateCopy.ini