### PR TITLE
Add the ability to skip running all or specific parts of the qa actions

### DIFF
--- a/.github/workflows/pull_request_qa.yml
+++ b/.github/workflows/pull_request_qa.yml
@@ -5,7 +5,17 @@ on:
   push:
 
 jobs:
+  debug:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Print GitHub vars
+        run: echo "$GITHUB_CONTEXT"
+        env:
+          GITHUB_CONTEXT: ${{ toJson(vars) }}
+
   check_release_notes:
+    if: "!(vars.SKIP_GHA_PULL_REQUEST_QA  == '1' || vars.SKIP_GHA_PULL_REQUEST_QA_CHECK_RELEASE_NOTES  == '1')"
     runs-on: ubuntu-latest
     
     steps:
@@ -34,6 +44,7 @@ jobs:
           fi
 
   check_tabs_vs_spaces:
+    if: "!(vars.SKIP_GHA_PULL_REQUEST_QA  == '1' || vars.SKIP_GHA_PULL_REQUEST_QA_CHECK_TABS_VS_SPACES  == '1')"
     runs-on: ubuntu-latest
 
     steps:
@@ -90,6 +101,7 @@ jobs:
           exit $EXIT_CODE
 
   check_create_site_for_docker:
+    if: "!(vars.SKIP_GHA_PULL_REQUEST_QA  == '1' || vars.SKIP_GHA_PULL_REQUEST_QA_CHECK_CREATE_SITE_FOR_DOCKER  == '1')"
     runs-on: ubuntu-latest
 
     steps:

--- a/code/web/release_notes/24.11.00.MD
+++ b/code/web/release_notes/24.11.00.MD
@@ -32,6 +32,7 @@
 
 ### Other Updates
 - Use natural sort for selecting items to place a hold so that volumes are in order. (Ticket 137784 (partial)) (*KP*)
+- Add ability to skip running all or parts of QA GitHub Actions for forked repos (*KMH*)
 
 //kirstien - bywater
 


### PR DESCRIPTION
Right now, all pull requests will trigger the Github Actions for .github/workflows/pull_request_qa.yml. Some developers are using wei/pull to generate pull requests to keep personal branches up to date with the same branches in the official repo. The bot creates pull requests, and these pull requests can fail some actions as they are not like feature branches.

This commit adds the ability to specify one or more github actions variables to disable all or just some of the qa action jobs.

You can set your variables from:
https://github.com/GITHUB_USERNAME/aspen-discovery/settings/variables/actions

SKIP_GHA_PULL_REQUEST_QA will disable all the tests if created and the value is set to 1 ( or anything else that would evaluate to true )

Alternatively, the following variables will disable indvidual tests: SKIP_GHA_PULL_REQUEST_QA_CHECK_RELEASE_NOTES
SKIP_GHA_PULL_REQUEST_QA_CHECK_TABS_VS_SPACES
SKIP_GHA_PULL_REQUEST_QA_CHECK_CREATE_SITE_FOR_DOCKER