### PR TITLE
DIS-334: Payflow modal cutoff

### DIFF
--- a/code/web/release_notes/25.03.00.MD
+++ b/code/web/release_notes/25.03.00.MD
@@ -15,6 +15,8 @@
 // leo
 
 // imani
+### Other Updates
+- Allow scrolling in the payflow-link-iframe modal (*IT*) (DIS-334)
 
 // yanjun
 

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -6284,7 +6284,7 @@ class MyAccount_AJAX extends JSON_Action {
 
 			return [
 				'success' => true,
-				'paymentIframe' => "<iframe class='fulfillmentFrame' id='payflow-link-iframe' src='{$iframeUrl}/?SECURETOKEN={$token}&SECURETOKENID={$tokenId}' sandbox='allow-top-navigation allow-scripts allow-same-origin allow-forms allow-modals' border='0' frameborder='0' scrolling='no' allowtransparency='true'>\n</iframe>",
+				'paymentIframe' => "<iframe class='fulfillmentFrame' id='payflow-link-iframe' src='{$iframeUrl}/?SECURETOKEN={$token}&SECURETOKENID={$tokenId}' sandbox='allow-top-navigation allow-scripts allow-same-origin allow-forms allow-modals' border='0' frameborder='0' scrolling='yes' allowtransparency='true'>\n</iframe>",
 			];
 		}
 	}


### PR DESCRIPTION
to test:
1. Sign in as Aspen Admin (fallslibrary.aspendiscovery.org)
2. Masquerade as PTMPL000000006
3. View their fines
4. Click "Continue to payment"

If you do not have access to fallslibrary another library with paypal set up should suffice. Before this change the iframe is not scrollable if it overflows the space inside the modal. After the change you should be able to scroll to see the entire iframe.