### PR TITLE
Alternate Library Card/cloudLibrary form updates

### DIFF
--- a/code/web/interface/themes/responsive/CloudLibrary/add-alternate-library-card.tpl
+++ b/code/web/interface/themes/responsive/CloudLibrary/add-alternate-library-card.tpl
@@ -14,7 +14,7 @@
                     {if !empty($alternateLibraryCardLabel)}
                         {translate text=$alternateLibraryCardLabel isPublicFacing=true isAdminEnteredData=true}
                     {else}
-                        Alternate Library Card
+                        {translate text="Alternate Library Card" isPublicFacing=true isAdminEnteredData=false}
                     {/if}
                 </label>
                 <div class="col-md-6">
@@ -27,7 +27,7 @@
                         {if !empty($alternateLibraryCardPasswordLabel)}
                             {translate text=$alternateLibraryCardPasswordLabel isPublicFacing=true isAdminEnteredData=true}
                         {else}
-                            Password/PIN
+                            {translate text="Password/PIN" isPublicFacing=true isAdminEnteredData=false}
                         {/if}
                     </label>
                     <div class="col-md-6">

--- a/code/web/interface/themes/responsive/CloudLibrary/add-alternate-library-card.tpl
+++ b/code/web/interface/themes/responsive/CloudLibrary/add-alternate-library-card.tpl
@@ -4,26 +4,37 @@
         <input type="hidden" name="patronId" id="patronId" value="{$patronId}"/>
         <input type="hidden" name="type" id="type" value="{$type}"/>
         <div>
-            <div class="form-group">
-                <label for="alternateLibraryCard" class="control-label col-xs-12 col-sm-4">{translate text=$alternateLibraryCardLabel isPublicFacing=true isAdminEnteredData=true} </label>
+            {if !empty($alternateLibraryCardFormMessage)}
+                <div class="row">
+                    <div class="col-xs-12">{$alternateLibraryCardFormMessage}</div>
+                </div>
+            {/if}
+            <div class="form-group row">
+                <label for="alternateLibraryCard" class="control-label col-xs-12 col-sm-4">
+                    {if !empty($alternateLibraryCardLabel)}
+                        {translate text=$alternateLibraryCardLabel isPublicFacing=true isAdminEnteredData=true}
+                    {else}
+                        Alternate Library Card
+                    {/if}
+                </label>
                 <div class="col-md-6">
                     <input type="text" name="alternateLibraryCard" id="alternateLibraryCard" value="{$user->alternateLibraryCard}" maxlength="60" class="form-control" >
                 </div>
             </div>
             {if !empty($showAlternateLibraryCardPassword)}
-                <br/><br/>
-                <div class="form-group">
-                    <label for="alternateLibraryCardPassword" class="control-label col-xs-12 col-sm-4">{translate text=$alternateLibraryCardPasswordLabel isPublicFacing=true isAdminEnteredData=true} </label>
+                <div class="form-group row">
+                    <label for="alternateLibraryCardPassword" class="control-label col-xs-12 col-sm-4">
+                        {if !empty($alternateLibraryCardPasswordLabel)}
+                            {translate text=$alternateLibraryCardPasswordLabel isPublicFacing=true isAdminEnteredData=true}
+                        {else}
+                            Password/PIN
+                        {/if}
+                    </label>
                     <div class="col-md-6">
                         <input type="password" name="alternateLibraryCardPassword" id="alternateLibraryCardPassword" value="{$user->alternateLibraryCardPassword}"  maxlength="60" class="form-control">
                     </div>
                 </div>
             {/if}
-{*            <div class="form-group">*}
-{*                <div class="col-md-6 col-md-offset-3 text-center">*}
-{*                    <input type="submit" name="submit" value="{translate text="Update" isPublicFacing=true}" id="alternateLibraryCardFormSubmit" class="btn btn-primary">*}
-{*                </div>*}
-{*            </div>*}
         </div>
     </form>
 {/strip}

--- a/code/web/interface/themes/responsive/MyAccount/libraryCard.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/libraryCard.tpl
@@ -64,7 +64,7 @@
 					{if !empty($alternateLibraryCardLabel)}
 						{translate text=$alternateLibraryCardLabel isPublicFacing=true isAdminEnteredData=true}
 					{else}
-						Alternate Library Card
+						{translate text="Alternate Library Card" isPublicFacing=true isAdminEnteredData=false}
 					{/if}
 				</label>
 				<div class="col-md-6 col-md-offset-3">
@@ -77,14 +77,14 @@
 						{if !empty($alternateLibraryCardPasswordLabel)}
 							{translate text=$alternateLibraryCardPasswordLabel isPublicFacing=true isAdminEnteredData=true}
 						{else}
