### PR TITLE
DIS-287 Debian Installer Improvements

### DIFF
--- a/code/web/release_notes/25.03.00.MD
+++ b/code/web/release_notes/25.03.00.MD
@@ -42,7 +42,7 @@
 ### Install Updates
 - Properly install the logrotate configuration file on debian systems. (DIS-366) (*MDN*)
 - Increase max_input_vars for php to 5000 on debian systems. (DIS-431) (*MDN*)
-- Update Debian installer to incoporate the above and upgrade Debian systems to PHP 8.4 (DIS-287) (*JBoyer*)
+- Update Debian installer to incoporate the above, upgrade Debian systems to PHP 8.4, optionally install ClamAV, and use a Debian-specific logrotate config (DIS-287) (*JBoyer*)
 
 ### IP Address Usage
 - Make IP Address usage updates atomic to ensure they update accurately when multiple pages load at the same time from the same IP. (DIS-378) (*MDN*)

--- a/code/web/release_notes/25.03.00.MD
+++ b/code/web/release_notes/25.03.00.MD
@@ -42,6 +42,7 @@
 ### Install Updates
 - Properly install the logrotate configuration file on debian systems. (DIS-366) (*MDN*)
 - Increase max_input_vars for php to 5000 on debian systems. (DIS-431) (*MDN*)
+- Update Debian installer to incoporate the above and upgrade Debian systems to PHP 8.4 (DIS-287) (*JBoyer*)
 
 ### IP Address Usage
 - Make IP Address usage updates atomic to ensure they update accurately when multiple pages load at the same time from the same IP. (DIS-378) (*MDN*)
@@ -230,6 +231,9 @@
   - Leo Stoyanov (LS)
   - Imani Thomas (IT)
   - Yanjun Li (YL)
+
+### Equinox Open Library Initiative
+  - Jason Boyer (JBoyer)
 
 ### Grove For Libraries
   - Mark Noble (MDN)

