### PR TITLE
Handle multiple OverDrive collections in LiDA

### DIFF
--- a/code/aspen_app/src/helpers/item.js
+++ b/code/aspen_app/src/helpers/item.js
@@ -402,3 +402,20 @@ export const getRenewalCount = (count, available = null) => {
           return null;
      }
 };
+
+export const getCollectionName = (source, collectionName = null) => {
+	const { language } = React.useContext(LanguageContext);
+	if (source === 'overdrive' && collectionName) {
+		return (
+			<Text
+				fontSize={{
+					base: 'xs',
+					lg: 'sm',
+				}}>
+				<Text bold>{getTermFromDictionary(language, 'collection')}:</Text> {collectionName}
+			</Text>
+		);
+	} else {
+		return null;
+	}
+}

--- a/code/aspen_app/src/screens/GroupedWork/Editions.js
+++ b/code/aspen_app/src/screens/GroupedWork/Editions.js
@@ -311,8 +311,10 @@ const Edition = (payload) => {
      const holdTypeForFormat = records.holdType ?? 'default';
      const variationId = records.variationId ?? null;
 
-     const handleOnPress = () => {
-          navigate('WhereIsIt', { id: id, format: format, prevRoute: prevRoute, type: 'record', recordId: fullRecordId });
+	const status = records.statusIndicator;
+
+	const handleOnPress = () => {
+          navigate('WhereIsIt', { id: id, format: format, prevRoute: prevRoute, type: 'record', recordId: fullRecordId, numHolds: status.numHolds, source });
      };
 
      const statusIndicator = getStatusIndicator(records.statusIndicator, language);
@@ -333,7 +335,7 @@ const Edition = (payload) => {
                                         <BadgeText textTransform="none">{statusIndicator.label}</BadgeText>
                                    </Badge>
                               </Center>
-                              {records.source === 'ils' ? (
+                              {records.source === 'ils' || status.isEContent ? (
                                    <Button variant="link" size="xs" onPress={handleOnPress}>
                                         <ButtonIcon as={MaterialIcons} name="location-pin" size="xs" color={theme['colors']['tertiary']['500']} />
                                         <ButtonText color={theme['colors']['tertiary']['500']}>{getTermFromDictionary(language, 'where_is_it')}</ButtonText>

--- a/code/aspen_app/src/screens/GroupedWork/Variations.js
+++ b/code/aspen_app/src/screens/GroupedWork/Variations.js
@@ -265,6 +265,7 @@ const Variation = (payload) => {
      const actions = variation.actions;
      const source = variation.source;
      const status = getStatusIndicator(variation.statusIndicator, language);
+	 const statusIndicator = variation.statusIndicator;
      const holdTypeForFormat = variation.holdType ?? 'default';
      const variationId = variation.variationId ?? null;
      const title = variation.title ?? null;
@@ -314,7 +315,7 @@ const Variation = (payload) => {
      });
 
      const handleOnPress = () => {
-          navigate('CopyDetails', { id: id, format: format, prevRoute: prevRoute, type: 'groupedWork', recordId: null });
+          navigate('CopyDetails', { id: id, format: format, prevRoute: prevRoute, type: 'groupedWork', recordId: null, numHolds: statusIndicator.numHolds, source });
      };
 
      const handleOpenEditions = () => {
@@ -339,7 +340,7 @@ const Variation = (payload) => {
                                         {status.label}
                                    </BadgeText>
                               </Badge>
-                              {source === 'ils' ? (
+                              {source === 'ils' || statusIndicator.isEContent ? (
                                    <Button variant="link" size="xs" onPress={handleOnPress}>
                                         <ButtonIcon as={MapPinIcon} size="xs" color={theme['colors']['tertiary']['500']} mr="$1" />
                                         <ButtonText color={theme['colors']['tertiary']['500']}>{getTermFromDictionary(language, 'where_is_it')}</ButtonText>

--- a/code/aspen_app/src/screens/GroupedWork/WhereIsIt.js
+++ b/code/aspen_app/src/screens/GroupedWork/WhereIsIt.js
@@ -10,7 +10,7 @@ import {getTermFromDictionary} from '../../translations/TranslationService';
 
 export const WhereIsIt = () => {
      const route = useRoute();
-     const { id, format, prevRoute, type, recordId } = route.params;
+     const { id, format, prevRoute, type, recordId, source } = route.params;
      const { language } = React.useContext(LanguageContext);
      const { library } = React.useContext(LibrarySystemContext);
     const { theme, textColor } = React.useContext(ThemeContext);
@@ -27,7 +27,7 @@ export const WhereIsIt = () => {
           },
      });
 
-     return (
+	 return (
           <Box p="$5">
                {isLoading || status === 'loading' || isFetching ? (
                     loadingSpinner()
@@ -42,11 +42,17 @@ export const WhereIsIt = () => {
                               <Text bold w="30%" size="xs" color={textColor}>
                                    {getTermFromDictionary(language, 'location')}
                               </Text>
+							 {source === 'overdrive' ? (
+								 <Text bold w="30%" size="xs" color={textColor}>
+									 {getTermFromDictionary(language, 'holds')}
+								 </Text>
+							 ) : (
                               <Text bold w="30%" size="xs" color={textColor}>
                                    {getTermFromDictionary(language, 'call_num')}
                               </Text>
+							 )}
                          </HStack>
-                         <FlatList data={Object.keys(data.manifestation)} renderItem={({ item }) => <Details manifestation={data.manifestation[item]} />} />
+                         <FlatList data={Object.keys(data.manifestation)} renderItem={({ item }) => <Details manifestation={data.manifestation[item]} source={source} />} />
                     </Box>
                )}
           </Box>
@@ -54,9 +60,10 @@ export const WhereIsIt = () => {
 };
 
 const Details = (data) => {
-     console.log(data.manifestation);
+     //console.log(data.manifestation);
     const { theme, textColor } = React.useContext(ThemeContext);
      const manifestation = data.manifestation;
+	 const source = data.source;
      return (
           <HStack space="md" justifyContent="space-between">
                <Text w="30%" size="xs" color={textColor}>
@@ -65,9 +72,15 @@ const Details = (data) => {
                <Text w="30%" size="xs" color={textColor}>
                     {manifestation.shelfLocation}
                </Text>
+			  {source === 'overdrive' ? (
+				  <Text w="30%" size="xs" color={textColor}>
+					  {manifestation.numHolds}
+				  </Text>
+			  ) : (
                <Text w="30%" size="xs" color={textColor}>
                     {manifestation.callNumber}
                </Text>
+			  )}
           </HStack>
      );
 };

--- a/code/aspen_app/src/screens/MyAccount/CheckedOutTitles/MyCheckout.js
+++ b/code/aspen_app/src/screens/MyAccount/CheckedOutTitles/MyCheckout.js
@@ -7,7 +7,7 @@ import React, { useState } from 'react';
 
 // custom components and helper files
 import { LanguageContext, LibrarySystemContext, UserContext } from '../../../context/initialContext';
-import { getAuthor, getCheckedOutTo, getCleanTitle, getDueDate, getFormat, getRenewalCount, getTitle, isOverdue, willAutoRenew } from '../../../helpers/item';
+import { getAuthor, getCheckedOutTo, getCleanTitle, getDueDate, getFormat, getRenewalCount, getTitle, isOverdue, willAutoRenew, getCollectionName } from '../../../helpers/item';
 import { navigate, navigateStack } from '../../../helpers/RootNavigator';
 import { getTermFromDictionary, getTranslationsWithValues } from '../../../translations/TranslationService';
 import { renewCheckout, returnCheckout, viewOnlineItem, viewOverDriveItem } from '../../../util/accountActions';
@@ -130,6 +130,11 @@ export const MyCheckout = (props) => {
           itemId = checkout.renewalId;
      }
 
+	let record = checkout.recordId;
+	if(checkout.source === 'overdrive') {
+		record = checkout.sourceId
+	}
+
      const handleOpenPalaceProjectInstructions = () => {
           navigate('PalaceProjectInstructionsModal');
      };
@@ -154,6 +159,7 @@ export const MyCheckout = (props) => {
                          {isOverdue(checkout.overdue)}
                          {getAuthor(checkout.author)}
                          {getFormat(checkout.format, checkout.source)}
+						{getCollectionName(checkout.source, checkout.collectionName ?? null)}
                          {getCheckedOutTo(checkout.user)}
                          {getDueDate(checkout.dueDate)}
                          {getRenewalCount(checkout.renewCount ?? 0, checkout.maxRenewals ?? null)}
@@ -192,7 +198,7 @@ export const MyCheckout = (props) => {
                                    isLoadingText={getTermFromDictionary(language, 'renewing', true)}
                                    onPress={() => {
                                         setRenew(true);
-                                        renewCheckout(checkout.barcode, checkout.recordId, checkout.source, itemId, library.baseUrl, checkout.userId).then((result) => {
+                                        renewCheckout(checkout.barcode, record, checkout.source, itemId, library.baseUrl, checkout.userId).then((result) => {
                                              setRenew(false);
 
                                              if (result?.confirmRenewalFee && result.confirmRenewalFee) {
@@ -201,7 +207,7 @@ export const MyCheckout = (props) => {
                                                        title: result.api.title,
                                                        confirmRenewalFee: result.confirmRenewalFee ?? false,
                                                        action: result.api.action,
-                                                       recordId: checkout.recordId ?? null,
+                                                       recordId: record ?? null,
                                                        barcode: checkout.barcode ?? null,
                                                        source: checkout.source ?? null,
                                                        itemId: itemId ?? null,
@@ -263,7 +269,7 @@ export const MyCheckout = (props) => {
                                         isLoadingText={getTermFromDictionary(language, 'returning', true)}
                                         onPress={() => {
                                              setReturn(true);
-                                             returnCheckout(checkout.userId, checkout.recordId, checkout.source, checkout.overDriveId, library.baseUrl, version, checkout.transactionId, language).then((result) => {
+                                             returnCheckout(checkout.userId, record, checkout.source, checkout.overDriveId, library.baseUrl, version, checkout.transactionId, language).then((result) => {
                                                   setReturn(false);
                                                   reloadCheckouts();
                                                   toggle();
@@ -281,7 +287,7 @@ export const MyCheckout = (props) => {
                                         isLoadingText={getTermFromDictionary(language, 'returning', true)}
                                         onPress={() => {
                                              setReturn(true);
-                                             returnCheckout(checkout.userId, checkout.recordId, checkout.source, checkout.overDriveId, library.baseUrl, version, checkout.transactionId, language).then((result) => {
+                                             returnCheckout(checkout.userId, record, checkout.source, checkout.overDriveId, library.baseUrl, version, checkout.transactionId, language).then((result) => {
                                                   setReturn(false);
                                                   reloadCheckouts();
                                                   toggle();

--- a/code/aspen_app/src/translations/defaults.json
+++ b/code/aspen_app/src/translations/defaults.json
@@ -591,5 +591,6 @@
   "delete_account": "Delete Account",
   "confirm_delete_account_message": "This will only delete your Aspen Discovery account with your library, including any personal data on Aspen Discovery such as lists and saved searches, but will not delete your card with the library. If you want to close your library account, you must contact your library.",
   "confirm_delete_account": "Yes, Delete Account",
-  "deleting": "Deleting"
+  "deleting": "Deleting",
+	"collection": "Collection"
 }

--- a/code/web/release_notes/24.11.00.MD
+++ b/code/web/release_notes/24.11.00.MD
@@ -2,9 +2,12 @@
 - Show home library name of linked accounts on Library Card page. Only show the library logo if it's correct for the home library. (Ticket 128681) (*KP*)
 - Fixed a bug where holds needing confirmation were causing the app to crash. (Ticket 139245) (*KK*)
 - Fixed a bug where Koha was returning a 400 error when placing a hold. (Ticket 137232) (*KK*)
+- Updated functions for renewing checkouts, returning checkouts, thawing/freezing holds that are OverDrive items to send sourceId instead of recordId to accommodate for multiple OverDrive settings. (DIS-40) (*KK-G*)
+- For libraries with multiple OverDrive connections, holds and checkouts will now display Collection name. (DIS-40) (*KK-G*)
+- On the Grouped Work screen, OverDrive items will now display "Where Is It?" to give patrons the Collection name when multiple OverDrive are present. (DIS-40) (*KK-G*)
 - Added Self Registration to the Login screen. (*KK*)
 - To comply with the app store rules when enabling self registration users can now delete their Aspen Discovery account within Aspen LiDA in the 'More' menu. This only deletes user data related to Aspen Discovery such as lists, searches, cached holds/checkouts, etc. and does not affect their account with the ILS. (*KK*)
-- When looking at which Greenhouse call to make for fetching libraries, updated checking the app slug to only look at the beginning of the string to start with "aspen-lida" to determine if it's the Aspen LiDA Community app, or a branded/alternative app. (*KK*)
+- When looking at which Greenhouse call to make for fetching libraries, updated checking the app slug to only look at the beginning of the string to start with "aspen-lida" to determine if it's the Aspen LiDA Community app, or a branded/alternative app. (*KK-G*)
 
 ## Aspen Discovery Updates
 //mark - grove
@@ -176,6 +179,7 @@
 
 ###Grove For Libraries
   - Mark Noble (MDN)
+  - Kirstien Kroeger (KK-G)
 
 ###Howell Carnegie District Library
   - Jeremy Eden (JE)


### PR DESCRIPTION
- Updated functions for renewing checkouts, returning checkouts, thawing/freezing holds that are OverDrive items to send sourceId instead of recordId to accommodate for multiple OverDrive settings.
- For libraries with multiple OverDrive connections, holds and checkouts will now display Collection name.
- On the Grouped Work screen, OverDrive items will now display "Where Is It?" to show users the Collection name.