### PR TITLE
Missing translations for shelf location facets

### DIFF
--- a/code/reindexer/src/org/aspen_discovery/reindexer/IlsRecordProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/IlsRecordProcessor.java
@@ -461,7 +461,7 @@ abstract class IlsRecordProcessor extends MarcRecordProcessor {
 				//Create virtual items with one for each location code
 				ItemInfo virtualItem = new ItemInfo();
 				virtualItem.setLocationCode(locationCode.trim());
-				virtualItem.setShelfLocation(locationCode.trim());
+				virtualItem.setShelfLocation(translateValue("shelf_location", locationCode.trim(), recordInfo.getRecordIdentifier(), true));
 				virtualItem.setIsVirtualHoldingsRecord(true);
 				recordInfo.addItem(virtualItem);
 			}

--- a/code/web/release_notes/24.08.00.MD
+++ b/code/web/release_notes/24.08.00.MD
@@ -87,6 +87,7 @@
 
 ### Indexing Updates
 - Add setting to choose which fields to use to look for bib-level call numbers. (Ticket 133082) (*KP*)
+- Fix inconsistent shelf-location facet translation for records with an 852 and 866. (Ticket 133350) (*KP*)
 
 // alexander
 ### Summon Updates


### PR DESCRIPTION
- Added missing translation for shelf location facets that were coming from records with both an 852 and an 866 (Ticket 133350).
- Updated release notes.