### PR TITLE
Fetching ILS Messaging fixes

### DIFF
--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -8416,7 +8416,7 @@ class Koha extends AbstractIlsDriver {
 		$this->initDatabaseConnection();
 
 		/** @noinspection SqlResolve */
-		$sql = "SELECT * FROM message_queue where message_transport_type like 'email'";
+		$sql = "SELECT * FROM message_queue where message_transport_type like 'email' and time_queue < DATE_SUB(NOW(), INTERVAL 24 HOUR)";
 		$results = mysqli_query($this->dbConnection, $sql);
 		if($results) {
 			$numAdded = 0;
@@ -8481,7 +8481,7 @@ class Koha extends AbstractIlsDriver {
 		$this->initDatabaseConnection();
 
 		/** @noinspection SqlResolve */
-		$sql = "SELECT * FROM message_queue where message_transport_type like 'email' and borrowernumber = '" . mysqli_escape_string($this->dbConnection, $patron->unique_ils_id) . "'";
+		$sql = "SELECT * FROM message_queue where message_transport_type like 'email' and time_queue < DATE_SUB(NOW(), INTERVAL 24 HOUR) and borrowernumber = '" . mysqli_escape_string($this->dbConnection, $patron->unique_ils_id) . "'";
 		$results = mysqli_query($this->dbConnection, $sql);
 		if($results) {
 			require_once ROOT_DIR . '/sys/Account/UserILSMessage.php';

--- a/code/web/release_notes/24.08.01.MD
+++ b/code/web/release_notes/24.08.01.MD
@@ -1,0 +1,7 @@
+## Aspen Discovery Updates
+### Koha Updates
+- Changed data fetch for message_queue table to only query rows created in the last 24 hours. (*KK*)
+
+## This release includes code contributions from
+- ByWater Solutions
+    - Kirstien Kroeger (KK)

--- a/code/web/sys/SearchObject/GroupedWorkSearcher2.php
+++ b/code/web/sys/SearchObject/GroupedWorkSearcher2.php
@@ -806,12 +806,14 @@ class SearchObject_GroupedWorkSearcher2 extends SearchObject_AbstractGroupedWork
 				// if populating the array of facet options for 'available at'
 				// then filter out any branch (location) for which showInSearchFacet has been set to "0"
 				// thus preventing these branches from being displayed as search by options
-				if ($field == 'available_at' || $field == 'owning_location') {
+
+				// Commenting out 8/14/24 post 24.08 release due to unexpected bugs and disappearing facets - KK
+				/*if ($field == 'available_at' || $field == 'owning_location') {
 					$branchName = substr($facetValue, 5);
 					if (empty($branchList[$branchName]->showInSearchFacet)) {
 						continue;
 					}
-				}
+				}*/
 			
 				if ($isScopedField && strpos($facetValue, '#') !== false) {
 					$facetValue = substr($facetValue, strpos($facetValue, '#') + 1);

--- a/install/updateCron_24_08_01.php
+++ b/install/updateCron_24_08_01.php
@@ -1,0 +1,56 @@
+<?php
+
+if (count($_SERVER['argv']) > 1) {
+	$serverName = $_SERVER['argv'][1];
+	//Check to see if the update already exists properly.
+	$fhnd = fopen("/usr/local/aspen-discovery/sites/$serverName/conf/crontab_settings.txt", 'r');
+	if ($fhnd) {
+		$lines = [];
+		$replaceFetchILSMessages = true;
+		while (($line = fgets($fhnd)) !== false) {
+			if (strpos($line, 'fetchILSMessages') > 0) {
+				$replaceFetchILSMessages = true;
+			}
+			$lines[] = $line;
+		}
+		fclose($fhnd);
+
+		if ($replaceFetchILSMessages) {
+			$lines[] = "*/40 * * * * root php /usr/local/aspen-discovery/code/web/cron/fetchILSMessages.php $serverName\n";
+		}
+		if ($replaceFetchILSMessages) {
+			$newContent = implode('', $lines);
+			file_put_contents("/usr/local/aspen-discovery/sites/$serverName/conf/crontab_settings.txt", $newContent);
+		}
+
+	} else {
+		echo("- Could not find cron settings file\n");
+	}
+
+} else {
+	echo 'Must provide servername as first argument';
+	exit();
+}
+
+function getOSInformation() {
+	if (false == function_exists('shell_exec') || false == is_readable('/etc/os-release')) {
+		return null;
+	}
+
+	$os = shell_exec('cat /etc/os-release');
+	$listIds = preg_match_all('/.*=/', $os, $matchListIds);
+	$listIds = $matchListIds[0];
+
+	$listVal = preg_match_all('/=.*/', $os, $matchListVal);
+	$listVal = $matchListVal[0];
+
+	array_walk($listIds, function (&$v, $k) {
+		$v = strtolower(str_replace('=', '', $v));
+	});
+
+	array_walk($listVal, function (&$v, $k) {
+		$v = preg_replace('/=|"/', '', $v);
+	});
+
+	return array_combine($listIds, $listVal);
+}


### PR DESCRIPTION
- Update the Koha.php message_queue queries to include timestamp of less than 24 hours from time of query to reduce load on servers.
- Update fetchILSMessages cron to run every 40 minutes to relieve other crons happening on the ILS.