### PR TITLE
Use natural sort for selecting items when placing a hold

### DIFF
--- a/code/web/release_notes/24.11.00.MD
+++ b/code/web/release_notes/24.11.00.MD
@@ -30,6 +30,9 @@
 - Add the patron's display name to Aspen when adding a Linked Account. (Tickets 136957, 127427, 128681 (partial)) (*KP*)
 - Include the expiry date for linked accounts in the API and LiDA. (Ticket 136902) (*KP*) 
 
+### Other Updates
+- Use natural sort for selecting items to place a hold so that volumes are in order. (Ticket 137784 (partial)) (*KP*)
+
 //kirstien - bywater
 
 //kodi - bywater

--- a/code/web/services/Record/AJAX.php
+++ b/code/web/services/Record/AJAX.php
@@ -263,6 +263,7 @@ class Record_AJAX extends Action {
 
 			//Figure out what types of holds to allow
 			$items = $marcRecord->getCopies();
+			array_multisort(array_column($items, 'description'), SORT_NATURAL, $items);
 			$relatedRecord = $marcRecord->getGroupedWorkDriver()->getRelatedRecord($marcRecord->getIdWithSource());
 			if (count($relatedRecord->recordVariations) > 1){
 				foreach ($relatedRecord->recordVariations as $variation){


### PR DESCRIPTION
Use natural sort for hold items so that if they include volume numbers, they will appear in the expected order (1, 2, 3 not 1, 10, 11).  