### PR TITLE
24.11.00 encrypt fields

### DIFF
--- a/code/web/release_notes/24.11.00.MD
+++ b/code/web/release_notes/24.11.00.MD
@@ -52,6 +52,8 @@
 //alexander - ptfse
 
 //chloe - ptfse
+### Other
+- Ebsco EDS and host passwords are encrypted before being stored in the Aspen database (*CZ*)
 
 //lucas - theke
 ### Aspen Materials Request Updates

--- a/code/web/sys/DBMaintenance/version_updates/24.11.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/24.11.00.php
@@ -50,6 +50,15 @@ function getUpdates24_11_00(): array {
 		//alexander - PTFS-Europe
 
 		//chloe - PTFS-Europe
+		'ebsco_passwords_are_stored_as_hash' => [
+			'title' => 'EBSCO Passwords Are Stored As Hash',
+			'description' => 'allow for longer strings so passwords can be stored as hashed values',
+			'continueOnError' => false,
+			'sql' => [
+				"ALTER TABLE ebsco_eds_settings MODIFY COLUMN edsApiPassword VARCHAR(255)",
+				"ALTER TABLE ebscohost_settings MODIFY COLUMN profilePwd VARCHAR(255)"
+			]
+		] // ebsco_passwords_are_stored_as_hash
 
 		//pedro - PTFS-Europe
 

--- a/code/web/sys/Ebsco/EBSCOhostSetting.php
+++ b/code/web/sys/Ebsco/EBSCOhostSetting.php
@@ -13,6 +13,10 @@ class EBSCOhostSetting extends DataObject {
 
 	private $_searchSettings;
 
+	function getEncryptedFieldNames(): array {
+		return ['profilePwd'];
+	}
+
 	static function getObjectStructure($context = ''): array {
 		$ebscoHostSearchSettingStructure = EBSCOhostSearchSetting::getObjectStructure($context);
 

--- a/code/web/sys/Ebsco/EDSSettings.php
+++ b/code/web/sys/Ebsco/EDSSettings.php
@@ -11,6 +11,10 @@ class EDSSettings extends DataObject {
 	public $edsSearchProfile;
 	public $fullTextLimiter;
 
+	function getEncryptedFieldNames(): array {
+		return ['edsApiPassword'];
+	}
+
 	public static function getObjectStructure($context = ''): array {
 		return [
 			'id' => [


### PR DESCRIPTION
Store EBSCO passwords as hashed values.

Test plan:

- In Aspen Administration > System Adminstration > modules, enable EBSCO
EDS and EBSCO host
- In Aspen Administration > EBSCO EDS > Settings, create a new setting
and save it
- In Aspen Administration > EBSCOhost > Settings, create a new setting
and save it
- In the Aspen database, check the values of the profilePwd in
ebscohost_settings and edsApiPassword in ebsco_eds_settings

Expected behaviour:
Before the patch, these will be stored as plain text.

Apply the patch, run the db maintenance, then go through the test plan
once more: the values should now be stored as hashed values.