### PR TITLE
DIS-305: Improved Performance When Fetching List Entries for Browse Categories

### DIFF
--- a/code/web/release_notes/25.02.00.MD
+++ b/code/web/release_notes/25.02.00.MD
@@ -144,6 +144,12 @@
 ### Instance Validation Updates
 - Reorganized the user agent and IP address usage tracking, so it only runs once the instance is confirmed valid and found. (DIS-257) (*LS*)
 
+//leo
+### Browse Category Updates
+- Modified `UserList::getListEntries()` to do SQL-level pagination rather than PHP array slicing of all list entries. (DIS-305) (*LS*)
+- Removed dynamic weighting from `UserList::getListEntries()`. (DIS-305) (*LS*)
+- Moved weighting to be performed when titles are added or removed from a patron's list. (DIS-305) (*LS*)
+
 //katherine
 
 //kirstien

--- a/code/web/services/MyAccount/MyList.php
+++ b/code/web/services/MyAccount/MyList.php
@@ -97,6 +97,7 @@ class MyAccount_MyList extends MyAccount {
 					}
 					$this->reloadCover();
 					$list->update();
+					$list->fixWeights();
 				} elseif ($actionToPerform == 'deleteList') {
 					$list->delete();
 
@@ -112,6 +113,7 @@ class MyAccount_MyList extends MyAccount {
 				$list->removeListEntry($recordToDelete);
 				$this->reloadCover();
 				$list->update();
+				$list->fixWeights();
 			}
 
 			//Redirect back to avoid having the parameters stay in the URL.


### PR DESCRIPTION
- Modified `UserList::getListEntries()` to do SQL-level pagination rather than PHP array slicing of all list entries.
- Removed dynamic weighting from `UserList::getListEntries()`.
- Moved weighting to be performed when titles are added or removed from a patron's list.

To test:
1. Create a very large list of titles (e.g., 600-1,000+) for a patron as which you are masquerading.
2. Create a browse category out of that list.
3. Navigate to the browse category page, and it will likely output an AJAX request error. Depending on the load the server can bear, there may be no error; but, with 1,000+ titles being loaded from the list, an error is guaranteed.
4. Apply the patch and reload the browse category page. The page should load faster with no AJAX request error.