### PR TITLE
Update Administer Hold Groups description

### DIFF
--- a/code/web/release_notes/24.12.00.MD
+++ b/code/web/release_notes/24.12.00.MD
@@ -54,7 +54,7 @@
 - Add new settings to configure the Local ILL system in use. (*MDN*)
   - Within library systems, administrators can set the type of Local ILL system to use. None is the default option, and Symphony Demand Management Using Books by Mail is also an option.
   - Within locations, administrators can set the ILL form to be used when making request.
-- Update hold groups to not be specific to VDX, so they can be used for both Local ILL and VDX. (*MDN*)
+- Update hold groups to not be specific to VDX, so they can be used for both Local ILL and VDX. (*MDN*, *MAF*)
 - Add new Local ILL forms to allow configuration of the information that patrons can provide when submitting Local ILL requests. (*MDN*)
 - Update the holds process to use the Local ILL process when configured. (*MDN*)
 - Local ILL Requests may be limited to a maximum number of requests by library. (*MDN*)

--- a/code/web/sys/DBMaintenance/version_updates/24.12.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/24.12.00.php
@@ -27,6 +27,7 @@ function getUpdates24_12_00(): array {
 			'continueOnError' => true,
 			'sql' => [
 				"UPDATE permissions SET name = 'Administer Hold Groups' where name = 'Administer VDX Hold Groups'",
+				"UPDATE permissions SET description = 'Allows the user to define Hold Groups for Interlibrary Loans.' where description = 'Allows the user to define Hold Groups for Interlibrary Loans with VDX.'",
 				"RENAME TABLE vdx_hold_groups TO hold_groups",
 				"RENAME TABLE vdx_hold_group_location TO hold_group_location",
 				"ALTER TABLE hold_group_location CHANGE COLUMN vdxHoldGroupId holdGroupId INT"


### PR DESCRIPTION
Removes VDX specificity in the default Administer Hold Groups permission description when updating to 24.12.00. 

@mdnoble73 I thought making a new line in the release notes for just this would be extra, so I included myself on your existing entries about updating hold groups, but that's also overselling this PR. I'll bow to your preference about how to represent this in the release notes if you have one.