### PR TITLE
DIS-394: Catalog Instance Must Exist Before Calling ILS Consent Method

### DIFF
--- a/code/web/release_notes/25.03.00.MD
+++ b/code/web/release_notes/25.03.00.MD
@@ -22,6 +22,7 @@
 
 ### Other Updates
 - Remove unused AspenLiDASettings class. (DIS-393) (*MDN*)
+- Added check to make sure `$catalog` is not null before calling `hasIlsConsentSupport()` in `Library.php`. (DIS-394) (*LS*)
 
 // kirstien
 

--- a/code/web/sys/LibraryLocation/Library.php
+++ b/code/web/sys/LibraryLocation/Library.php
@@ -4185,7 +4185,7 @@ class Library extends DataObject {
 		if (!array_key_exists('Single sign-on', $enabledModules)) {
 			unset($structure['ssoSection']);
 		}
-		if (!$catalog->hasIlsConsentSupport()) {
+		if ($catalog && !$catalog->hasIlsConsentSupport()) {
 			unset($structure['dataProtectionRegulations']['properties']['ilsConsentEnabled']);
 		}
 


### PR DESCRIPTION
- Added check to make sure `$catalog` is not null before calling `hasIlsConsentSupport()` in `Library.php`.