### PR TITLE
Add improvements to docker deploy

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -12,8 +12,7 @@ the directory pointed by `$ASPEN_DATA_DIR`. You will need to adjust it for a pro
 deployment.
 
 ```
-ASPEN_INSTANCE=aspen
-echo "export ASPEN_INSTANCE" >> ~/.bashrc
+echo "export ASPEN_INSTANCE=aspen" >> ~/.bashrc
 echo "export ASPEN_DATA_DIR=~/aspen-repos/${ASPEN_INSTANCE}" >> ~/.bashrc
 source ~/.bashrc
 ```
@@ -21,7 +20,6 @@ source ~/.bashrc
 
 ```
 mkdir -p ${ASPEN_DATA_DIR}/database \
-         ${ASPEN_DATA_DIR}/solr \
          ${ASPEN_DATA_DIR}/conf \
          ${ASPEN_DATA_DIR}/data \
          ${ASPEN_DATA_DIR}/logs
@@ -30,8 +28,8 @@ mkdir -p ${ASPEN_DATA_DIR}/database \
 ### 3.0) Copy docker-compose.yml and .env
 
 ```
-curl -O ${ASPEN_DATA_DIR}/docker-compose.yml https://raw.githubusercontent.com/Aspen-Discovery/aspen-discovery/24.07.00/docker/docker-compose.yml
-curl -O ${ASPEN_DATA_DIR}/.env https://raw.githubusercontent.com/Aspen-Discovery/aspen-discovery/24.07.00/docker/env/default.env
+curl -O ${ASPEN_DATA_DIR}/docker-compose.yml https://raw.githubusercontent.com/Aspen-Discovery/aspen-discovery/24.08.00/docker/docker-compose.yml
+curl -O ${ASPEN_DATA_DIR}/.env https://raw.githubusercontent.com/Aspen-Discovery/aspen-discovery/24.08.00/docker/env/default.env
 ```
  
 ### 4) Create and start containers

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,9 +1,13 @@
 networks:
   net-aspen:
+volumes:
+  solr:
 services:
 
   backend:
-    image: ${BACKEND_IMAGE_TAG:-aspendiscoveryofficial/aspen}
+    image: ${BACKEND_IMAGE_TAG:-aspendiscovery/aspen}
+    env_file:
+      - .env
     environment:
       - ASPEN_BACKEND=yes
     ports:
@@ -19,7 +23,9 @@ services:
       - db
 
   cron:
-    image: ${BACKEND_IMAGE_TAG:-aspendiscoveryofficial/aspen}
+    image: ${BACKEND_IMAGE_TAG:-aspendiscovery/aspen}
+    env_file:
+      - .env
     environment:
       - ASPEN_CRON=yes
     networks:
@@ -37,6 +43,8 @@ services:
   db:
     image: ${MARIADB_IMAGE:-mariadb:10.5}
     restart: always
+    env_file:
+      - .env
     environment:
       - MARIADB_ROOT_PASSWORD=${DATABASE_ROOT_PASSWORD:-password}
       - MARIADB_USER=${DATABASE_USER:-user123}
@@ -46,15 +54,28 @@ services:
       - ${ASPEN_DATA_DIR}/database:/var/lib/mysql
     networks:
       - net-aspen
+    healthcheck:
+      interval: 60s
+      retries: 10
+      test:
+        [
+          "CMD",
+          "healthcheck.sh",
+          "--su-mysql",
+          "--connect",
+          "--innodb_initialized"
+        ]
 
   solr:
-    image: ${SOLR_IMAGE_TAG:-aspendiscoveryofficial/solr}
+    image: ${SOLR_IMAGE_TAG:-aspendiscovery/solr}
+    env_file:
+      - .env
     environment:
-      - SOLR_PORT=${SOLR_PORT}
+      - SOLR_PORT=${SOLR_PORT:-8983}
     ports:
-      - "${SOLR_PORT}:${SOLR_PORT}"
+      - "${SOLR_PORT}:${SOLR_PORT:-8983}"
     volumes:
-      - ${ASPEN_DATA_DIR}/solr:/var/solr
+      - solr:/var/solr
     networks:
       - net-aspen
     depends_on:

--- a/docker/files/scripts/start.sh
+++ b/docker/files/scripts/start.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Wait for 'db' service responses
-while ! nc -z "$DATABASE_HOST" "$DATABASE_PORT"; do sleep 3; done
+while ! nc -z "$DATABASE_HOST" "$DATABASE_PORT"; do sleep 1; done
 
 export CONFIG_DIRECTORY="/usr/local/aspen-discovery/sites/$SITE_NAME"
 

--- a/docker/files/tunnel/docker-compose.tunnel.yml
+++ b/docker/files/tunnel/docker-compose.tunnel.yml
@@ -1,5 +1,5 @@
 tunnel:
-  image: ${TUNNEL_IMAGE_TAG:-aspendiscoveryofficial/tunnel}
+  image: ${TUNNEL_IMAGE_TAG:-aspendiscovery/tunnel}
   env_file:
     - .env
   networks:


### PR DESCRIPTION
- Fix image's default name used in the stack (docker-compose.yml)
- Add a new label which indicates .env file path
- Add a health check for database's service
- Add a fallback value for the port used for Solr (default : 8983)
- Use a docker volume instead a mount directory to store Solr configurations
- Update README based on new changes