### PR TITLE
DIS 45 - A search with 'ampersand' should be the same as 'and'

### DIFF
--- a/code/web/release_notes/24.12.00.MD
+++ b/code/web/release_notes/24.12.00.MD
@@ -67,8 +67,8 @@
 - Update Patron Types so Year in Review functionality can be enabled or disabled by Patron Type. (*MDN*)
 - After a patron logs in, check to see if they should see the Year In Review functionality and if so, display a message to the user and add a link from the account sidebar and account menu. (*MDN*)
 - When selecting Year in Review, display a slideshow to the user based on data loaded from their account. (*MDN*)
-  - Slides are based on a configuration file that can be updated each year. 
-  - Data is loaded from the patron account and overlaid onto background images. 
+  - Slides are based on a configuration file that can be updated each year.
+  - Data is loaded from the patron account and overlaid onto background images.
 
 <div markdown="1" class="settings">
 
@@ -90,6 +90,8 @@
 - Fix so tooltips work within the modal dialog. (*MDN*)
 
 // katherine
+### Indexing Updates
+- Update Grouped Works Index schema so that searches with '&' and 'and' are treated the same way. (DIS-45) (*KP*)
 
 // kirstien
 
@@ -101,7 +103,7 @@
 ### Indexing Updates
 - Add Regular Expression field for item types to be treated as eContent to Indexing Profiles in order to allow libraries to add to this. All item types currently treated as eContent are included by default. (*AB*)
 
-### Web Builder Updates 
+### Web Builder Updates
 - Remove edit button in admin view of Grapes JS Pages as breadcrumbs allow navigation back to the editor and are in keeping with the rest of Aspen. (*AB*)
 
 // Chloe - PTFSE
@@ -154,4 +156,4 @@
 - Lauren Conley (ByWater Solutions)
 
 ## This release includes sponsored developments from
-- Wyoming State Library 
+- Wyoming State Library

--- a/data_dir_setup/solr7/grouped_works_v2/conf/schema.xml
+++ b/data_dir_setup/solr7/grouped_works_v2/conf/schema.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <schema name="Aspen Grouped Work Index" version="1.5">
 	<types>
-		<fieldType name="unchanged_string" class="StrField"/> 
+		<fieldType name="unchanged_string" class="StrField"/>
 		<fieldType name="integer" class="IntPointField"/>
 		<fieldType name="long" class="LongPointField"/>
 		<fieldType name="float" class="FloatPointField"/>
@@ -10,12 +10,14 @@
 		<fieldType name="text_general" class="solr.TextField" positionIncrementGap="100">
 			<analyzer type="index">
 				<tokenizer class="solr.StandardTokenizerFactory"/>
+				<charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(\&amp;)" replacement="and"/>
 				<filter class="solr.ICUFoldingFilterFactory" />
 				<filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"  />
 				<filter class="solr.LowerCaseFilterFactory"/>
 			</analyzer>
 			<analyzer type="query">
 				<tokenizer class="solr.StandardTokenizerFactory"/>
+				<charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(\&amp;)" replacement="and"/>
 				<filter class="solr.ICUFoldingFilterFactory" />
 				<filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"  />
 <!--				<filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>-->
@@ -28,6 +30,7 @@
 				 For example, this allows E.T. The Extra-Terrestrial to be handled properly.  #ARL-168
 				-->
 				<tokenizer class="solr.StandardTokenizerFactory"/>
+				<charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(\&amp;)" replacement="and"/>
 				<filter class="solr.ICUFoldingFilterFactory"/>
 				<filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1" preserveOriginal="1"/>
 				<!-- We have not defined words so this is not needed <filter class="solr.CommonGramsFilterFactory" words="stopwords.txt" ignoreCase="true"/> -->
@@ -42,6 +45,7 @@
 				 For example, this allows E.T. The Extra-Terrestrial to be handled properly.  #ARL-168
 				-->
 				<tokenizer class="solr.StandardTokenizerFactory"/>
+				<charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(\&amp;)" replacement="and"/>
 				<filter class="solr.ICUFoldingFilterFactory"/>
 <!--				<filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>-->
 				<filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1" preserveOriginal="1"/>
@@ -59,6 +63,7 @@
 				 For example, this allows E.T. The Extra-Terrestrial to be handled properly.  #ARL-168
 				-->
 				<tokenizer class="solr.StandardTokenizerFactory"/>
+				<charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(\&amp;)" replacement="and"/>
 				<filter class="solr.ICUFoldingFilterFactory"/>
 				<filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1" preserveOriginal="1"/>
 				<filter class="solr.KeywordRepeatFilterFactory" />
