### PR TITLE
Symphony List Import

### DIFF
--- a/code/web/migrations/importSymphonyLists.php
+++ b/code/web/migrations/importSymphonyLists.php
@@ -59,7 +59,7 @@ function importLists($startTime, $exportPath, &$existingUsers, &$missingUsers, &
 	while ($patronListRow = fgetcsv($listsfHnd, 0, '|')) {
 		$numImports++;
 
-		if (sizeof($patronListRow) != 12) {
+		if (sizeof($patronListRow) != 10) {
 			echo("Skipping row because it has the wrong number of columns");
 			//We got a bad export, likely
 			continue;
@@ -74,10 +74,10 @@ function importLists($startTime, $exportPath, &$existingUsers, &$missingUsers, &
 		$userKey = $patronListRow[2];
 		//last activity
 		//email
-		$listName = $patronListRow[5];
-		$listId = $patronListRow[6];
-		$myListOrder = $patronListRow[7];
-		$originalTime = $patronListRow[8];
+		$listName = $patronListRow[3];
+		$listId = $patronListRow[4];
+		$myListOrder = $patronListRow[5];
+		$originalTime = $patronListRow[6];
 		$dateAddedToList = strtotime($originalTime);
 		if ($dateAddedToList == false) {
 			$firstDot = strpos($originalTime, '.');
@@ -92,9 +92,9 @@ function importLists($startTime, $exportPath, &$existingUsers, &$missingUsers, &
 			$timeWithHoursAndMinutes = str_replace('.', ':', $timeWithHoursAndMinutes);
 			$dateAddedToList = strtotime($timeWithHoursAndMinutes);
 		}
-		$documentId = $patronListRow[9];
-		$title = $patronListRow[10];
-		$titleOrder = $patronListRow[11];
+		$documentId = $patronListRow[7];
+		$title = $patronListRow[8];
+		$titleOrder = $patronListRow[9];
 
 		//Figure out the user for the list
 		$userId = getUserIdForBarcode($userBarcode, $existingUsers, $missingUsers, $usersWithSearchPermissions);

--- a/code/web/release_notes/24.10.10.MD
+++ b/code/web/release_notes/24.10.10.MD
@@ -12,6 +12,7 @@
 
 ### Other updates
 - Fix issue that doesn't allow users to freeze a hold without an end date. (*LM*)
+- Change array position for columns in symphony list import to reflect their current practices (*KL*)
 
 ## This release includes code contributions from
 - Grove For Libraries

--- a/code/web/release_notes/24.10.10.MD
+++ b/code/web/release_notes/24.10.10.MD
@@ -15,10 +15,12 @@
 - Change array position for columns in symphony list import to reflect their current practices (*KL*)
 
 ## This release includes code contributions from
-- Grove For Libraries
-    - Mark Noble (MDN)
-- Theke Solutions
-    - Lucas Montoya (LM)
+- Grove For Libraries 
+  - Mark Noble (MDN)
+- Theke Solutions 
+  - Lucas Montoya (LM)
+- ByWater Solutions 
+  - Kodi Lein (KL)
 
 ## This release includes sponsored developments from
 - CLEVNET


### PR DESCRIPTION
change array position for columns in symphony list import to reflect their current practices (no more last activity and email columns)

updated release notes