### PR TITLE
DIS-180 Follow up hide Hoopla indexByday in Hoopla Settings

### DIFF
--- a/code/web/release_notes/25.01.00.MD
+++ b/code/web/release_notes/25.01.00.MD
@@ -52,6 +52,7 @@
 
 ### Hoopla Updates
 - Optimize Hoopla daily indexing behavior and set "Index By Day" as a default setting. (DIS-180) (*YL*)
+- Hide "Index By Day" in the Hoopla settings page. (DIS-180) (*YL*)
 
 ### Indexing Updates
 - When indexing the 100, 700 and 800 fields to load information about authors and contributors include subfield c to distinguish between authors where titles and additional information is important. (DIS-161) (*MDN*)

--- a/code/web/sys/Hoopla/HooplaSetting.php
+++ b/code/web/sys/Hoopla/HooplaSetting.php
@@ -74,8 +74,8 @@ class HooplaSetting extends DataObject {
 				'label' => 'Index By Day',
 				'description' => 'Whether or hoopla indexing should only occur once a day',
 				'default' => 1,
-				'readOnly' => true,
-				'note' => 'This setting is defaulted to true for all Hoopla instances',  
+				'type' => "hidden",
+				'hideInLists' => true,
 			],
 			'lastUpdateOfChangedRecords' => [
 				'property' => 'lastUpdateOfChangedRecords',


### PR DESCRIPTION
In the DIS-180 original pull request, Hoopla indexByDay is set to default 1 and readOnly. This will cause the problem once the user clicks "save" for Hoopla Settings, the submission form will not include the value of indexByDay and cause indexByDay to be set as 0. 
In this pull request the indexByDay remains to be default 1 and set it to hidden. So it's unchangeable for the users. 