### PR TITLE
feat: summon usage graphs

### DIFF
--- a/code/web/interface/themes/responsive/Summon/summonDashboard.tpl
+++ b/code/web/interface/themes/responsive/Summon/summonDashboard.tpl
@@ -6,7 +6,7 @@
 			<div class="dashboardCategory col-sm-6">
 				<div class="row">
 					<div class="col-sm-10 col-sm-offset-1">
-						<h2 class="dashboardCategoryLabel">{translate text="Active Users" isAdminFacing=true}</h2>
+						<h2 class="dashboardCategoryLabel">{translate text="Active Users" isAdminFacing=true} <a href="/Summon/UsageGraphs?stat=activeUsers&instance={$selectedInstance}" title="{translate text="Show Active Users Graph" inAttribute="true" isAdminFacing=true}"><i class="fas fa-chart-line"></i></a></h2>
 					</div>
 				</div>
 				<div class="row">
@@ -32,7 +32,7 @@
 			<div class="dashboardCategory col-sm-6">
 				<div class="row">
 					<div class="col-sm-10 col-sm-offset-1">
-						<h2 class="dashboardCategoryLabel">{translate text="Number of Records Viewed" isAdminFacing=true}</h2>
+						<h2 class="dashboardCategoryLabel">{translate text="Number of Records Viewed" isAdminFacing=true} <a href="/Summon/UsageGraphs?stat=numRecordsViewed&instance={$selectedInstance}" title="{translate text="Show Number of Records Viewed Graph" inAttribute="true" isAdminFacing=true}"><i class="fas fa-chart-line"></i></a></h2>	
 					</div>
 				</div>
 				<div class="row">
@@ -58,7 +58,7 @@
 			<div class="dashboardCategory col-sm-6">
 				<div class="row">
 					<div class="col-sm-10 col-sm-offset-1">
-						<h2 class="dashboardCategoryLabel">{translate text="Number of Records Clicked" isAdminFacing=true}</h2>
+						<h2 class="dashboardCategoryLabel">{translate text="Number of Records Clicked" isAdminFacing=true} <a href="/Summon/UsageGraphs?stat=numRecordsClicked&instance={$selectedInstance}" title="{translate text="Show Number of Records Clicked Graph" inAttribute="true" isAdminFacing=true}"><i class="fas fa-chart-line"></i></a></h2>	
 					</div>
 				</div>
 				<div class="row">
@@ -84,7 +84,7 @@
 			<div class="dashboardCategory col-sm-6">
 				<div class="row">
 					<div class="col-sm-10 col-sm-offset-1">
-						<h2 class="dashboardCategoryLabel">{translate text="Total Clicks" isAdminFacing=true}</h2>
+						<h2 class="dashboardCategoryLabel">{translate text="Total Clicks" isAdminFacing=true} <a href="/Summon/UsageGraphs?stat=totalClicks&instance={$selectedInstance}" title="{translate text="Show Total Clicks Graph" inAttribute="true" isAdminFacing=true}"><i class="fas fa-chart-line"></i></a></h2>	
 					</div>
 				</div>
 				<div class="row">

--- a/code/web/interface/themes/responsive/Summon/usage-graph.tpl
+++ b/code/web/interface/themes/responsive/Summon/usage-graph.tpl
@@ -1,0 +1,85 @@
+{strip}
+	<div id="main-content" class="col-sm-12">
+		<h1>{translate text=$graphTitle isAdminFacing=true}</h1>
+		<div class="chart-container" style="position: relative; height:50%; width:100%">
+			<canvas id="chart"></canvas>
+		</div>
+
+		<h2>{translate text="Raw Data" isAdminFacing=true}</h2>
+		<div class="adminTableRegion fixed-height-table">
+			<table class="adminTable table table-responsive table-striped table-bordered table-condensed smallText table-sticky">
+				<thead>
+					<tr>
+						<th>{translate text="Date" isAdminFacing=true}</th>
+						{foreach from=$dataSeries key=seriesLabel item=seriesData}
+							<th>{if !empty($translateDataSeries)}{translate text=$seriesLabel isAdminFacing=true}{else}{$seriesLabel}{/if}</th>
+						{/foreach}
+					</tr>
+				</thead>
+				<tbody>
+					{foreach from=$columnLabels item=label}
+						<tr>
+							<td>{if !empty($translateColumnLabels)}{translate text=$label isAdminFacing=true}{else}{$label}{/if}</td>
+							{foreach from=$dataSeries item=seriesData}
+								<td>{if (empty($seriesData.data.$label))}0{else}{$seriesData.data.$label|number_format}{/if}</td>
+							{/foreach}
+						</tr>
+					{/foreach}
+				</tbody>
+			</table>
+		</div>
+	</div>
+{/strip}
+{literal}
+<script>
+var ctx = document.getElementById('chart');
+var myChart = new Chart(ctx, {
+	type: 'line',
+	data: {
+		labels: [
+			{/literal}
+			{foreach from=$columnLabels item=columnLabel}
+				'{$columnLabel}',
+			{/foreach}
+			{literal}
+		],
+		datasets: [
+			{/literal}
+			{foreach from=$dataSeries key=seriesLabel item=seriesData}
+				{ldelim}
+				label: "{translate text=$seriesLabel isAdminFacing=true}",
+				data: [
+					{foreach from=$seriesData.data item=curValue}
+						{$curValue},
+					{/foreach}
+				],
+				borderWidth: 1,
+				borderColor: '{$seriesData.borderColor}',
+				backgroundColor: '{$seriesData.backgroundColor}',
+				{rdelim},
+			{/foreach}
+			{literal}
+		]
+	},
+	options: {
+		scales: {
+			yAxes: [{
+				ticks: {
+					beginAtZero: true
+				}
+			}],
+			xAxes: [{
+				type: 'category',
+				labels: [
+					{/literal}
+					{foreach from=$columnLabels item=columnLabel}
+						'{$columnLabel}',
+					{/foreach}
+					{literal}
+				]
+			}]
+		}
+	}
+});
+</script>
+{/literal}

