### PR TITLE
Allow alternate library cards to be used with cloudLibrary

### DIFF
--- a/code/web/interface/themes/responsive/CloudLibrary/add-alternate-library-card.tpl
+++ b/code/web/interface/themes/responsive/CloudLibrary/add-alternate-library-card.tpl
@@ -1,0 +1,29 @@
+{strip}
+    <form method="post" action="" id="addAlternateLibraryCardForm" class="form">
+        <input type="hidden" name="id" id="id" value="{$id}"/>
+        <input type="hidden" name="patronId" id="patronId" value="{$patronId}"/>
+        <input type="hidden" name="type" id="type" value="{$type}"/>
+        <div>
+            <div class="form-group">
+                <label for="alternateLibraryCard" class="control-label col-xs-12 col-sm-4">{translate text=$alternateLibraryCardLabel isPublicFacing=true isAdminEnteredData=true} </label>
+                <div class="col-md-6">
+                    <input type="text" name="alternateLibraryCard" id="alternateLibraryCard" value="{$user->alternateLibraryCard}" maxlength="60" class="form-control" >
+                </div>
+            </div>
+            {if !empty($showAlternateLibraryCardPassword)}
+                <br/><br/>
+                <div class="form-group">
+                    <label for="alternateLibraryCardPassword" class="control-label col-xs-12 col-sm-4">{translate text=$alternateLibraryCardPasswordLabel isPublicFacing=true isAdminEnteredData=true} </label>
+                    <div class="col-md-6">
+                        <input type="password" name="alternateLibraryCardPassword" id="alternateLibraryCardPassword" value="{$user->alternateLibraryCardPassword}"  maxlength="60" class="form-control">
+                    </div>
+                </div>
+            {/if}
+{*            <div class="form-group">*}
+{*                <div class="col-md-6 col-md-offset-3 text-center">*}
+{*                    <input type="submit" name="submit" value="{translate text="Update" isPublicFacing=true}" id="alternateLibraryCardFormSubmit" class="btn btn-primary">*}
+{*                </div>*}
+{*            </div>*}
+        </div>
+    </form>
+{/strip}

--- a/code/web/interface/themes/responsive/CloudLibrary/ajax-checkout-prompt.tpl
+++ b/code/web/interface/themes/responsive/CloudLibrary/ajax-checkout-prompt.tpl
@@ -3,13 +3,19 @@
 	<div>
 		<input type="hidden" id="id" name="id" value="{$id}">
 		<input type="hidden" id="checkoutType" name="checkoutType" value="{$checkoutType}">
+		<input type="hidden" id="useAlternateLibraryCard" name="useAlternateLibraryCard" value="{$useAlternateLibraryCard}">
 		{if count($users) > 1} {* Linked Users contains the active user as well*}
 			<div class="form-group">
 				<label class="control-label" for="patronId">{translate text="Checkout to account" isPublicFacing=true} </label>
 				<div class="controls">
 					<select name="patronId" id="patronId" class="form-control">
 						{foreach from=$users item=tmpUser}
-							<option value="{$tmpUser->id}">{$tmpUser->displayName|escape} - {$tmpUser->getHomeLibrarySystemName()|escape}</option>
+							<option
+									value="{$tmpUser->id}"
+									data-valid-card="{in_array($tmpUser, $validCards)}"
+							>
+								{$tmpUser->displayName|escape} - {$tmpUser->getHomeLibrarySystemName()|escape}
+							</option>
 						{/foreach}
 					</select>
 				</div>

--- a/code/web/interface/themes/responsive/CloudLibrary/ajax-hold-prompt.tpl
+++ b/code/web/interface/themes/responsive/CloudLibrary/ajax-hold-prompt.tpl
@@ -2,13 +2,19 @@
 <form method="post" action="" id="holdPromptsForm" class="form">
 	<div>
 		<input type="hidden" name="id" id="id" value="{$id}"/>
+		<input type="hidden" id="useAlternateLibraryCard" name="useAlternateLibraryCard" value="{$useAlternateLibraryCard}">
 		{if count($users) > 1} {* Linked Users contains the active user as well*}
 			<div id='pickupLocationOptions' class="form-group">
 				<label class='control-label' for="patronId">{translate text="Place hold for account" isPublicFacing=true} </label>
 				<div class='controls'>
 					<select name="patronId" id="patronId" class="form-control">
 						{foreach from=$users item=tmpUser}
-							<option value="{$tmpUser->id}">{$tmpUser->displayName|escape} - {$tmpUser->getHomeLibrarySystemName()|escape}</option>
+							<option
+									value="{$tmpUser->id}"
+									data-valid-card="{in_array($tmpUser, $validCards)}"
+							>
+								{$tmpUser->displayName|escape} - {$tmpUser->getHomeLibrarySystemName()|escape}
+							</option>
 						{/foreach}
 					</select>
 				</div>

