### PR TITLE
Change order of permission changes for debian

### DIFF
--- a/install/updateSitePermissions_debian.sh
+++ b/install/updateSitePermissions_debian.sh
@@ -55,8 +55,8 @@ chown -R www-data:aspen_apache /usr/local/aspen-discovery/tmp
 echo "Updating /var/log directory"
 chmod -R 755 /var/log/aspen-discovery/$1
 chmod -R 755 /var/log/aspen-discovery/$1/logs
-chown -R aspen:aspen /var/log/aspen-discovery/$1/logs
 chown www-data:aspen_apache /var/log/aspen-discovery/$1/*
+chown -R aspen:aspen /var/log/aspen-discovery/$1/logs
 
 echo "Updating sideload permissions"
 php /usr/local/aspen-discovery/install/updateAllSideloadPermissions.php $1 debian


### PR DESCRIPTION
Logs directory was getting wrong ownership, moving the logs directory ownership command to after the permission changes for the parent should fix it

to test: 
run updateSitePermissions.sh <sitename>, observe that the permissions for var/log/aspen-discovery/<site>/logs are www-data:aspen_apache

apply this patch
run updateSitePermissions.sh <sitename>, observer that the permissions for /var/log/aspen-dsicovery/<site>/logs are now aspen:aspen