-							Password/PIN
+							{translate text="Password/PIN" isPublicFacing=true isAdminEnteredData=false}
 						{/if}
 					</label>
 					<div class="col-md-6 col-md-offset-3">
 						<input type="password" name="alternateLibraryCardPassword" id="alternateLibraryCardPassword" value="{$profile->alternateLibraryCardPassword}"  maxlength="60" class="form-control">
 					</div>
 				</div>
-			{/if}s
+			{/if}
 			<div class="form-group">
 				<div class="col-md-6 col-md-offset-3 text-center">
 					<input type="submit" name="submit" value="{translate text="Update" isPublicFacing=true}" id="alternateLibraryCardFormSubmit" class="btn btn-primary">

--- a/code/web/interface/themes/responsive/MyAccount/libraryCard.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/libraryCard.tpl
@@ -45,6 +45,11 @@
 
 	{if !empty($showAlternateLibraryCard)}
 		<h1>{translate text=$alternateLibraryCardLabel isPublicFacing=true isAdminEnteredData=true}</h1>
+		{if !empty($alternateLibraryCardFormMessage)}
+			<div class="row">
+				<div class="col-xs-12">{$alternateLibraryCardFormMessage}<div>
+			</div>
+		{/if}
 		{if $alternateLibraryCardStyle != 'none'}
 			<div class="row">
 				<div class="col-xs-12 text-center" id="library-alternateLibraryCard" style="display: none">
@@ -55,19 +60,31 @@
 		{/if}
 		<form name="alternateLibraryCard" method="post" class="form-horizontal">
 			<div class="form-group">
-				<label for="alternateLibraryCard" class="control-label col-xs-12 col-sm-4">{translate text=$alternateLibraryCardLabel isPublicFacing=true isAdminEnteredData=true} </label>
+				<label for="alternateLibraryCard" class="control-label col-xs-12 col-sm-4">
+					{if !empty($alternateLibraryCardLabel)}
+						{translate text=$alternateLibraryCardLabel isPublicFacing=true isAdminEnteredData=true}
+					{else}
+						Alternate Library Card
+					{/if}
+				</label>
 				<div class="col-md-6 col-md-offset-3">
-					<input type="text" name="alternateLibraryCard" id="alternateLibraryCard" value="{$user->alternateLibraryCard}" maxlength="60" class="form-control" onchange="updateAlternateLibraryCardBarcode()">
+					<input type="text" name="alternateLibraryCard" id="alternateLibraryCard" value="{$profile->alternateLibraryCard}" maxlength="60" class="form-control" onchange="updateAlternateLibraryCardBarcode()">
 				</div>
 			</div>
 			{if !empty($showAlternateLibraryCardPassword)}
 				<div class="form-group">
-					<label for="alternateLibraryCardPassword" class="control-label col-xs-12 col-sm-4">{translate text=$alternateLibraryCardPasswordLabel isPublicFacing=true isAdminEnteredData=true} </label>
+					<label for="alternateLibraryCardPassword" class="control-label col-xs-12 col-sm-4">
+						{if !empty($alternateLibraryCardPasswordLabel)}
+							{translate text=$alternateLibraryCardPasswordLabel isPublicFacing=true isAdminEnteredData=true}
+						{else}
+							Password/PIN
+						{/if}
+					</label>
 					<div class="col-md-6 col-md-offset-3">
-						<input type="password" name="alternateLibraryCardPassword" id="alternateLibraryCardPassword" value="{$user->alternateLibraryCardPassword}"  maxlength="60" class="form-control">
+						<input type="password" name="alternateLibraryCardPassword" id="alternateLibraryCardPassword" value="{$profile->alternateLibraryCardPassword}"  maxlength="60" class="form-control">
 					</div>
 				</div>
-			{/if}
+			{/if}s
 			<div class="form-group">
 				<div class="col-md-6 col-md-offset-3 text-center">
 					<input type="submit" name="submit" value="{translate text="Update" isPublicFacing=true}" id="alternateLibraryCardFormSubmit" class="btn btn-primary">
@@ -116,7 +133,9 @@
 			var alternateLibraryCardVal = $("#alternateLibraryCard").val();
 			var alternateLibraryCardSvg = $("#library-alternateLibraryCard-svg");
 			if (alternateLibraryCardVal.length > 0){ldelim}
-				alternateLibraryCardSvg.JsBarcode(alternateLibraryCardVal, {ldelim}format:'{$alternateLibraryCardStyle}',displayValue:false{rdelim});
+				{if $alternateLibraryCardStyle != 'none'}
+					alternateLibraryCardSvg.JsBarcode(alternateLibraryCardVal, {ldelim}format:'{$alternateLibraryCardStyle}',displayValue:false{rdelim});
+				{/if}
 				$("#library-alternateLibraryCard").show();
 			{rdelim}else{ldelim}
 				$("#library-alternateLibraryCard").hide();

