### PR TITLE
Small Bug Fixes

### DIFF
--- a/code/web/Drivers/Sierra.php
+++ b/code/web/Drivers/Sierra.php
@@ -1867,7 +1867,15 @@ class Sierra extends Millennium {
 						preg_match($this->urlIdRegExp, $fineEntry->item, $m);
 						$itemIdShort = $m[1];
 						$itemId = ".i" . $itemIdShort . $this->getCheckDigit($itemIdShort);
-						$message = $this->getTitleByItemId($itemId, $itemIdShort);
+						if ($itemIdShort !=null ) {
+							$message = $this->getTitleByItemId($itemId, $itemIdShort);
+						} else {
+							$message = translate([
+								'text' => 'Title not available - contact library. ',
+								'isPublicFacing' => true,
+								'inAttribute' => true,
+							]);
+						}
 					}
 				}
 				$fines[] = [

--- a/code/web/interface/themes/responsive/MaterialsRequest/manageRequests.tpl
+++ b/code/web/interface/themes/responsive/MaterialsRequest/manageRequests.tpl
@@ -99,6 +99,17 @@
 		</div>
 		{if count($allRequests) > 0}
 			<form id="updateRequests" method="post" action="/MaterialsRequest/ManageRequests" class="form form-horizontal">
+				<div class="form-group col-xs-4">
+					<label for="pageSize" class="control-label">{translate text="Entries Per Page" isAdminFacing=true}&nbsp;</label>
+					<select id="pageSize" name="pageSize" class="pageSize form-control input-sm" onchange="AspenDiscovery.changePageSize()">
+						<option value="30"{if $materialsRequestsPerPage == 30} selected="selected"{/if}>30</option>
+						<option value="50"{if $materialsRequestsPerPage == 50} selected="selected"{/if}>50</option>
+						<option value="75"{if $materialsRequestsPerPage == 75} selected="selected"{/if}>75</option>
+						<option value="100"{if $materialsRequestsPerPage == 100} selected="selected"{/if}>100</option>
+						<option value="250"{if $materialsRequestsPerPage == 250} selected="selected"{/if}>250</option>
+						<option value="500"{if $materialsRequestsPerPage == 500} selected="selected"{/if}>500</option>
+					</select>
+				</div>
 				<table id="requestedMaterials" class="table tablesorter table-striped table-hover table-sticky">
 					<thead>
 						<tr>
@@ -219,10 +230,7 @@
 								{if !empty($page)}
 									<input type="hidden" name="page" value="{$page}">
 								{/if}
-								{if !empty($pageSize)}
-									<input type="hidden" name="pageSize" value="{$pageSize}">
-								{/if}
-								<input class="btn btn-sm btn-default" type="submit" name="exportSelected" value="{translate text="Export Selected To CSV" inAttribute=true isAdminFacing=true}" onclick="return AspenDiscovery.MaterialsRequest.exportSelectedRequests();">
+								<input class="btn btn-default" type="submit" name="exportSelected" value="{translate text="Export Selected To CSV" inAttribute=true isAdminFacing=true}" onclick="return AspenDiscovery.MaterialsRequest.exportSelectedRequests();">
 							</div>
 						</div>
 					</div>

--- a/code/web/release_notes/24.10.00.MD
+++ b/code/web/release_notes/24.10.00.MD
@@ -54,6 +54,7 @@
 - Fix export of materials requests to CSV to properly handle pagination. (*MDN*)
 - Remove deprecated method to load additional information about a request from WorldCat. (*MDN*)
 - Remove old Import Materials Requests function that attempted to import Materials Requests from an XLS file. (*MDN*)
+- Fix pagination for materials request management page to allow viewing/exporting larger sets of data (Tickets 138920, 139026, 138640, 138905, 138920, 139599)(*KL*)
 
 <div markdown="1" class="settings">
 
@@ -133,6 +134,7 @@
 
 ### Sierra Updates
 - Extract item replacement costs from Sierra if the replacement cost field is defined within the indexing profile. (*MDN*)
+- Fix issue where overdue fines for the Sierra ILL Module causes an error (Ticket 139343) (*KL*)
 
 ### Symphony Updates
 - Add notice and billing notice preferences based on Symphony User Categories to Contact Information page. (Ticket 136296) (*KP*)

--- a/code/web/services/MaterialsRequest/ManageRequests.php
+++ b/code/web/services/MaterialsRequest/ManageRequests.php
@@ -217,7 +217,8 @@ class MaterialsRequest_ManageRequests extends Admin_Admin {
 				$interface->assign('idsToShow', $idsToShow);
 			}
 
-			$materialsRequestsPerPage = $_REQUEST['pageSize'] ?? 30;
+			$materialsRequestsPerPage = isset($_REQUEST['pageSize']) && (is_numeric($_REQUEST['pageSize'])) ? $_REQUEST['pageSize'] : 30;
+			$interface->assign('materialsRequestsPerPage', $materialsRequestsPerPage);
 			$page = $_REQUEST['page'] ?? 1;
 			$materialsRequests->limit(($page - 1) * $materialsRequestsPerPage, $materialsRequestsPerPage);
 			$materialsRequestCount = $materialsRequests->count();


### PR DESCRIPTION
- Fix pagination for materials request management page to allow viewing/exporting larger sets of data 
- Fix issue where overdue Sierra ILL items that accrue fines no longer had an item ID and caused the following error: Sierra::getTitleByItemID(): Argument #2 ($itemShortID) must be of type string, null given
- Updated release notes