--- a/install/debian_install_php.sh
+++ b/install/debian_install_php.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# Install the version of PHP passed in $1. This script can be used for initial
+# installs from installer_debian.sh or in upgrade_debian_*.sh scripts to upgrade
+
+php_vers="${1:-8.4}"
+
+echo "Installing PHP $php_vers"
+
+# Install Ondrej Sury's php repo for access to additional versions
+keyrings="/etc/apt/keyrings"
+if ! [ -d "$keyrings" ]; then
+  mkdir -m 0755 -p "$keyrings"
+fi
+
+if ! [ -s "$keyrings/sury.gpg" ] || ! [ -s /etc/apt/sources.list.d/sury.list ]; then
+  wget -q -O - https://packages.sury.org/php/apt.gpg | gpg -o "$keyrings/sury.gpg" --dearmor
+  echo "deb [signed-by=$keyrings/sury.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" >/etc/apt/sources.list.d/sury.list
+  apt-get update -q
+fi
+
+# disable older version of php apache module if present
+# will be empty on new installs
+curr_php=$(a2query -m | grep -Eo php...)
+curr_php=${curr_php#php}
+
+if [ -n "$curr_php" ] && [ "$curr_php" != "$php_vers" ]; then
+	a2dismod "php${curr_php}"
+fi
+
+# install new package versions
+apt-get install -y -q "php${php_vers}" "php${php_vers}-mcrypt" "php${php_vers}-gd" "php${php_vers}-imagick" "php${php_vers}-curl" "php${php_vers}-mysql" "php${php_vers}-zip" "php${php_vers}-xml" "php${php_vers}-intl" "php${php_vers}-mbstring" "php${php_vers}-soap" "php${php_vers}-pgsql" "php${php_vers}-ssh2" "php${php_vers}-ldap"
+
+# Make sure the active apache module has the correct settings
+cp php.ini "/etc/php/$php_vers/apache2/"
+
+# and turn it on
+a2enmod "php${php_vers}"
+systemctl restart apache2
+

--- a/install/installer_debian.sh
+++ b/install/installer_debian.sh
@@ -2,37 +2,13 @@
 
 git config --global --add safe.directory /usr/local/aspen-discovery
 
-#Expects to be installed on Debian 10 Buster or later
+#Expects to be installed on Debian 11 Bullseye or later
 #Run as sudo ./installer_debian.sh
 apt-get update
-apt-get -y install gpg openjdk-17-jre-headless openjdk-17-jdk-headless apache2 certbot python3-certbot-apache mariadb-server apt-transport-https lsb-release ca-certificates curl zip
+apt-get -y install cron wget rsyslog gpg openjdk-17-jre-headless apache2 certbot python3-certbot-apache mariadb-server apt-transport-https lsb-release ca-certificates zip clamav clamav-daemon
 
-# Install Ondrej Sury's php repo for access to additional PHP versions
-keyrings="/etc/apt/keyrings"
-test -d "$keyrings" || (
-	mkdir -p "$keyrings"
-	chmod 0755 "$keyrings"
-)
-if ! test -f "$keyrings/sury.gpg" || ! test -f /etc/apt/sources.list.d/sury.list; then
-	wget -q -O - https://packages.sury.org/php/apt.gpg | gpg -o "$keyrings/sury.gpg" --dearmor
-	echo "deb [signed-by=$keyrings/sury.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" >/etc/apt/sources.list.d/sury.list
-	apt-get update
-fi
-
-# Override default OS PHP version
-php_vers="8.0"
-
-# Have to use versions for these or the highest version available is installed.
-apt-get install -y "php${php_vers}" "php${php_vers}-mcrypt" "php${php_vers}-gd" "php${php_vers}-imagick" "php${php_vers}-curl" "php${php_vers}-mysql" "php${php_vers}-zip" "php${php_vers}-xml" "php${php_vers}-intl" "php${php_vers}-mbstring" "php${php_vers}-soap" "php${php_vers}-pgsql" "php${php_vers}-ssh2" "php${php_vers}-ldap"
-
-# - Change max_memory to 256M
-# - Increase max post size to 75M
-php_ini="/etc/php/${php_vers}/apache2/php.ini"
-grep -q '^memory_limit = 256M' "$php_ini" || sed -Ei 's/^memory_limit = [0-9]+M/memory_limit = 256M/' "$php_ini"
-grep -q '^post_max_size = 75M' "$php_ini" || sed -Ei 's/^post_max_size = [0-9]+M/post_max_size = 75M/' "$php_ini"
-grep -q '^upload_max_filesize = 75M' "$php_ini" || sed -Ei 's/^upload_max_filesize = [0-9]+M/upload_max_filesize = 75M/' "$php_ini"
-grep -q '^session.gc_probability = 0' "$php_ini" || sed -Ei 's/^session.gc_probability = 0/session.gc_probability = 1/' "$php_ini"
-grep -q '^;max_input_vars = 1000' "$php_ini" || sed -Ei 's/^;max_input_vars = 1000/max_input_vars = 5000/' "$php_ini"
+# modify version as needed
+./debian_install_php.sh 8.4
 
 # MariaDB overrides
 cp 60-aspen.cnf /etc/mysql/mariadb.conf.d/
@@ -41,16 +17,15 @@ a2enmod rewrite
 systemctl restart apache2 mysql
 
 # Create temp smarty directories
-mkdir -p /usr/local/aspen-discovery/tmp
+mkdir -m 0755 -p /usr/local/aspen-discovery/tmp
 chown -R www-data:www-data /usr/local/aspen-discovery/tmp
-chmod -R 755 /usr/local/aspen-discovery/tmp
+
+# logrotate setup
+cp logrotate-debian.conf /etc/logrotate.d/aspen_discovery
 
 # Raise process and open file limits for the aspen and solr users
 cp solr_limits.conf /etc/security/limits.d/solr.conf
 cp aspen_limits.conf /etc/security/limits.d/aspen.conf
-
-# Setup logrotate
-cp logrotate.conf /etc/logrotate.d/aspen_discovery
 
 # Create aspen MySQL superuser
 printf "Please enter the username for the Aspen MySQL superuser (cannot be root) : " >&2
@@ -68,3 +43,4 @@ mysql_secure_installation
 dpkg-reconfigure tzdata
 
 ./setup_aspen_user_debian.sh
+

--- a/install/installer_debian.sh
+++ b/install/installer_debian.sh
@@ -5,7 +5,7 @@ git config --global --add safe.directory /usr/local/aspen-discovery
 #Expects to be installed on Debian 11 Bullseye or later
 #Run as sudo ./installer_debian.sh
 apt-get update
-apt-get -y install cron wget rsyslog gpg openjdk-17-jre-headless apache2 certbot python3-certbot-apache mariadb-server apt-transport-https lsb-release ca-certificates zip clamav clamav-daemon
+apt-get -y install cron wget rsyslog gpg openjdk-17-jre-headless apache2 certbot python3-certbot-apache mariadb-server apt-transport-https lsb-release ca-certificates zip
 
 # modify version as needed
 ./debian_install_php.sh 8.4
@@ -26,6 +26,13 @@ cp logrotate-debian.conf /etc/logrotate.d/aspen_discovery
 # Raise process and open file limits for the aspen and solr users
 cp solr_limits.conf /etc/security/limits.d/solr.conf
 cp aspen_limits.conf /etc/security/limits.d/aspen.conf
+
+# Install ClamAV?
+printf "Install ClamAV virus scanner? [Y/n] " >&2
+read -r instaclam
+if ! echo "$instaclam" | cut -c 1 | grep -i n >/dev/null ; then
+  apt-get -y install clamav clamav-daemon
+fi
 
 # Create aspen MySQL superuser
 printf "Please enter the username for the Aspen MySQL superuser (cannot be root) : " >&2

--- a/install/installer_debian_w_av.sh
+++ b/install/installer_debian_w_av.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-./installer_debian.sh
-
-apt-get -y install clamav clamav-daemon
-
-touch /var/log/aspen-discovery/clam_av.log
-chown root:aspen_apache /var/log/aspen-discovery/clam_av.log

--- a/install/logrotate-debian.conf
+++ b/install/logrotate-debian.conf
@@ -1,0 +1,32 @@
+# Java log files are handled by the site's log4j configs
+/var/log/aspen-discovery/*/*.log {
+    daily
+    missingok
+    rotate 14
+    compress
+    delaycompress
+    notifempty
+    create 640 www-data aspen_apache
+    sharedscripts
+    prerotate
+	if [ -d /etc/logrotate.d/httpd-prerotate ]; then
+	    run-parts /etc/logrotate.d/httpd-prerotate
+	fi
+    endscript
+    postrotate
+	if pgrep -f ^/usr/sbin/apache2 > /dev/null; then
+	    invoke-rc.d apache2 reload 2>&1 | logger -t apache2.logrotate
+	fi
+    endscript
+}
+
+/var/mail/* {
+    maxsize 20M
+    rotate 2
+    daily
+    missingok
+    notifempty
+    copytruncate
+    compress
+    nocreate
+

--- a/install/setup_aspen_user_debian.sh
+++ b/install/setup_aspen_user_debian.sh
@@ -31,3 +31,8 @@ chown -R aspen:aspen_apache /data/aspen-discovery
 #Change file permissions so /var/log/aspen-discovery is owned by the aspen user
 mkdir -p /var/log/aspen-discovery
 chown -R aspen:aspen /var/log/aspen-discovery
+
+# Setup Clam Log
+touch /var/log/aspen-discovery/clam_av.log
+chown root:aspen_apache /var/log/aspen-discovery/clam_av.log
+

--- a/install/upgrade_debian_25.03.00.sh
+++ b/install/upgrade_debian_25.03.00.sh
@@ -12,6 +12,6 @@ truncate -s0 /var/mail/root
 
 cp logrotate.conf /etc/logrotate.d/aspen_discovery
 
-php_vers="8.0"
-php_ini="/etc/php/${php_vers}/apache2/php.ini"
-grep -q '^;max_input_vars = 1000' "$php_ini" || sed -Ei 's/^;max_input_vars = 1000/max_input_vars = 5000/' "$php_ini"
+# Upgrade to PHP 8.4
+./debian_install_php.sh 8.4
+


### PR DESCRIPTION
Default to php 8.4 and add a helper script to install or upgrade php as needed. Also added some necessary packages that are no longer installed by default (cron, rsyslog, etc.)
Addresses DIS-287