--- a/code/web/services/CloudLibrary/AJAX.php
+++ b/code/web/services/CloudLibrary/AJAX.php
@@ -517,6 +517,7 @@ class CloudLibrary_AJAX extends JSON_Action {
 		$user = $user->getUserReferredTo($patronId);
 		$interface->assign('id', $titleId);
 		$interface->assign('showAlternateLibraryCard', $library->showAlternateLibraryCard);
+		$interface->assign('alternateLibraryCardFormMessage', $library->alternateLibraryCardFormMessage);
 		$interface->assign('showAlternateLibraryCardPassword', $library->showAlternateLibraryCardPassword);
 		$interface->assign('alternateLibraryCardLabel', $library->alternateLibraryCardLabel);
 		$interface->assign('alternateLibraryCardPasswordLabel', $library->alternateLibraryCardPasswordLabel);

--- a/code/web/services/MyAccount/LibraryCard.php
+++ b/code/web/services/MyAccount/LibraryCard.php
@@ -12,6 +12,7 @@ class LibraryCard extends MyAccount {
 
 		$interface->assign('libraryCardBarcodeStyle', $library->libraryCardBarcodeStyle);
 		$interface->assign('showAlternateLibraryCard', $library->showAlternateLibraryCard);
+		$interface->assign('alternateLibraryCardFormMessage', $library->alternateLibraryCardFormMessage);
 		$interface->assign('showAlternateLibraryCardPassword', $library->showAlternateLibraryCardPassword);
 		$interface->assign('alternateLibraryCardLabel', $library->alternateLibraryCardLabel);
 		$interface->assign('alternateLibraryCardPasswordLabel', $library->alternateLibraryCardPasswordLabel);

--- a/code/web/sys/DBMaintenance/library_location_updates.php
+++ b/code/web/sys/DBMaintenance/library_location_updates.php
@@ -2313,6 +2313,14 @@ function getLibraryLocationUpdates() {
 				"ALTER TABLE library ADD tiktokLink VARCHAR(255) DEFAULT ''",
 			],
 		],
+
+		'alternate_library_card_form_message' => [
+			'title' => 'Add field for Alternate Library Card Form Message',
+			'description' => 'Add field for Alternate Library Card Form Message',
+			'sql' => [
+				"ALTER TABLE library ADD COLUMN alternateLibraryCardFormMessage MEDIUMTEXT DEFAULT ''",
+			],
+		],
 	];
 }
 

--- a/code/web/sys/LibraryLocation/Library.php
+++ b/code/web/sys/LibraryLocation/Library.php
@@ -284,6 +284,7 @@ class Library extends DataObject {
 		$maxBarcodeLength;
 
 	public $showAlternateLibraryCard;
+	public $alternateLibraryCardFormMessage;
 	public $alternateLibraryCardStyle;
 	public $showAlternateLibraryCardPassword;
 	public $alternateLibraryCardLabel;
@@ -1692,11 +1693,19 @@ class Library extends DataObject {
 								'hideInLists' => true,
 								'default' => 0,
 							],
+							'alternateLibraryCardFormMessage' => [
+								'property' => 'alternateLibraryCardFormMessage',
+								'type' => 'html',
+								'label' => 'Alternate Library Card Form Message',
+								'description' => 'Optional message shown to users with the form add or edit their alternate library card.',
+								'hideInLists' => true,
+								'default' => '',
+							],
 							'alternateLibraryCardLabel' => [
 								'property' => 'alternateLibraryCardLabel',
 								'type' => 'text',
 								'label' => 'Alternate Library Card Label',
-								'description' => 'A label describing the alternate library card.',
+								'description' => 'A label describing the alternate library card - if blank will display default.',
 								'hideInLists' => true,
 								'default' => '',
 							],
@@ -1704,7 +1713,7 @@ class Library extends DataObject {
 								'property' => 'alternateLibraryCardPasswordLabel',
 								'type' => 'text',
 								'label' => 'Alternate Library Card PIN/Password Label',
-								'description' => 'A label describing the PIN/Password field for the alternate library card',
+								'description' => 'A label describing the PIN/Password field for the alternate library card  - if blank will display default',
 								'hideInLists' => true,
 								'default' => '',
 							],


### PR DESCRIPTION
Fixed some QA problems:
 - Labels didn't wrap correctly if they were long
 - Added default labels if they aren't added at setup
 - Fixed problem where adding a card on Your Library Card(s) screen didn't show the updated card number
 - Added new field Alternate Library Card Form Message so that optionally an explanation can be added to the form explaining what an alternate card is and how to get one.