### PR TITLE
DIS-179: Fixed Duplicated Titles in Reading History

### DIFF
--- a/code/web/CatalogConnection.php
+++ b/code/web/CatalogConnection.php
@@ -664,7 +664,11 @@ class CatalogConnection {
 									$userReadingHistoryEntry->isIll = 1;
 								}
 								$userReadingHistoryEntry->deleted = 0;
-								$userReadingHistoryEntry->insert();
+								if ($userReadingHistoryEntry->find(true)) {
+									$userReadingHistoryEntry->update();
+								} else {
+									$userReadingHistoryEntry->insert();
+								}
 								$userReadingHistoryEntry = null;
 								//}
 							}
@@ -1204,25 +1208,23 @@ class CatalogConnection {
 				//TODO: This should check to see if the grouped work has been checked out rather than the record
 				$historyEntryDB = new ReadingHistoryEntry();
 				$historyEntryDB->userId = $patron->id;
-				if (!empty($checkout->groupedWorkId)) {
-					$historyEntryDB->groupedWorkPermanentId = $checkout->groupedWorkId;
+				$historyEntryDB->sourceId = $checkout->sourceId;
+				$existingEntry = $historyEntryDB->find(true); // Now only checks userId+sourceId
+				if ($existingEntry) {
+					$historyEntryDB->update();
 				} else {
-					$historyEntryDB->groupedWorkPermanentId = "";
-				}
-
-				$historyEntryDB->source = $source;
-				$historyEntryDB->sourceId = $sourceId;
-				$historyEntryDB->title = StringUtils::trimStringToLengthAtWordBoundary($checkout->title, 150, true);
-				$historyEntryDB->author = isset($checkout->author) ? StringUtils::trimStringToLengthAtWordBoundary($checkout->author, 75, true) : "";
-				$historyEntryDB->format = substr($checkout->format, 0, 50);
-				$historyEntryDB->checkOutDate = time();
-				$historyEntryDB->costSavings = $checkout->getReplacementCost();
-				if (!$historyEntryDB->insert()) {
-					global $logger;
-					$logger->log("Could not insert new reading history entry", Logger::LOG_ERROR);
-				} else {
-					if ($patron->enableCostSavings) {
-						$patron->__set('totalCostSavings', $patron->totalCostSavings + $historyEntryDB->costSavings);
+					$historyEntryDB->title = StringUtils::trimStringToLengthAtWordBoundary($checkout->title, 150, true);
+					$historyEntryDB->author = isset($checkout->author) ? StringUtils::trimStringToLengthAtWordBoundary($checkout->author, 75, true) : "";
+					$historyEntryDB->format = substr($checkout->format, 0, 50);
+					$historyEntryDB->checkOutDate = time();
+					$historyEntryDB->costSavings = $checkout->getReplacementCost();
+					if (!$historyEntryDB->insert()) {
+						global $logger;
+						$logger->log("Could not insert new reading history entry", Logger::LOG_ERROR);
+					} else {
+						if ($patron->enableCostSavings) {
+							$patron->__set('totalCostSavings', $patron->totalCostSavings + $historyEntryDB->costSavings);
+						}
 					}
 				}
 			}

--- a/code/web/release_notes/25.02.00.MD
+++ b/code/web/release_notes/25.02.00.MD
@@ -144,6 +144,12 @@
 ### Instance Validation Updates
 - Reorganized the user agent and IP address usage tracking, so it only runs once the instance is confirmed valid and found. (DIS-257) (*LS*)
 
+// leo
+### Reading History Updates
+- Added a SQL query to delete old duplicates and to prevent future duplicates by creating a unique index. (DIS-179) (*LS*)
+- Modified `CatalogConnection.php` to prevent duplicates during checkout-based history updates. (DIS-179) (*LS*)
+- Updated `AJAX.php` to check `userId` and `sourceId` instead of `groupedWorkPermanentId` when adding manual entries. (DIS-179) (*LS*)
+
 //katherine
 
 //kirstien

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -7444,12 +7444,9 @@ class MyAccount_AJAX extends JSON_Action {
 						$readingHistoryEntry->isIll = 0;
 						$readingHistoryEntry->isManuallyAdded = 1;
 						//No cost savings updates since this is outside the library
+						$readingHistoryEntry->userId = $user->id;
+						$readingHistoryEntry->sourceId = $sourceId;
 						if ($readingHistoryEntry->find(true)) {
-							$existingEntry = true;
-						} else {
-							$existingEntry = false;
-						}
-						if ($existingEntry) {
 							$readingHistoryEntry->deleted = 0;
 							$readingHistoryEntry->update();
 						} else {

--- a/code/web/sys/DBMaintenance/version_updates/25.02.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.02.00.php
@@ -156,6 +156,25 @@ function getUpdates25_02_00(): array {
 				"ALTER TABLE user_checkout ADD COLUMN showFineButton TINYINT(1) DEFAULT 0",
 			]
 		], //user_checkout_add_showFineButton
+		// Leo Stoyanov - BWS
+		'deduplicate_reading_history' => [
+			'title' => 'De-duplicate reading history & add unique key',
+			'description' => 'Combine multiple rows per (userId, sourceId) into one row before adding unique key.',
+			'continueOnError' => true,
+			'sql' => [
+				// 1. Keep the latest entry of the duplicated titles.
+				"DELETE t1 FROM user_reading_history_work t1
+				INNER JOIN user_reading_history_work t2 
+				WHERE 
+					t1.id < t2.id AND
+					t1.userId = t2.userId AND
+					t1.sourceId = t2.sourceId;",
+
+				// 2. Create the unique index.
+				"ALTER TABLE user_reading_history_work 
+				ADD UNIQUE INDEX user_source (userId, sourceId);"
+			],
+		], //deduplicate_reading_history
 
 		//Lucas Montoya - Theke Solutions
 


### PR DESCRIPTION
- Added a SQL query to delete old duplicates and to prevent future duplicates by creating a unique index.
- Modified `CatalogConnection.php` to prevent duplicates during checkout-based history updates.
- Updated `AJAX.php` to check `userId` and `sourceId` instead of `groupedWorkPermanentId` when adding manual entries.

The cron job `UpdateReadingHistory.java` eventually calls `updateReadingHistoryBasedOnCurrentCheckouts()` in `CatalogConnection.php`, which has new validation to prevent duplicates. This means the cron job should not create any duplicates as well.

To test:
1. Checkout a couple of items for a patron from an ILS (e.g., Koha).
2. Force reload the reading history for that patron.
3. On the patron's reading history page, and in the `user_reading_history_work` table, there will likely be duplicated items.
4. Apply the patch, run the appropriate DB maintenance update, and force reload the patron's reading history.