--- a/code/web/interface/themes/responsive/MyAccount/libraryCard.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/libraryCard.tpl
@@ -11,6 +11,13 @@
 	{if !empty($ilsMessages)}
 		{include file='ilsMessages.tpl' messages=$ilsMessages}
 	{/if}
+	{if !empty($message)}
+		<div class="row">
+			<div class="col-xs-12">
+				<div class="alert alert-success">{translate text=$message isPublicFacing=true isMetadata=true}</div>
+			</div>
+		</div>
+	{/if}
 
 	<h1>{translate text="Library Card" isPublicFacing=true}</h1>
 	<div class="row">

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -11491,15 +11491,59 @@ AspenDiscovery.CloudLibrary = (function () {
 		processCheckoutPrompts: function () {
 			var id = $("#id").val();
 			var patronId = $("#patronId option:selected").val();
-			AspenDiscovery.closeLightbox();
-			return AspenDiscovery.CloudLibrary.doCheckOut(patronId, id);
+			var useAlternateCard = $("#useAlternateLibraryCard").val();
+			var validCard = $("#patronId option:selected").attr("data-valid-card");
+			if (useAlternateCard === 0 || validCard === "1") {
+				return AspenDiscovery.CloudLibrary.doCheckOut(patronId, id);
+			} else {
+				var url = Globals.path + "/CloudLibrary/" + id + "/AJAX?method=prepareAlternateLibraryCardPrompts&type=checkOutTitle&patronId=" + patronId;
+				var result = true;
+				$.ajax({
+					url: url,
+					cache: false,
+					success: function (data) {
+						result = data;
+						// noinspection JSUnresolvedVariable
+						AspenDiscovery.showMessageWithButtons(data.promptTitle, data.prompts, data.buttons);
+					},
+					dataType: 'json',
+					async: false,
+					error: function () {
+						alert("An error occurred processing your request.  Please try again in a few minutes.");
+						AspenDiscovery.closeLightbox();
+					}
+				});
+				return result;
+			}
 		},
 
 		processHoldPrompts: function () {
 			var id = $("#id").val();
 			var patronId = $("#patronId option:selected").val();
-			AspenDiscovery.closeLightbox();
-			return AspenDiscovery.CloudLibrary.doHold(patronId, id);
+			var useAlternateCard = $("#useAlternateLibraryCard").val();
+			var validCard = $("#patronId option:selected").attr("data-valid-card");
+			if (useAlternateCard === 0 || validCard === "1") {
+				return AspenDiscovery.CloudLibrary.doHold(patronId, id);
+			} else {
+				var url = Globals.path + "/CloudLibrary/" + id + "/AJAX?method=prepareAlternateLibraryCardPrompts&type=placeHold&patronId=" + patronId;
+				var result = true;
+				$.ajax({
+					url: url,
+					cache: false,
+					success: function (data) {
+						result = data;
+						// noinspection JSUnresolvedVariable
+						AspenDiscovery.showMessageWithButtons(data.promptTitle, data.prompts, data.buttons);
+					},
+					dataType: 'json',
+					async: false,
+					error: function () {
+						alert("An error occurred processing your request.  Please try again in a few minutes.");
+						AspenDiscovery.closeLightbox();
+					}
+				});
+				return result;
+			}
 		},
 
 		renewCheckout: function (patronId, recordId) {
@@ -11563,7 +11607,45 @@ AspenDiscovery.CloudLibrary = (function () {
 				}
 			);
 			return false;
-		}
+		},
+
+		addAlternateLibraryCard: function () {
+			var id = $("#id").val();
+			var patronId = $("#patronId").val();
+			var type = $("#type").val();
+			var url = Globals.path + "/CloudLibrary/" + id + "/AJAX?method=addAlternateLibraryCard&type=" + type;
+			var alternateLibraryCard = $("#alternateLibraryCard").val();
+			var alternateLibraryCardPassword = $("#alternateLibraryCardPassword").val();
+			$.ajax({
+				url: url,
+				cache: false,
+				type: "POST",
+				data:  JSON.stringify({
+					alternateLibraryCard: alternateLibraryCard,
+					alternateLibraryCardPassword: alternateLibraryCardPassword,
+					patronId: patronId,
+				}),
+				success: function (data) {
+					if (data.success) {
+						if (type === "checkOutTitle") {
+							AspenDiscovery.CloudLibrary.doCheckOut(patronId, id);
+						} else if (type === "placeHold") {
+							AspenDiscovery.CloudLibrary.doHold(patronId, id);
+						} else {
+							AspenDiscovery.showMessage("Card Added", data.message, false);
+						}
+					} else {
+						AspenDiscovery.showMessage("Error Adding Card", data.message, true);
+					}
+
+				},
+				dataType: 'json',
+				async: false,
+				error: function () {
+					AspenDiscovery.showMessage("Error Adding Card", "An error occurred processing your request in cloudLibrary.  Please try again in a few minutes.", false);
+				}
+			});
+		},
 	}
 }(AspenDiscovery.CloudLibrary || {}));
 AspenDiscovery.CourseReserves = (function(){

--- a/code/web/interface/themes/responsive/js/aspen/cloud-library.js
+++ b/code/web/interface/themes/responsive/js/aspen/cloud-library.js
@@ -167,15 +167,59 @@ AspenDiscovery.CloudLibrary = (function () {
 		processCheckoutPrompts: function () {
 			var id = $("#id").val();
 			var patronId = $("#patronId option:selected").val();
-			AspenDiscovery.closeLightbox();
-			return AspenDiscovery.CloudLibrary.doCheckOut(patronId, id);
+			var useAlternateCard = $("#useAlternateLibraryCard").val();
+			var validCard = $("#patronId option:selected").attr("data-valid-card");
+			if (useAlternateCard === 0 || validCard === "1") {
+				return AspenDiscovery.CloudLibrary.doCheckOut(patronId, id);
+			} else {
+				var url = Globals.path + "/CloudLibrary/" + id + "/AJAX?method=prepareAlternateLibraryCardPrompts&type=checkOutTitle&patronId=" + patronId;
+				var result = true;
+				$.ajax({
+					url: url,
+					cache: false,
+					success: function (data) {
+						result = data;
+						// noinspection JSUnresolvedVariable
+						AspenDiscovery.showMessageWithButtons(data.promptTitle, data.prompts, data.buttons);
+					},
+					dataType: 'json',
+					async: false,
+					error: function () {
+						alert("An error occurred processing your request.  Please try again in a few minutes.");
+						AspenDiscovery.closeLightbox();
+					}
+				});
+				return result;
+			}
 		},
 
 		processHoldPrompts: function () {
 			var id = $("#id").val();
 			var patronId = $("#patronId option:selected").val();
-			AspenDiscovery.closeLightbox();
-			return AspenDiscovery.CloudLibrary.doHold(patronId, id);
+			var useAlternateCard = $("#useAlternateLibraryCard").val();
+			var validCard = $("#patronId option:selected").attr("data-valid-card");
+			if (useAlternateCard === 0 || validCard === "1") {
+				return AspenDiscovery.CloudLibrary.doHold(patronId, id);
+			} else {
+				var url = Globals.path + "/CloudLibrary/" + id + "/AJAX?method=prepareAlternateLibraryCardPrompts&type=placeHold&patronId=" + patronId;
+				var result = true;
+				$.ajax({
+					url: url,
+					cache: false,
+					success: function (data) {
+						result = data;
+						// noinspection JSUnresolvedVariable
+						AspenDiscovery.showMessageWithButtons(data.promptTitle, data.prompts, data.buttons);
+					},
+					dataType: 'json',
+					async: false,
+					error: function () {
+						alert("An error occurred processing your request.  Please try again in a few minutes.");
+						AspenDiscovery.closeLightbox();
+					}
+				});
+				return result;
+			}
 		},
 
 		renewCheckout: function (patronId, recordId) {
@@ -239,6 +283,44 @@ AspenDiscovery.CloudLibrary = (function () {
 				}
 			);
 			return false;
-		}
+		},
+
+		addAlternateLibraryCard: function () {
+			var id = $("#id").val();
+			var patronId = $("#patronId").val();
+			var type = $("#type").val();
+			var url = Globals.path + "/CloudLibrary/" + id + "/AJAX?method=addAlternateLibraryCard&type=" + type;
+			var alternateLibraryCard = $("#alternateLibraryCard").val();
+			var alternateLibraryCardPassword = $("#alternateLibraryCardPassword").val();
+			$.ajax({
+				url: url,
+				cache: false,
+				type: "POST",
+				data:  JSON.stringify({
+					alternateLibraryCard: alternateLibraryCard,
+					alternateLibraryCardPassword: alternateLibraryCardPassword,
+					patronId: patronId,
+				}),
+				success: function (data) {
+					if (data.success) {
+						if (type === "checkOutTitle") {
+							AspenDiscovery.CloudLibrary.doCheckOut(patronId, id);
+						} else if (type === "placeHold") {
+							AspenDiscovery.CloudLibrary.doHold(patronId, id);
+						} else {
+							AspenDiscovery.showMessage("Card Added", data.message, false);
+						}
+					} else {
+						AspenDiscovery.showMessage("Error Adding Card", data.message, true);
+					}
+
+				},
+				dataType: 'json',
+				async: false,
+				error: function () {
+					AspenDiscovery.showMessage("Error Adding Card", "An error occurred processing your request in cloudLibrary.  Please try again in a few minutes.", false);
+				}
+			});
+		},
 	}
 }(AspenDiscovery.CloudLibrary || {}));

