### PR TITLE
DIS-231 Add notification to Koha exporter if offline mode is enabled

### DIFF
--- a/code/java_shared_libraries/src/com/turning_leaf_technologies/util/SystemUtils.java
+++ b/code/java_shared_libraries/src/com/turning_leaf_technologies/util/SystemUtils.java
@@ -1,11 +1,16 @@
 package com.turning_leaf_technologies.util;
 
+import com.turning_leaf_technologies.indexing.IlsExtractLogEntry;
 import com.turning_leaf_technologies.strings.AspenStringUtils;
 import org.apache.logging.log4j.Logger;
 import org.ini4j.Ini;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -54,4 +59,34 @@ public class SystemUtils {
 		Runtime runtime = Runtime.getRuntime();
 		logger.debug("Max: " + AspenStringUtils.formatBytes(runtime.maxMemory()) + " | Total: " + AspenStringUtils.formatBytes(runtime.totalMemory()) + " | Used: " + (AspenStringUtils.formatBytes(runtime.totalMemory() - runtime.freeMemory())) + " | Free: " + AspenStringUtils.formatBytes(runtime.freeMemory()));
 	}
+
+	public static boolean isOffline(Connection dbConn, Logger logger) {
+		try {
+			PreparedStatement getOfflineStatusStmt = dbConn.prepareStatement("SELECT catalogStatus FROM system_variables", ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+			ResultSet getOfflineStatusRS = getOfflineStatusStmt.executeQuery();
+			if (getOfflineStatusRS.next()) {
+				int catalogStatus = getOfflineStatusRS.getInt("catalogStatus");
+				getOfflineStatusStmt.close();
+				getOfflineStatusRS.close();
+				return (catalogStatus != 0);
+			}else{
+				getOfflineStatusStmt.close();
+				getOfflineStatusRS.close();
+				return false;
+			}
+		} catch (SQLException e) {
+			logger.error("Error determining if the catalog is offline, quitting to be safe", e);
+			System.exit(-9);
+		}
+		return true;
+	}
+
+    public static void QuitIfOffline(Connection dbConn, Logger logger, IlsExtractLogEntry logEntry)
+    {
+        if (isOffline(dbConn, logger)) {
+            logEntry.addNote("ILS is offline, won't index.");
+            logEntry.saveResults();
+            System.exit(0);
+        }
+    }
 }

--- a/code/koha_export/src/com/turning_leaf_technologies/koha_export/KohaExportMain.java
+++ b/code/koha_export/src/com/turning_leaf_technologies/koha_export/KohaExportMain.java
@@ -133,11 +133,7 @@ public class KohaExportMain {
 				}
 
 				//Check to see if the ILS connection is offline and don't index
-				if (isOffline()) {
-					logEntry.addNote("ILS is offline, won't index.");
-					logEntry.saveResults();
-					System.exit(0);
-				}
+				SystemUtils.QuitIfOffline(dbConn, logger, logEntry);
 
 				//Connect to the Koha database
 				Connection kohaConn;

--- a/code/koha_export/src/com/turning_leaf_technologies/koha_export/KohaExportMain.java
+++ b/code/koha_export/src/com/turning_leaf_technologies/koha_export/KohaExportMain.java
@@ -134,6 +134,8 @@ public class KohaExportMain {
 
 				//Check to see if the ILS connection is offline and don't index
 				if (isOffline()) {
+					logEntry.addNote("ILS is offline, won't index.");
+					logEntry.saveResults();
 					System.exit(0);
 				}
 

--- a/code/web/release_notes/25.02.00.MD
+++ b/code/web/release_notes/25.02.00.MD
@@ -87,6 +87,9 @@
 //alexander
 
 //chloe
+
+//imani
+- added a note to KohaExportMain when it tries to run in offline Mode and attempt to save the log before exiting
 ### WebBuilder Updates
 - Fixed an issue preventing administrators from saving a 'URL to link image to' from the 'WebBuilder Portal Cells' page. (*CZ*)
 

--- a/code/web/release_notes/25.02.00.MD
+++ b/code/web/release_notes/25.02.00.MD
@@ -118,6 +118,7 @@ Use mb_substr to presrve diacritics in lists (DIS-178) (*WNC*)
   - Nick Clemens (WNC)
   - Yanjun Li (YL)
   - Leo Stoyanov (LS)
+  - Imani Thomas (IT)
 
 ### Grove For Libraries
   - Mark Noble (MDN)

--- a/code/web/release_notes/25.02.00.MD
+++ b/code/web/release_notes/25.02.00.MD
@@ -88,7 +88,8 @@
 
 //imani
 ### Indexing Updates
-- added a note to KohaExportMain when it tries to run in offline Mode and attempt to save the log before exiting
+- Created isOffline and QuitIfOffline in SystemUtils to share common behavior across exporters
+- Changed existing offline checks in KohaExportMain to use SystemUtils instead.
 
 //chloe
 ### WebBuilder Updates

--- a/code/web/release_notes/25.02.00.MD
+++ b/code/web/release_notes/25.02.00.MD
@@ -86,10 +86,11 @@
 
 //alexander
 
-//chloe
-
 //imani
+### Indexing Updates
 - added a note to KohaExportMain when it tries to run in offline Mode and attempt to save the log before exiting
+
+//chloe
 ### WebBuilder Updates
 - Fixed an issue preventing administrators from saving a 'URL to link image to' from the 'WebBuilder Portal Cells' page. (*CZ*)
 


### PR DESCRIPTION
to test:
* put aspen in offline mode: https://help.aspendiscovery.org/help/admin/SystemAdministration#Cell-1804-PanelBody
* enter the adb shell and run the command aspen_koha_import
* you should see a line in the output about the ILS being in offline mode
* log into aspen and navigate to the ILS export log
* the same note about the ILS being in offline mode should appear in the latest entry here as well.

ticket link for convenience: https://aspen-discovery.atlassian.net/browse/DIS-231

added a log note that the exporter was quitting due to being in offline mode and a call to save the logEntry notes so they everything up to that point is actually saved in the log.