### PR TITLE
DIS-228 Add stack traces to the default log4j configurations

### DIFF
--- a/sites/default/conf/log4j.properties
+++ b/sites/default/conf/log4j.properties
@@ -6,14 +6,14 @@ appender.console.type = Console
 appender.console.name = consoleLogger
 appender.console.filter.threshold.type = ThresholdFilter
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%t] %-5p %d{MM/dd HH:mm:ss,SSS} - %m%n
+appender.console.layout.pattern = [%t] %-5p %d{MM/dd HH:mm:ss,SSS} - %m%n%throwable
 
 appender.rolling.type = RollingFile
 appender.rolling.name = fileLogger
 appender.rolling.fileName = /var/log/aspen-discovery/<<sitename>>/logs/<<processname>>.log
 appender.rolling.filePattern = /var/log/aspen-discovery/<<sitename>>/logs/<<processname>>/%d{MM-dd-yy-HH-mm-ss}-%i.log.gz
 appender.rolling.layout.type = PatternLayout
-appender.rolling.layout.pattern = [%t] %-5p %d{MM/dd HH:mm:ss,SSS} - %m%n
+appender.rolling.layout.pattern = [%t] %-5p %d{MM/dd HH:mm:ss,SSS} - %m%n%throwable
 appender.rolling.policies.type = Policies
 appender.rolling.policies.size.type = SizeBasedTriggeringPolicy
 appender.rolling.policies.size.size=100MB


### PR DESCRIPTION
Test plan:
1) Create a new instance in your test aspen
2) Note the log4j config files include "%throwable" at the end of the
   pattern lines