### PR TITLE
DIS-432 Fix Boundless Cancel Holds API Request URL

### DIFF
--- a/code/web/Drivers/Axis360Driver.php
+++ b/code/web/Drivers/Axis360Driver.php
@@ -402,7 +402,7 @@ class Axis360Driver extends AbstractEContentDriver {
 		];
 		if ($this->getAxis360AccessToken($patron)) {
 			$settings = $this->getSettings($patron);
-			$cancelHoldUrl = $settings->apiUrl . "/Services/VendorAPI/removeHold/v2/$recordId/{$patron->getBarcode()}";
+			$cancelHoldUrl = $settings->apiUrl . "/Services/VendorAPI/removeHold/v2/$recordId/{$patron->getBarcode()}/";
 			$headers = [
 				'Authorization: ' . $this->accessToken,
 				'Library: ' . $settings->libraryPrefix,

--- a/code/web/release_notes/25.03.00.MD
+++ b/code/web/release_notes/25.03.00.MD
@@ -66,6 +66,8 @@
 - Allow scrolling in the payflow-link-iframe modal (*IT*) (DIS-334)
 
 // yanjun
+### Boundless Updates
+- Fix Boundless incorrect API request for canceling holds. (DIS-432) (*YL*)
 
 // james
 


### PR DESCRIPTION
In My Account > Titles on Hold > Boundless, patrons can’t cancel their boundless holds, this pull request is to fix this little bug.

In `code/web/Drivers/Axis360Driver.php`  in `cancelHold()`, the API request should be 
`$cancelHoldUrl = $settings->apiUrl . "/Services/VendorAPI/removeHold/v2/$recordId/{$patron->getBarcode()}/"` , missing / at the end of the request