### PR TITLE
[#2135] Make the CurlWrapper decode compressed contents automatically

### DIFF
--- a/.github/workflows/pull_request_qa.yml
+++ b/.github/workflows/pull_request_qa.yml
@@ -17,10 +17,9 @@ jobs:
       - name: Check for changes in release notes
         run: |
           if git diff --name-only ${{ github.event.pull_request.base.sha }} | grep -q 'code/web/release_notes/'; then
-            echo "Release notes have been modified."
+            echo "Release notes have been modified"
           else
-            echo "No changes detected in the release notes."
-            exit 1
+            echo "::warning::Release notes not modified"
           fi
 
   check_tabs_vs_spaces:

--- a/.github/workflows/pull_request_qa.yml
+++ b/.github/workflows/pull_request_qa.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Check for spaces instead of tabs
         run: |
           # Find files that are modified in the pull request
-          MODIFIED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }})
+          MODIFIED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} | grep -v 'code/aspen_app')
 
           # Loop through each file and check for spaces used instead of tabs
           EXIT_CODE=0

--- a/.github/workflows/pull_request_qa.yml
+++ b/.github/workflows/pull_request_qa.yml
@@ -11,22 +11,12 @@ jobs:
     steps:
       - name: Checkout pull request branch
         uses: actions/checkout@v4
-
-      - name: Add official Aspen Discovery repo as another remote
-        run: git remote add official https://github.com/Aspen-Discovery/aspen-discovery.git && git fetch official
-
-      - name: Get default branch
-        id: get_default_branch
-        run: |
-          default_branch=$(curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/Aspen-Discovery/aspen-discovery | jq -r .default_branch)
-          echo "Default branch is $default_branch"
-          echo "DEFAULT_BRANCH=$default_branch" >> $GITHUB_ENV
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          fetch-depth: 2
 
       - name: Check for changes in release notes
         run: |
-          if git diff --name-only official/$DEFAULT_BRANCH HEAD | grep -q 'code/web/release_notes/'; then
+          if git diff --name-only ${{ github.event.pull_request.base.sha }} | grep -q 'code/web/release_notes/'; then
             echo "Release notes have been modified."
           else
             echo "No changes detected in the release notes."
@@ -39,23 +29,13 @@ jobs:
     steps:
       - name: Checkout pull request branch
         uses: actions/checkout@v4
-
-      - name: Add official Aspen Discovery repo as another remote
-        run: git remote add official https://github.com/Aspen-Discovery/aspen-discovery.git && git fetch official
-
-      - name: Get default branch
-        id: get_default_branch
-        run: |
-          default_branch=$(curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/Aspen-Discovery/aspen-discovery | jq -r .default_branch)
-          echo "Default branch is $default_branch"
-          echo "DEFAULT_BRANCH=$default_branch" >> $GITHUB_ENV
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          fetch-depth: 2
 
       - name: Check for spaces instead of tabs
         run: |
           # Find files that are modified in the pull request
-          MODIFIED_FILES=$(git diff --name-only official/$DEFAULT_BRANCH HEAD)
+          MODIFIED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }})
 
           # Loop through each file and check for spaces used instead of tabs
           EXIT_CODE=0
@@ -63,7 +43,7 @@ jobs:
           for file in $MODIFIED_FILES; do
             echo "Found modified file: $file";
             if [[ $file == *.php || $file == *.js || $file == *.java ]]; then
-              DIFF=$(git diff official/$DEFAULT_BRANCH HEAD -- $file)
+              DIFF=$(git diff ${{ github.event.pull_request.base.sha }} -- $file)
               #echo "DIFF: $DIFF"
               while IFS= read -r RAW_LINE; do
                 if [[ $RAW_LINE =~ ^\+ ]]; then
@@ -95,26 +75,16 @@ jobs:
     steps:
       - name: Checkout pull request branch
         uses: actions/checkout@v4
