### PR TITLE
Get volume info for holds from MARC record when there is no volumes.txt for Symphony

### DIFF
--- a/code/web/release_notes/24.09.00.MD
+++ b/code/web/release_notes/24.09.00.MD
@@ -65,6 +65,7 @@
 // katherine
 ### Indexing Updates
 - Add target audience to grouped works diagnostic panel (Ticket 134227) (*KP*)
+- Get volume information for holds from MARC record when not provided via volumes.txt for Symphony (Ticket 134021) (*KP*)
 
 ### Language Updates
 - Sort languages by weight, then alphabetically by display name to make consistent with LiDA. (*KP*)


### PR DESCRIPTION
Sirsi is not putting volume information in volumes.txt anymore for new Aspen libraries.  The volume description is in the MARC record in the volume subfield, but the call number key (necessary for placing holds) is not.  Existing libraries still use volumes.txt, so that needs to continue to work unchanged.
- Get the volume information from the MARC record from the item field, volume subfield.  
- Prefix volumeId in the ils_volume_info table with LOOKUP: to trigger looking up the call number key while placing the hold.
- Use the Sirsi API to look up all the call number keys for the record, then look up the keys one by one and find the first one that matches the volume description.  There does not appear to be a more efficient way to do this with the Sirsi API.  Holds with lots of items may be slow.  Use this key to actually place the hold.
- I tested this using CLEVNET's records and API connection.
- Updated release notes.

ByWater ticket 134021. 