### PR TITLE
Fix for call number searches not returning expected results

### DIFF
--- a/code/web/release_notes/24.08.00.MD
+++ b/code/web/release_notes/24.08.00.MD
@@ -28,10 +28,13 @@
 
 // katherine
 ### Other Updates
-- Fixed bug with unexpected 404 errors on Web Builder pages.  (Ticket 123122) (*KP*)
+- Fix bug with unexpected 404 errors on Web Builder pages.  (Ticket 123122) (*KP*)
 
 ### cloudLibrary Updates
-- Add the ability to use alternate library cards (such as state library cards) with cloudLibrary (Ticket 69336, 133101) (*KP*)
+- Add the ability to use alternate library cards (such as state library cards) with cloudLibrary. (Ticket 69336, 133101) (*KP*)
+
+### Search Updates
+- Fix bug where call number searches were not returning expected results. (Ticket 135530) (*KP*)
 
 // alexander
 

--- a/code/web/sys/SolrConnector/Solr.php
+++ b/code/web/sys/SolrConnector/Solr.php
@@ -653,7 +653,7 @@ abstract class Solr {
 			$cleanedQuery = str_replace('“', '"', $cleanedQuery);
 			$cleanedQuery = str_replace('”', '"', $cleanedQuery);
             // Fix for date ranges
-            $cleanedQuery = preg_replace("/([0-9a-zA-Z])([-.])([0-9a-zA-Z])/", "$1 $3", $cleanedQuery);
+            $cleanedQuery = preg_replace("/([0-9a-zA-Z])([-])([0-9a-zA-Z])/", "$1 $3", $cleanedQuery);
             // Fix for ordinal numbers
             $cleanedQuery = preg_replace("/([0-9])([a-zA-Z])/", "$1 $2", $cleanedQuery);
 			$cleanedQuery = str_replace('-', '\-', $cleanedQuery);


### PR DESCRIPTION
- This was related to the fixes for special character searches - periods in the middle of words/numbers were getting stripped out and replaced with spaces.  This made the results for something like 1.0 slightly better, but broke call number searching, so it's better to just leave periods alone.
- Updated release notes.