-
-      - name: Add official Aspen Discovery repo as another remote
-        run: git remote add official https://github.com/Aspen-Discovery/aspen-discovery.git && git fetch official
-
-      - name: Get default branch
-        id: get_default_branch
-        run: |
-          default_branch=$(curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/Aspen-Discovery/aspen-discovery | jq -r .default_branch)
-          echo "Default branch is $default_branch"
-          echo "DEFAULT_BRANCH=$default_branch" >> $GITHUB_ENV
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          fetch-depth: 2
 
       - name: Check for changes in site creation that may necessitate a change to the Docker file
         run: |
-          LINES_CHANGED=$(git diff official/$DEFAULT_BRANCH HEAD -- install/createSiteTemplate.ini | wc -l)
+          LINES_CHANGED=$(git diff ${{ github.event.pull_request.base.sha }} -- install/createSiteTemplate.ini | wc -l)
           echo "LINES CHANGED: $LINES_CHANGED"
           if [[ $LINES_CHANGED -gt 0 ]]; then
             echo "Changes to createSiteTemplate.ini have been detected"
-            if git diff --name-only official/$DEFAULT_BRANCH HEAD | grep docker; then
+            if git diff --name-only git diff --name-only ${{ github.event.pull_request.base.sha }} | grep docker; then
               echo "Changes to docker files has also been detected"
             else
               echo "No changes to docker files have been detected"

--- a/code/web/release_notes/24.10.11.MD
+++ b/code/web/release_notes/24.10.11.MD
@@ -1,6 +1,10 @@
 ## Aspen Discovery Updates
 
+### Other updates
+
+- Make sure cURL decodes the compressed response contents automatically (*TC*)
 
 ## This release includes code contributions from
+
 - Theke Solutions 
   - Tomas Cohen Arazi (TC)

--- a/code/web/release_notes/24.10.11.MD
+++ b/code/web/release_notes/24.10.11.MD
@@ -3,6 +3,7 @@
 ### Other updates
 
 - Make sure cURL decodes the compressed response contents automatically (*TC*)
+- Github actions improvements to avoid false positives (*TC*)
 
 ## This release includes code contributions from
 

--- a/code/web/sys/CurlWrapper.php
+++ b/code/web/sys/CurlWrapper.php
@@ -40,6 +40,7 @@ class CurlWrapper {
 			CURLOPT_FORBID_REUSE => false,
 			CURLOPT_HEADER => false,
 			CURLOPT_AUTOREFERER => true,
+			CURLOPT_ENCODING => '',
 		];
 		$this->options = $default_options;
 	}


### PR DESCRIPTION
This patch relies on a flag that exists for this purpose [CURLOPT_ENCODING](https://www.php.net/manual/en/curl.constants.php#constant.curlopt-encoding).

By setting this flag to an empty string two things happen, according to the docs:

* All supported compression methods are set on the `Accept-Encoding` header (which should be better than hardcoding a specific set of values)
* The response contents get automatically decoded, if required.

I tested keeping the current header we set, and not setting it (I picked the `getOutstandingCreditTotal()` method in the Koha.php file for testing purposes.

In both cases, this change worked. So this change feels forward safe.

To test:
1. Have a dev Aspen instance running along with KTD or connected to *some* Koha instance.
2. Have a valid patron with a debt of $100
3. Log into Aspen with the user => FAIL: Notice the `Fines` item in the left column says *$0* when it should
   be something else
4. Click on the `Fines` link => FAIL: No debts
5. Apply this patch and reload the page => SUCCESS: `Fines` now shows $100
6. Repeat 4 => SUCCESS: Debt is now displayed!
7. If you have an interactive debugger, set a breakpoint in Koha.php:3014, without the patch applied.
8. Repeat 4 => FAIL: The debugger shows `$response['content']` is full of garbage chars after the `->get` call
9. Apply this patch
10. Repeat 4 => SUCCESS: The content is automatically decoded!!!!
11. Sign off :-D