### PR TITLE
DIS-147 Fix volumeId check for the items without valid item group while placing volume holds

### DIFF
--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -1940,7 +1940,7 @@ class Koha extends AbstractIlsDriver {
 		} else {
 			$apiUrl = $this->getWebServiceUrl() . "/api/v1/holds";
 			if ($this->getKohaVersion() >= 22.11) {
-				if ($volumeId != 0){
+				if (!empty($volumeId)){
 					$postParams = [
 						'patron_id' => $patron->unique_ils_id,
 						'pickup_library_id' => $pickupBranch,

--- a/code/web/release_notes/24.12.00.MD
+++ b/code/web/release_notes/24.12.00.MD
@@ -50,6 +50,7 @@
 
 ### Koha Updates
 - Add a fallback value for the 'Library ID' field instead of sending an empty field when submitting Material Requests. (*LM*)
+- Fix volumeId check for the items without valid item group when placing volume holds. (*YL*)
 
 ### Local ILL (DIS-34)
 - Add new settings to configure the Local ILL system in use. (*MDN*)
@@ -216,6 +217,7 @@
 ## This release includes code contributions from
 ### ByWater Solutions
   - Kyle Hall (KMH)
+  - Yanjun Li (YL)
 
 ### Grove For Libraries
   - Mark Noble (MDN)


### PR DESCRIPTION
In code/web/Drivers/Koha.php, modified the conditional check for `$volumeId` to use `!empty($volumeId)` instead of `$volumeId != 0`. This ensures that when volumeId is undefined, the check can work successfully and remove the "item_group_id" in $postParams. In this case, the items can be placed successfully even without a valid volume Id. 

Use-Case:
1. Before PR:
   - Placing a hold on a volume with a valid item group worked correctly.
   - Placing a hold without selecting a specific volume caused a server error.
2. After PR: Both holds (with and without selecting a specific volume) are placed successfully without errors.







   

