### PR TITLE
FIX: 24.10.00 handle EDS search error

### DIFF
--- a/code/web/interface/themes/responsive/EBSCO/searchError.tpl
+++ b/code/web/interface/themes/responsive/EBSCO/searchError.tpl
@@ -10,10 +10,10 @@
 	</div>
 	{/if}
 
-	{if !empty($searchError) && !empty($searchError.error.msg)}
+	{if !empty($searchError) && !empty($searchError->getMessage())}
 		<h2>{translate text="Error description" isPublicFacing=true}</h2>
 		<div>
-			{$searchError.error.msg}
+			{$searchError->getMessage()}
 		</div>
 	{/if}
 </div>

--- a/code/web/release_notes/24.10.00.MD
+++ b/code/web/release_notes/24.10.00.MD
@@ -173,6 +173,7 @@
 - E-commerce: SnapPay: drop unused database field and other small fixes. (*JStaub*)
 - Correct cron artifact within new default intellij project. (*MDN*)
 - When batch updating enumerations, display the label for the new value rather than the internal value. (*MDN*)
+- Fix an issue where EBSCO EDS search errors were echoed to the UI on the search page (visible to any visitor) by adding the error message to the logs instead. (*CZ*)
 
 ## This release includes code contributions from
 ###ByWater Solutions

--- a/code/web/sys/SearchObject/EbscoEdsSearcher.php
+++ b/code/web/sys/SearchObject/EbscoEdsSearcher.php
@@ -187,12 +187,12 @@ BODY;
 							return true;
 						} elseif ($createSessionResponse->ErrorDescription) {
 							$logger->log("create session failed, " . print_r($createSessionResponse, true), Logger::LOG_WARNING);
-							return new AspenError("Error processing search in EBSCO EDS");
+							return new AspenError("EBSCO EDS Authentication failed");
 						}
 					}
 				} else {
-					$logger->log("Error processing search in EBSCO EDS: " . print_r($return, true), Logger::LOG_WARNING);
-					return new AspenError("Error processing search in EBSCO EDS: Authentication failed");
+					$logger->log("EBSCO EDS Authentication failed: " . print_r($return, true), Logger::LOG_WARNING);
+					return new AspenError("EBSCO EDS Authentication failed");
 				}
 			} else {
 				return false;
@@ -661,12 +661,12 @@ BODY;
 					$logger->log(print_r($curlInfo(true)), Logger::LOG_WARNING);
 				}
 				$this->lastSearchResults = false;
-				return new AspenError("Error processing search in EBSCO EDS");
+				return new AspenError("Could not process search in EBSCO EDS");
 			}
 		} catch (Exception $e) {
 			global $logger;
-			$logger->log("Error loading data from EBSCO $e", Logger::LOG_ERROR);
-			return new AspenError("Error loading data from EBSCO $e");
+			$logger->log("Error loading data from EBSCO EDS: $e", Logger::LOG_ERROR);
+			return new AspenError("Could not load data from EBSCO EDS");
 		}
 	}
 


### PR DESCRIPTION
EDS errors should be logged and not echoed, and a standard Aspen Error should be displayed to the user.

**Displaying the Aspen Error:** 

Bug: When an Aspen error is thrown for EBSCO EDS search and the `searchError.tpl` file is displayed, instead of the original error message, a PHP error is shown: `Cannot use object of type AspenError as array`

Expected behaviour: ~~The error message refers to a specific cause~~.
Instead of the rather obscure 'Cannot use object of type AspenError as array', the message should clearly indicate that it is to do with processing the EDS search, and indicate whether it is related to authentication. 
(EDITED)

Test plan:
- navigate to Aspen Administration > EBSCO EDS >
Settings
- create a new Setting, make sure to use invalid
credentials and save
- navigate to Aspen Administration > Primary
Configuration > Library Systems and select your
current Library
- set its EDS Setting to the setting you just
created
- run a search in Articles and Databases

**Logging EDS errors instead of echoing**

Issue: When an EDS search error is thrown, its message gets printed on screen to the user. This occurs on the search page and is publicly visible.
Expected behaviour: The error message does not show on the UI anymore and is logged instead.

Test plan:
- navigate to Aspen Administration > EBSCO EDS >
Settings
- create a new Setting, make sure to use invalid
credentials and save
- navigate to Aspen Administration > Primary
Configuration > Library Systems and select your
current Library
- set its EDS Setting to the setting you just
created
- log out
- run a search in Articles and Databases