### PR TITLE
DIS-242: simple fix for Open Archives dates

### DIFF
--- a/code/web/RecordDrivers/OpenArchivesRecordDriver.php
+++ b/code/web/RecordDrivers/OpenArchivesRecordDriver.php
@@ -54,7 +54,16 @@ class OpenArchivesRecordDriver extends IndexRecordDriver {
 			$interface->assign('date', $this->fields['date_text']);
 		} else {
 			if (array_key_exists('date', $this->fields)) {
-				$interface->assign('date', $this->fields['date']);
+				// check to see whether $this->fields['date'] is an array then loop through each member
+				if (is_array($this->fields['date'])) {
+					$date = '';
+					foreach ($this->fields['date'] as $datePart) {
+						$date .= date('Y-m-d', strtotime($datePart)) . ' ';
+					}
+					$interface->assign('date', $date);
+				} else {
+					$interface->assign('date', date('Y-m-d', $this->fields['date']));
+				}
 			} else {
 				$interface->assign('date', null);
 			}

--- a/code/web/interface/themes/responsive/RecordDrivers/OpenArchives/result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/OpenArchives/result.tpl
@@ -57,7 +57,12 @@
 			<div class="row">
 				<div class="result-label col-tn-3">{translate text="Date" isPublicFacing=true} </div>
 				<div class="result-value col-tn-8 notranslate">
-					{implode subject=$date}
+					{assign var="formattedDates" value=[]}
+					{foreach from=$date item=singleDate}
+						{assign var="formattedDate" value=$singleDate|date_format:"%Y-%m-%d"}
+						{append var="formattedDates" value=$formattedDate}
+					{/foreach}
+					{implode subject=$formattedDates glue=", "}
 				</div>
 			</div>
 		{/if}

--- a/code/web/interface/themes/responsive/RecordDrivers/OpenArchives/result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/OpenArchives/result.tpl
@@ -57,12 +57,7 @@
 			<div class="row">
 				<div class="result-label col-tn-3">{translate text="Date" isPublicFacing=true} </div>
 				<div class="result-value col-tn-8 notranslate">
-					{assign var="formattedDates" value=[]}
-					{foreach from=$date item=singleDate}
-						{assign var="formattedDate" value=$singleDate|date_format:"%Y-%m-%d"}
-						{append var="formattedDates" value=$formattedDate}
-					{/foreach}
-					{implode subject=$formattedDates glue=", "}
+					{implode subject=$date}
 				</div>
 			</div>
 		{/if}

--- a/code/web/release_notes/25.02.00.MD
+++ b/code/web/release_notes/25.02.00.MD
@@ -85,7 +85,7 @@
 
 //james
 ### Open Archives Updates
-- Eliminate the time portion of display dates from Aspen Open Archives search results
+- Eliminate the time portion of display dates from Aspen Open Archives search results (DIS-242) (*JStaub*)
 
 //alexander
 

--- a/code/web/release_notes/25.02.00.MD
+++ b/code/web/release_notes/25.02.00.MD
@@ -84,6 +84,8 @@
 //kirstien
 
 //james
+### Open Archives Updates
+- Eliminate the time portion of display dates from Aspen Open Archives search results
 
 //alexander
 


### PR DESCRIPTION
This fix only eliminates the time portion of display dates from Aspen Open Archives search results.