### PR TITLE
LiDA: show linked account home library on Library Card page

### DIFF
--- a/code/aspen_app/src/screens/MyAccount/MyLibraryCard/MyLibraryCard.js
+++ b/code/aspen_app/src/screens/MyAccount/MyLibraryCard/MyLibraryCard.js
@@ -285,7 +285,7 @@ const CreateLibraryCard = (data) => {
      }
 
      let icon = library.favicon;
-     if (library.logoApp) {
+     if (card.homeLocation === library.displayName && library.logoApp) {
           icon = library.logoApp;
      }
 
@@ -302,7 +302,7 @@ const CreateLibraryCard = (data) => {
                          <Flex direction="row">
                               {icon ? <Image source={{ uri: icon }} fallbackSource={require('../../../themes/default/aspenLogo.png')} w={42} h={42} alt={getTermFromDictionary(language, 'library_card')} /> : null}
                               <Text bold ml={3} mt={2} fontSize="lg" color="darkText">
-                                   {library.displayName}
+                                   {card.homeLocation}
                               </Text>
                          </Flex>
                     </Center>
@@ -339,7 +339,7 @@ const CreateLibraryCard = (data) => {
                               <Flex direction="row">
                                    {icon ? <Image source={{ uri: icon }} fallbackSource={require('../../../themes/default/aspenLogo.png')} w={42} h={42} alt={getTermFromDictionary(language, 'library_card')} /> : null}
                                    <Text bold ml={3} mt={2} fontSize="lg" color={cardText}>
-                                        {library.displayName}
+                                        {card.homeLocation}
                                    </Text>
                               </Flex>
                          </Center>

--- a/code/aspen_app/src/util/api/user.js
+++ b/code/aspen_app/src/util/api/user.js
@@ -439,6 +439,7 @@ export async function getLinkedAccounts(primaryUser, cards, barcodeStyle, url, l
                expired: primaryUser.expired,
                expires: primaryUser.expires,
                barcodeStyle: barcodeStyle,
+               homeLocation: primaryUser.homeLocation,
           };
           cardStack.push(primaryCard);
           if (!_.isUndefined(response.data.result.linkedAccounts)) {
@@ -456,6 +457,7 @@ export async function getLinkedAccounts(primaryUser, cards, barcodeStyle, url, l
                                    expired: account.expired,
                                    expires: account.expires,
                                    barcodeStyle: account.barcodeStyle ?? barcodeStyle,
+                                   homeLocation: account.homeLocation,
                               };
                               cardStack.push(card);
                          } else if (_.includes(cards, account.cat_username) === false) {
@@ -468,6 +470,7 @@ export async function getLinkedAccounts(primaryUser, cards, barcodeStyle, url, l
                                    expired: account.expired,
                                    expires: account.expires,
                                    barcodeStyle: account.barcodeStyle ?? barcodeStyle,
+                                   homeLocation: account.homeLocation,
                               };
                               cardStack.push(card);
                          }

--- a/code/web/release_notes/24.11.00.MD
+++ b/code/web/release_notes/24.11.00.MD
@@ -1,4 +1,5 @@
 ## Aspen LiDA Updates
+- Show home library name of linked accounts on Library Card page. Only show the library logo if it's correct for the home library. (Ticket 128681) (*KP*)  
 
 ## Aspen Discovery Updates
 //mark - grove


### PR DESCRIPTION
- On the library card page in LiDA, show the home library name instead of the logged-in library for each card.  
- Only show the library logo if the name matches the account's home library.  Ideally, the logo for other libraries would show here, but that might require updates to the Discovery API.