### PR TITLE
Sort volume numbers correctly

### DIFF
--- a/code/web/Drivers/CloudLibraryDriver.php
+++ b/code/web/Drivers/CloudLibraryDriver.php
@@ -943,6 +943,9 @@ class CloudLibraryDriver extends AbstractEContentDriver {
 		$postParams = [
 			'username' => $this->getPatronId($patron),
 			'password' => $this->getCloudLibraryPasswordOrPin($patron),
+			'eula' => 'eula',
+			'login_form' => 'true',
+			'library_id' => $settings->accountId,
 		];
 		$curlWrapper = new CurlWrapper();
 		$headers = [

--- a/code/web/release_notes/24.08.00.MD
+++ b/code/web/release_notes/24.08.00.MD
@@ -66,6 +66,7 @@
 
 ### cloudLibrary Updates
 - Add the ability to use alternate library cards (such as state library cards) with cloudLibrary. (Ticket 69336, 133101) (*KP*)
+- Fix automatic login for Open in cloudLibrary button. (*KP*)
 
 ### Search Updates
 - Fix bug where call number searches were not returning expected results. (Ticket 135530) (*KP*)

--- a/code/web/release_notes/24.08.00.MD
+++ b/code/web/release_notes/24.08.00.MD
@@ -62,6 +62,7 @@
 // katherine
 ### Other Updates
 - Fix bug with unexpected 404 errors on Web Builder pages.  (Ticket 123122) (*KP*)
+- Sort volume numbers correctly. (Ticket 133280) (*KP*)
 
 ### cloudLibrary Updates
 - Add the ability to use alternate library cards (such as state library cards) with cloudLibrary. (Ticket 69336, 133101) (*KP*)

--- a/code/web/sys/Grouping/Manifestation.php
+++ b/code/web/sys/Grouping/Manifestation.php
@@ -326,7 +326,7 @@ class Grouping_Manifestation {
 			foreach ($this->_variations as $variation) {
 				$itemSummary = mergeItemSummary($itemSummary, $variation->getItemSummary());
 			}
-			ksort($itemSummary);
+			ksort($itemSummary, SORT_NATURAL);
 			$this->_itemSummary = $itemSummary;
 			$timer->logTime("Got item summary for manifestation");
 		}
@@ -345,7 +345,7 @@ class Grouping_Manifestation {
 					$itemsDisplayedByDefault = mergeItemSummary($itemsDisplayedByDefault, $variation->getItemsDisplayedByDefault());
 				}
 			}
-			ksort($itemsDisplayedByDefault);
+			ksort($itemsDisplayedByDefault, SORT_NATURAL);
 			$this->_itemsDisplayedByDefault = $itemsDisplayedByDefault;
 		}
 		return $this->_itemsDisplayedByDefault;

--- a/code/web/sys/Grouping/Record.php
+++ b/code/web/sys/Grouping/Record.php
@@ -470,7 +470,7 @@ class Grouping_Record {
 	}
 
 	public function sortItemSummary($variationId): void {
-		ksort($this->_itemSummary[$variationId]);
+		ksort($this->_itemSummary[$variationId], SORT_NATURAL);
 	}
 
 	/**
@@ -534,7 +534,7 @@ class Grouping_Record {
 	}
 
 	public function sortItemDetails($variationId): void {
-		ksort($this->_itemDetails[$variationId]);
+		ksort($this->_itemDetails[$variationId], SORT_NATURAL);
 	}
 
 	/**


### PR DESCRIPTION
- Changed sorting to natural sort so that volumes would sort Vol 1, Vol 2, Vol 10, Vol 11 instead of Vol 1, Vol 10, Vol 11, Vol 2.
- Updated release notes.