### PR TITLE
Implement dependent issues for GitHub Issues

### DIFF
--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -1,0 +1,59 @@
+name: Dependent Issues
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - closed
+      - reopened
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - closed
+      - reopened
+      # Makes sure we always add status check for PRs. Useful only if
+      # this action is required to pass before merging. Otherwise, it
+      # can be removed.
+      - synchronize
+
+  # Schedule a daily check. Useful if you reference cross-repository
+  # issues or pull requests. Otherwise, it can be removed.
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: z0al/dependent-issues@v1
+        env:
+          # (Required) The token to use to make API calls to GitHub.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # (Optional) The token to use to make API calls to GitHub for remote repos.
+          GITHUB_READ_TOKEN: ${{ secrets.GITHUB_READ_TOKEN }}
+
+        with:
+          # (Optional) The label to use to mark dependent issues
+          label: dependent
+
+          # (Optional) Enable checking for dependencies in issues.
+          # Enable by setting the value to "on". Default "off"
+          check_issues: off
+
+          # (Optional) Ignore dependabot PRs.
+          # Enable by setting the value to "on". Default "off"
+          ignore_dependabot: off
+
+          # (Optional) A comma-separated list of keywords. Default
+          # "depends on, blocked by"
+          keywords: depends on, blocked by
+
+          # (Optional) A custom comment body. It supports `{{ dependencies }}` token.
+          comment: >
+            This PR/issue depends on:
+
+            {{ dependencies }}
+
+            By **[Dependent Issues](https://github.com/z0al/dependent-issues)** (🤖). Happy coding!


### PR DESCRIPTION
    We are currently using GitHub Issues for issue tracking While we
    are deciding on a long term issue tracker for the community ( Issues or Jira ),
    In the meantime it would be nice if we could use the dependent-issues
    action to deal with issue dependencies in the community.

    Once this branch is merged, setting a dependency requires only that
    one leave a comment on the issue in the format:

    Depends on Aspen-Discovery/aspen-discovery#XXXX

    Where XXXX is the dependent issue number.
    Any number of "Depends on" lines can exist in one or more comments.

    https://github.com/marketplace/actions/dependent-issues#dependent-issues