### PR TITLE
24.08.00

### DIFF
--- a/code/reindexer/src/org/aspen_discovery/reindexer/SideLoadedEContentProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/SideLoadedEContentProcessor.java
@@ -234,7 +234,7 @@ class SideLoadedEContentProcessor extends MarcRecordProcessor{
 						econtentItem.setFormat("Newspaper");
 						econtentItem.setFormatCategory("eBook");
 						econtentRecord.setFormatBoost(2);
-					} else if (format.equalsIgnoreCase("GraphicNovel")) {
+					} else if (format.equalsIgnoreCase("GraphicNovel") || format.equalsIgnoreCase("Manga")) {
 						econtentItem.setFormat("eComic");
 						econtentItem.setFormatCategory("eBook");
 						econtentRecord.setFormatBoost(8);

--- a/code/web/release_notes/24.08.00.MD
+++ b/code/web/release_notes/24.08.00.MD
@@ -25,6 +25,9 @@
 // kirstien
 
 // kodi
+### Indexing Updates
+- Add check for "Manga" in addition to "GraphicNovel" to determine eComic format for side loads (Ticket 134952) (*KL*)
+- Add clearer debugging info for Libby if our authentication requests are unsuccessful (*KL*)
 
 // katherine
 ### Other Updates

--- a/code/web/release_notes/24.08.00.MD
+++ b/code/web/release_notes/24.08.00.MD
@@ -28,6 +28,7 @@
 ### Indexing Updates
 - Add check for "Manga" in addition to "GraphicNovel" to determine eComic format for side loads (Ticket 134952) (*KL*)
 - Add clearer debugging info for Libby if our authentication requests are unsuccessful (*KL*)
+- Increase series length allowed in overdrive_api_products table for Libby (*KL*)
 
 // katherine
 ### Other Updates

--- a/code/web/sys/DBMaintenance/version_updates/24.08.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/24.08.00.php
@@ -52,6 +52,13 @@ function getUpdates24_08_00(): array {
 		 ], //add_user_ils_messages
 
 		//kodi - ByWater
+		'overdrive_series_length' => [
+			'title' => 'Series Length',
+			'description' => 'Increase column length for series in overdrive_api_products table to accommodate long series names in Libby',
+			'sql' => [
+				'ALTER TABLE overdrive_api_products CHANGE COLUMN series series VARCHAR(255)',
+			],
+		],//overdrive_series_length
 
 		//katherine - ByWater
 


### PR DESCRIPTION
- Add check for "Manga" in addition to "GraphicNovel" to determine eComic format for side loads
- Increase series length allowed for Libby titles in DB from 215 to 255 to mitigate errors about data truncation
- Updated release notes