### PR TITLE
DIS 257: Prevented Spamming of Usage Tables

### DIFF
--- a/code/web/bootstrap.php
+++ b/code/web/bootstrap.php
@@ -48,14 +48,6 @@ if (isset($_SERVER['SERVER_NAME'])) {
 	$aspenUsage->instance = 'aspen_internal';
 }
 
-//This has to be done after reading configuration so we can get the servername
-global $usageByIPAddress;
-$usageByIPAddress = new UsageByIPAddress();
-$usageByIPAddress->year = date('Y');
-$usageByIPAddress->month = date('n');
-$usageByIPAddress->ipAddress = IPAddress::getClientIP();
-$usageByIPAddress->instance = $aspenUsage->getInstance();
-
 require_once ROOT_DIR . '/sys/Timer.php';
 global $timer;
 $timer = new Timer($startTime);
@@ -72,6 +64,51 @@ ob_start();
 
 initMemcache();
 initDatabase();
+
+if ($aspenUsage->getInstance() != 'aspen_internal') {
+	$isValidServerName = true;
+	//Validate that we are getting a valid, non-spoofed name.
+	if (!empty($_SERVER['SERVER_NAME'])) {
+		if (strip_tags($_SERVER['SERVER_NAME']) !== $_SERVER['SERVER_NAME']) {
+			$isValidServerName = false;
+		} elseif (html_entity_decode($_SERVER['SERVER_NAME']) !== $_SERVER['SERVER_NAME']) {
+			$isValidServerName = false;
+		}
+	}
+
+	if ($isValidServerName) {
+		$isValidServerName = false;
+		$validServerNames = getValidServerNames();
+
+		foreach ($validServerNames as $validServerName) {
+			if (strcasecmp($aspenUsage->getInstance(), $validServerName) === 0) {
+				$isValidServerName = true;
+				break;
+			}
+		}
+	}
+	if (!$isValidServerName) {
+		http_response_code(404);
+		if (IPAddress::showDebuggingInformation()) {
+			echo("<html><head><title>Invalid Request</title></head><body>Invalid Host $aspenUsage->getInstance(), valid instances are " . implode(', ', $validServerNames) . "</body></html>");
+		} else {
+			echo("<html><head><title>Invalid Request</title></head><body>Invalid Host</body></html>");
+		}
+		die();
+	}
+}
+
+//Check to see if timings should be enabled
+if (IPAddress::logTimingInformation()) {
+	$timer->enableTimings(true);
+}
+$timer->logTime("Initial configuration");
+
+try {
+	$aspenUsage->find(true);
+} catch (Exception $e) {
+	//Table has not been created yet, ignore it
+}
 
 global $userAgent;
 $userAgentString = 'Unknown';
@@ -126,50 +163,13 @@ try {
 	//This happens before tables are created, ignore it
 }
 
-if ($aspenUsage->getInstance() != 'aspen_internal') {
-	$isValidServerName = true;
-	//Validate that we are getting a valid, non-spoofed name.
-	if (!empty($_SERVER['SERVER_NAME'])) {
-		if (strip_tags($_SERVER['SERVER_NAME']) !== $_SERVER['SERVER_NAME']) {
-			$isValidServerName = false;
-		} elseif (html_entity_decode($_SERVER['SERVER_NAME']) !== $_SERVER['SERVER_NAME']) {
-			$isValidServerName = false;
-		}
-	}
-
-	if ($isValidServerName) {
-		$isValidServerName = false;
-		$validServerNames = getValidServerNames();
-
-		foreach ($validServerNames as $validServerName) {
-			if (strcasecmp($aspenUsage->getInstance(), $validServerName) === 0) {
-				$isValidServerName = true;
-				break;
-			}
-		}
-	}
-	if (!$isValidServerName) {
-		http_response_code(404);
-		if (IPAddress::showDebuggingInformation()) {
-			echo("<html><head><title>Invalid Request</title></head><body>Invalid Host $aspenUsage->getInstance(), valid instances are " . implode(', ', $validServerNames) . "</body></html>");
-		} else {
-			echo("<html><head><title>Invalid Request</title></head><body>Invalid Host</body></html>");
-		}
-		die();
-	}
-}
-
-//Check to see if timings should be enabled
-if (IPAddress::logTimingInformation()) {
-	$timer->enableTimings(true);
-}
-$timer->logTime("Initial configuration");
-
-try {
-	$aspenUsage->find(true);
-} catch (Exception $e) {
-	//Table has not been created yet, ignore it
-}
+//This has to be done after reading configuration so we can get the servername
+global $usageByIPAddress;
+$usageByIPAddress = new UsageByIPAddress();
+$usageByIPAddress->year = date('Y');
+$usageByIPAddress->month = date('n');
+$usageByIPAddress->ipAddress = IPAddress::getClientIP();
+$usageByIPAddress->instance = $aspenUsage->getInstance();
 
 try {
 	$usageByIPAddress->find(true);

--- a/code/web/release_notes/25.02.00.MD
+++ b/code/web/release_notes/25.02.00.MD
@@ -87,6 +87,10 @@
 ### Indexing Updates
 - Enhanced subtitle filtering for OverDrive records by ignoring the subtitle "number one bestseller". (DIS-211) (*LS*)
 
+//leo
+### Instance Validation Updates
+- Reorganized the user agent and IP address usage tracking so it only runs once the instance is confirmed valid and found. (DIS-257) (*LS*)
+
 //katherine
 
 //kirstien


### PR DESCRIPTION
- Reorganized the user agent and IP address usage tracking so it only runs once the instance is confirmed valid and found.

Note: This bug relates to DIS 250, so usage tables will still be spammed with only this patch applied, _but_ this patch works if you see that `aspen_internal` is no longer a table entry once your server has loaded and instance validated (e.g., `localhost` in a local environment).