### PR TITLE
add alternate library cards to LiDA

### DIFF
--- a/code/aspen_app/src/components/Action/ActionButton.js
+++ b/code/aspen_app/src/components/Action/ActionButton.js
@@ -41,6 +41,8 @@ export const ActionButton = (data) => {
           setHoldItemSelectIsOpen,
           onHoldItemSelectClose,
           cancelHoldItemSelectRef,
+          userHasAlternateLibraryCard,
+          shouldPromptAlternateLibraryCard,
      } = data;
      if (_.isObject(action)) {
           if (action.type === 'overdrive_sample') {
@@ -81,6 +83,9 @@ export const ActionButton = (data) => {
                          cancelHoldItemSelectRef={cancelHoldItemSelectRef}
                          holdSelectItemResponse={holdSelectItemResponse}
                          setHoldSelectItemResponse={setHoldSelectItemResponse}
+                         userHasAlternateLibraryCard={userHasAlternateLibraryCard}
+                         shouldPromptAlternateLibraryCard={shouldPromptAlternateLibraryCard}
+                         recordSource={recordSource}
                     />
                );
           } else if (action.type === 'vdx_request') {
@@ -136,6 +141,9 @@ export const ActionButton = (data) => {
                          cancelHoldConfirmationRef={cancelHoldConfirmationRef}
                          holdConfirmationResponse={holdConfirmationResponse}
                          setHoldConfirmationResponse={setHoldConfirmationResponse}
+                         userHasAlternateLibraryCard={userHasAlternateLibraryCard}
+                         shouldPromptAlternateLibraryCard={shouldPromptAlternateLibraryCard}
+                         recordSource={recordSource}
                     />
                );
           }

--- a/code/aspen_app/src/components/Action/AddAlternateLibraryCard.js
+++ b/code/aspen_app/src/components/Action/AddAlternateLibraryCard.js
@@ -1,0 +1,223 @@
+import React from 'react';
+import _ from 'lodash';
+import { CloseIcon, Modal, ModalBackdrop, ModalContent, ModalHeader, ModalCloseButton, ModalBody, ModalFooter, FormControl, FormControlLabel, FormControlLabelText, Heading, Button, ButtonGroup, ButtonText, SelectTrigger, SelectInput, SelectIcon, SelectPortal, SelectBackdrop, SelectContent, SelectDragIndicatorWrapper, SelectDragIndicator, SelectItem, Icon, ChevronDownIcon, ButtonSpinner, Input, InputField, InputSlot, InputIcon } from '@gluestack-ui/themed';
+import { LanguageContext, LibrarySystemContext, ThemeContext, UserContext } from '../../context/initialContext';
+import { getTermFromDictionary } from '../../translations/TranslationService';
+import { refreshProfile, updateAlternateLibraryCard } from '../../util/api/user';
+import { decodeHTML } from '../../util/apiAuth';
+import { completeAction } from '../../util/recordActions';
+import { useWindowDimensions } from 'react-native';
+import RenderHtml from 'react-native-render-html';
+import { EyeOff, Eye } from 'lucide-react-native';
+
+export const AddAlternateLibraryCard = (props) => {
+     const {
+          id,
+          title,
+          action,
+          volumeInfo,
+          holdTypeForFormat,
+          variationId,
+          prevRoute,
+          isEContent,
+          response,
+          setResponse,
+          responseIsOpen,
+          setResponseIsOpen,
+          onResponseClose,
+          cancelResponseRef,
+          holdConfirmationResponse,
+          setHoldConfirmationResponse,
+          holdConfirmationIsOpen,
+          setHoldConfirmationIsOpen,
+          onHoldConfirmationClose,
+          cancelHoldConfirmationRef,
+          holdSelectItemResponse,
+          setHoldSelectItemResponse,
+          holdItemSelectIsOpen,
+          setHoldItemSelectIsOpen,
+          onHoldItemSelectClose,
+          cancelHoldItemSelectRef,
+          recordSource,
+          activeAccount,
+     } = props;
+
+     let isPlacingHold = false;
+     if (_.isObject(action)) {
+          isPlacingHold = action.includes('hold');
+     }
+
+     const { library } = React.useContext(LibrarySystemContext);
+     const { user, updateUser } = React.useContext(UserContext);
+     const { language } = React.useContext(LanguageContext);
+     const { theme, textColor, colorMode } = React.useContext(ThemeContext);
+     const queryClient = useQueryClient();
+     const { width } = useWindowDimensions();
+     const [card, setCard] = React.useState(user?.alternateLibraryCard ?? '');
+     const [password, setPassword] = React.useState(user?.alternateLibraryCardPassword ?? '');
+     const [showModal, setShowModal] = React.useState(true);
+     const [loading, setLoading] = React.useState(false);
+
+     const [showPassword, setShowPassword] = React.useState(false);
+     const toggleShowPassword = () => setShowPassword(!showPassword);
+
+     let cardLabel = getTermFromDictionary(language, 'alternate_library_card');
+     let passwordLabel = getTermFromDictionary(language, 'password');
+     let formMessage = '';
+     let showAlternateLibraryCardPassword = false;
+
+     if (library?.alternateLibraryCardConfig?.alternateLibraryCardLabel) {
+          cardLabel = library.alternateLibraryCardConfig.alternateLibraryCardLabel;
+     }
+
+     if (library?.alternateLibraryCardConfig?.alternateLibraryCardPasswordLabel) {
+          passwordLabel = library.alternateLibraryCardConfig.alternateLibraryCardPasswordLabel;
+     }
+
+     if (library?.alternateLibraryCardConfig?.alternateLibraryCardFormMessage) {
+          formMessage = decodeHTML(library.alternateLibraryCardConfig.alternateLibraryCardFormMessage);
+     }
+
+     if (library?.alternateLibraryCardConfig?.showAlternateLibraryCardPassword) {
+          if (library.alternateLibraryCardConfig.showAlternateLibraryCardPassword === '1' || library.alternateLibraryCardConfig.showAlternateLibraryCardPassword === 1) {
+               showAlternateLibraryCardPassword = true;
+          }
+     }
+
+     const source = {
+          baseUrl: library.baseUrl,
+          html: formMessage,
+     };
+
+     const tagsStyles = {
+          body: {
+               color: textColor,
+          },
+          a: {
+               color: textColor,
+               textDecorationColor: textColor,
+          },
+     };
+
+     const updateCard = async () => {
+          await updateAlternateLibraryCard(card, password, false, library.baseUrl, language);
+          await refreshProfile(library.baseUrl).then(async (result) => {
+               updateUser(result);
+          });
+     };
+
+     return (
+          <Modal isOpen={showModal} onClose={() => setShowModal(false)} closeOnOverlayClick={false} size="lg">
+               <ModalBackdrop />
+               <ModalContent maxWidth="90%" bgColor={colorMode === 'light' ? theme['colors']['warmGray']['50'] : theme['colors']['coolGray']['700']}>
+                    <ModalHeader borderBottomWidth="$1" borderBottomColor={colorMode === 'light' ? theme['colors']['warmGray']['300'] : theme['colors']['coolGray']['500']}>
+                         <Heading size="md" color={textColor}>
+                              {isPlacingHold ? getTermFromDictionary(language, 'hold_options') : getTermFromDictionary(language, 'checkout_options')}
+                         </Heading>
+                         <ModalCloseButton hitSlop={{ top: 30, bottom: 30, left: 30, right: 30 }}>
+                              <Icon as={CloseIcon} color={textColor} />
+                         </ModalCloseButton>
+                    </ModalHeader>
+                    <ModalBody mt="$3">
+                         {formMessage ? <RenderHtml contentWidth={width} source={source} tagsStyles={tagsStyles} /> : null}
+                         <FormControl mb="$2">
+                              <FormControlLabel>
+                                   <FormControlLabelText color={textColor} size="sm">
+                                        {cardLabel}
+                                   </FormControlLabelText>
+                              </FormControlLabel>
+                              <Input>
+                                   <InputField textContentType="none" color={textColor} name="card" defaultValue={card} accessibilityLabel={cardLabel} onChangeText={(value) => setCard(value)} />
+                              </Input>
+                         </FormControl>
+                         {showAlternateLibraryCardPassword ? (
+                              <FormControl mb="$2">
+                                   <FormControlLabel>
+                                        <FormControlLabelText color={textColor} size="sm">
+                                             {passwordLabel}
+                                        </FormControlLabelText>
+                                   </FormControlLabel>
+                                   <Input>
+                                        <InputField textContentType="none" type={showPassword ? 'text' : 'password'} color={textColor} name="password" defaultValue={password} accessibilityLabel={passwordLabel} onChangeText={(value) => setPassword(value)} />
+                                        <InputSlot onPress={toggleShowPassword}>
+                                             <InputIcon as={showPassword ? Eye : EyeOff} mr="$2" color={textColor} />
+                                        </InputSlot>
+                                   </Input>
+                              </FormControl>
+                         ) : null}
+                    </ModalBody>
+                    <ModalFooter borderTopWidth="$1" borderTopColor={colorMode === 'light' ? theme['colors']['warmGray']['300'] : theme['colors']['coolGray']['500']}>
+                         <ButtonGroup space="sm">
+                              <Button
+                                   variant="outline"
+                                   borderColor={colorMode === 'light' ? theme['colors']['warmGray']['300'] : theme['colors']['coolGray']['500']}
+                                   onPress={() => {
+                                        setShowModal(false);
+                                        setLoading(false);
+                                   }}>
+                                   <ButtonText color={colorMode === 'light' ? theme['colors']['warmGray']['500'] : theme['colors']['coolGray']['300']}>{getTermFromDictionary(language, 'close_window')}</ButtonText>
+                              </Button>
+                              <Button
+                                   bgColor={theme['colors']['primary']['500']}
+                                   isDisabled={loading}
+                                   onPress={async () => {
+                                        setLoading(true);
+                                        await completeAction(id, action, activeAccount, '', '', location, library.baseUrl, volume, holdType, holdNotificationPreferences, item).then(async (result) => {
+                                             setResponse(result);
+                                             if (result) {
+                                                  if (result.success === true || result.success === 'true') {
+                                                       queryClient.invalidateQueries({ queryKey: ['holds', activeAccount, library.baseUrl, language] });
+                                                       queryClient.invalidateQueries({ queryKey: ['user', library.baseUrl, language] });
+                                                       /*await refreshProfile(library.baseUrl).then((profile) => {
+                                               updateUser(profile);
+                                               });*/
+                                                  }
+
+                                                  if (result?.confirmationNeeded && result.confirmationNeeded === true) {
+                                                       let tmp = holdConfirmationResponse;
+                                                       const obj = {
+                                                            message: result.message,
+                                                            title: result.title,
+                                                            confirmationNeeded: result.confirmationNeeded ?? false,
+                                                            confirmationId: result.confirmationId ?? null,
+                                                            recordId: id ?? null,
+                                                       };
+                                                       tmp = _.merge(obj, tmp);
+                                                       setHoldConfirmationResponse(tmp);
+                                                  }
+
+                                                  if (result?.shouldBeItemHold && result.shouldBeItemHold === true) {
+                                                       let tmp = holdSelectItemResponse;
+                                                       const obj = {
+                                                            message: result.message,
+                                                            title: 'Select an Item',
+                                                            patronId: activeAccount,
+                                                            pickupLocation: location,
+                                                            bibId: id ?? null,
+                                                            items: result.items ?? [],
+                                                       };
+
+                                                       tmp = _.merge(obj, tmp);
+                                                       setHoldSelectItemResponse(tmp);
+                                                  }
+
+                                                  setLoading(false);
+                                                  setShowModal(false);
+                                                  if (result?.confirmationNeeded && result.confirmationNeeded) {
+                                                       setHoldConfirmationIsOpen(true);
+                                                  } else if (result?.shouldBeItemHold && result.shouldBeItemHold) {
+                                                       setHoldItemSelectIsOpen(true);
+                                                  } else {
+                                                       setResponseIsOpen(true);
+                                                  }
+                                             }
+                                        });
+                                   }}>
+                                   {loading ? <ButtonSpinner color={theme['colors']['primary']['500-text']} /> : <ButtonText color={theme['colors']['primary']['500-text']}>{title}</ButtonText>}
+                              </Button>
+                         </ButtonGroup>
+                    </ModalFooter>
+               </ModalContent>
+          </Modal>
+     );
+};

--- a/code/aspen_app/src/components/Action/CheckOut/CheckOut.js
+++ b/code/aspen_app/src/components/Action/CheckOut/CheckOut.js
@@ -1,23 +1,27 @@
-import { Box, Button, ButtonSpinner, ButtonGroup, ButtonIcon, ButtonText, Text } from '@gluestack-ui/themed';
+import { Box, Button, ButtonSpinner, ButtonGroup, ButtonIcon, ButtonText, Text, Heading, Icon, CloseIcon, Modal, ModalBackdrop, ModalContent, ModalHeader, ModalCloseButton, ModalBody, ModalFooter, FormControl, FormControlLabel, FormControlLabelText, Input, InputField, InputSlot, InputIcon } from '@gluestack-ui/themed';
 import React from 'react';
 import _ from 'lodash';
 import { useQueryClient } from '@tanstack/react-query';
+import { EyeOff, Eye } from 'lucide-react-native';
+import { useWindowDimensions } from 'react-native';
+import RenderHtml from 'react-native-render-html';
 
 // custom components and helper files
 import { LanguageContext, LibraryBranchContext, LibrarySystemContext, ThemeContext, UserContext } from '../../../context/initialContext';
+import { decodeHTML } from '../../../util/apiAuth';
 import { completeAction } from '../../../util/recordActions';
-import { refreshProfile } from '../../../util/api/user';
+import { refreshProfile, updateAlternateLibraryCard } from '../../../util/api/user';
 import { HoldPrompt } from '../Holds/HoldPrompt';
 import { getTermFromDictionary } from '../../../translations/TranslationService';
 
 export const CheckOut = (props) => {
      const queryClient = useQueryClient();
-     const { id, title, type, record, prevRoute, response, setResponse, responseIsOpen, setResponseIsOpen, onResponseClose, cancelResponseRef, holdConfirmationResponse, setHoldConfirmationResponse, holdConfirmationIsOpen, setHoldConfirmationIsOpen, onHoldConfirmationClose, cancelHoldConfirmationRef } = props;
+     const { id, title, type, record, prevRoute, response, setResponse, responseIsOpen, setResponseIsOpen, onResponseClose, cancelResponseRef, holdConfirmationResponse, setHoldConfirmationResponse, holdConfirmationIsOpen, setHoldConfirmationIsOpen, onHoldConfirmationClose, cancelHoldConfirmationRef, userHasAlternateLibraryCard, shouldPromptAlternateLibraryCard } = props;
      const { user, updateUser, accounts } = React.useContext(UserContext);
      const { library } = React.useContext(LibrarySystemContext);
      const { language } = React.useContext(LanguageContext);
      const [loading, setLoading] = React.useState(false);
-     const { theme } = React.useContext(ThemeContext);
+     const { theme, colorMode, textColor } = React.useContext(ThemeContext);
 
      const volumeInfo = {
           numItemsWithVolumes: 0,
@@ -47,7 +51,144 @@ export const CheckOut = (props) => {
                     cancelHoldConfirmationRef={cancelHoldConfirmationRef}
                     holdConfirmationResponse={holdConfirmationResponse}
                     setHoldConfirmationResponse={setHoldConfirmationResponse}
+                    userHasAlternateLibraryCard={userHasAlternateLibraryCard}
+                    shouldPromptAlternateLibraryCard={shouldPromptAlternateLibraryCard}
                />
+          );
+     } else if (shouldPromptAlternateLibraryCard && !userHasAlternateLibraryCard) {
+          const [showAddAlternateLibraryCardModal, setShowAddAlternateLibraryCardModal] = React.useState(false);
+
+          let cardLabel = getTermFromDictionary(language, 'alternate_library_card');
+          let passwordLabel = getTermFromDictionary(language, 'password');
+          let formMessage = '';
+          let showAlternateLibraryCardPassword = false;
+
+          if (library?.alternateLibraryCardConfig?.alternateLibraryCardLabel) {
+               cardLabel = library.alternateLibraryCardConfig.alternateLibraryCardLabel;
+          }
+
+          if (library?.alternateLibraryCardConfig?.alternateLibraryCardPasswordLabel) {
+               passwordLabel = library.alternateLibraryCardConfig.alternateLibraryCardPasswordLabel;
+          }
+
+          if (library?.alternateLibraryCardConfig?.alternateLibraryCardFormMessage) {
+               formMessage = decodeHTML(library.alternateLibraryCardConfig.alternateLibraryCardFormMessage);
+          }
+
+          if (library?.alternateLibraryCardConfig?.showAlternateLibraryCardPassword) {
+               if (library.alternateLibraryCardConfig.showAlternateLibraryCardPassword === '1' || library.alternateLibraryCardConfig.showAlternateLibraryCardPassword === 1) {
+                    showAlternateLibraryCardPassword = true;
+               }
+          }
+
+          const { width } = useWindowDimensions();
+          const [card, setCard] = React.useState(user?.alternateLibraryCard ?? '');
+          const [password, setPassword] = React.useState(user?.alternateLibraryCardPassword ?? '');
+          const [showPassword, setShowPassword] = React.useState(false);
+          const toggleShowPassword = () => setShowPassword(!showPassword);
+
+          const source = {
+               baseUrl: library.baseUrl,
+               html: formMessage,
+          };
+
+          const tagsStyles = {
+               body: {
+                    color: textColor,
+               },
+               a: {
+                    color: textColor,
+                    textDecorationColor: textColor,
+               },
+          };
+
+          const updateCard = async () => {
+               await updateAlternateLibraryCard(card, password, false, library.baseUrl, language);
+               await refreshProfile(library.baseUrl).then(async (result) => {
+                    updateUser(result);
+               });
+               setCard('');
+               setPassword('');
+          };
+          return (
+               <>
+                    <Button minWidth="100%" maxWidth="100%" bgColor={theme['colors']['primary']['500']} onPress={() => setShowAddAlternateLibraryCardModal(true)}>
+                         <ButtonText color={theme['colors']['primary']['500-text']}>{title}</ButtonText>
+                    </Button>
+                    <Modal isOpen={showAddAlternateLibraryCardModal} onClose={() => setShowAddAlternateLibraryCardModal(false)} closeOnOverlayClick={false} size="lg">
+                         <ModalBackdrop />
+                         <ModalContent maxWidth="90%" bgColor={colorMode === 'light' ? theme['colors']['warmGray']['50'] : theme['colors']['coolGray']['700']}>
+                              <ModalHeader borderBottomWidth="$1" borderBottomColor={colorMode === 'light' ? theme['colors']['warmGray']['300'] : theme['colors']['coolGray']['500']}>
+                                   <Heading size="md" color={textColor}>
+                                        {getTermFromDictionary(language, 'add_alternate_library_card')}
+                                   </Heading>
+                                   <ModalCloseButton hitSlop={{ top: 30, bottom: 30, left: 30, right: 30 }}>
+                                        <Icon as={CloseIcon} color={textColor} />
+                                   </ModalCloseButton>
+                              </ModalHeader>
+                              <ModalBody mt="$3">
+                                   {formMessage ? <RenderHtml contentWidth={width} source={source} tagsStyles={tagsStyles} /> : null}
+                                   <FormControl mb="$2">
+                                        <FormControlLabel>
+                                             <FormControlLabelText color={textColor} size="sm">
+                                                  {cardLabel}
+                                             </FormControlLabelText>
+                                        </FormControlLabel>
+                                        <Input>
+                                             <InputField textContentType="none" color={textColor} name="card" defaultValue={card} accessibilityLabel={cardLabel} onChangeText={(value) => setCard(value)} />
+                                        </Input>
+                                   </FormControl>
+                                   {showAlternateLibraryCardPassword ? (
+                                        <FormControl mb="$2">
+                                             <FormControlLabel>
+                                                  <FormControlLabelText color={textColor} size="sm">
+                                                       {passwordLabel}
+                                                  </FormControlLabelText>
+                                             </FormControlLabel>
+                                             <Input>
+                                                  <InputField textContentType="none" type={showPassword ? 'text' : 'password'} color={textColor} name="password" defaultValue={password} accessibilityLabel={passwordLabel} onChangeText={(value) => setPassword(value)} />
+                                                  <InputSlot onPress={toggleShowPassword}>
+                                                       <InputIcon as={showPassword ? Eye : EyeOff} mr="$2" color={textColor} />
+                                                  </InputSlot>
+                                             </Input>
+                                        </FormControl>
+                                   ) : null}
+                              </ModalBody>
+                              <ModalFooter borderTopWidth="$1" borderTopColor={colorMode === 'light' ? theme['colors']['warmGray']['300'] : theme['colors']['coolGray']['500']}>
+                                   <ButtonGroup space="sm">
+                                        <Button
+                                             variant="outline"
+                                             borderColor={colorMode === 'light' ? theme['colors']['warmGray']['300'] : theme['colors']['coolGray']['500']}
+                                             onPress={() => {
+                                                  setShowAddAlternateLibraryCardModal(false);
+                                                  setLoading(false);
+                                             }}>
+                                             <ButtonText color={colorMode === 'light' ? theme['colors']['warmGray']['500'] : theme['colors']['coolGray']['300']}>{getTermFromDictionary(language, 'close_window')}</ButtonText>
+                                        </Button>
+                                        <Button
+                                             bgColor={theme['colors']['primary']['500']}
+                                             isDisabled={loading}
+                                             onPress={async () => {
+                                                  setLoading(true);
+                                                  await updateCard();
+                                                  await completeAction(record, type, user.id, null, null, null, library.baseUrl).then(async (eContentResponse) => {
+                                                       setResponse(eContentResponse);
+                                                       if (eContentResponse.success) {
+                                                            queryClient.invalidateQueries({ queryKey: ['checkouts', user.id, library.baseUrl, language] });
+                                                            queryClient.invalidateQueries({ queryKey: ['user', library.baseUrl, language] });
+                                                       }
+                                                       setLoading(false);
+                                                       setResponseIsOpen(true);
+                                                       setShowAddAlternateLibraryCardModal(false);
+                                                  });
+                                             }}>
+                                             {loading ? <ButtonSpinner color={theme['colors']['primary']['500-text']} /> : <ButtonText color={theme['colors']['primary']['500-text']}>{title}</ButtonText>}
+                                        </Button>
+                                   </ButtonGroup>
+                              </ModalFooter>
+                         </ModalContent>
+                    </Modal>
+               </>
           );
      } else {
           return (

--- a/code/aspen_app/src/components/Action/Holds/PlaceHold.js
+++ b/code/aspen_app/src/components/Action/Holds/PlaceHold.js
@@ -38,6 +38,8 @@ export const PlaceHold = (props) => {
           setHoldItemSelectIsOpen,
           onHoldItemSelectClose,
           cancelHoldItemSelectRef,
+          userHasAlternateLibraryCard,
+          shouldPromptAlternateLibraryCard,
      } = props;
      const { user, updateUser, accounts, locations } = React.useContext(UserContext);
      const { library } = React.useContext(LibrarySystemContext);
@@ -73,7 +75,7 @@ export const PlaceHold = (props) => {
      let promptForHoldNotifications = user.promptForHoldNotifications ?? false;
 
      let loadHoldPrompt = false;
-     if (volumeInfo.numItemsWithVolumes >= 1 || _.size(accounts) > 0 || _.size(locations) > 1 || promptForHoldNotifications || holdTypeForFormat === 'item' || holdTypeForFormat === 'either') {
+     if (volumeInfo.numItemsWithVolumes >= 1 || _.size(accounts) > 0 || _.size(locations) > 1 || promptForHoldNotifications || holdTypeForFormat === 'item' || holdTypeForFormat === 'either' || (shouldPromptAlternateLibraryCard && !userHasAlternateLibraryCard)) {
           loadHoldPrompt = true;
      }
 

--- a/code/aspen_app/src/navigations/drawer/DrawerContent.js
+++ b/code/aspen_app/src/navigations/drawer/DrawerContent.js
@@ -415,6 +415,7 @@ export const DrawerContent = () => {
                               <VStack>
                                    <UserProfile />
                                    <LinkedAccounts />
+                                   <AlternateLibraryCard />
                               </VStack>
                          </VStack>
                     </VStack>
@@ -809,6 +810,39 @@ const UserPreferences = () => {
                </HStack>
           </Pressable>
      );
+};
+
+const AlternateLibraryCard = () => {
+     const { library } = React.useContext(LibrarySystemContext);
+     const { language } = React.useContext(LanguageContext);
+     const version = formatDiscoveryVersion(library.discoveryVersion);
+
+     let shouldShowAlternateLibraryCard = false;
+     if (typeof library.showAlternateLibraryCard !== 'undefined') {
+          shouldShowAlternateLibraryCard = library.showAlternateLibraryCard;
+     }
+
+     if (version >= '24.09.00' && (shouldShowAlternateLibraryCard === '1' || shouldShowAlternateLibraryCard === 1)) {
+          return (
+               <Pressable
+                    px="2"
+                    py="3"
+                    rounded="md"
+                    onPress={() => {
+                         navigateStack('LibraryCardTab', 'MyAlternateLibraryCard', {
+                              prevRoute: 'AccountDrawer',
+                              hasPendingChanges: false,
+                         });
+                    }}>
+                    <HStack space="1" alignItems="center">
+                         <Icon as={MaterialIcons} name="chevron-right" size="7" />
+                         <Text fontWeight="500">{getTermFromDictionary(language, 'alternate_library_card')}</Text>
+                    </HStack>
+               </Pressable>
+          );
+     }
+
+     return null;
 };
 
 const Fines = () => {

--- a/code/aspen_app/src/navigations/stack/LibraryCardStackNavigator.js
+++ b/code/aspen_app/src/navigations/stack/LibraryCardStackNavigator.js
@@ -1,5 +1,6 @@
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import React from 'react';
+import { MyAlternateLibraryCard } from '../../screens/MyAccount/MyLibraryCard/MyAlternateLibraryCard';
 
 import { MyLibraryCard } from '../../screens/MyAccount/MyLibraryCard/MyLibraryCard';
 import { LanguageContext, LibrarySystemContext } from '../../context/initialContext';
@@ -22,6 +23,13 @@ const LibraryCardStackNavigator = () => {
                     options={{ title: getTermFromDictionary(language, 'library_card') }}
                     initialParams={{
                          libraryContext: JSON.stringify(React.useContext(LibrarySystemContext)),
+                    }}
+               />
+               <Stack.Screen
+                    name="MyAlternateLibraryCard"
+                    component={MyAlternateLibraryCard}
+                    options={{
+                         title: getTermFromDictionary(language, 'alternate_library_card'),
                     }}
                />
           </Stack.Navigator>

--- a/code/aspen_app/src/screens/GroupedWork/Editions.js
+++ b/code/aspen_app/src/screens/GroupedWork/Editions.js
@@ -17,7 +17,7 @@ import { stripHTML } from '../../util/apiAuth';
 import { placeHold } from '../../util/recordActions';
 import { getStatusIndicator } from './StatusIndicator';
 import { ActionButton } from '../../components/Action/ActionButton';
-import { LanguageContext, LibrarySystemContext, ThemeContext } from '../../context/initialContext';
+import { LanguageContext, LibrarySystemContext, ThemeContext, UserContext } from '../../context/initialContext';
 import { getTermFromDictionary } from '../../translations/TranslationService';
 
 export const Editions = () => {
@@ -28,6 +28,7 @@ export const Editions = () => {
      const params = route[0].params;
      const { id, recordId, format, source, volumeInfo, prevRoute } = params;
      const { library } = React.useContext(LibrarySystemContext);
+     const { user } = React.useContext(UserContext);
      const { language } = React.useContext(LanguageContext);
      const { colorMode, theme, textColor } = React.useContext(ThemeContext);
      const [isLoading, setLoading] = React.useState(false);
@@ -53,6 +54,39 @@ export const Editions = () => {
      const cancelHoldItemSelectRef = React.useRef(null);
      const [holdSelectItemResponse, setHoldSelectItemResponse] = React.useState('');
      const [placingItemHold, setPlacingItemHold] = React.useState(false);
+
+     let shouldPromptAlternateLibraryCard = false;
+     let shouldShowAlternateLibraryCard = false;
+     let useAlternateCardForCloudLibrary = false;
+     let userHasAlternateLibraryCard = false;
+
+     if (typeof library.showAlternateLibraryCard !== 'undefined') {
+          if (library.showAlternateLibraryCard === '1' || library.showAlternateLibraryCard === 1) {
+               shouldShowAlternateLibraryCard = true;
+          }
+     }
+
+     if (typeof library.useAlternateCardForCloudLibrary !== 'undefined') {
+          if (library.useAlternateCardForCloudLibrary === '1' || library.useAlternateCardForCloudLibrary === 1) {
+               useAlternateCardForCloudLibrary = true;
+          }
+     }
+
+     if (shouldShowAlternateLibraryCard && useAlternateCardForCloudLibrary && source === 'cloud_library') {
+          shouldPromptAlternateLibraryCard = true;
+     }
+
+     if (typeof user.alternateLibraryCard !== 'undefined') {
+          if (user.alternateLibraryCard && user.alternateLibraryCard !== '') {
+               if (library.alternateLibraryCardConfig?.showAlternateLibraryCardPassword === '1') {
+                    if (user.alternateLibraryCardPassword !== '') {
+                         userHasAlternateLibraryCard = true;
+                    }
+               } else {
+                    userHasAlternateLibraryCard = true;
+               }
+          }
+     }
 
      const handleNavigation = (action) => {
           if (prevRoute === 'DiscoveryScreen' || prevRoute === 'SearchResults' || prevRoute === 'HomeScreen') {
@@ -117,6 +151,8 @@ export const Editions = () => {
                                         cancelHoldItemSelectRef={cancelHoldItemSelectRef}
                                         holdSelectItemResponse={holdSelectItemResponse}
                                         setHoldSelectItemResponse={setHoldSelectItemResponse}
+                                        userHasAlternateLibraryCard={userHasAlternateLibraryCard}
+                                        shouldPromptAlternateLibraryCard={shouldPromptAlternateLibraryCard}
                                    />
                               )}
                          />
@@ -256,7 +292,7 @@ export const Editions = () => {
 const Edition = (payload) => {
      const { language } = React.useContext(LanguageContext);
      const { theme, textColor } = React.useContext(ThemeContext);
-     const { response, setResponse, responseIsOpen, setResponseIsOpen, onResponseClose, cancelResponseRef, holdConfirmationResponse, setHoldConfirmationResponse, holdConfirmationIsOpen, setHoldConfirmationIsOpen, onHoldConfirmationClose, cancelHoldConfirmationRef, holdSelectItemResponse, setHoldSelectItemResponse, holdItemSelectIsOpen, setHoldItemSelectIsOpen, onHoldItemSelectClose, cancelHoldItemSelectRef } = payload;
+     const { response, setResponse, responseIsOpen, setResponseIsOpen, onResponseClose, cancelResponseRef, holdConfirmationResponse, setHoldConfirmationResponse, holdConfirmationIsOpen, setHoldConfirmationIsOpen, onHoldConfirmationClose, cancelHoldConfirmationRef, holdSelectItemResponse, setHoldSelectItemResponse, holdItemSelectIsOpen, setHoldItemSelectIsOpen, onHoldItemSelectClose, cancelHoldItemSelectRef, userHasAlternateLibraryCard, shouldPromptAlternateLibraryCard } = payload;
      const prevRoute = payload.prevRoute;
      const records = payload.records;
      const id = payload.id;
@@ -343,6 +379,8 @@ const Edition = (payload) => {
                                         cancelHoldItemSelectRef={cancelHoldItemSelectRef}
                                         holdSelectItemResponse={holdSelectItemResponse}
                                         setHoldSelectItemResponse={setHoldSelectItemResponse}
+                                        userHasAlternateLibraryCard={userHasAlternateLibraryCard}
+                                        shouldPromptAlternateLibraryCard={shouldPromptAlternateLibraryCard}
                                    />
                               )}
                          />

--- a/code/aspen_app/src/screens/GroupedWork/Variations.js
+++ b/code/aspen_app/src/screens/GroupedWork/Variations.js
@@ -257,6 +257,7 @@ export const Variations = (props) => {
 };
 
 const Variation = (payload) => {
+     const { user } = React.useContext(UserContext);
      const { library } = React.useContext(LibrarySystemContext);
      const { language } = React.useContext(LanguageContext);
      const { textColor, colorMode, theme } = React.useContext(ThemeContext);
@@ -272,6 +273,39 @@ const Variation = (payload) => {
      const publisher = variation.publisher ?? null;
      const isbn = variation.isbn ?? null;
      const oclcNumber = variation.oclcNumber ?? null;
+
+     let shouldPromptAlternateLibraryCard = false;
+     let shouldShowAlternateLibraryCard = false;
+     let useAlternateCardForCloudLibrary = false;
+     let userHasAlternateLibraryCard = false;
+
+     if (typeof library.showAlternateLibraryCard !== 'undefined') {
+          if (library.showAlternateLibraryCard === '1' || library.showAlternateLibraryCard === 1) {
+               shouldShowAlternateLibraryCard = true;
+          }
+     }
+
+     if (typeof library.useAlternateCardForCloudLibrary !== 'undefined') {
+          if (library.useAlternateCardForCloudLibrary === '1' || library.useAlternateCardForCloudLibrary === 1) {
+               useAlternateCardForCloudLibrary = true;
+          }
+     }
+
+     if (shouldShowAlternateLibraryCard && useAlternateCardForCloudLibrary && source === 'cloud_library') {
+          shouldPromptAlternateLibraryCard = true;
+     }
+
+     if (typeof user.alternateLibraryCard !== 'undefined') {
+          if (user.alternateLibraryCard && user.alternateLibraryCard !== '') {
+               if (library.alternateLibraryCardConfig?.showAlternateLibraryCardPassword === '1') {
+                    if (user.alternateLibraryCardPassword !== '') {
+                         userHasAlternateLibraryCard = true;
+                    }
+               } else {
+                    userHasAlternateLibraryCard = true;
+               }
+          }
+     }
 
      let fullRecordId = _.split(variation.id, ':');
      const recordId = _.toString(fullRecordId[1]);
@@ -357,6 +391,8 @@ const Variation = (payload) => {
                                         cancelHoldItemSelectRef={cancelHoldItemSelectRef}
                                         holdSelectItemResponse={holdSelectItemResponse}
                                         setHoldSelectItemResponse={setHoldSelectItemResponse}
+                                        userHasAlternateLibraryCard={userHasAlternateLibraryCard}
+                                        shouldPromptAlternateLibraryCard={shouldPromptAlternateLibraryCard}
                                    />
                               )}
                          />

--- a/code/aspen_app/src/screens/MyAccount/MyLibraryCard/MyAlternateLibraryCard.js
+++ b/code/aspen_app/src/screens/MyAccount/MyLibraryCard/MyAlternateLibraryCard.js
@@ -1,0 +1,186 @@
+import _ from 'lodash';
+import { EyeOff, Eye } from 'lucide-react-native';
+import { Pressable, ChevronLeftIcon, Box, ScrollView, ButtonGroup, Button, ButtonText, FormControl, FormControlLabel, FormControlLabelText, Input, InputField, InputSlot, InputIcon } from '@gluestack-ui/themed';
+import React from 'react';
+import { useWindowDimensions } from 'react-native';
+import RenderHtml from 'react-native-render-html';
+import { useQueryClient } from '@tanstack/react-query';
+import { useRoute, useNavigation, CommonActions, StackActions } from '@react-navigation/native';
+import { LoadingSpinner } from '../../../components/loadingSpinner';
+
+// custom components and helper files
+import { LanguageContext, LibrarySystemContext, SystemMessagesContext, ThemeContext, UserContext } from '../../../context/initialContext';
+import { DisplaySystemMessage } from '../../../components/Notifications';
+import { BackIcon } from '../../../themes/theme';
+import { getTermFromDictionary } from '../../../translations/TranslationService';
+import { refreshProfile, updateAlternateLibraryCard } from '../../../util/api/user';
+import { decodeHTML } from '../../../util/apiAuth';
+
+export const MyAlternateLibraryCard = () => {
+     const navigation = useNavigation();
+     const route = useRoute();
+     const { library } = React.useContext(LibrarySystemContext);
+     const { user, updateUser } = React.useContext(UserContext);
+     const { language } = React.useContext(LanguageContext);
+     const { theme, textColor, colorMode } = React.useContext(ThemeContext);
+     const queryClient = useQueryClient();
+     const { systemMessages, updateSystemMessages } = React.useContext(SystemMessagesContext);
+     const { width } = useWindowDimensions();
+     const [card, setCard] = React.useState(user?.alternateLibraryCard ?? '');
+     const [password, setPassword] = React.useState(user?.alternateLibraryCardPassword ?? '');
+
+     const [isLoading, setIsLoading] = React.useState(false);
+     const [showPassword, setShowPassword] = React.useState(false);
+     const toggleShowPassword = () => setShowPassword(!showPassword);
+
+     const handleGoBack = () => {
+          console.log(route?.params);
+          if (route?.params?.prevRoute === 'AccountDrawer') {
+               navigation.dispatch(CommonActions.setParams({ prevRoute: null }));
+               navigation.dispatch(StackActions.replace('LibraryCard'));
+          } else {
+               navigation.goBack();
+          }
+     };
+
+     React.useLayoutEffect(() => {
+          navigation.setOptions({
+               headerLeft: () => (
+                    <Pressable onPress={handleGoBack} mr={3} hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}>
+                         <ChevronLeftIcon size="md" ml={1} color={theme['colors']['primary']['baseContrast']} />
+                    </Pressable>
+               ),
+          });
+     }, [navigation]);
+     let cardLabel = getTermFromDictionary(language, 'alternate_library_card');
+     let passwordLabel = getTermFromDictionary(language, 'password');
+     let formMessage = '';
+     let showAlternateLibraryCardPassword = false;
+     let alternateLibraryCardStyle = 'none';
+
+     if (library?.alternateLibraryCardConfig?.alternateLibraryCardLabel) {
+          cardLabel = library.alternateLibraryCardConfig.alternateLibraryCardLabel;
+     }
+
+     if (library?.alternateLibraryCardConfig?.alternateLibraryCardPasswordLabel) {
+          passwordLabel = library.alternateLibraryCardConfig.alternateLibraryCardPasswordLabel;
+     }
+
+     if (library?.alternateLibraryCardConfig?.alternateLibraryCardFormMessage) {
+          formMessage = decodeHTML(library.alternateLibraryCardConfig.alternateLibraryCardFormMessage);
+     }
+
+     if (library?.alternateLibraryCardConfig?.showAlternateLibraryCardPassword) {
+          if (library.alternateLibraryCardConfig.showAlternateLibraryCardPassword === '1' || library.alternateLibraryCardConfig.showAlternateLibraryCardPassword === 1) {
+               showAlternateLibraryCardPassword = true;
+          }
+     }
+
+     if (library?.alternateLibraryCardConfig?.alternateLibraryCardStyle) {
+          alternateLibraryCardStyle = library.alternateLibraryCardConfig.alternateLibraryCardStyle;
+     }
+
+     const showSystemMessage = () => {
+          if (_.isArray(systemMessages)) {
+               return systemMessages.map((obj, index, collection) => {
+                    if (obj.showOn === '0' || obj.showOn === '1' || obj.showOn === '5') {
+                         return <DisplaySystemMessage style={obj.style} message={obj.message} dismissable={obj.dismissable} id={obj.id} all={systemMessages} url={library.baseUrl} updateSystemMessages={updateSystemMessages} queryClient={queryClient} />;
+                    }
+               });
+          }
+          return null;
+     };
+
+     const source = {
+          baseUrl: library.baseUrl,
+          html: formMessage,
+     };
+
+     const tagsStyles = {
+          body: {
+               color: textColor,
+          },
+          a: {
+               color: textColor,
+               textDecorationColor: textColor,
+          },
+     };
+
+     const deleteCard = async () => {
+          await updateAlternateLibraryCard('', '', true, library.baseUrl, language);
+          await refreshProfile(library.baseUrl).then(async (result) => {
+               updateUser(result);
+          });
+     };
+
+     const updateCard = async () => {
+          await updateAlternateLibraryCard(card, password, false, library.baseUrl, language);
+          await refreshProfile(library.baseUrl).then(async (result) => {
+               updateUser(result);
+          });
+          setCard('');
+          setPassword('');
+     };
+
+     return (
+          <ScrollView>
+               {isLoading ? (
+                    LoadingSpinner()
+               ) : (
+                    <Box p="$5">
+                         {showSystemMessage()}
+                         <Box>
+                              {formMessage ? <RenderHtml contentWidth={width} source={source} tagsStyles={tagsStyles} /> : null}
+                              <FormControl mb="$2">
+                                   <FormControlLabel>
+                                        <FormControlLabelText color={textColor} size="sm">
+                                             {cardLabel}
+                                        </FormControlLabelText>
+                                   </FormControlLabel>
+                                   <Input>
+                                        <InputField textContentType="none" color={textColor} name="card" defaultValue={card} accessibilityLabel={cardLabel} onChangeText={(value) => setCard(value)} />
+                                   </Input>
+                              </FormControl>
+                              {showAlternateLibraryCardPassword ? (
+                                   <FormControl mb="$2">
+                                        <FormControlLabel>
+                                             <FormControlLabelText color={textColor} size="sm">
+                                                  {passwordLabel}
+                                             </FormControlLabelText>
+                                        </FormControlLabel>
+                                        <Input>
+                                             <InputField textContentType="none" type={showPassword ? 'text' : 'password'} color={textColor} name="password" defaultValue={password} accessibilityLabel={passwordLabel} onChangeText={(value) => setPassword(value)} />
+                                             <InputSlot onPress={toggleShowPassword}>
+                                                  <InputIcon as={showPassword ? Eye : EyeOff} mr="$2" color={textColor} />
+                                             </InputSlot>
+                                        </Input>
+                                   </FormControl>
+                              ) : null}
+                              <ButtonGroup>
+                                   <Button
+                                        bgColor={theme['colors']['primary']['500']}
+                                        onPress={() => {
+                                             setIsLoading(true);
+                                             updateCard().then(() => {
+                                                  setIsLoading(false);
+                                             });
+                                        }}>
+                                        <ButtonText color={theme['colors']['primary']['500-text']}>{getTermFromDictionary(language, 'update')}</ButtonText>
+                                   </Button>
+                                   <Button
+                                        bgColor={theme['colors']['danger']['700']}
+                                        onPress={() => {
+                                             setIsLoading(true);
+                                             deleteCard().then(() => {
+                                                  setIsLoading(false);
+                                             });
+                                        }}>
+                                        <ButtonText color={theme['colors']['white']}>{getTermFromDictionary(language, 'delete')}</ButtonText>
+                                   </Button>
+                              </ButtonGroup>
+                         </Box>
+                    </Box>
+               )}
+          </ScrollView>
+     );
+};

--- a/code/aspen_app/src/screens/MyAccount/MyLibraryCard/MyLibraryCard.js
+++ b/code/aspen_app/src/screens/MyAccount/MyLibraryCard/MyLibraryCard.js
@@ -15,8 +15,10 @@ import Carousel from 'react-native-reanimated-carousel';
 // custom components and helper files
 import { PermissionsPrompt } from '../../../components/PermissionsPrompt';
 import { LanguageContext, LibrarySystemContext, UserContext } from '../../../context/initialContext';
+import { navigateStack } from '../../../helpers/RootNavigator';
 import { getTermFromDictionary, getTranslationsWithValues } from '../../../translations/TranslationService';
 import { getLinkedAccounts, updateScreenBrightnessStatus } from '../../../util/api/user';
+import { formatDiscoveryVersion } from '../../../util/loadLibrary';
 
 export const MyLibraryCard = () => {
      const queryClient = useQueryClient();
@@ -165,6 +167,15 @@ export const MyLibraryCard = () => {
           return <PermissionsPrompt promptTitle="permissions_screen_brightness_title" promptBody="permissions_screen_brightness_body" setShouldRequestPermissions={setShouldRequestPermissions} updateStatus={updateStatus} />;
      }
 
+     const version = formatDiscoveryVersion(library.discoveryVersion);
+     let shouldShowAlternateLibraryCard = false;
+     if (typeof library.showAlternateLibraryCard !== 'undefined') {
+          shouldShowAlternateLibraryCard = library.showAlternateLibraryCard;
+     }
+     if (version >= '24.09.00' && (shouldShowAlternateLibraryCard === '1' || shouldShowAlternateLibraryCard === 1)) {
+          shouldShowAlternateLibraryCard = true;
+     }
+
      /* useFocusEffect(
 	 React.useCallback(() => {
 	 console.log("numCards listener > " + numCards);
@@ -193,6 +204,21 @@ export const MyLibraryCard = () => {
      return (
           <>
                <CardCarousel cards={cards} orientation={isLandscape} />
+               {shouldShowAlternateLibraryCard ? (
+                    <Center>
+                         <Button
+                              size="md"
+                              colorScheme="secondary"
+                              onPress={() => {
+                                   navigateStack('LibraryCardTab', 'MyAlternateLibraryCard', {
+                                        prevRoute: 'MyLibraryCard',
+                                        hasPendingChanges: false,
+                                   });
+                              }}>
+                              {getTermFromDictionary(language, 'manage_alternate_library_card')}
+                         </Button>
+                    </Center>
+               ) : null}
           </>
      );
 };

--- a/code/aspen_app/src/translations/defaults.json
+++ b/code/aspen_app/src/translations/defaults.json
@@ -570,5 +570,8 @@
   "mark_as_unread": "Mark As Unread",
   "date_sent": "Date Sent",
   "sent_on": "Sent on %1%",
-  "open": "Open"
+  "open": "Open",
+  "alternate_library_card": "Alternate Library Card",
+  "manage_alternate_library_card": "Manage Alternate Library Card",
+  "add_alternate_library_card": "Add Alternate Library Card"
 }

--- a/code/aspen_app/src/util/api/user.js
+++ b/code/aspen_app/src/util/api/user.js
@@ -188,6 +188,42 @@ export async function logoutUser(url) {
      }
 }
 
+/**
+ * Updates the users alternate library card
+ * @param {string} cardNumber
+ * @param {string} cardPassword
+ * @param {boolean} deleteCard
+ * @param {string} url
+ * @param {string} language
+ **/
+export async function updateAlternateLibraryCard(cardNumber = '', cardPassword = '', deleteCard = false, url, language = 'en') {
+     const postBody = await postData();
+     postBody.append('alternateLibraryCard', cardNumber);
+     postBody.append('alternateLibraryCardPassword', cardPassword);
+
+     const api = create({
+          baseURL: url + '/API',
+          headers: getHeaders(true),
+          auth: createAuthTokens(),
+          params: {
+               deleteAlternateLibraryCard: deleteCard,
+               language,
+          },
+     });
+
+     const response = await api.post('/UserAPI?method=updateAlternateLibraryCard', postBody);
+     let data = [];
+     if (response.ok) {
+          data = response.data;
+     }
+
+     return {
+          success: data?.success ?? false,
+          title: data?.title ?? null,
+          message: data?.message ?? null,
+     };
+}
+
 /** *******************************************************************
  * Checkouts and Holds
  ******************************************************************* **/

--- a/code/web/release_notes/24.09.00.MD
+++ b/code/web/release_notes/24.09.00.MD
@@ -1,4 +1,6 @@
 ## Aspen LiDA Updates
+- Added prompts for providing an alternate library card while placing a hold or checking out cloudLibrary items. (*KK*)
+- Added a screen to modify or remove alternative library card information, if enabled for the library. This screen is accessible in both the Account Drawer and on the Card screens. (*KK*)
 
 ## Aspen Discovery Updates
 // mark - ByWater

--- a/code/web/services/API/UserAPI.php
+++ b/code/web/services/API/UserAPI.php
@@ -6062,7 +6062,7 @@ class UserAPI extends AbstractAPI {
 			$alternateLibraryCard = $_REQUEST['alternateLibraryCard'] ?? null;
 			$alternateLibraryCardPassword = $_REQUEST['alternateLibraryCardPassword'] ?? null;
 			$deleteAlternateLibraryCard = $_REQUEST['deleteAlternateLibraryCard'] ?? false;
-			if(!$deleteAlternateLibraryCard) {
+			if(!$deleteAlternateLibraryCard || $deleteAlternateLibraryCard === "false") {
 				if ($alternateLibraryCard) {
 					$user->alternateLibraryCard = $alternateLibraryCard;
 				}


### PR DESCRIPTION
- Added prompts for providing an alternate library card while placing a hold or checking out cloudLibrary items.
- Added a screen to modify or remove alternative library card information, if enabled for the library. This screen is accessible in both the Account Drawer and on the Card screens.