### PR TITLE
fix: populate authorizedValues properly

### DIFF
--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -4102,6 +4102,7 @@ class Koha extends AbstractIlsDriver {
 			if (!empty($extendedAttributes)) {
 				$borrowerAttributes = [];
 				foreach ($extendedAttributes as $attribute) {
+					$authorizedValues = [];
 					foreach ($attribute['authorized_values'] as $key => $value) {
 						$authorizedValues[$key] = $value;
 					}


### PR DESCRIPTION
To reproduce the bug:
- set up Koha as the ILS Aspen uses
- in Koha, create at least two new patron attributes and give each of these at least two
authorised values
- on Aspen, visit /MyAccount/SelfReg, and scroll down to the Additional Information section
- notice that, while the first dropdown field contains the options it is expected to, further
field will contain the options of the fields
before them as well as their own.

Test plan:
- Apply the patch
- Reload the /MyAccount/SelfReg page
- Notice that the dropdowns now only contain the options they are supposed to