### PR TITLE
Update EbscoEdsSearcher.php

### DIFF
--- a/code/web/sys/SearchObject/EbscoEdsSearcher.php
+++ b/code/web/sys/SearchObject/EbscoEdsSearcher.php
@@ -558,7 +558,7 @@ BODY;
 		if (empty($isAuthenticated)) {
 			return null;
 		}
-		if (get_class($isAuthenticated) == 'AspenError') {
+		if (is_object($isAuthenticated) && get_class($isAuthenticated) == 'AspenError') {
 			return $isAuthenticated;
 		}
 


### PR DESCRIPTION
Fix the following error:
get_class(): Argument #1 ($object) must be of type object, bool given on line 561 of EbscoEdsSearcher.php