### PR TITLE
Fix adding API documentation to interface

### DIFF
--- a/code/web/interface/themes/responsive/API/apiDocumentation.tpl
+++ b/code/web/interface/themes/responsive/API/apiDocumentation.tpl
@@ -1,12 +1,3 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Aspen API</title>
-</head>
-<body>
-    <redoc spec-url="<?php echo $githubRawUrl; ?>"></redoc>
-</body>
-    <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
-</html>
+<head><title>Aspen Discovery API</title></head>
+<redoc spec-url="{$apiFile}"></redoc>
+<script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>

--- a/code/web/openapi/.htaccess
+++ b/code/web/openapi/.htaccess
@@ -1,0 +1,3 @@
+<IfModule mod_rewrite.c>
+  RewriteEngine Off
+</IfModule>

--- a/code/web/openapi/aspen_openapi.json
+++ b/code/web/openapi/aspen_openapi.json
@@ -25,12 +25,6 @@
   ],
   "tags": [
     {
-      "name": "AbstractAPI"
-    },
-    {
-      "name": "AnodeAPI"
-    },
-    {
       "name": "CommunityAPI"
     },
     {

--- a/code/web/services/API/Documentation.php
+++ b/code/web/services/API/Documentation.php
@@ -1,14 +1,14 @@
 <?php
 
-$gitBranch = trim(shell_exec('git rev-parse --abbrev-ref HEAD'));
-$githubRawUrl = "https://raw.githubusercontent.com/Aspen-Discovery/aspen-discovery/refs/heads/$gitBranch/code/web/openapi/aspen_openapi.json";
-
 require_once ROOT_DIR . '/Action.php';
 
 class API_Documentation extends Action {
 	function launch() {
 		global $interface;
 
+		$apiFile = "/openapi/aspen_openapi.json";
+
+		$interface->assign('apiFile', $apiFile);
 		$interface->display('API/apiDocumentation.tpl');
 	}
 


### PR DESCRIPTION
Just some changes after some office hours with Mark:

- Changed how the json file is being referenced
- Removed unnecessary HTML from apiDocumentation.tpl
- Removed Abstract and Anode API tags in API documentation
- Added htaccess file to openapi folder