@@ -71,6 +76,7 @@
 				 For example, this allows E.T. The Extra-Terrestrial to be handled properly.  #ARL-168
 				-->
 				<tokenizer class="solr.StandardTokenizerFactory"/>
+				<charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(\&amp;)" replacement="and"/>
 				<filter class="solr.ICUFoldingFilterFactory"/>
 				<!--				<filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>-->
 				<filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1" preserveOriginal="1"/>
@@ -86,6 +92,7 @@
 				 For example, this allows E.T. The Extra-Terrestrial to be handled properly.  #ARL-168
 				-->
 				<tokenizer class="solr.StandardTokenizerFactory"/>
+				<charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(\&amp;)" replacement="and"/>
 				<filter class="solr.ICUFoldingFilterFactory"/>
 				<filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1" preserveOriginal="1"/>
 				<filter class="solr.KeywordRepeatFilterFactory" />
@@ -97,6 +104,7 @@
 				 For example, this allows E.T. The Extra-Terrestrial to be handled properly.  #ARL-168
 				-->
 				<tokenizer class="solr.StandardTokenizerFactory"/>
+				<charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(\&amp;)" replacement="and"/>
 				<filter class="solr.ICUFoldingFilterFactory"/>
 				<!--				<filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>-->
 				<filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1" preserveOriginal="1"/>
@@ -110,6 +118,7 @@
 				 For example, this allows E.T. The Extra-Terrestrial to be handled properly.  #ARL-168
 				-->
 				<tokenizer class="solr.KeywordTokenizerFactory"/>
+				<charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(\&amp;)" replacement="and"/>
 				<charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^\s*(.*)\s*$" replacement="aaaa $1 zzzz"/>
 				<filter class="solr.LowerCaseFilterFactory"/>
 				<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
@@ -118,6 +127,7 @@
 		<fieldType name="text-left" class="solr.TextField" sortMissingLast="true" omitNorms="true">
 			<analyzer type="index">
 				<tokenizer class="solr.KeywordTokenizerFactory"/>
+				<charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(\&amp;)" replacement="and"/>
 				<charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^\s*(.*)\s*$" replacement="aaaa $1"/>
 				<filter class="solr.LowerCaseFilterFactory"/>
 				<filter class="solr.EdgeNGramFilterFactory" minGramSize="5" maxGramSize="50"/>
@@ -125,6 +135,7 @@
 			</analyzer>
 			<analyzer type="query">
 				<tokenizer class="solr.KeywordTokenizerFactory"/>
+				<charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(\&amp;)" replacement="and"/>
 				<charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^\s*(.*)\s*$" replacement="aaaa $1"/>
 				<filter class="solr.LowerCaseFilterFactory"/>
 				<filter class="solr.TrimFilterFactory"/>
@@ -134,6 +145,7 @@
 		<fieldType name="textProper" class="solr.TextField" positionIncrementGap="100">
 			<analyzer>
 				<tokenizer class="solr.WhitespaceTokenizerFactory"/>
+				<charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(\&amp;)" replacement="and"/>
 				<filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1" preserveOriginal="1"/>
 				<filter class="solr.LowerCaseFilterFactory"/>
 				<filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
@@ -173,7 +185,7 @@
 				<filter class="solr.PatternReplaceFilterFactory" pattern="([^a-z1-9\s])" replacement="" replace="all"/>
 			</analyzer>
 		</fieldType>
-	</types>	
+	</types>
 
 	<fields>
 		<field name="id" type="unchanged_string" indexed="true" stored="true" multiValued="false" required="true"/>
@@ -370,7 +382,7 @@
 		<!-- Field to get random titles -->
 		<dynamicField name="random*" type="random" indexed="true" stored="true"/>
 	</fields>
-	
+
 	<uniqueKey>id</uniqueKey>
 
 	<copyField source="title" dest="title_suggestions"/>


### PR DESCRIPTION
- Updated Grouped Work Index so that ampersands are replaced with the word 'and' for both the indexed value and the query.  This way a search for 'Love and olives' will return the same results as 'Love & olives'.
- Updated release notes.

Testing Plan
- Copy /usr/local/aspen-discovery/data_dir_setup/solr7/grouped_works_v2/conf/schema.xml into your site's data directory, [data-directory]/aspen-discovery/[your site]/solr7/grouped_works_v2/conf/schema.xml.
- Restart Solr and reindex records.
- Perform a variety of searches that include and or & and verify that they return the same results and that these results are good.  Examples:
  - Love and olives / love & olives (keyword or title)
  - Bonnie and Clyde / Bonnie & Clyde (keyword or title or subject)
  - Dollars and Sense / Dollars & Sense (keyword or title)
  - AT&T (keyword or title or subject)
- Perform a variety of searches that do not include and or & and verify that they return the expected results.