### PR TITLE
DIS-394: Catalog Instance Must Exist Before Calling ILS Consent Method For 25.02.00

### DIFF
--- a/code/web/release_notes/25.02.00.MD
+++ b/code/web/release_notes/25.02.00.MD
@@ -21,6 +21,7 @@
 - Display a popup message to patrons if app settings cannot be loaded when loading LiDA. (DIS-268) (*MDN*)
 - When copying .env files during the build process, check for local .env files (prefixed by the slug). (DIS-270) (*MDN*)
 - Pass app slug to Aspen Discovery as a header. (DIS-270) (*MDN*)
+- Added check to make sure `$catalog` is not null before calling `hasIlsConsentSupport()` in `Library.php`. (DIS-394) (*LS*)
 
 ## Aspen Discovery Updates
 ### Account Updates

--- a/code/web/sys/LibraryLocation/Library.php
+++ b/code/web/sys/LibraryLocation/Library.php
@@ -4185,7 +4185,7 @@ class Library extends DataObject {
 		if (!array_key_exists('Single sign-on', $enabledModules)) {
 			unset($structure['ssoSection']);
 		}
-		if (!$catalog->hasIlsConsentSupport()) {
+		if ($catalog && !$catalog->hasIlsConsentSupport()) {
 			unset($structure['dataProtectionRegulations']['properties']['ilsConsentEnabled']);
 		}
 


### PR DESCRIPTION
- Added check to make sure `$catalog` is not null before calling `hasIlsConsentSupport()` in `Library.php` for v25.02.00.