### PR TITLE
Small Bug Fixes

### DIFF
--- a/code/reindexer/src/org/aspen_discovery/format_classification/MarcRecordFormatClassifier.java
+++ b/code/reindexer/src/org/aspen_discovery/format_classification/MarcRecordFormatClassifier.java
@@ -948,6 +948,10 @@ public class MarcRecordFormatClassifier {
 								result.add("PhysicalObject");
 								break;
 						}
+					} else {
+						if (groupedWork != null && groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Adding bib level format PhysicalObject based on Leader and no 008 field", 2);}
+						result.add("PhysicalObject");
+						break;
 					}
 					break;
 				case 'T':

--- a/code/web/release_notes/24.07.00.MD
+++ b/code/web/release_notes/24.07.00.MD
@@ -46,6 +46,7 @@
 - Correct loading Days Since Added Facet for item items at libraries where the display status is not "On Order". (Tickets 134372, 134501, 134543, 134618) (*MDN*)
 - Check the fallback format if the only format detected with earlier rules is "Book" as well as checking fallback format if no formats are found. (Ticket 134503) (*MDN*)
 - Check for null formats when determining inclusion of records. (*MDN*) 
+- Add logic for assigning the format 'Physical Object' if position 6 of the Leader is 'R' and the record has no 008 field (Ticket 134996) (*KL*)
 
 ### Koha Updates
 - Add control over whether holidays and hours are automatically loaded from Koha for each library and location. (Tickets 130879, 132358) (*MDN*) 
@@ -92,6 +93,7 @@
 - Delete old tables in the database while initializing the database for unit test. (*MDN*)
 - Add a utility to generate a site template to aid in migrating servers. (*MDN*)
 - Update updateSitePermissions scripts to include all directories. (*MDN*)
+- Increase column length for format in user_hold table to accommodate concatenated OverDrive/Libby formats (Ticket 134832) (*KL*)
 
 ## This release includes code contributions from
 - ByWater Solutions

--- a/code/web/sys/DBMaintenance/version_updates/24.07.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/24.07.00.php
@@ -56,6 +56,14 @@ function getUpdates24_07_00(): array {
 				) ENGINE INNODB',
 			],
 		], // self_registration_form_carlx
+		'overdrive_format_length' => [
+			'title' => 'Format Length',
+			'description' => 'Increase column length for format in user_hold table to accomodate concatenated OverDrive/Libby formats',
+			'sql' => [
+				'ALTER TABLE user_hold CHANGE COLUMN format format VARCHAR(150)',
+			],
+		],//overdrive_format_length
+
 		//katherine - ByWater
 		//greenhouseMonitoring
 		'greenhouseSlackIntegration2' => [


### PR DESCRIPTION
- Add logic for assigning the format 'Physical Object' if position 6 of the Leader is 'R' and the record has no 008 field 
- Increase column length for format in user_hold table to accommodate concatenated OverDrive/Libby formats 
- Updated release notes
- Tested on my local