### PR TITLE
DIS-376: Added SQL Pagination for List Record Handling

### DIFF
--- a/code/web/release_notes/25.02.00.MD
+++ b/code/web/release_notes/25.02.00.MD
@@ -230,6 +230,7 @@
 - Update UserListEntry to grab a title from the grouped work associated with its source ID if it is given no title and the grouped work is available. (DIS-225) (*IT*)
 - Change substr to mb_substr in MyList.php BulkAddTitles when figuring out the title for the new user list entry (DIS-225) (*IT*)
 - Use mb_substr to preserve diacritics in lists (DIS-178) (*WNC*)
+- `UserList::getListRecords()` now calls `UserList::getListEntries()` with a proper number of arguments for SQL-level pagination. (DIS-376) (*LS*)
 
 ### Web Builder Updates
 - Add a message when saving a Grapes JS Template or Page to confirm it has been updated successfully. (DIS-92) (*AB*)

--- a/code/web/sys/UserLists/UserList.php
+++ b/code/web/sys/UserLists/UserList.php
@@ -386,14 +386,9 @@ class UserList extends DataObject {
 		if ($sortName == null) {
 			$sortName = $this->defaultSort;
 		}
-		$listEntryInfo = $this->getListEntries($sortName, $forLiDA, $appVersion);
-
-		//Trim to the number of records we want to return
-		if ($numItems > 0) {
-			$filteredListEntries = array_slice($listEntryInfo['listEntries'], $start, $numItems);
-		} else {
+			$listEntryInfo = $this->getListEntries($sortName, $forLiDA, $appVersion, $start, $numItems);
+			// No need to check $numItems as getListEntries() already checks for this before limiting the query.
 			$filteredListEntries = $listEntryInfo['listEntries'];
-		}
 
 		$filteredIdsBySource = [];
 		foreach ($filteredListEntries as $listItemEntry) {


### PR DESCRIPTION
- `UserList::getListRecords()` now calls `UserList::getListEntries()` with a proper number of arguments for SQL-level pagination.
- Offshoot addition of DIS-305.