### PR TITLE
Update Sierra.php

### DIFF
--- a/code/web/Drivers/Sierra.php
+++ b/code/web/Drivers/Sierra.php
@@ -1780,7 +1780,6 @@ class Sierra extends Millennium {
 		$params = [];
 
 		if ($formFields != null) {
-			$params['patronType'] = $selfRegistrationForm->selfRegPatronCode;
 			foreach ($formFields as $fieldObj){
 				$field = $fieldObj->ilsName;
 				if ($field == 'firstName') {
@@ -1824,6 +1823,7 @@ class Sierra extends Millennium {
 					$params['pin'] = $_REQUEST['pin'];
 				}
 			}
+			$params['patronType'] = (int)$selfRegistrationForm->selfRegPatronCode;
 		}
 
 		$sierraUrl = $this->accountProfile->vendorOpacUrl . "/iii/sierra-api/v{$this->accountProfile->apiVersion}/patrons/";


### PR DESCRIPTION
cast patronType to int for Sierra self registration - fix for invalid json errors being returned

To Test:
- set up self registration for Sierra instance on Aspen 
- create a test patron
- you will now get a success message instead of "Unknown Error"