### PR TITLE
Allow custom fields for bib-level call numbers

### DIFF
--- a/code/java_shared_libraries/src/com/turning_leaf_technologies/indexing/IndexingProfile.java
+++ b/code/java_shared_libraries/src/com/turning_leaf_technologies/indexing/IndexingProfile.java
@@ -46,6 +46,7 @@ public class IndexingProfile extends BaseIndexingSettings {
 	private char yearToDateCheckoutsSubfield;
 	private char totalCheckoutsSubfield;
 	private boolean useItemBasedCallNumbers;
+	private String bibCallNumberFields;
 	private char callNumberPrestampSubfield;
 	private char callNumberPrestamp2Subfield;
 	private char callNumberSubfield;
@@ -203,6 +204,7 @@ public class IndexingProfile extends BaseIndexingSettings {
 		this.setICode2Subfield(getCharFromRecordSet(indexingProfileRS, "iCode2"));
 
 		this.useItemBasedCallNumbers = indexingProfileRS.getBoolean("useItemBasedCallNumbers");
+		this.bibCallNumberFields = (indexingProfileRS.getString("bibCallNumberFields"));
 		this.setCallNumberPrestampSubfield(getCharFromRecordSet(indexingProfileRS,"callNumberPrestamp"));
 		callNumberPrestamp2Subfield = getCharFromRecordSet(indexingProfileRS, "callNumberPrestamp2");
 		this.setCallNumberSubfield(getCharFromRecordSet(indexingProfileRS,"callNumber"));
@@ -982,6 +984,14 @@ public class IndexingProfile extends BaseIndexingSettings {
 
 	public void setUseItemBasedCallNumbers(boolean useItemBasedCallNumbers) {
 		this.useItemBasedCallNumbers = useItemBasedCallNumbers;
+	}
+
+	public String getBibCallNumberFields() {
+		return this.bibCallNumberFields;
+	}
+
+	public void setBibCallNumberFields(String bibCallNumberFields) {
+		this.bibCallNumberFields = bibCallNumberFields;
 	}
 
 	public char getCallNumberPrestamp2Subfield() {

--- a/code/reindexer/src/org/aspen_discovery/reindexer/ArlingtonKohaRecordProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/ArlingtonKohaRecordProcessor.java
@@ -168,8 +168,5 @@ class ArlingtonKohaRecordProcessor extends KohaRecordProcessor {
 			}
 		}
 	}
-
-	protected boolean use099forBibLevelCallNumbers() {
-		return false;
-	}
+	
 }

--- a/code/reindexer/src/org/aspen_discovery/reindexer/IlsRecordProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/IlsRecordProcessor.java
@@ -1248,33 +1248,20 @@ abstract class IlsRecordProcessor extends MarcRecordProcessor {
 			}
 		}
 		if (!hasCallNumber){
+			String[] bibCallNumberFields = settings.getBibCallNumberFields().split(":");
 			StringBuilder callNumber = null;
-			if (use099forBibLevelCallNumbers()) {
-				DataField localCallNumberField = record.getDataField(99);
-				if (localCallNumberField != null) {
-					callNumber = new StringBuilder();
-					for (Subfield curSubfield : localCallNumberField.getSubfields()) {
-						callNumber.append(" ").append(curSubfield.getData().trim());
-					}
+			for (String field : bibCallNumberFields) {
+				if (Objects.equals(field, "099") && !use099forBibLevelCallNumbers()) {
+					//MDN #ARL-217 do not use 099 as a call number
+					continue;
 				}
-			}
-			//MDN #ARL-217 do not use 099 as a call number
-			if (callNumber == null) {
-				DataField deweyCallNumberField = record.getDataField(92);
-				if (deweyCallNumberField != null) {
+				DataField bibCallNumberField = record.getDataField(field);
+				if (bibCallNumberField != null) {
 					callNumber = new StringBuilder();
-					for (Subfield curSubfield : deweyCallNumberField.getSubfields()) {
+					for (Subfield curSubfield : bibCallNumberField.getSubfields()) {
 						callNumber.append(" ").append(curSubfield.getData().trim());
 					}
-				}
-			}
-			if (callNumber == null) {
-				DataField deweyCallNumberField = record.getDataField(82);
-				if (deweyCallNumberField != null) {
-					callNumber = new StringBuilder();
-					for (Subfield curSubfield : deweyCallNumberField.getSubfields()) {
-						callNumber.append(" ").append(curSubfield.getData().trim());
-					}
+					break;
 				}
 			}
 			if (callNumber != null) {

--- a/code/reindexer/src/org/aspen_discovery/reindexer/IlsRecordProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/IlsRecordProcessor.java
@@ -1251,10 +1251,6 @@ abstract class IlsRecordProcessor extends MarcRecordProcessor {
 			String[] bibCallNumberFields = settings.getBibCallNumberFields().split(":");
 			StringBuilder callNumber = null;
 			for (String field : bibCallNumberFields) {
-				if (Objects.equals(field, "099") && !use099forBibLevelCallNumbers()) {
-					//MDN #ARL-217 do not use 099 as a call number
-					continue;
-				}
 				DataField bibCallNumberField = record.getDataField(field);
 				if (bibCallNumberField != null) {
 					callNumber = new StringBuilder();
@@ -1288,10 +1284,6 @@ abstract class IlsRecordProcessor extends MarcRecordProcessor {
 			itemInfo.setCallNumber(callNumber.trim());
 			itemInfo.setSortableCallNumber(callNumber.trim());
 		}
-	}
-
-	protected boolean use099forBibLevelCallNumbers() {
-		return true;
 	}
 
 	private final HashMap<String, Boolean> iTypesThatHaveHoldabilityChecked = new HashMap<>();

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -15756,7 +15756,7 @@ AspenDiscovery.IndexingClass = (function () {
 					'propertyRowdetermineAudienceBy', 'propertyRowaudienceSubfield', 'propertyRowtreatUnknownAudienceAs',
 					'propertyRowdetermineLiteraryFormBy', 'propertyRowliteraryFormSubfield', 'propertyRowhideUnknownLiteraryForm',
 					'propertyRowhideNotCodedLiteraryForm', 'propertyRowitemSection', 'propertyRowsuppressItemlessBibs',
-					'propertyRowitemTag', 'propertyRowitemRecordNumber', 'propertyRowuseItemBasedCallNumbers',
+					'propertyRowitemTag', 'propertyRowitemRecordNumber', 'propertyRowbibCallNumberFields', 'propertyRowuseItemBasedCallNumbers',
 					'propertyRowcallNumberPrestamp', 'propertyRowcallNumberPrestamp2', 'propertyRowcallNumber', 'propertyRowcallNumberCutter', 'propertyRowcallNumberPoststamp',
 					'propertyRowlocation', 'propertyRowincludeLocationNameInDetailedLocation', 'propertyRownonHoldableLocations',
 					'propertyRowlocationsToSuppress', 'propertyRowsubLocation', 'propertyRowshelvingLocation', 'propertyRowcollection',

--- a/code/web/interface/themes/responsive/js/aspen/indexing-profile.js
+++ b/code/web/interface/themes/responsive/js/aspen/indexing-profile.js
@@ -26,7 +26,7 @@ AspenDiscovery.IndexingClass = (function () {
 					'propertyRowdetermineAudienceBy', 'propertyRowaudienceSubfield', 'propertyRowtreatUnknownAudienceAs',
 					'propertyRowdetermineLiteraryFormBy', 'propertyRowliteraryFormSubfield', 'propertyRowhideUnknownLiteraryForm',
 					'propertyRowhideNotCodedLiteraryForm', 'propertyRowitemSection', 'propertyRowsuppressItemlessBibs',
-					'propertyRowitemTag', 'propertyRowitemRecordNumber', 'propertyRowuseItemBasedCallNumbers',
+					'propertyRowitemTag', 'propertyRowitemRecordNumber', 'propertyRowbibCallNumberFields', 'propertyRowuseItemBasedCallNumbers',
 					'propertyRowcallNumberPrestamp', 'propertyRowcallNumberPrestamp2', 'propertyRowcallNumber', 'propertyRowcallNumberCutter', 'propertyRowcallNumberPoststamp',
 					'propertyRowlocation', 'propertyRowincludeLocationNameInDetailedLocation', 'propertyRownonHoldableLocations',
 					'propertyRowlocationsToSuppress', 'propertyRowsubLocation', 'propertyRowshelvingLocation', 'propertyRowcollection',

--- a/code/web/release_notes/24.08.00.MD
+++ b/code/web/release_notes/24.08.00.MD
@@ -44,6 +44,9 @@
 ### Search Updates
 - Fix bug where call number searches were not returning expected results. (Ticket 135530) (*KP*)
 
+### Indexing Updates
+- Add setting to choose which fields to use to look for bib-level call numbers. (Ticket 133082) (*KP*)
+
 // alexander
 ### Summon Updates
 - Adjust code to ensure that the filter applies correctly no matter what page of results users are on when they apply it. (*AB*)

--- a/code/web/sys/DBMaintenance/indexing_updates.php
+++ b/code/web/sys/DBMaintenance/indexing_updates.php
@@ -1049,6 +1049,14 @@ function getIndexingUpdates() {
 			],
 		],
 
+		'indexing_profile_bibCallNumberFields' => [
+			'title' => 'Indexing Profile - Bib Call Number Fields',
+			'description' => 'Add ability to set which fields to look for call numbers in the bib record',
+			'sql' => [
+				"ALTER TABLE indexing_profiles ADD COLUMN bibCallNumberFields VARCHAR(25) DEFAULT '099:092:082'",
+			],
+		],
+
 	];
 }
 

--- a/code/web/sys/DBMaintenance/indexing_updates.php
+++ b/code/web/sys/DBMaintenance/indexing_updates.php
@@ -1054,6 +1054,7 @@ function getIndexingUpdates() {
 			'description' => 'Add ability to set which fields to look for call numbers in the bib record',
 			'sql' => [
 				"ALTER TABLE indexing_profiles ADD COLUMN bibCallNumberFields VARCHAR(25) DEFAULT '099:092:082'",
+				"UPDATE indexing_profiles SET bibCallNumberFields = '092:082' WHERE indexingClass = 'ArlingtonKoha'",
 			],
 		],
 

--- a/code/web/sys/Indexing/IndexingProfile.php
+++ b/code/web/sys/Indexing/IndexingProfile.php
@@ -613,7 +613,7 @@ class IndexingProfile extends DataObject {
 					'bibCallNumberFields' => [
 						'property' => 'bibCallNumberFields',
 						'type' => 'text',
-						'label' => 'Bib based call number fields',
+						'label' => 'Bib Based Call Number Fields',
 						'maxLength' => 25,
 						'description' => 'Which bib record fields to use for call numbers in order of preference - separate fields with a colon (ex. 099:092:082)',
 						'default' => '099:092:082',

--- a/code/web/sys/Indexing/IndexingProfile.php
+++ b/code/web/sys/Indexing/IndexingProfile.php
@@ -53,6 +53,8 @@ class IndexingProfile extends DataObject {
 	public /** @noinspection PhpUnused */
 		$itemRecordNumber;
 	public /** @noinspection PhpUnused */
+		$bibCallNumberFields;
+	public /** @noinspection PhpUnused */
 		$useItemBasedCallNumbers;
 	public /** @noinspection PhpUnused */
 		$callNumberPrestamp;
@@ -606,6 +608,15 @@ class IndexingProfile extends DataObject {
 						'label' => 'Item Record Number',
 						'maxLength' => 1,
 						'description' => 'Subfield for the record number for the item',
+						'forcesReindex' => true,
+					],
+					'bibCallNumberFields' => [
+						'property' => 'bibCallNumberFields',
+						'type' => 'text',
+						'label' => 'Bib based call number fields',
+						'maxLength' => 25,
+						'description' => 'Which bib record fields to use for call numbers in order of preference - separate fields with a colon (ex. 099:092:082)',
+						'default' => '099:092:082',
 						'forcesReindex' => true,
 					],
 					'useItemBasedCallNumbers' => [


### PR DESCRIPTION
- Added setting in the Indexing Profile, 'Bib Based Call Number Field', which defaults to the standard Dewey fields (099:092:082), but can be changed to LC fields instead (090:086:050) or whatever the library uses.  These are in order of preference, so only if 099 doesn't exist, use 092, etc.
- Updated database to add new setting field.
- The ILS Record Processor now uses the fields defined in the new setting.  If "use099forBibLevelCallNumbers()"  is set to false (just Arlington), it will skip the 099 even if it's listed.
- Updated release notes.
This is for ticket #133082.