### PR TITLE
DIS-224: Change backup cron job to use mydumper

### DIFF
--- a/code/web/release_notes/25.02.00.MD
+++ b/code/web/release_notes/25.02.00.MD
@@ -69,6 +69,10 @@
 
 // kyle
 
+### Cron Updates
+- When loading patron types and libraries from Polaris, automatically associate them with the correct account profile. (DIS-214) (*MDN*)
+- Switch default backup script to mydumper. (DIS-224) (*KMH*)
+
 //kidclamp
 
 Use mb_substr to presrve diacritics in lists (DIS-178) (*WNC*)

--- a/sites/template.linux/conf/crontab_settings.txt
+++ b/sites/template.linux/conf/crontab_settings.txt
@@ -38,7 +38,7 @@
 # MySQL Nightly Dump #
 ######################
 # backup important bits at 12:10am daily
-10 0 * * *    root    php /usr/local/aspen-discovery/code/web/cron/backupAspen.php {sitename}
+10 0 * * *    root   rm /data/aspen-discovery/{sitename}/sql_backup/mydumper/* && php /usr/local/aspen-discovery/code/web/cron/backupAspen-mydumper.php {sitename}
 
 #############################################
 # New York Times Best seller Lists Updating #


### PR DESCRIPTION
This commit changs the default backup script to use mydumper.

Test Plan:
1) Set up a new instance of Aspen using createSite.php 2) Note the cron file uses myDumper for backups now!