### PR TITLE
Syndetics upc

### DIFF
--- a/code/web/interface/themes/responsive/Report/studentBarcodes.tpl
+++ b/code/web/interface/themes/responsive/Report/studentBarcodes.tpl
@@ -50,7 +50,7 @@ var patron = [];
 				textAlign: "left",
 				textMargin: 2,
 				textPosition: "top",
-				height: 40,
+				height: 33,
 				margin: 0,
 				width: barcodeWidth
 			});
@@ -66,6 +66,7 @@ document.addEventListener("DOMContentLoaded", function(event) {
 <style>
 .avery5160 {
 	/* Avery 5160 labels */
+	box-sizing: border-box !important;
 	width: 2.625in !important;
 	height: 1in !important;
 	margin: 0in .125in 0in 0in !important;
@@ -73,7 +74,7 @@ document.addEventListener("DOMContentLoaded", function(event) {
 	float: left;
 	display: inline-block;
 	text-align: left;
-	overflow: hidden;
+	overflow: hidden !important;
 	outline: 1px dotted;  /*outline doesn't occupy space like border does */
 }
 .gradehomeroom {
@@ -91,7 +92,7 @@ document.addEventListener("DOMContentLoaded", function(event) {
 @media print {
 	@page {
 		size: letter !important;
-		margin: 0.5in 0.0675in 0.5in 0.1875in; /* Adjust the margin to fit content within the page */
+		margin: 0.5in 0.0675in 0.5in 0.1875in !important; /* Adjust the margin to fit content within the page */
 	}
 	.avery5160 {
 		break-inside: avoid-page !important;
@@ -102,7 +103,7 @@ document.addEventListener("DOMContentLoaded", function(event) {
 	, #horizontal-menu-bar-wrapper
 	, #page-header
 	, #side-bar
-	, #system-message-header
+	, #system-messages
 	, .breadcrumbs {
 		display: none;
 	}

--- a/code/web/release_notes/24.12.00.MD
+++ b/code/web/release_notes/24.12.00.MD
@@ -210,6 +210,7 @@
 - Fix so tooltips work within the modal dialog. (*MDN*)
 - Remove the display of patron types to show a menu item for when viewing the list of all menu items within library settings. (*MDN*)
 - Remove unused old SSO fields from the library table. (DIS-63) (*MDN*)
+- Syndetics cover images should display correctly even if record's UPC contains leading zeroes.(*PA*)
 - Redirect to selfRegistrationUrl if the /MyAccount/SelfReg URL is accessed directly.(*PA*)
 - Remove old database update scripts for versions that are more than a year old. (*MDN*)
 

--- a/code/web/sys/Covers/BookCoverProcessor.php
+++ b/code/web/sys/Covers/BookCoverProcessor.php
@@ -748,13 +748,13 @@ class BookCoverProcessor {
 			$imageChecksum = md5($image);
 			if ($imageChecksum == 'e89e0e364e83c0ecfba5da41007c9a2c') {
 				return false;
-			} elseif ($imageChecksum == 'f017f94ed618a86d0fa7cecd7112ab7e') {
+			} elseif ($imageChecksum == 'f017f94ed618a86d0fa7cecd7112ab7e' || $imageChecksum == '798f904eabf783405079eaf699414801') {
 				//Syndetics Unbound default image at medium size
 				return false;
-			} elseif ($imageChecksum == 'dadde13fdb5f3775cdbdd25f34c0389b') {
+			} elseif ($imageChecksum == 'dadde13fdb5f3775cdbdd25f34c0389b' || $imageChecksum == 'b13e33c0262a3a1f21dd20b826710cbc') {
 				//Syndetics Unbound default image at small size
 				return false;
-			} elseif ($imageChecksum == 'c6ddaf338cf667df0bf60045f05146db') {
+			} elseif ($imageChecksum == 'c6ddaf338cf667df0bf60045f05146db' || $imageChecksum == '821d0d442dbee0f51f4c803e8e9fc87a') {
 				//Syndetics Unbound default image at large size
 				return false;
 			}


### PR DESCRIPTION
On adb, with ktd, we can use record '76' as that has a UPC with a leading zero:
http://localhost:8083/Record/76

Enter valid syndetics credentials or apply the test only patch to override the need for syndetics credentials through the UI, though you still need to add a valid key through the code, your pick.
Access the record:
http://localhost:8083/Record/76
Notice the image is not found, this is because this record's UPC is '021561601628', and processImageURL is not identifying the returned image as a "not found" because it doesn't match any of the checksums it's verifying.
Apply the patch. Repeat the test plan. You'll need to click "Staff View" -> "Reload Cover" on the record page to clear the cover cache and force the request again but now the image should be displaying correctly. This is because the leading zeroes fail check and the returned image is properly identified as a 'not found' image, so getGroupedWorkCover will then check again but without stripping the leading zeroes, and work then.

Finally, I decided to test for the other sizes as well, and noticed all the checksums are wrong, not the just the medium. Possibly caused by a change of default 'not found' images on syndetics' end.

To test this, visit the following locally:
http://localhost:8083/bookcover.php?id=ils:76&size=small&upc=021561601628&reload=1
http://localhost:8083/bookcover.php?id=ils:76&size=medium&upc=021561601628&reload=1
http://localhost:8083/bookcover.php?id=ils:76&size=large&upc=021561601628&reload=1

None of these work before the fix. All work after the fix.