--- a/code/web/release_notes/24.08.00.MD
+++ b/code/web/release_notes/24.08.00.MD
@@ -30,6 +30,9 @@
 ### Other Updates
 - Fixed bug with unexpected 404 errors on Web Builder pages.  (Ticket 123122) (*KP*)
 
+### cloudLibrary Updates
+- Add the ability to use alternate library cards (such as state library cards) with cloudLibrary (Ticket 69336, 133101) (*KP*)
+
 // alexander
 
 // jacob

--- a/code/web/services/MyAccount/LibraryCard.php
+++ b/code/web/services/MyAccount/LibraryCard.php
@@ -61,6 +61,11 @@ class LibraryCard extends MyAccount {
 				$user->alternateLibraryCardPassword = $_REQUEST['alternateLibraryCardPassword'];
 			}
 			$user->update();
+			$message = translate([
+				'text' => 'Your alternate library card has been updated. ',
+				'isPublicFacing' => true,
+			]);
+			$interface->assign('message', $message);
 		}
 
 		$interface->assign('profile', $user);

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -379,6 +379,14 @@ class User extends DataObject {
 		return 'ils_barcode';
 	}
 
+	function getAlternateLibraryCardBarcode() {
+		return empty($this->alternateLibraryCard) ? '' : $this->alternateLibraryCard;
+	}
+
+	function getAlternateLibraryCardPasswordOrPin() {
+		return empty($this->alternateLibraryCardPassword) ? '' : $this->alternateLibraryCardPassword;
+	}
+
 	function saveRoles() {
 		if (isset($this->id) && isset($this->_roles) && is_array($this->_roles)) {
 			require_once ROOT_DIR . '/sys/Administration/Role.php';

--- a/code/web/sys/CloudLibrary/CloudLibrarySetting.php
+++ b/code/web/sys/CloudLibrary/CloudLibrarySetting.php
@@ -11,6 +11,7 @@ class CloudLibrarySetting extends DataObject {
 	public $accountId;
 	public $accountKey;
 	public $runFullUpdate;
+	public $useAlternateLibraryCard;
 	public $lastUpdateOfChangedRecords;
 	public $lastUpdateOfAllRecords;
 
@@ -61,6 +62,13 @@ class CloudLibrarySetting extends DataObject {
 				'type' => 'checkbox',
 				'label' => 'Run Full Update',
 				'description' => 'Whether or not a full update of all records should be done on the next pass of indexing',
+				'default' => 0,
+			],
+			'useAlternateLibraryCard' => [
+				'property' => 'useAlternateLibraryCard',
+				'type' => 'checkbox',
+				'label' => 'Use Alternate Library Card',
+				'description' => 'Whether or not to use the alternate library card (for example, a state library card), for cloudLibrary checkouts',
 				'default' => 0,
 			],
 			'lastUpdateOfChangedRecords' => [

--- a/code/web/sys/DBMaintenance/cloud_library_updates.php
+++ b/code/web/sys/DBMaintenance/cloud_library_updates.php
@@ -221,5 +221,13 @@ function getCloudLibraryUpdates() {
 				'UPDATE cloud_library_settings set runFullUpdate = 1',
 			],
 		],
+
+		'add_use_alternate_library_card_setting_for_cloud_library' => [
+			'title' => 'Add a setting to Cloud Library to use the alternate library card',
+			'description' => 'Add a setting to Cloud Library to use the alternate library card.',
+			'sql' => [
+				'ALTER table cloud_library_settings ADD column useAlternateLibraryCard TINYINT(1) DEFAULT 0',
+			],
+		],
 	];
 }


### PR DESCRIPTION
This is for Tickets 69336 and 133101 to allow Kansas State Library cards to be used for cloudLibrary.

- Added new field to Cloud Library settings to use the alternate library card for checkout (instead of the main card) and updated database with new field.
- Added success message when updating Alternate Library Card from the Your Library Card(s) page
- If Use Alternate Library Card is turned on for cloudLibrary, then Aspen will send that barcode and password to cloudLibrary for checkouts, holds, etc.  Otherwise it will continue to send the main card information.
- If a user does not have an alternate library card set up or if it's not a valid cloudLibrary account, then they will have an opportunity to add/update it during checkout.  
- If they don't have a valid account, the transaction won't go through.  They must have both a username/barcode and a password/pin in order to pass this check.
- If a user has linked accounts, then they will still be able to checkout from cloudLibrary using linked account's alternate library card, which they can also add/update during checkout.
- Updated release notes.

I tested this in Edge and Firefox.  The Kansas State Library cloudLibrary test account info is in Ticket 69336 and there are some valid Kansas library cards in ticket 69602.