### PR TITLE
Redirect to selfRegistrationUrl if accessing the /MyAccount/SelfReg URL directly.

### DIFF
--- a/code/web/release_notes/24.12.00.MD
+++ b/code/web/release_notes/24.12.00.MD
@@ -15,11 +15,16 @@
 
 // Chloe - PTFSE
 
+// Pedro - PTFSE
+
 // Lucas - Theke
 
 // Tomas - Theke
 
 // ByWater
+
+### Other Updates
+- Redirect to selfRegistrationUrl if the /MyAccount/SelfReg URL is accessed directly.(*PA*)
 
 ## This release includes code contributions from
 ### ByWater Solutions
@@ -35,6 +40,7 @@
 ### PTFS-Europe
   - Alexander Blanchard (AB)
   - Chloe Zermatten (CZ)
+  - Pedro Amorim (PA)
 
 ### Theke Solutions
   - Lucas Montoya (LM)

--- a/code/web/services/MyAccount/SelfReg.php
+++ b/code/web/services/MyAccount/SelfReg.php
@@ -12,6 +12,12 @@ class SelfReg extends Action {
 		$selfRegFields = $catalog->getSelfRegistrationFields();
 		if ($library->enableSelfRegistration == 0) {
 			$this->display('selfRegistrationNotAllowed.tpl', 'Register for a Library Card', '');
+		} elseif ($library->enableSelfRegistration == 2) {
+			if (!empty($library->selfRegistrationUrl)) {
+				header("Location: {$library->selfRegistrationUrl}");
+				exit;
+			}
+			$this->display('selfRegistrationNotAllowed.tpl', 'Register for a Library Card', '');
 		} else {
 			if (isset($_REQUEST['submit'])) {
 


### PR DESCRIPTION
    Motivation:
    Some users are accessing <aspen_url>/MyAccount/SelfReg directly,
    possibly through search engines, even though
    $library->enableSelfRegistration is set to 2 ('Redirect to Self
    Registration URL').
    This page does not consider that option, and still shows the local
    registration form.
    This patch aims to fix that.
    
    Test plan (adb):
    1) Edit Main Library, visit:
      http://localhost:8083/Admin/Libraries?objectAction=edit&id=1
    2) Expand 'ILS/Account Integration'
    3) Expand 'Self Registration'
    4) On 'Enable Self Registration', pick 'Redirect to Self Registration
       URL'
    5) On 'Self Registration URL, put some valid URL e.g.
       'https://help.aspendiscovery.org/'
    6) Access the self reg URL directly:
      http://localhost:8083/MyAccount/SelfReg
    7) Notice you are now directed to the configured selfReg URL