### PR TITLE
Fix search by grouped work ID and ISSN

### DIFF
--- a/code/web/release_notes/24.08.00.MD
+++ b/code/web/release_notes/24.08.00.MD
@@ -65,6 +65,7 @@
 
 ### Search Updates
 - Fix bug where call number searches were not returning expected results. (Ticket 135530) (*KP*)
+- Fix searching by grouped work ID and by ISSN (Ticket 135616) (*KP*)
 
 ### Indexing Updates
 - Add setting to choose which fields to use to look for bib-level call numbers. (Ticket 133082) (*KP*)

--- a/code/web/sys/SolrConnector/Solr.php
+++ b/code/web/sys/SolrConnector/Solr.php
@@ -644,7 +644,7 @@ abstract class Solr {
 	 * @access    private
 	 * @param string $lookfor The string to search for in the field
 	 * @param array $custom Custom munge settings from YAML search specs
-	 * @param bool $basic Is $lookfor a basic (true) or advanced (false) query?(ISN:2166-3262)
+	 * @param bool $basic Is $lookfor a basic (true) or advanced (false) query?
 	 * @return    array                             Array for use as _applySearchSpecs() values param
 	 */
 	private function _buildMungeValues($lookfor, $custom = null, $basic = true) {

--- a/code/web/sys/SolrConnector/Solr.php
+++ b/code/web/sys/SolrConnector/Solr.php
@@ -579,7 +579,7 @@ abstract class Solr {
 							continue;
 						}
 					} elseif ($field == 'issn') {
-						if (!preg_match('/^"?[\dXx-]+"?$/', $fieldValue)) {
+						if (!preg_match('/^"?[\d\hXx-]+"?$/', $fieldValue)) {
 							continue;
 						}
 					} elseif ($field == 'upc') {
@@ -644,23 +644,30 @@ abstract class Solr {
 	 * @access    private
 	 * @param string $lookfor The string to search for in the field
 	 * @param array $custom Custom munge settings from YAML search specs
-	 * @param bool $basic Is $lookfor a basic (true) or advanced (false) query?
+	 * @param bool $basic Is $lookfor a basic (true) or advanced (false) query?(ISN:2166-3262)
 	 * @return    array                             Array for use as _applySearchSpecs() values param
 	 */
 	private function _buildMungeValues($lookfor, $custom = null, $basic = true) {
+		$grouped_word_id_pattern_1 = '/^"?(\d+|.[boi]\d+x?|[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12})(-\w{3})?"?$/i';
+		$grouped_word_id_pattern_2 = '/^"?(\d+|.?[boi]\d+x?|[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}|MWT\d+|CARL\d+)"?$/i';
 		if ($basic) {
-			$cleanedQuery = str_replace(':', ' ', $lookfor);
-			$cleanedQuery = str_replace('“', '"', $cleanedQuery);
-			$cleanedQuery = str_replace('”', '"', $cleanedQuery);
-            // Fix for date ranges
-            $cleanedQuery = preg_replace("/([0-9a-zA-Z])([-])([0-9a-zA-Z])/", "$1 $3", $cleanedQuery);
-            // Fix for ordinal numbers
-            $cleanedQuery = preg_replace("/([0-9])([a-zA-Z])/", "$1 $2", $cleanedQuery);
-			$cleanedQuery = str_replace('-', '\-', $cleanedQuery);
-			$cleanedQuery = str_replace('–', '\-\-', $cleanedQuery);
-            $cleanedQuery = str_replace('+', '\+', $cleanedQuery);
-            $cleanedQuery = str_replace('?', '\?', $cleanedQuery);
-			$cleanedQuery = str_replace('/', '\/', $cleanedQuery);
+			// Don't strip characters out/escape them if it's a grouped work ID
+			if (!preg_match($grouped_word_id_pattern_1, $lookfor) && !preg_match($grouped_word_id_pattern_2, $lookfor)) {
+				$cleanedQuery = str_replace(':', ' ', $lookfor);
+				$cleanedQuery = str_replace('“', '"', $cleanedQuery);
+				$cleanedQuery = str_replace('”', '"', $cleanedQuery);
+				// Fix for date ranges
+				$cleanedQuery = preg_replace("/([0-9a-zA-Z])([-])([0-9a-zA-Z])/", "$1 $3", $cleanedQuery);
+				// Fix for ordinal numbers
+				$cleanedQuery = preg_replace("/([0-9])(st|nd|rd|th)/", "$1 $2", $cleanedQuery);
+				$cleanedQuery = str_replace('-', '\-', $cleanedQuery);
+				$cleanedQuery = str_replace('–', '\-\-', $cleanedQuery);
+				$cleanedQuery = str_replace('+', '\+', $cleanedQuery);
+				$cleanedQuery = str_replace('?', '\?', $cleanedQuery);
+				$cleanedQuery = str_replace('/', '\/', $cleanedQuery);
+			} else {
+				$cleanedQuery = $lookfor;
+			}
 			require_once ROOT_DIR . '/sys/Utils/StringUtils.php';
 			$noTrailingPunctuation = StringUtils::removeTrailingPunctuation($cleanedQuery);
 

--- a/sites/default/conf/groupedWorksSearchSpecs2.yaml
+++ b/sites/default/conf/groupedWorksSearchSpecs2.yaml
@@ -141,12 +141,15 @@ ISN:
   QueryFields:
     - issn:
       - [and, 100]
+      - [onephrase, 100]
       - [or, ~]
     - isbn:
       - [and, 100]
+      - [onephrase, 100]
       - [or, ~]
     - upc:
       - [and, 100]
+      - [onephrase, 100]
       - [or, ~]
 
 Subject:


### PR DESCRIPTION
Changes made to improve searches with special characters broke searching by grouped work ID and by ISSN (Ticket 135616).
- If the search query looks like a grouped work ID, skip all special character processing.
- ISSNs are indistinguishable from year ranges (such as '1939-1945') so we can't just skip them since hyphens in year ranges cause lots of subject and author searches to fail.  So instead, allow ISSNs to have a space in place of the hyphen.
- Updated release notes.