### PR TITLE
Don't show old Year in Review messages

### DIFF
--- a/code/web/release_notes/24.12.00.MD
+++ b/code/web/release_notes/24.12.00.MD
@@ -124,6 +124,7 @@
 
 ### Year in Review Updates
 - Generate slide data for top author, top genres, top series, top formats, and for recommendations for next year. (*KP*)
+- Dismiss old Year in Review messages so that only one is shown at a time (*KP*)
 
 // kirstien
 ### API Updates

--- a/code/web/sys/YearInReview/YearInReviewGenerator.php
+++ b/code/web/sys/YearInReview/YearInReviewGenerator.php
@@ -129,6 +129,16 @@ function generateYearInReview(User $patron) : void {
 				if ($userYearInReview->wrappedActive) {
 					//Create a user message for the user
 					require_once ROOT_DIR . '/sys/Account/UserMessage.php';
+					//First check for and dismiss existing Year in Review messages
+					$userMessage = new UserMessage();
+					$userMessage->userId = UserAccount::getActiveUserId();
+					$userMessage->messageType = 'yearInReview';
+					$userMessage->isDismissed = 0;
+					$userMessage->find();
+					while ($userMessage->fetch()) {
+						$userMessage->isDismissed = 1;
+						$userMessage->update();
+					}
 					$userMessage = new UserMessage();
 					$userMessage->userId = UserAccount::getActiveUserId();
 					$userMessage->message = $yearInReviewSetting->getTextBlockTranslation('promoMessage', $patron->interfaceLanguage);


### PR DESCRIPTION
- When generating a new Year in Review, check for and dismiss old Year in Review messages if they haven't already been dismissed.