### PR TITLE
[#2135] Make the CurlWrapper decode compressed contents automatically

### DIFF
--- a/code/web/release_notes/24.11.00.MD
+++ b/code/web/release_notes/24.11.00.MD
@@ -153,6 +153,7 @@
 - Make the setting to enable the Grapes Editor visible to any with the appropriate permissions (*KL*)
 - Add check to saveToList function to ensure the user attempting to add a book to the list is authorised to do so. (*AB*)
 - Ebsco EDS and host passwords are encrypted before being stored in the Aspen database (*CZ*)
+- Make sure cURL decodes the compressed response contents automatically (*TC*)
 
 ## This release includes code contributions from
 ###ByWater Solutions

--- a/code/web/sys/CurlWrapper.php
+++ b/code/web/sys/CurlWrapper.php
@@ -40,6 +40,7 @@ class CurlWrapper {
 			CURLOPT_FORBID_REUSE => false,
 			CURLOPT_HEADER => false,
 			CURLOPT_AUTOREFERER => true,
+			CURLOPT_ENCODING => '',
 		];
 		$this->options = $default_options;
 	}


### PR DESCRIPTION
This patch relies on a flag that exists for this purpose [CURLOPT_ENCODING](https://www.php.net/manual/en/curl.constants.php#constant.curlopt-encoding).

By setting this flag to an empty string two things happen, according to the docs:

* All supported compression methods are set on the `Accept-Encoding` header (which should be better than hardcoding a specific set of values)
* The response contents get automatically decoded, if required.

I tested keeping the current header we set, and not setting it (I picked the `getOutstandingCreditTotal()` method in the Koha.php file for testing purposes.

In both cases, this change worked. So this change feels forward safe.

To test:
1. Have a dev Aspen instance running along with KTD or connected to *some* Koha instance.
2. Have a valid patron with a debt of $100
3. Log into Aspen with the user => FAIL: Notice the `Fines` item in the left column says *$0* when it should
   be something else
4. Click on the `Fines` link => FAIL: No debts
5. Apply this patch and reload the page => SUCCESS: `Fines` now shows $100
6. Repeat 4 => SUCCESS: Debt is now displayed!
7. If you have an interactive debugger, set a breakpoint in Koha.php:3014, without the patch applied.
8. Repeat 4 => FAIL: The debugger shows `$response['content']` is full of garbage chars after the `->get` call
9. Apply this patch
10. Repeat 4 => SUCCESS: The content is automatically decoded!!!!
11. Sign off :-D