### PR TITLE
Fixes Nashville student report

### DIFF
--- a/code/web/interface/themes/responsive/Report/studentReport.tpl
+++ b/code/web/interface/themes/responsive/Report/studentReport.tpl
@@ -1,3 +1,4 @@
+{debug}
 {strip}
 	<div id="main-content" class="col-md-12">
 		<div class="doNotPrint">
@@ -175,7 +176,6 @@
 			<tbody>
 {assign var=previousPatron value=0}
 {foreach from=$reportData item=dataRow name=overdueData}
-	{if empty($smarty.foreach.overdueData.first)}
 	{if $dataRow.P_BARCODE != $previousPatron}
 		{if $smarty.foreach.overdueData.index > 0}</div></div></td></tr>{/if}
 				<tr class="overdueSlipContainer">
@@ -219,7 +219,6 @@
 									<div class="DUE_DATE">{$dataRow.DUE_DATE}</div>
 									<div class="PRICE">{$dataRow.OWED|regex_replace:"/^ *0\.00$/":"10.00"}</div>
 								</div>	
-	{/if}
 {/foreach}
 					</td>
 				</tr>

--- a/code/web/interface/themes/responsive/Report/studentReport.tpl
+++ b/code/web/interface/themes/responsive/Report/studentReport.tpl
@@ -1,4 +1,3 @@
-{debug}
 {strip}
 	<div id="main-content" class="col-md-12">
 		<div class="doNotPrint">

--- a/code/web/release_notes/24.10.00.MD
+++ b/code/web/release_notes/24.10.00.MD
@@ -98,6 +98,9 @@
 </div>
 
 // james - Nashville
+### Reports Updates
+- Fixes a bug in Show Data on all three Student Reports in Aspen Admin, where the first line of data is being dropped. (*JStaub*)
+
 ### Other Updates
 - Fixes a bug where users with linked accounts received an error when trying to log in. (*JStaub*)
 


### PR DESCRIPTION
Fixes: In Show Data on all three Student Reports in Aspen Admin, the first line of data is being dropped. https://trello.com/c/aZeH6q7C