### PR TITLE
Fix typo issue

### DIFF
--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -3088,7 +3088,7 @@ class Koha extends AbstractIlsDriver {
 
 		$postParams = (object) [];
 		if (strlen($dateToReactivate) > 0) {
-			$postParams['end_date'] = $dateToReactivate;	
+			$postParams->end_date = $dateToReactivate;	
 		} 
 
 		$endpoint = "/api/v1/holds/$itemToFreezeId/suspension";


### PR DESCRIPTION
- Correctly use parameters as object properties instead of array elements after casting parameter array