### PR TITLE
Square AJAX Error

### DIFF
--- a/code/web/release_notes/24.08.00.MD
+++ b/code/web/release_notes/24.08.00.MD
@@ -37,6 +37,7 @@
 
 ### eCommerce Updates
 - Fix issues with Stripe and Square donations where the card info box does not appear when user is not logged in (*KL*)
+- Fix issue with Square donations resulting in AJAX errors (Ticket 135756) (*MDN*, *KL*)
 
 // katherine
 ### Other Updates

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -4084,7 +4084,10 @@ class MyAccount_AJAX extends JSON_Action {
 			$currencyCode = $systemVariables->currencyCode;
 		}
 
-		$donateToLocation = $_REQUEST['toLocation'];
+		$donateToLocation = false;
+		if (!empty($_REQUEST['toLocation'])) {
+			$donateToLocation = $_REQUEST['toLocation'];
+		}
 		$toLocation = -1;
 		if($donateToLocation) {
 			require_once ROOT_DIR . '/sys/LibraryLocation/Location.php';
@@ -4220,7 +4223,11 @@ class MyAccount_AJAX extends JSON_Action {
 		$payment->paidFromInstance = $library->subdomain;
 
 		if (isset($_REQUEST['token'])) {
-			$payment->aciToken = $_REQUEST['token'];
+			if ($paymentType == 'square'){
+				$payment->squareToken = $_REQUEST['token'];
+			} else {
+				$payment->aciToken = $_REQUEST['token'];
+			}
 		}
 
 		$paymentInsert = $payment->insert();


### PR DESCRIPTION
- Add !empty check for 'toLocation' for donations
- Correctly assign Square Token values in 'squareToken'  column instead of 'aciToken' in user_payments table 
- Updated release notes