### PR TITLE
Remove superfluous loop in Koha driver function updateHomeLibrary

### DIFF
--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -43,10 +43,9 @@ class Koha extends AbstractIlsDriver {
 		$address = '';
 		$city = '';
 		if ($results !== false) {
-			while ($curRow = $results->fetch_assoc()) {
-				$address = $curRow['address'];
-				$city = $curRow['city'];
-			}
+			$curRow = $results->fetch_assoc();
+			$address = $curRow['address'];
+			$city = $curRow['city'];
 		}
 
 		$postVariables = [

--- a/code/web/release_notes/24.09.00.MD
+++ b/code/web/release_notes/24.09.00.MD
@@ -41,6 +41,10 @@
 
 // James Staub
 
+// Kyle M Hall
+### Koha Driver Updates
+- Remove superfluous loop in Koha driver function updateHomeLibrary #1968
+
 // other
 
 ## This release includes code contributions from


### PR DESCRIPTION
In the function updateHomeLibrary, there is a select to pull the user data from the database. The fetch_assoc is in a while loop that will only ever have a single result because it is a query of the borrowers table based on the borrowernumber. There is no need for a while loop and we can simply call fetch_assoc after checking that the query succeeded.

Test Plan:
1) Check out the latest working branch of Aspen
2) Set up an instance of Aspen connected to Koha with the latest Aspen
   and Koha 24.05
3) Log in as a user, browse to Your Account / Your Preferences 4) Set the home library to a different value, click "Update My Preferences" 5) Note the home library has been updated
6) Check out the branch from this pull request
7) Repeat steps 3-5
8) Note there is no change in behavior!