### PR TITLE
debuginfo column length

### DIFF
--- a/code/web/release_notes/24.09.01.MD
+++ b/code/web/release_notes/24.09.01.MD
@@ -12,3 +12,6 @@
 
 - PTFS-Europe
     - Chloe Zermatten (CZ)
+
+- ByWater Solutions
+  - Kodi Lein (KL)

--- a/code/web/release_notes/24.09.01.MD
+++ b/code/web/release_notes/24.09.01.MD
@@ -4,6 +4,7 @@
 
 ### Other updates
 - Disabled the 'Show This Branch In Available At and Owning Location Facets' filter and setting as it is interacting poorly with facet labels. (*CZ*)
+- Increased the length for debuginfo column in the grouped_work_debug_info table (Ticket 138696) (*KL*)
 
 ## This release includes code contributions from
 - Grove For Libraries

--- a/code/web/sys/DBMaintenance/version_updates/24.09.01.php
+++ b/code/web/sys/DBMaintenance/version_updates/24.09.01.php
@@ -4,13 +4,13 @@ function getUpdates24_09_01(): array {
 	$curTime = time();
 	return [
 		/*'name' => [
-			 'title' => '',
-			 'description' => '',
-			 'continueOnError' => false,
-			 'sql' => [
-				 ''
-			 ]
-		 ], //name*/
+			'title' => '',
+			'description' => '',
+			'continueOnError' => false,
+			'sql' => [
+				''
+			]
+		], //name*/
 
 		//kodi - ByWater
 		'debug_info_update' => [
@@ -20,6 +20,5 @@ function getUpdates24_09_01(): array {
 				'ALTER TABLE grouped_work_debug_info CHANGE COLUMN debugInfo debugInfo MEDIUMTEXT',
 			],
 		],
-
 	];
 }

--- a/code/web/sys/DBMaintenance/version_updates/24.09.01.php
+++ b/code/web/sys/DBMaintenance/version_updates/24.09.01.php
@@ -1,0 +1,25 @@
+<?php
+
+function getUpdates24_09_01(): array {
+	$curTime = time();
+	return [
+		/*'name' => [
+			 'title' => '',
+			 'description' => '',
+			 'continueOnError' => false,
+			 'sql' => [
+				 ''
+			 ]
+		 ], //name*/
+
+		//kodi - ByWater
+		'debug_info_update' => [
+			'title' => 'Update Debug Info Column',
+			'description' => 'Increase size of debuginfo column to accommodate more information.',
+			'sql' => [
+				'ALTER TABLE grouped_work_debug_info CHANGE COLUMN debugInfo debugInfo MEDIUMTEXT',
+			],
+		],
+
+	];
+}


### PR DESCRIPTION
Increase the length for debuginfo column in the grouped_work_debug_info table to prevent data truncation errors Updated release notes