### PR TITLE
DIS-397 Add logging to INN-Reach results fetch method

### DIFF
--- a/code/web/release_notes/25.03.00.MD
+++ b/code/web/release_notes/25.03.00.MD
@@ -36,6 +36,7 @@
 ### Other Updates
 - Remove unused AspenLiDASettings class. (DIS-393) (*MDN*)
 - Added check to make sure `$catalog` is not null before calling `hasIlsConsentSupport()` in `Library.php`. (DIS-394) (*LS*)
+- Add logging to INN-Reach contents fetching (DIS-397) (*TC*)
 
 // kirstien
 
@@ -81,6 +82,7 @@
 
 ### Theke Solutions
   - Lucas Montoya (LM)
+  - Tomás Cohen Arazi (TC)
 
 ## Special Testing thanks to
 - Myranda Fuentes (Grove)


### PR DESCRIPTION
This patch adds

* logging of the external request made to INN-Reach, through `ExternalRequestLogEntry::logRequest`
* a check for the HTTP response status code, and if it is not 200, an error log will be generated

Test plan:
1. Enable the INN-Reach integration
2. Have random credentials for the OAuth2 section
3. Perform a search
4. Make sure your IP gets external requests logged => An error log should be generated
=> There's a log on the external requests logs