### PR TITLE
Fix typos in password reset email text

### DIFF
--- a/code/aspen_app/src/translations/defaults.json
+++ b/code/aspen_app/src/translations/defaults.json
@@ -443,7 +443,7 @@
   "evergreen_password_reset_body": "To reset your %1%, enter your %2% or your email address.  You must have an email associated with your account to reset your %1%.  If you do not, please contact the library.",
   "millennium_password_reset_body": "Enter your %1%. We will send a %2% reset link to the email address we have on file.",
   "symphony_password_reset_body": "Please enter your complete %1%.  An email will be sent to the email address on file for your account containing a link to reset your %1%.",
-  "password_reset_success_body_1": "A email has been sent to the email address on the circulation system for your account containing a link to reset your %1%.",
+  "password_reset_success_body_1": "An email has been sent to the email address on the circulation system for your account containing a link to reset your %1%.",
   "password_reset_success_body_2": "If you do not receive an email within a few minutes, please check any spam folder your email service may have.   If you do not receive any email, please contact your library to have them reset your %1%.",
   "try_again": "Try Again",
   "card_number": "Card Number",

--- a/code/web/interface/themes/responsive/MyAccount/aspenEmailResetPinResults.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/aspenEmailResetPinResults.tpl
@@ -21,7 +21,7 @@
 					</form>
 				{else}
 					<p class="alert alert-success">
-						{translate text="A email has been sent to the email address on the circulation system for your account containing a link to reset your PIN." isPublicFacing=true}
+						{translate text="An email has been sent to the email address on the circulation system for your account containing a link to reset your PIN." isPublicFacing=true}
 					</p>
 					<p class="alert alert-warning">
 						{translate text="If you do not receive an email within a few minutes, please check any spam folder your email service may have.   If you do not receive any email, please contact your library to have them reset your pin." isPublicFacing=true}

--- a/code/web/interface/themes/responsive/MyAccount/emailResetPinResults.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/emailResetPinResults.tpl
@@ -15,7 +15,7 @@
 					</p>
 				{else}
 					<p class="alert alert-success">
-						{translate text="A email has been sent to the email address on the circulation system for your account containing a link to reset your PIN." isPublicFacing=true}
+						{translate text="An email has been sent to the email address on the circulation system for your account containing a link to reset your PIN." isPublicFacing=true}
 					</p>
 					<p class="alert alert-warning">
 						{translate text="If you do not receive an email within a few minutes, please check any spam folder your email service may have.   If you do not receive any email, please contact your library to have them reset your pin." isPublicFacing=true}

--- a/code/web/services/API/UserAPI.php
+++ b/code/web/services/API/UserAPI.php
@@ -428,7 +428,7 @@ class UserAPI extends AbstractAPI {
 				];
 
 				$result['message'] = translate([
-					'text' => 'A email has been sent to the email address on the circulation system for your account containing a link to reset your PIN.',
+					'text' => 'An email has been sent to the email address on the circulation system for your account containing a link to reset your PIN.',
 					'isPublicFacing' => true,
 				]) . ' ' . translate([
 					'text' => 'If you do not receive an email within a few minutes, please check any spam folder your email service may have.   If you do not receive any email, please contact your library to have them reset your pin.',


### PR DESCRIPTION
This patch replaces 'A email' with 'An email' in the password reset email text