### PR TITLE
Fix typos in GitHub Actions for building docker images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,18 +26,18 @@ jobs:
         id: extract_branch
 
       - name: Log in to Docker Hub
-        if: github.repository == 'Aspen-Discover/aspen-discovery'
+        if: github.repository == 'Aspen-Discovery/aspen-discovery'
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Log in to GHCR
-        if: github.repository == 'Aspen-Discover/aspen-discovery'
+        if: github.repository == 'Aspen-Discovery/aspen-discovery'
         run: echo "${{ secrets.GHCR_PASSWORD }}" | docker login ghcr.io -u ${{ secrets.GHCR_USERNAME }} --password-stdin
 
       - name: Log in to Quay.io
-        if: github.repository == 'Aspen-Discover/aspen-discovery'
+        if: github.repository == 'Aspen-Discovery/aspen-discovery'
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
           registry: quay.io
@@ -78,18 +78,18 @@ jobs:
         id: extract_branch
 
       - name: Log in to Docker Hub
-        if: github.repository == 'Aspen-Discover/aspen-discovery'
+        if: github.repository == 'Aspen-Discovery/aspen-discovery'
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Log in to GHCR
-        if: github.repository == 'Aspen-Discover/aspen-discovery'
+        if: github.repository == 'Aspen-Discovery/aspen-discovery'
         run: echo "${{ secrets.GHCR_PASSWORD }}" | docker login ghcr.io -u ${{ secrets.GHCR_USERNAME }} --password-stdin
 
       - name: Log in to Quay.io
-        if: github.repository == 'Aspen-Discover/aspen-discovery'
+        if: github.repository == 'Aspen-Discovery/aspen-discovery'
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
           registry: quay.io
@@ -130,18 +130,18 @@ jobs:
         id: extract_branch
 
       - name: Log in to Docker Hub
-        if: github.repository == 'Aspen-Discover/aspen-discovery'
+        if: github.repository == 'Aspen-Discovery/aspen-discovery'
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Log in to GHCR
-        if: github.repository == 'Aspen-Discover/aspen-discovery'
+        if: github.repository == 'Aspen-Discovery/aspen-discovery'
         run: echo "${{ secrets.GHCR_PASSWORD }}" | docker login ghcr.io -u ${{ secrets.GHCR_USERNAME }} --password-stdin
 
       - name: Log in to Quay.io
-        if: github.repository == 'Aspen-Discover/aspen-discovery'
+        if: github.repository == 'Aspen-Discovery/aspen-discovery'
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
           registry: quay.io

--- a/code/web/release_notes/24.11.00.MD
+++ b/code/web/release_notes/24.11.00.MD
@@ -148,6 +148,7 @@
 - Use natural sort for selecting items to place a hold so that volumes are in order. (Ticket 137784 (partial)) (*KP*)
 - Add an [EditorConfig](https://editorconfig.org) file to the project source. (*TC*)
 - Github actions improvements to avoid false positives (*TC*)
+- Fix typos in GitHub Actions for building docker images (*KMH*)
 - Remove partner-specific directories in the /sites directory (*KL*)
 - Increase the allowed length for the alternate library card label (*KL*)
 - Make the setting to enable the Grapes Editor visible to any with the appropriate permissions (*KL*)


### PR DESCRIPTION
At some point Aspen-Discovery/aspen-discovery became Aspen-Discover/aspen-discovery, without they "y" in the org name. This is causing GitHub actions to never run the docker image build process.