### PR TITLE
For GitHub Actions only attempt to log in and push to container repos if the commit is pushed to the official repo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,15 +26,18 @@ jobs:
         id: extract_branch
 
       - name: Log in to Docker Hub
+        if: github.repository == 'Aspen-Discover/aspen-discovery'
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Log in to GHCR
+        if: github.repository == 'Aspen-Discover/aspen-discovery'
         run: echo "${{ secrets.GHCR_PASSWORD }}" | docker login ghcr.io -u ${{ secrets.GHCR_USERNAME }} --password-stdin
 
       - name: Log in to Quay.io
+        if: github.repository == 'Aspen-Discover/aspen-discovery'
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
           registry: quay.io
@@ -75,15 +78,18 @@ jobs:
         id: extract_branch
 
       - name: Log in to Docker Hub
+        if: github.repository == 'Aspen-Discover/aspen-discovery'
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Log in to GHCR
+        if: github.repository == 'Aspen-Discover/aspen-discovery'
         run: echo "${{ secrets.GHCR_PASSWORD }}" | docker login ghcr.io -u ${{ secrets.GHCR_USERNAME }} --password-stdin
 
       - name: Log in to Quay.io
+        if: github.repository == 'Aspen-Discover/aspen-discovery'
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
           registry: quay.io
@@ -124,15 +130,18 @@ jobs:
         id: extract_branch
 
       - name: Log in to Docker Hub
+        if: github.repository == 'Aspen-Discover/aspen-discovery'
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Log in to GHCR
+        if: github.repository == 'Aspen-Discover/aspen-discovery'
         run: echo "${{ secrets.GHCR_PASSWORD }}" | docker login ghcr.io -u ${{ secrets.GHCR_USERNAME }} --password-stdin
 
       - name: Log in to Quay.io
+        if: github.repository == 'Aspen-Discover/aspen-discovery'
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
           registry: quay.io

--- a/code/web/release_notes/24.09.00.MD
+++ b/code/web/release_notes/24.09.00.MD
@@ -135,6 +135,7 @@
 
 ### GitHub Actions
 - Add GitHub Actions to check pull requests for release notes (*KMH*)
+- Prevent GitHub Actions from attempting to push Docker images unless the push is to the official rep (*KMH*)
 
 // Liz Rea
 ### Other Updates


### PR DESCRIPTION


When a developer pushes a branch of Aspen Discovery to their own repo to create a pull request, it triggers the building of Docker images. The building of the images itself is good to find issues in the build process, but the actions fail because the the actions can only log in on the official repo.

This change resolves this be only logging in to the registries if the commit is pushed to the official repo, while still allowing the docker images to be build for testing purposes.

You can see it working successfully in my personal repo: https://github.com/kylemhall/aspen-discovery/actions/runs/10510807021