### PR TITLE
DIS-395 Remove redundant code block on InnReach-related method

### DIFF
--- a/code/web/release_notes/25.03.00.MD
+++ b/code/web/release_notes/25.03.00.MD
@@ -35,6 +35,7 @@
 
 ### Other Updates
 - Remove unused AspenLiDASettings class. (DIS-393) (*MDN*)
+- Remove redundant code in `getInnReachResults` method (DIS-395) (*TC*)
 - Added check to make sure `$catalog` is not null before calling `hasIlsConsentSupport()` in `Library.php`. (DIS-394) (*LS*)
 
 // kirstien
@@ -81,6 +82,7 @@
 
 ### Theke Solutions
   - Lucas Montoya (LM)
+  - Tomás Cohen Arazi (TC)
 
 ## Special Testing thanks to
 - Myranda Fuentes (Grove)

--- a/code/web/services/Search/AJAX.php
+++ b/code/web/services/Search/AJAX.php
@@ -126,10 +126,6 @@ class AJAX extends Action {
 				$innReachResults = $innReach->getTopSearchResults($searchObject->getSearchTerms(), 5);
 				$interface->assign('innReachResults', $innReachResults['records']);
 			}
-			if ($library && $library->ILLSystem == 3 && $library->showInnReachResultsAtEndOfSearch) {
-				$innReachResults = $innReach->getTopSearchResults($searchObject->getSearchTerms(), 5);
-				$interface->assign('innReachResults', $innReachResults['records']);
-			}
 
 			$innReachLink = $innReach->getSearchLink($searchObject->getSearchTerms());
 			$interface->assign('innReachLink', $innReachLink);


### PR DESCRIPTION
This patch removes a duplicated block from Search/AJAX.php, in the `getInnReachResults` method, that could yield duplicated hits to the INN-Reach server.