### PR TITLE
Fix searches that contain slashes

### DIFF
--- a/code/web/sys/SolrConnector/Solr.php
+++ b/code/web/sys/SolrConnector/Solr.php
@@ -660,6 +660,7 @@ abstract class Solr {
 			$cleanedQuery = str_replace('–', '\-\-', $cleanedQuery);
             $cleanedQuery = str_replace('+', '\+', $cleanedQuery);
             $cleanedQuery = str_replace('?', '\?', $cleanedQuery);
+			$cleanedQuery = str_replace('/', '\/', $cleanedQuery);
 			require_once ROOT_DIR . '/sys/Utils/StringUtils.php';
 			$noTrailingPunctuation = StringUtils::removeTrailingPunctuation($cleanedQuery);
 
@@ -732,6 +733,7 @@ abstract class Solr {
 			$cleanedQuery = str_replace('”', '"', $cleanedQuery);
             $cleanedQuery = str_replace('+', '\+', $cleanedQuery);
             $cleanedQuery = str_replace('?', '\?', $cleanedQuery);
+			$cleanedQuery = str_replace('/', '\/', $cleanedQuery);
             // Fix for ordinal numbers
             $cleanedQuery = preg_replace("/([0-9])([a-zA-Z])/", "$1 $2", $cleanedQuery);
 			if (strlen($cleanedQuery) > 0 && $cleanedQuery[0] == '(') {
@@ -1894,9 +1896,11 @@ abstract class Solr {
 		//Remove any semi-colons that Solr will handle incorrectly.
 		$input = str_replace(';', ' ', $input);
 
-		//Remove any slashes that Solr will handle incorrectly.
-		$input = str_replace('\\', ' ', $input);
-		$input = str_replace('/', ' ', $input);
+		//Remove slashes occur in the middle of a word that Solr will handle incorrectly.
+		$input = preg_replace("/([0-9a-zA-Z])([\/])([0-9a-zA-Z])/", "$1 $3", $input);
+		$input = preg_replace("/([0-9a-zA-Z])([\\\\])([0-9a-zA-Z])/", "$1 $3", $input);
+		$input = str_replace('\\', '\\\\', $input);
+
 		//$input = preg_replace('/\\\\(?![&:])/', ' ', $input);
 
 		//Look for any colons that are not identifying fields


### PR DESCRIPTION
Quoted searches that contained a slash on its own (not in the middle of a word) were not returning results.  This was a problem for subject heading searches like "fiction / fantasy".  This change continues to remove slashes in the middle of words but retains and escapes slashes that are not part of words.  

This works well for forward slashes and you get the correct results for backslashes, but they will show up as escaped in the query in the search box, which causes issues if you resubmit the search.  Backslashes in subject headings ought to be really rare though, so it's probably not going to impact many searches.