### PR TITLE
Koha showopacnote

### DIFF
--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -1357,11 +1357,6 @@ class Koha extends AbstractIlsDriver {
 			$user->_state = $userFromDb['state'];
 			$user->_zip = $userFromDb['zipcode'];
 			$user->phone = $userFromDb['phone'];
-
-			$user_library = $user->getHomeLibrary();
-			if ($user_library !== null && $user_library->showOpacNotes) {
-				$user->_web_note = $userFromDb['opacnote'];
-			}
 		}
 	}
 
@@ -6942,6 +6937,14 @@ class Koha extends AbstractIlsDriver {
 		$results = mysqli_query($this->dbConnection, $sql);
 		if ($results !== false) {
 			if ($curRow = $results->fetch_assoc()) {
+				if ($library->showOpacNotes) {
+					if (!empty($curRow['opacnote'])) {
+						$messages[] = [
+							'message' => $curRow['opacnote'],
+							'messageStyle' => 'info',
+						];
+					}
+				}
 				if ($curRow['debarred'] != null) {
 					$message = '<strong>' . translate([
 							'text' => 'Please note: Your account has been frozen.',

--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -1358,7 +1358,10 @@ class Koha extends AbstractIlsDriver {
 			$user->_zip = $userFromDb['zipcode'];
 			$user->phone = $userFromDb['phone'];
 
-			$user->_web_note = $userFromDb['opacnote'];
+			$user_library = $user->getHomeLibrary();
+			if ($user_library !== null && $user_library->showOpacNotes) {
+				$user->_web_note = $userFromDb['opacnote'];
+			}
 		}
 	}
 
@@ -6939,15 +6942,6 @@ class Koha extends AbstractIlsDriver {
 		$results = mysqli_query($this->dbConnection, $sql);
 		if ($results !== false) {
 			if ($curRow = $results->fetch_assoc()) {
-				if ($library->showOpacNotes) {
-					if (!empty($curRow['opacnote'])) {
-						$messages[] = [
-							'message' => $curRow['opacnote'],
-							'messageStyle' => 'info',
-						];
-					}
-				}
-
 				if ($curRow['debarred'] != null) {
 					$message = '<strong>' . translate([
 							'text' => 'Please note: Your account has been frozen.',

--- a/code/web/release_notes/25.01.00.MD
+++ b/code/web/release_notes/25.01.00.MD
@@ -64,6 +64,7 @@
 ### Other Updates
 - Fix linking to library websites for consortia within Web Builder and the Hours and Location dialog. (*MDN*)
 - Add an editorconfig file for template files to standardize using tabs across all files. (*MDN*)
+- Library card page (under 'My Account') no longer shows Koha user's opac notes if user's library 'Show OPAC Notes' is disabled.(*PA*)
 
 //katherine
 


### PR DESCRIPTION
Previously, when library's 'showOpacNote' was disabled, the Koha user's
opac note was still being displayed. This is because it's getting added
to _web_note regardless of the setting's value.
This patch removes the opacnote from Koha's getILSMessages, and adds the
setting check to when opacnote should be added to loadContactInformation
or not.