### PR TITLE
Book+DVD and Available Now At Facet

### DIFF
--- a/code/reindexer/src/org/aspen_discovery/format_classification/MarcRecordFormatClassifier.java
+++ b/code/reindexer/src/org/aspen_discovery/format_classification/MarcRecordFormatClassifier.java
@@ -265,7 +265,7 @@ public class MarcRecordFormatClassifier {
 						}
 					} else if (subfield.getCode() == 'a' && (pagesPattern2.matcher(physicalDescriptionData).matches())){
 						Subfield subfieldE = field.getSubfield('e');
-						if (subfieldE != null && subfieldE.getData().toLowerCase().contains("dvd")){
+						if (subfieldE != null && (subfieldE.getData().toLowerCase().contains("dvd") || subfieldE.getData().toLowerCase().contains("videodisc"))){
 							if (groupedWork != null && groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Adding bib level format Book+DVD based on 300 Physical Description", 2);}
 							result.add("Book+DVD");
 						}else if (subfieldE != null && subfieldE.getData().toLowerCase().contains("cd-rom")){

--- a/code/web/release_notes/24.11.00.MD
+++ b/code/web/release_notes/24.11.00.MD
@@ -154,6 +154,7 @@
 - Make the setting to enable the Grapes Editor visible to any with the appropriate permissions (*KL*)
 - Add check to saveToList function to ensure the user attempting to add a book to the list is authorised to do so. (*AB*)
 - Ebsco EDS and host passwords are encrypted before being stored in the Aspen database (*CZ*)
+- Fix issue where the Available Now At facet was not showing related locations and home locations at the top of the list (Ticket 122986 (partial)) (*KL*)
 
 ## This release includes code contributions from
 ###ByWater Solutions

--- a/code/web/release_notes/24.11.00.MD
+++ b/code/web/release_notes/24.11.00.MD
@@ -31,6 +31,7 @@
 - When determining CD+Book format, do not mark as CD+Book if the 300e includes booklet rather than book. (*MDN*)
 - Add a new format for Zines based on the 655a (*MDN*)
 - Update indexer to avoid errors during concurrent (multithreaded) indexing of materials. (*MDN*)
+- When determining Book+DVD format, check for videodisc in addition to dvd in 300e (Ticket 139639) (*KL*)
 
 ### Install Updates
 - Make it easier to create new Symphony sites by creating account profiles and indexing profiles (similar to how Koha sites can be set up). (*MDN*)

--- a/code/web/sys/SearchObject/GroupedWorkSearcher2.php
+++ b/code/web/sys/SearchObject/GroupedWorkSearcher2.php
@@ -726,12 +726,17 @@ class SearchObject_GroupedWorkSearcher2 extends SearchObject_AbstractGroupedWork
 			}
 			$relatedLocationFacets = $locationSingleton->getLocationsFacetsForLibrary($currentLibrary->libraryId);
 			if (strlen($currentLibrary->additionalLocationsToShowAvailabilityFor) > 0) {
-				$locationsToLookfor = explode('|', $currentLibrary->additionalLocationsToShowAvailabilityFor);
-				$location = new Location();
-				$location->whereAddIn('code', $locationsToLookfor, true);
-				$location->find();
 				$additionalAvailableAtLocations = [];
+				$location = new Location();
+				if ($currentLibrary->additionalLocationsToShowAvailabilityFor != ".*"){
+					$locationsToLookfor = explode('|', $currentLibrary->additionalLocationsToShowAvailabilityFor);
+					$location->whereAddIn('code', $locationsToLookfor, true);
+				}
+				$location->find();
 				while ($location->fetch()) {
+					if ($location->facetLabel == null){
+						$location->facetLabel = $location->displayName;
+					}
 					$additionalAvailableAtLocations[] = $location->facetLabel;
 				}
 			}
@@ -864,7 +869,7 @@ class SearchObject_GroupedWorkSearcher2 extends SearchObject_AbstractGroupedWork
 							$valueKey = '2' . $valueKey;
 							$numValidRelatedLocations++;
 						} elseif (!is_null($additionalAvailableAtLocations) && in_array($facetValue, $additionalAvailableAtLocations)) {
-							$valueKey = '2' . $valueKey;
+							$valueKey = '3' . $valueKey;
 							$numValidRelatedLocations++;
 						} else {
 							$valueKey = '4' . $valueKey;


### PR DESCRIPTION
**Book+DVD Format:**
When determining Book+DVD format, check for videodisc in addition to dvd in 300e
Update release notes

To Test:
Add videodisc to a Book+DVD record in the 300e and remove any "dvd" strings
Reindex the record
It will then show as Book+DVD

**Available Now At Facet:**
Fix issue where the Available Now At facet was not showing related locations and home locations at the top of the list
Update release notes

Tested on my local

To Test:
Add locations to additional locations to show availability for that are not related to the main library
When performing a search, you should see the active library first, then any related locations or home locations, then additional locations you've added, and then any other locations