### PR TITLE
DIS-147 Fix volumeId check for the items without valid item group while placing volume holds

### DIFF
--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -1938,7 +1938,7 @@ class Koha extends AbstractIlsDriver {
 		} else {
 			$apiUrl = $this->getWebServiceUrl() . "/api/v1/holds";
 			if ($this->getKohaVersion() >= 22.11) {
-				if ($volumeId != 0){
+				if (!empty($volumeId)){
 					$postParams = [
 						'patron_id' => $patron->unique_ils_id,
 						'pickup_library_id' => $pickupBranch,

--- a/code/web/release_notes/25.01.00.MD
+++ b/code/web/release_notes/25.01.00.MD
@@ -128,6 +128,9 @@ For records found in an Articles and Database search through the EBSCO host or E
 ### Boundless/Axis360 Updates
 - Update Boundless/Axis360 get records availability API URL and adjusted response processing (DIS-162) (*YL*)
 
+### Koha Updates
+- Fix volumeId check for the items without valid item group when placing volume holds (DIS-147) (*YL*)
+
 //lukeg
 ### Authentication Updates
 - Fix typo in Authentication/DatabaseAuthentication.php (DIS-159) (*LG*)


### PR DESCRIPTION
In code/web/Drivers/Koha.php, modified the conditional check for $volumeId to use !empty($volumeId) instead of $volumeId != 0. This ensures that when volumeId is undefined, the check can work successfully and remove the "item_group_id" in $postParams. In this case, the items can be placed successfully even without a valid volume Id.

Use-Case:

Before PR:
Placing a hold on a volume with a valid item group worked correctly.
Placing a hold without selecting a specific volume caused a server error.
After PR: Both holds (with and without selecting a specific volume) are placed successfully without errors.