### PR TITLE
DIS-139 Syndetics bookcover not showing

### DIFF
--- a/code/web/release_notes/25.01.00.MD
+++ b/code/web/release_notes/25.01.00.MD
@@ -46,6 +46,7 @@
 - Allow multiple Syndetics settings to be created within a single Aspen instance so links within Syndetics Unbound can direct to the proper catalog. (DIS-121) (*MDN*)
 - Add a name for each Syndetics Setting, so they can be identified within Aspen. (DIS-121) (*MDN*)
 - Hide or show appropriate fields for Syndetics based on if Syndetics Unbound is selected or deselected. (DIS-121) (*MDN*)
+- Syndetics cover images now display correctly even if record's UPC contains leading zeroes.(*PA*)
 
 ### User List Updates
 - When searching lists, allow the results to be sorted by Date Added. (DIS-136) (*MDN*)

--- a/code/web/sys/Covers/BookCoverProcessor.php
+++ b/code/web/sys/Covers/BookCoverProcessor.php
@@ -750,13 +750,13 @@ class BookCoverProcessor {
 			$imageChecksum = md5($image);
 			if ($imageChecksum == 'e89e0e364e83c0ecfba5da41007c9a2c') {
 				return false;
-			} elseif ($imageChecksum == 'f017f94ed618a86d0fa7cecd7112ab7e') {
+			} elseif ($imageChecksum == 'f017f94ed618a86d0fa7cecd7112ab7e' || $imageChecksum == '798f904eabf783405079eaf699414801') {
 				//Syndetics Unbound default image at medium size
 				return false;
-			} elseif ($imageChecksum == 'dadde13fdb5f3775cdbdd25f34c0389b') {
+			} elseif ($imageChecksum == 'dadde13fdb5f3775cdbdd25f34c0389b' || $imageChecksum == 'b13e33c0262a3a1f21dd20b826710cbc') {
 				//Syndetics Unbound default image at small size
 				return false;
-			} elseif ($imageChecksum == 'c6ddaf338cf667df0bf60045f05146db') {
+			} elseif ($imageChecksum == 'c6ddaf338cf667df0bf60045f05146db' || $imageChecksum == '821d0d442dbee0f51f4c803e8e9fc87a') {
 				//Syndetics Unbound default image at large size
 				return false;
 			}


### PR DESCRIPTION
Inadvertently closed the original PR:
https://github.com/Aspen-Discovery/aspen-discovery/pull/2180

On adb, with ktd, we can use record '76' as that has a UPC with a leading zero:
http://localhost:8083/Record/76

Enter valid syndetics credentials or apply the test only patch to override the need for syndetics credentials through the UI, though you still need to add a valid key through the code, your pick.
Access the record:
http://localhost:8083/Record/76
Notice the image is not found, this is because this record's UPC is '021561601628', and processImageURL is not identifying the returned image as a "not found" because it doesn't match any of the checksums it's verifying.
Apply the patch. Repeat the test plan. You'll need to click "Staff View" -> "Reload Cover" on the record page to clear the cover cache and force the request again but now the image should be displaying correctly. This is because the leading zeroes fail check and the returned image is properly identified as a 'not found' image, so getGroupedWorkCover will then check again but without stripping the leading zeroes, and work then.

Finally, I decided to test for the other sizes as well, and noticed all the checksums are wrong, not the just the medium. Possibly caused by a change of default 'not found' images on syndetics' end.

To test this, visit the following locally:
http://localhost:8083/bookcover.php?id=ils:76&size=small&upc=021561601628&reload=1
http://localhost:8083/bookcover.php?id=ils:76&size=medium&upc=021561601628&reload=1
http://localhost:8083/bookcover.php?id=ils:76&size=large&upc=021561601628&reload=1

None of these work before the fix. All work after the fix.