### PR TITLE
add Year In Review link to Account Drawer in LiDA

### DIFF
--- a/code/aspen_app/src/navigations/drawer/DrawerContent.js
+++ b/code/aspen_app/src/navigations/drawer/DrawerContent.js
@@ -422,6 +422,7 @@ export const DrawerContent = () => {
                               <UserLists />
                               <SavedSearches />
                               <ReadingHistory />
+							  <YearInReview />
                               <Fines />
                               <NotificationHistory />
                               <Events />
@@ -958,6 +959,41 @@ const Events = () => {
      }
 
      return null;
+};
+
+const YearInReview = () => {
+	const { user } = React.useContext(UserContext);
+	const { library } = React.useContext(LibrarySystemContext);
+	const { language } = React.useContext(LanguageContext);
+	const version = formatDiscoveryVersion(library.discoveryVersion);
+	const backgroundColor = useToken('colors', useColorModeValue('warmGray.200', 'coolGray.900'));
+	const textColor = useToken('colors', useColorModeValue('gray.800', 'coolGray.200'));
+
+	let shouldShowYearInReview = false;
+	if (typeof user.hasYearInReview !== 'undefined') {
+		shouldShowYearInReview = user.hasYearInReview;
+	}
+
+	if (version >= '24.12.00' && shouldShowYearInReview) {
+		return (
+			<Pressable px="2" py="3" rounded="md" onPress={async () => await passUserToDiscovery(library.baseUrl, 'YearInReview', user.id, backgroundColor, textColor)}>
+				<HStack space="1" alignItems="center">
+					<Icon as={MaterialIcons} name="chevron-right" size="7" />
+					<VStack w="100%">
+						<Text fontWeight="500">{user.yearInReviewName ?? getTermFromDictionary(language, 'year_in_review')}</Text>
+					</VStack>
+				</HStack>
+
+				<Container>
+					<Badge colorScheme="info" ml={10} rounded="4px" _text={{ fontSize: 'xs' }}>
+						{getTermFromDictionary(language, 'view_now')}
+					</Badge>
+				</Container>
+			</Pressable>
+		);
+	}
+
+	return null;
 };
 
 async function getStoredNotifications() {

--- a/code/web/release_notes/24.12.00.MD
+++ b/code/web/release_notes/24.12.00.MD
@@ -2,6 +2,7 @@
 - Fixed a bug causing some users to occasionally be booted from an active session due to an erroneous API return that the user's credentials were invalid. (*KK*)
 - Update the record page to add a Request button for records needing Local ILL requests. (DIS-34) (*MDN, KK-G*)
 - Update the holds process to use the Local ILL process when configured. (DIS-34) (*MDN, KK-G*)
+- If enabled, added a link in the Account Drawer to open up the user's Year In Review. (*KK-G*)
 
 ## Aspen Discovery Updates
 // mark - Grove
@@ -114,6 +115,12 @@
 - Generate slide data for top author, top genres, top series, top formats, and for recommendations for next year. (*KP*)
 
 // kirstien
+### API Updates
+- In User API, added hasYearInReview in getPatronProfile to check if the user has Year In Review available for determining if a link should be displayed in the Account Drawer in Aspen LiDA. (*KK-G*)
+- In User API, added yearInReviewName in getPatronProfile to get the library specific name for Year In Review. (*KK-G*)
+
+### Year in Review Updates
+- Added a direct route to Year In Review, if available, for user MyAccount/YearInReview that can be opened from Aspen LiDA. (*KK-G*)
 
 // kodi
 


### PR DESCRIPTION
- If enabled for the user, Year in Review link (labeled as named in the Year in Review settings) will display in Account Drawer and open up a session in Aspen Discovery to load the slideshow.