### PR TITLE
DIS-110 Add clarification to Check Record for Large Print

### DIFF
--- a/code/reindexer/src/org/aspen_discovery/reindexer/IlsRecordProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/IlsRecordProcessor.java
@@ -1592,6 +1592,7 @@ abstract class IlsRecordProcessor extends MarcRecordProcessor {
 	public void loadPrintFormatInformation(AbstractGroupedWorkSolr groupedWork, RecordInfo recordInfo, org.marc4j.marc.Record record, boolean hasChildRecords) {
 		//Check to see if we have child records, if so format will be Serials
 		if (hasChildRecords) {
+			if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Title has child records, loading format from bib.", 2);}
 			//A record with children will not generally have items, so we will load from the bib.
 			loadPrintFormatFromBib(groupedWork, recordInfo, record);
 			if (recordInfo.getFormats().isEmpty()) {
@@ -1649,9 +1650,14 @@ abstract class IlsRecordProcessor extends MarcRecordProcessor {
 			if (settings.getCheckRecordForLargePrint()){
 				boolean doLargePrintCheck = false;
 				if ((uniqueItemFormats.size() == 1) && uniqueItemFormats.iterator().next().equalsIgnoreCase("Book")){
+					if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("All items are Book, checking record for Large Print.",2);}
+
 					doLargePrintCheck = true;
 				}else if ((uniqueItemFormats.size() == 2) && uniqueItemFormats.contains("Book") && uniqueItemFormats.contains("Large Print")){
+					if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("All items are Book or Large Print, checking record for Large Print.",2);}
 					doLargePrintCheck = true;
+				}else {
+					if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Record has items that are not Book/Large Print, skipping Large Print check.",2);}
 				}
 				if (doLargePrintCheck) {
 					LinkedHashSet<String> printFormats = formatClassifier.getUntranslatedFormatsFromBib(groupedWork, record, settings);

--- a/code/web/sys/Indexing/IndexingProfile.php
+++ b/code/web/sys/Indexing/IndexingProfile.php
@@ -1017,6 +1017,7 @@ class IndexingProfile extends DataObject {
 						'label' => 'Check Record for Large Print',
 						'default' => true,
 						'description' => 'Check metadata within the record to see if a book is large print',
+						'note'        => 'Only applies when all items have formats of either Book or Large Print',
 						'forcesReindex' => true,
 					],
 					'formatMap' => [


### PR DESCRIPTION
This patch adds a few debug statements to the diagnostics when determining format and adds a note to the 'Check Record for Large Print' setting

To test:
 1 - Add two records to ILS:
      One with some 'Books' type items and some 'Large Print' items
      One with an item with an item type that has a blank 'Format' colum in the format map, and some 'Book' type items
      Both records should have 'large print' in the 250 field
 2 - Ensure 'Check Record for Large Print' is checked in:
      ILS Integration->Indexing profiles->Format Information
 3 - View the records, note they are not listed as 'Large Print' only
 4 - Go to Staff View->Diagnostics (may need to force reindex the record)
 5 - Note that there is no info on 'Large Print' check
 6 - Apply patch, rebuild reindexer.jar, reindex the records
 7 - View diagnostic information and note new info about why Large Print check didn't happen
 8 - Change 'Books' to 'Book' and define a Format of 'Book' or 'Large Print' for previously undefined item
 9 - Reindex records, they should now be large print
10 - View diagnostics and note info about the Large Print check