### PR TITLE
Hide empty item groups for volume-level holds

### DIFF
--- a/code/koha_export/src/com/turning_leaf_technologies/koha_export/KohaExportMain.java
+++ b/code/koha_export/src/com/turning_leaf_technologies/koha_export/KohaExportMain.java
@@ -534,8 +534,8 @@ public class KohaExportMain {
 				getVolumeInfoStmt = kohaConn.prepareStatement("SELECT * from volumes", ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
 				getItemsForVolumeStmt = kohaConn.prepareStatement("SELECT * from volume_items", ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
 			}else {
-				//community code for
-				getVolumeInfoStmt = kohaConn.prepareStatement("SELECT * from item_groups", ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+				// Filter out any item groups that do not currently contain items
+				getVolumeInfoStmt = kohaConn.prepareStatement("SELECT item_groups.* FROM item_groups LEFT JOIN item_group_items USING (item_group_id) GROUP BY item_group_id HAVING COUNT(item_id) > 0", ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
 				getItemsForVolumeStmt = kohaConn.prepareStatement("SELECT * from item_group_items", ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
 			}
 			PreparedStatement addVolumeStmt = dbConn.prepareStatement("INSERT INTO ils_volume_info (recordId, volumeId, displayLabel, relatedItems, displayOrder) VALUES (?,?,?,?, ?) ON DUPLICATE KEY update recordId = VALUES(recordId), displayLabel = VALUES(displayLabel), relatedItems = VALUES(relatedItems), displayOrder = VALUES(displayOrder)");

--- a/code/web/release_notes/24.09.00.MD
+++ b/code/web/release_notes/24.09.00.MD
@@ -73,6 +73,7 @@
 - Improve docker image build time and add support for GHCR
 ### Koha Driver Updates
 - Remove superfluous loop in Koha driver function updateHomeLibrary #1968
+- Hide empty item groups for volume-level holds in Koha
 
 // other
 


### PR DESCRIPTION
In Koha, it is possible to create item groups (i.e. volumes) without attaching items to that group. If an item group has no items, the volume level hold will be unfillable unless items are added to it at a future time. For these reasons, it makes sense to filter these empty volumes out.

A possible future enhancement would be to make the display of empty volumes configurable.

Test Plan:
1) Set up an instance of Koha connected to Aspen Discovery 2) Create 10 items, and four item groups on one record 3) Attach 3 items to each of 3 of the item groups
4) Run koha_export.jar
5) Note the empty volume shows in the list of volumes you can place
   holds on
6) Check out this branch
7) Recompile koha_export.jar
8) Repeat step 4
8) Note the empty volume is no longer in the volume pulldown

Closes Aspen-Discovery/aspen-discovery#1989