### PR TITLE
Added title to cover images

### DIFF
--- a/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/browse_result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/browse_result.tpl
@@ -7,7 +7,7 @@
     {if $accessibleBrowseCategories == '1' && $action != 'Results' && !$isForSearchResults}
 	<div class="swiper-slide browse-thumbnail {$coverStyle}">
 		<a onclick="return AspenDiscovery.GroupedWork.showGroupedWorkInfo('{$summId}', {if !empty($browseCategoryId)}'{$browseCategoryId}'{/if});" href="{$summUrl}">
-			<img src="{$bookCoverUrlMedium}" alt="{$summTitle|escape}" class="{$coverStyle}" loading="lazy">
+			<img src="{$bookCoverUrlMedium}" alt="{$summTitle|escape}" title="{$summTitle|escape}" class="{$coverStyle}" loading="lazy">
 			<div class="swiper-lazy-preloader"></div>
 		</a>
 	</div>
@@ -15,7 +15,7 @@
 		{if $browseMode == '1'}
 			<div class="browse-list grid-item {$coverStyle} {if $browseStyle == 'grid'}browse-grid-style col-tn-6 col-xs-6 col-sm-6 col-md-4 col-lg-3{/if}">
 				<a onclick="return AspenDiscovery.GroupedWork.showGroupedWorkInfo('{$summId}', '{$browseCategoryId}');" href="{$summUrl}">
-					<img class="img-responsive" src="{$bookCoverUrl}" alt="{$summTitle|escape} {$vSummAuthor|escape}">
+					<img class="img-responsive" src="{$bookCoverUrl}" alt="{$summTitle|escape} {$vSummAuthor|escape}" title="{$summTitle|escape} {$vSummAuthor|escape}">
 					<div class="info">{if !empty($isNew)}<span class="new-result-badge">{translate text="New!" isPublicFacing=true}</span><br/>{/if}<strong>{$summTitle|truncate:40}</strong><span>{$vSummAuthor|truncate:40}</span></div>
 				</a>
 			</div>
@@ -25,7 +25,7 @@
 				<a onclick="return AspenDiscovery.GroupedWork.showGroupedWorkInfo('{$summId}', {if !empty($browseCategoryId)}'{$browseCategoryId}'{/if});" href="{$summUrl}">
 					{if !empty($isNew)}<span class="browse-cover-badge">{translate text="New!" isPublicFacing=true}</span> {/if}
 					<div>
-						<img src="{$bookCoverUrlMedium}" alt="{$summTitle|escape} {$vSummAuthor|escape}" class="{$coverStyle} browse-{$browseStyle} {if $browseCategoryRatingsMode != 0}ratings-on{/if}">
+						<img src="{$bookCoverUrlMedium}" alt="{$summTitle|escape} {$vSummAuthor|escape}" title="{$summTitle|escape} {$vSummAuthor|escape}" class="{$coverStyle} browse-{$browseStyle} {if $browseCategoryRatingsMode != 0}ratings-on{/if}">
 					</div>
 				</a>
 				{if !empty($showRatings) && $browseCategoryRatingsMode != 0}

--- a/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/result.tpl
@@ -12,7 +12,7 @@
 						<div class="listResultImage img-thumbnail {$coverStyle}">
 							<a href="{$summUrl}" tabindex="-1">
 								{if !empty($isNew)}<span class="list-cover-badge">{translate text="New!" isPublicFacing=true}</span> {/if}
-								<img src="{$bookCoverUrlMedium}" alt="{$summTitle|removeTrailingPunctuation|escapeCSS}">
+								<img src="{$bookCoverUrlMedium}" alt="{$summTitle|removeTrailingPunctuation|escapeCSS}" title="{$summTitle|removeTrailingPunctuation|escapeCSS}">
 							</a>
 						</div>
 					{/if}

--- a/code/web/release_notes/24.09.00.MD
+++ b/code/web/release_notes/24.09.00.MD
@@ -59,7 +59,8 @@
 
 // Jeremy Eden
 ### Other 
-- Explicitly disable on screen error display when debugging is disabled by IP. 
+- Explicitly disable on screen error display when debugging is disabled by IP.
+- Set cover title text to same as alt text for both browse category and search results views (Ticket 131697)
 
 // Kyle M Hall
 ### Koha Driver Updates


### PR DESCRIPTION
Set title to the same text as the alt text so a tooltip shows on hover of the cover image. This was done for both browse category view and search results view of GroupedWork. This fixes  ticket 131697