### PR TITLE
DIS-159 Fix DatabaseAuthentication Typo

### DIFF
--- a/code/web/sys/Authentication/DatabaseAuthentication.php
+++ b/code/web/sys/Authentication/DatabaseAuthentication.php
@@ -19,7 +19,7 @@ class DatabaseAuthentication implements Authentication {
 
 	private function login($username, $password, AccountProfile $accountProfile) {
 		if (($username == '') || ($password == '')) {
-			$user = new AspenError('Login information cannot be blank when logging in user with databse authentication.');
+			$user = new AspenError('Login information cannot be blank when logging in user with Database Authentication.');
 		} else {
 			if ($username == 'nyt_user') {
 				$user = new AspenError('Cannot login as the New York Times User');


### PR DESCRIPTION
DIS-159 - Fixing a typo in /code/web/sys/Authentication/DatabaseAuthentication.php

Replaced 'databse authentication' with 'Database Authentication'