### PR TITLE
DIS-425: Added Existence Checks for Polaris API Response Properties

### DIFF
--- a/code/web/Drivers/Polaris.php
+++ b/code/web/Drivers/Polaris.php
@@ -1277,8 +1277,16 @@ class Polaris extends AbstractIlsDriver {
 				if ($authenticationResponseRaw) {
 					$authenticationResponse = json_decode($authenticationResponseRaw);
 					if (empty($authenticationResponse->PAPIErrorCode) || $authenticationResponse->PAPIErrorCode == 0) {
-						$accessToken = $authenticationResponse->AccessToken;
-						$patronId = $authenticationResponse->PatronID;
+						$accessToken = $authenticationResponse->AccessToken ?? null;
+						$patronId = $authenticationResponse->PatronID ?? null;
+						if ($accessToken === null) {
+							global $logger;
+							$logger->log('Polaris authentication error: AccessToken is null. Raw response: ' . PHP_EOL . print_r($authenticationResponse, true), Logger::LOG_ERROR);
+						}
+						if ($patronId === null) {
+							global $logger;
+							$logger->log('Polaris authentication error: PatronID is null. Raw response: ' . PHP_EOL . print_r($authenticationResponse, true), Logger::LOG_ERROR);
+						}
 						$session = [
 							'userValid' => true,
 							'accessToken' => $accessToken,

--- a/code/web/release_notes/25.03.00.MD
+++ b/code/web/release_notes/25.03.00.MD
@@ -36,7 +36,7 @@
 ### Other Updates
 - Remove unused AspenLiDASettings class. (DIS-393) (*MDN*)
 - Added check to make sure `$catalog` is not null before calling `hasIlsConsentSupport()` in `Library.php`. (DIS-394) (*LS*)
-- Added check for existence of `$response->AccessToken` and `$response->PatronID`; set either to `null` and log it if either do not exist. (DIS-394) (*LS*)
+- Added check for existence of `$response->AccessToken` and `$response->PatronID`; set either to `null` and log it if either do not exist. (DIS-425) (*LS*)
 
 // kirstien
 

--- a/code/web/release_notes/25.03.00.MD
+++ b/code/web/release_notes/25.03.00.MD
@@ -36,6 +36,7 @@
 ### Other Updates
 - Remove unused AspenLiDASettings class. (DIS-393) (*MDN*)
 - Added check to make sure `$catalog` is not null before calling `hasIlsConsentSupport()` in `Library.php`. (DIS-394) (*LS*)
+- Added check for existence of `$response->AccessToken` and `$response->PatronID`; set either to `null` and log it if either do not exist. (DIS-394) (*LS*)
 
 // kirstien
 


### PR DESCRIPTION
- Added check for existence of `$response->AccessToken` and `$response->PatronID`; set either to `null` and log it if either do not exist.
- Underlying problem seems to be that Aspen was trying to make Polaris API calls with a null or empty password during masquerade mode, so undefined properties were being returned in a JSON response from the Polaris authentication API request. Thus, those properties must be set to `null` if they do not truly exist.