### PR TITLE
139355: Fixes login error

### DIFF
--- a/code/web/release_notes/24.10.00.MD
+++ b/code/web/release_notes/24.10.00.MD
@@ -98,6 +98,8 @@
 </div>
 
 // james - Nashville
+### Other Updates
+- Fixes a bug where users with linked accounts received an error when trying to log in. (*JStaub*)
 
 // alexander - PTFS-E
 ### Privacy Updates

--- a/code/web/sys/Administration/BlockPatronAccountLink.php
+++ b/code/web/sys/Administration/BlockPatronAccountLink.php
@@ -25,7 +25,7 @@ class BlockPatronAccountLink extends DataObject {
 	 * @return bool
 	 * @see DB/DB_DataObject::fetch()
 	 */
-	function fetch($includeBarCodes = true) {
+	function fetch($includeBarCodes = true): bool|DataObject|null {
 		$return = parent::fetch();
 		if (!is_null($return) & $includeBarCodes) {
 			// Default values (clear out any previous values


### PR DESCRIPTION
Fixes a bug where users with linked accounts received an error when trying to log in.

https://ticket.bywatersolutions.com/SelfService/Display.html?id=139355