--- a/code/web/release_notes/24.08.00.MD
+++ b/code/web/release_notes/24.08.00.MD
@@ -135,7 +135,8 @@ To generate the passkey file, the following command should be run (as root):
 
 // chloe
 ### Other Updates
-- Add usage graphs and raw data tables for ILS Integration. These can be accessed through the ILS Integration Dashboard
+- Add usage graphs and raw data tables for ILS Integration. These can be accessed through the ILS Integration Dashboard (*CZ*)
+- Add usage graphs and raw data tables for Summons. These can be accessed through the Summon Dashboard (*CZ*)
 
 ## This release includes code contributions from
 - ByWater Solutions

--- a/code/web/services/Summon/UsageGraphs.php
+++ b/code/web/services/Summon/UsageGraphs.php
@@ -1,0 +1,156 @@
+<?php
+
+require_once ROOT_DIR . '/services/Admin/Admin.php';
+require_once ROOT_DIR . '/sys/SystemLogging/AspenUsage.php';
+require_once ROOT_DIR . '/sys/Summon/UserSummonUsage.php';
+require_once ROOT_DIR . '/sys/Summon/SummonRecordUsage.php';
+
+class Summon_UsageGraphs extends Admin_Admin {
+
+	function launch() {
+		global $interface;
+
+		$title = 'Summon Usage Graph';
+		$stat = $_REQUEST['stat'];
+		if (!empty($_REQUEST['instance'])) {
+			$instanceName = $_REQUEST['instance'];
+		} else {
+			$instanceName = '';
+		}
+		
+		$dataSeries = [];
+		$columnLabels = [];
+
+		switch ($stat) {
+			case 'activeUsers':
+				$title .= ' - Active Users';
+			break;
+			case 'numRecordsViewed':
+				$title .= ' - Number of Records Viewed';
+			break;
+			case 'numRecordsClicked':
+				$title .= ' - Number of Records Clicked';
+			break;
+			case 'totalClicks':
+				$title .= ' - Total Clicks';
+			break;
+		}
+
+		// gets data from from user_summon_usage
+		if ($stat == 'activeUsers') {
+			$userSummonUsage = new UserSummonUsage();
+			$userSummonUsage->groupBy('year, month');
+			if (!empty($instanceName)) {
+				$userSummonUsage->instance = $instanceName;
+			}
+			$userSummonUsage->selectAdd();
+			$userSummonUsage->selectAdd('year');
+			$userSummonUsage->selectAdd('month');
+			$userSummonUsage->orderBy('year, month');
+
+			$dataSeries['Active Users'] = [
+				'borderColor' => 'rgba(255, 99, 132, 1)',
+				'backgroundColor' => 'rgba(255, 99, 132, 0.2)',
+				'data' => [],
+			];
+			$userSummonUsage->selectAdd('COUNT(DISTINCT userId) as activeUsers');
+
+			// Collects results
+			$userSummonUsage->find();
+			while($userSummonUsage->fetch()) {
+				$curPeriod = "{$userSummonUsage->month}-{$userSummonUsage->year}";
+				$columnLabels[] = $curPeriod;
+				/** @noinspection PhpUndefinedFieldInspection */
+				$dataSeries['Active Users']['data'][$curPeriod] = $userSummonUsage->activeUsers;
+			}
+		}
+			
+		// gets data from from summon_usage
+		if (
+			$stat == 'numRecordsViewed' ||
+			$stat == 'numRecordsClicked' ||
+			$stat == 'totalClicks'
+		){
+			$summonRecordUsage = new SummonRecordUsage();
+			$summonRecordUsage->groupBy('year, month');
+			if (!empty($instanceName)) {
+				$summonRecordUsage->instance = $instanceName;
+			}
+			$summonRecordUsage->selectAdd();
+			$summonRecordUsage->selectAdd('year');
+			$summonRecordUsage->selectAdd('month');
+			$summonRecordUsage->orderBy('year, month');
+		
+			if ($stat == 'numRecordsViewed') {
+				$dataSeries['Number of Records Viewed'] = [
+					'borderColor' => 'rgba(255, 99, 132, 1)',
+					'backgroundColor' => 'rgba(255, 99, 132, 0.2)',
+					'data' => [],
+				];
+				$summonRecordUsage ->selectAdd('SUM(IF(timesViewedInSearch>0,1,0)) as numRecordsViewed');
+			}
+			if ($stat == 'numRecordsClicked') {
+				$dataSeries['Number of Records Clicked'] = [
+					'borderColor' => 'rgba(255, 99, 132, 1)',
+					'backgroundColor' => 'rgba(255, 99, 132, 0.2)',
+					'data' => [],
+				];
+				$summonRecordUsage ->selectAdd('SUM(IF(timesUsed>0,1,0)) as numRecordsUsed');
+			}
+			if ($stat == 'totalClicks') {
+				$dataSeries['Total Clicks'] = [
+					'borderColor' => 'rgba(255, 99, 132, 1)',
+					'backgroundColor' => 'rgba(255, 99, 132, 0.2)',
+					'data' => [],
+				];
+				$summonRecordUsage ->selectAdd('SUM(timesUsed) as numClicks');
+			}
+			// Collect results
+			$summonRecordUsage->find();
+			while ($summonRecordUsage->fetch()) {
+				$curPeriod = "{$summonRecordUsage->month}-{$summonRecordUsage->year}";
+				$columnLabels[] = $curPeriod;
+				if ($stat == 'numRecordsViewed') {
+					/** @noinspection PhpUndefinedFieldInspection */
+					$dataSeries['Number of Records Viewed']['data'][$curPeriod] = $summonRecordUsage->numRecordsViewed;
+				}
+				if ($stat == 'numRecordsClicked') {
+					/** @noinspection PhpUndefinedFieldInspection */
+					$dataSeries['Number of Records Clicked']['data'][$curPeriod] = $summonRecordUsage->numRecordsUsed;
+				}
+				if ($stat == 'totalClicks') {
+					/** @noinspection PhpUndefinedFieldInspection */
+					$dataSeries['Total Clicks']['data'][$curPeriod] = $summonRecordUsage->numClicks;
+				}	
+			}
+		}	
+
+		$interface->assign('columnLabels', $columnLabels);
+		$interface->assign('dataSeries', $dataSeries);
+		$interface->assign('translateDataSeries', true);	
+		$interface->assign('translateColumnLabels', false);
+
+		$interface->assign('graphTitle', $title);
+		$this->display('usage-graph.tpl', $title);
+	}
+
+	function getActiveAdminSection(): string {
+		return 'summon';
+	}
+
+	function canView(): bool {
+		return UserAccount::userHasPermission([
+			'View Dashboards',
+			'View System Reports',
+		]);
+	}
+
+	function getBreadcrumbs(): array {
+		$breadcrumbs = [];
+		$breadcrumbs[] = new Breadcrumb('/Admin/Home', 'Administration Home');
+		$breadcrumbs[] = new Breadcrumb('/Admin/Home#summon', 'Summon');
+		$breadcrumbs[] = new Breadcrumb('/Summon/SummonDashboard', 'Summon Usage Dashboard');
+		$breadcrumbs[] = new Breadcrumb('', 'Usage Graph');
+		return $breadcrumbs;
+	}
+}


### PR DESCRIPTION
**Description**

An Aspen admin can now view a usage graph and a raw data table for each of the variables included in the Summon Dashboard. This feature used to be limited to the System Reports dashboard, is being added to the ILS Integration https://github.com/PTFS-Europe/aspen-discovery/pull/91, and it is now being extended further.

Note: as with ILS Integration, the implementation for Summons is based on the the System Reports existing usage graphs, and intends to mirror it where possible

Features:

The dashboard now includes links next to the title of each of its sections
Those links lead to the relevant Usage Graph page
The Usage Graph page contains both a graph and a raw data table
While the user is on a given Summon Usage Graph page, the Summon section on the left hand-side options menu remains open (active)

**Test plan:**

- apply the patch
- log in as an admin
- navigate to Administration Settings > Modules > Summon, and tick the 'enable' checkbox before saving (this will allow the 'Summon' section to display on the Administration left hand-side navigation bar)
- ensure that the user_summon_usage and summon_usage table contain some data: if not, insert mock data in both tables
- navigate to Administration Settings > Summon > Dashboard
- click on the link displayed next to a section's header (title) and access the relevant Usage Graph page
- notice that the data displayed matches the summary found on the dashboard
