### PR TITLE
Initial setup for Year In Review for LiDA

### DIFF
--- a/code/aspen_app/src/translations/defaults.json
+++ b/code/aspen_app/src/translations/defaults.json
@@ -592,5 +592,7 @@
   "confirm_delete_account_message": "This will only delete your Aspen Discovery account with your library, including any personal data on Aspen Discovery such as lists and saved searches, but will not delete your card with the library. If you want to close your library account, you must contact your library.",
   "confirm_delete_account": "Yes, Delete Account",
   "deleting": "Deleting",
-	"collection": "Collection"
+	"collection": "Collection",
+	"view_now": "View Now",
+	"year_in_review": "Year In Review"
 }

--- a/code/web/interface/themes/responsive/MyAccount/yearInReview.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/yearInReview.tpl
@@ -1,0 +1,4 @@
+{strip}
+	{$slides}
+	{$slide_navigation}
+{/strip}

--- a/code/web/services/API/UserAPI.php
+++ b/code/web/services/API/UserAPI.php
@@ -1007,6 +1007,15 @@ class UserAPI extends AbstractAPI {
 
 			$userData->isStaff = $user->isStaff();
 
+			$userData->hasYearInReview = $user->hasYearInReview();
+
+			$userData->yearInReviewName = null;
+			$yearInReviewSetting = $user->getYearInReviewSetting();
+			if($yearInReviewSetting) {
+				$yearInReviewName = $yearInReviewSetting->name;
+				$userData->yearInReviewName = translate(['text' => $yearInReviewName, 'isPublicFacing' => true]);
+			}
+
 			return [
 				'success' => true,
 				'profile' => $userData,

--- a/code/web/services/MyAccount/YearInReview.php
+++ b/code/web/services/MyAccount/YearInReview.php
@@ -1,0 +1,77 @@
+<?php
+
+require_once ROOT_DIR . '/services/MyAccount/MyAccount.php';
+
+class YearInReview extends MyAccount {
+	function launch() {
+		global $interface;
+		global $library;
+		$user = UserAccount::getLoggedInUser();
+
+		if ($user) {
+			if (!$user->hasYearInReview()) {
+				//User shouldn't get here
+				$module = 'Error';
+				$action = 'Handle404';
+				$interface->assign('module', 'Error');
+				$interface->assign('action', 'Handle404');
+				require_once ROOT_DIR . "/services/Error/Handle404.php";
+				$actionClass = new Error_Handle404();
+				$actionClass->launch();
+				die();
+			}
+
+			$interface->assign('profile', $user);
+
+			$slideNumber = $_REQUEST['slide'] ?? 1;
+			if (is_numeric($slideNumber)){
+				$yearInReviewSettings = $user->getYearInReviewSetting();
+				$result = $yearInReviewSettings->getSlide($user, (int)$slideNumber);
+				$interface->assign('slides', $result['modalBody']);
+				$interface->assign('slide_configuration', $result['slideConfiguration']);
+
+				$slideNavigation = '';
+				global $configArray;
+				$url = $configArray['Site']['url'] . '/MyAccount/YearInReview?minimalInterface=true';
+				if ($slideNumber > 1) {
+					$slideNavigation .= '<a class="btn btn-default" href="'. $url . '&slide=' . $slideNumber - 1 . '">' . translate([
+							'text' => 'Previous',
+							'isPublicFacing' => true,
+							'inAttribute' => true,
+						]) . '</a>';
+				}
+				if ($slideNumber < $result['numSlidesToShow']) {
+					$slideNavigation .= '<a class="btn btn-primary" href="'. $url . '&slide=' . $slideNumber + 1 . '">' . translate([
+							'text' => 'Next',
+							'isPublicFacing' => true,
+							'inAttribute' => true,
+						]) . '</a>';
+				}
+
+				$interface->assign('slide_navigation', $slideNavigation);
+
+			} else {
+				$module = 'Error';
+				$action = 'Handle404';
+				$interface->assign('module', 'Error');
+				$interface->assign('action', 'Handle404');
+				require_once ROOT_DIR . "/services/Error/Handle404.php";
+				$actionClass = new Error_Handle404();
+				$actionClass->launch();
+				die();
+			}
+
+
+		}
+
+
+		$this->display('yearInReview.tpl', 'Year In Review');
+	}
+
+	function getBreadcrumbs(): array {
+		$breadcrumbs = [];
+		$breadcrumbs[] = new Breadcrumb('/MyAccount/Home', 'Your Account');
+		$breadcrumbs[] = new Breadcrumb('', 'Year In Review');
+		return $breadcrumbs;
+	}
+}

--- a/code/web/sys/YearInReview/YearInReviewSetting.php
+++ b/code/web/sys/YearInReview/YearInReviewSetting.php
@@ -211,6 +211,7 @@ class YearInReviewSetting extends DataObject {
 					}
 
 					$result['slideConfiguration'] = $slideInfo;
+					$result['numSlidesToShow'] = $userYearInResults->numSlidesToShow;
 					$result['modalBody'] = $this->formatSlide($slideInfo, $patron, $slideNumber, $this->year);
 
 					$modalButtons = '';


### PR DESCRIPTION
- Adds a direct route to Year In Review if available for user MyAccount/YearInReview that can be called from Aspen LiDA
- Adds setting in User API to check if the user has Year In Review available for determining if a link should be displayed in the Account Drawer in Aspen LiDA