### PR TITLE
check smtp attachments array not empty before loop

### DIFF
--- a/code/web/release_notes/24.09.00.MD
+++ b/code/web/release_notes/24.09.00.MD
@@ -127,6 +127,7 @@
 ### Other Updates
 - If 'Show Hold and Copy Counts' in Library Systems is set to "Always", display copy count even if there are no holds or waitlist. (Ticket 128625) (*KK*)
 - Added pagination options to Manage Requests page to prevent performance issues when libraries have a large amount of requests. (Ticket 135632) (*KK*)
+- When sending mail via SMTP, check that attachments exist before looping through them. (Ticket 136738) (*KK*)
 - Added Notification History as an inbox for ILS messages to Your Account to allow users to view what notifications have been sent. Applies to Koha libraries only at this time. (*KK*)
 - Added function to gather all the various alternate library card settings for a library system. (*KK*)
 - Changed how Aspen Discovery determines its current version by using the most recent release notes file instead of looking in the git file. (*KK*)

--- a/code/web/sys/Email/SMTPSetting.php
+++ b/code/web/sys/Email/SMTPSetting.php
@@ -118,8 +118,10 @@ class SMTPSetting extends DataObject {
 			$mail->addAddress($toAddress);
 		}
 
-		for($i = 0; $i < sizeof($attachments['name']); $i++){
-			$mail->addAttachment($attachments['tmp_name'][$i], $attachments['name'][0]);
+		if(!empty($attachments)) {
+			for ($i = 0; $i < sizeof($attachments['name']); $i++) {
+				$mail->addAttachment($attachments['tmp_name'][$i], $attachments['name'][0]);
+			}
 		}
 
 		$mail->Subject = $subject;


### PR DESCRIPTION
previously if attachments were not present, it would result in an error when reaching the for loop, and unable to send the email.