### PR TITLE
NCR Error Logging

### DIFF
--- a/code/web/Drivers/Sierra.php
+++ b/code/web/Drivers/Sierra.php
@@ -2276,7 +2276,11 @@ class Sierra extends Millennium {
 	 * @return bool
 	 */
 	public function showResetUsernameLink(): bool {
-		return true;
+		global $library;
+		if ($library->allowUsernameUpdates){
+			return true;
+		}
+		return false;
 	}
 
 	public function getUsernameValidationRules(): array {

--- a/code/web/release_notes/24.11.00.MD
+++ b/code/web/release_notes/24.11.00.MD
@@ -125,6 +125,7 @@
 
 ### Other Updates
 - Remove partner-specific directories in the /sites directory (*KL*)
+- Increase the allowed length for the alternate library card label (*KL*)
 
 //morgan - bywater
 

--- a/code/web/release_notes/24.11.00.MD
+++ b/code/web/release_notes/24.11.00.MD
@@ -122,6 +122,7 @@
 //kodi - bywater
 ### eCommerce Updates
 - Add extra error logging for NCR Payments (Ticket 134771) (*KL*)
+- Fix an issue where staff users with permissions to see only their library's ecommerce report yielded no results (Ticket 140792) (*KL*)
 
 ### Sierra Updates
 - Hide the update username link in My Account if updating username is not allowed for the patron (Ticket 139915) (*KL*)

--- a/code/web/release_notes/24.11.00.MD
+++ b/code/web/release_notes/24.11.00.MD
@@ -123,6 +123,9 @@
 ### eCommerce Updates
 - Add extra error logging for NCR Payments (Ticket 134771) (*KL*)
 
+### Sierra Updates
+- Hide the update username link in My Account if updating username is not allowed for the patron (Ticket 139915) (*KL*)
+
 ### Other Updates
 - Remove partner-specific directories in the /sites directory (*KL*)
 - Increase the allowed length for the alternate library card label (*KL*)

--- a/code/web/release_notes/24.11.00.MD
+++ b/code/web/release_notes/24.11.00.MD
@@ -120,6 +120,9 @@
 //kirstien - bywater
 
 //kodi - bywater
+### eCommerce Updates
+- Add extra error logging for NCR Payments (Ticket 134771) (*KL*)
+
 ### Other Updates
 - Remove partner-specific directories in the /sites directory (*KL*)
 

--- a/code/web/release_notes/24.11.00.MD
+++ b/code/web/release_notes/24.11.00.MD
@@ -130,6 +130,7 @@
 ### Other Updates
 - Remove partner-specific directories in the /sites directory (*KL*)
 - Increase the allowed length for the alternate library card label (*KL*)
+- Make setting to enable Grapes Editor visible to any with the appropriate permissions (*KL*)
 
 //morgan - bywater
 

--- a/code/web/services/Admin/eCommerceReport.php
+++ b/code/web/services/Admin/eCommerceReport.php
@@ -31,7 +31,7 @@ class Admin_eCommerceReport extends ObjectEditor {
 
 			$object->joinAdd(new User(), 'LEFT', 'user', 'userId', 'id');
 			$object->joinAdd(new Library(), 'LEFT', 'library', 'paidFromInstance', 'subdomain');
-			$object->whereAdd('user.homeLocationId IN (' . implode(', ', $adminHomeLibraryListIds) . ') OR library.libraryId in (' . implode(', ', $adminHomeLibraryLocationListIds) . ')');
+			$object->whereAdd('user.homeLocationId IN (' . implode(', ', $adminHomeLibraryLocationListIds) . ') OR library.libraryId in (' . implode(', ', $adminHomeLibraryListIds) . ')');
 		}
 		$object->find();
 		while ($object->fetch()) {

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -5907,8 +5907,14 @@ class MyAccount_AJAX extends JSON_Action {
 					'allowedPaymentMethod' => 3,
 				];
 
-				$result = $newRedirectRequest->curlPostBodyData($url, $postParams, true);
-				$result = json_decode($result);
+				$paymentRequestUrl = "https://magic.collectorsolutions.com/magic-ui/PaymentRedirect/" . $NCRPaymentsSetting->webKey . "/" . $transactionIdentifier;
+
+				$payment->orderId = $transactionIdentifier;
+				$payment->update();
+
+				$resultJSON = $newRedirectRequest->curlPostBodyData($url, $postParams, true);
+				$result = json_decode($resultJSON);
+				ExternalRequestLogEntry::logRequest('ncr.createNCROrder', 'POST', $url, $newRedirectRequest->getHeaders(), json_encode($postParams), $newRedirectRequest->getResponseCode(), $resultJSON, []);
 
 				if ($result->status != "ok"){
 					return [
@@ -5916,11 +5922,6 @@ class MyAccount_AJAX extends JSON_Action {
 						'message' => $result->errors[0]->message,
 					];
 				}
-				$paymentRequestUrl = "https://magic.collectorsolutions.com/magic-ui/PaymentRedirect/" . $NCRPaymentsSetting->webKey . "/" . $transactionIdentifier;
-
-				$payment->orderId = $transactionIdentifier;
-				$payment->update();
-
 				return [
 					'success' => true,
 					'message' => 'Redirecting to payment processor',

--- a/code/web/sys/Account/UserPayment.php
+++ b/code/web/sys/Account/UserPayment.php
@@ -248,6 +248,7 @@ class UserPayment extends DataObject {
 							if ($hostedTransactionResultsResponse && $curlWrapper->getResponseCode() == 200) {
 								$jsonResponse = json_decode($hostedTransactionResultsResponse);
 							}
+							ExternalRequestLogEntry::logRequest('ncr.completeNCROrder', 'GET', $url, $curlWrapper->getHeaders(), false, $curlWrapper->getResponseCode(), $hostedTransactionResultsResponse, []);
 
 							if ($jsonResponse->status == "ok") {
 								if($userPayment->transactionType == 'donation') {

--- a/code/web/sys/DBMaintenance/version_updates/24.11.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/24.11.00.php
@@ -197,6 +197,14 @@ function getUpdates24_11_00(): array {
 		//kirstien - ByWater
 
 		//kodi - ByWater
+		'alternate_card_varchar_limit' => [
+			'title' => 'Alternate Card Label Character Limits',
+			'description' => 'Increase the character limit for the alternate library car label and alternate library card password label fields',
+			'sql' => [
+				"ALTER TABLE library MODIFY COLUMN alternateLibraryCardLabel VARCHAR(100) DEFAULT ''",
+				"ALTER TABLE library MODIFY COLUMN alternateLibraryCardPasswordLabel VARCHAR(100) DEFAULT ''",
+			],
+		], //alternate_card_varchar_limit
 
 		//alexander - PTFS-Europe
 

--- a/code/web/sys/SystemVariables.php
+++ b/code/web/sys/SystemVariables.php
@@ -355,7 +355,6 @@ class SystemVariables extends DataObject {
 			$objectStructure['indexingSection']['properties']['storeRecordDetailsInDatabase']['type'] = 'hidden';
 			$objectStructure['indexingSection']['properties']['indexVersion']['type'] = 'hidden';
 			$objectStructure['indexingSection']['properties']['searchVersion']['type'] = 'hidden';
-			$objectStructure['webBuilderSection']['properties']['enableGrapesEditor']['type'] = 'hidden';
 			$objectStructure['enableBrandedApp']['type'] = 'hidden';
 		}
 


### PR DESCRIPTION
Add extra error logging for NCR integration to help debug persistent issues that cannot be replicated on a local machine 
Update the order ID in the user payment table whether we get a good response from NCR or not to help with debugging
Update release notes

Tested on my local

To Test:
Turn on debugging for your IP
As a user with fines, attempt to pay those fines
You should now see external request log entries for creating and completing an NCR order