### PR TITLE
Fix query to select circulation rules for Koha #2008

### DIFF
--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -539,12 +539,16 @@ class Koha extends AbstractIlsDriver {
 				$circulationRulesForCheckout = [];
 				/** @noinspection SqlResolve */
 				/** @noinspection SqlDialectInspection */
-				$circulationRulesSql = "SELECT *  FROM circulation_rules where (categorycode IN ('$patronType', '*') OR categorycode IS NULL) and (itemtype IN('$itemType', '*') OR itemtype is null) and (branchcode IN ('$checkoutBranch', '*') OR branchcode IS NULL) order by branchcode desc, categorycode desc, itemtype desc";
+				$circulationRulesSql = "
+				SELECT * FROM circulation_rules
+				WHERE (categorycode IN ('$patronType', '*') OR categorycode IS NULL)
+				  AND (itemtype IN('$itemType', '*') OR itemtype is null)
+				  AND (branchcode IN ('$checkoutBranch', '*') OR branchcode IS NULL)
+				ORDER BY branchcode desc, categorycode desc, itemtype desc LIMIT 1";
 				$circulationRulesRS = mysqli_query($this->dbConnection, $circulationRulesSql);
 				if ($circulationRulesRS !== false) {
-					while ($circulationRulesRow = $circulationRulesRS->fetch_assoc()) {
-						$circulationRulesForCheckout[] = $circulationRulesRow;
-					}
+					$circulationRulesRow = $circulationRulesRS->fetch_assoc();
+					$circulationRulesForCheckout[] = $circulationRulesRow;
 					$circulationRulesRS->close();
 				}
 				$timer->logTime("Load circulation rules for checkout");

--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -540,11 +540,12 @@ class Koha extends AbstractIlsDriver {
 				/** @noinspection SqlResolve */
 				/** @noinspection SqlDialectInspection */
 				$circulationRulesSql = "
-				SELECT * FROM circulation_rules
-				WHERE (categorycode IN ('$patronType', '*') OR categorycode IS NULL)
-				  AND (itemtype IN('$itemType', '*') OR itemtype is null)
-				  AND (branchcode IN ('$checkoutBranch', '*') OR branchcode IS NULL)
-				ORDER BY branchcode desc, categorycode desc, itemtype desc LIMIT 1";
+					SELECT * FROM circulation_rules
+					WHERE (categorycode IN ('$patronType', '*') OR categorycode IS NULL)
+					  AND (itemtype IN('$itemType', '*') OR itemtype is null)
+					  AND (branchcode IN ('$checkoutBranch', '*') OR branchcode IS NULL)
+					ORDER BY branchcode desc, categorycode desc, itemtype desc LIMIT 1
+				";
 				$circulationRulesRS = mysqli_query($this->dbConnection, $circulationRulesSql);
 				if ($circulationRulesRS !== false) {
 					$circulationRulesRow = $circulationRulesRS->fetch_assoc();

--- a/code/web/release_notes/24.09.00.MD
+++ b/code/web/release_notes/24.09.00.MD
@@ -132,6 +132,7 @@
 - Remove superfluous loop in Koha driver function updateHomeLibrary #1968 (*KMH*)
 - Hide empty item groups for volume-level holds in Koha (*KMH*)
 - Remove old pre-production Koha volumes code (*KMH*)
+- Fix query to select circulation rules for Koha (*KMH*)
 
 ### GitHub Actions
 - Add GitHub Actions to check pull requests for release notes (*KMH*)


### PR DESCRIPTION
Within Koha circulation rules are selected by branchcode, categorycode, and itemtype in that order where precedence takes the more specific rule over the less specific rule. This can be seen in the Koha code here: https://git.koha-community.org/Koha-community/Koha/src/branch/main/Koha/CirculationRules.pm#L275

Aspen attempts to replicate this but has a flaw.
The problem only comes into play if the query ends up selecting multiple rules. Koha will always select first rule of the results, but Aspen will always select the last rule of the results.

Closes Aspen-Discovery/aspen-discovery#2008