### PR TITLE
DIS-364: Added Image Source Check for Uploaded List Covers for 25.02.01

### DIFF
--- a/code/web/release_notes/25.02.01.MD
+++ b/code/web/release_notes/25.02.01.MD
@@ -8,9 +8,15 @@
 ### Symphony Updates
 - Do not allow changing pickup location, canceling, or freezing holds that have a status of ILLSHIPPED. (DIS-34) (*MDN*)
 
+#### Cover Images Updates
+- Added check to `BookCoverProcessor::getUploadedListCover()` to make sure the list's cover is actually from an 'upload' source. (DIS-364) (*LS*)
+
 ## This release includes code contributions from
 ### Grove For Libraries
 - Mark Noble (MDN)
+
+### ByWater Solutions
+- Leo Stoyanov (LS)
 
 ## Special Testing thanks to
 - Desiree Saunders (WYLD)

--- a/code/web/sys/Covers/BookCoverProcessor.php
+++ b/code/web/sys/Covers/BookCoverProcessor.php
@@ -1869,8 +1869,9 @@ class BookCoverProcessor {
 
 	private function getUploadedListCover($id) {
 		$uploadedImage = $this->bookCoverPath . '/original/' . $id . '.png';
-		if (file_exists($uploadedImage)) {
-			return $this->processImageURL('upload', $uploadedImage);
+		$source = $this->bookCoverInfo->imageSource;
+		if ($source == 'upload' && file_exists($uploadedImage)) {
+			return $this->processImageURL($source, $uploadedImage);
 		}
 		return false;
 	}


### PR DESCRIPTION
- Added check to `BookCoverProcessor::getUploadedListCover()` to make sure the list's cover is actually from an 'upload' source.

Note to anyone who stumbles upon this ticket/pull request:
After this patch has been applied, if there is an existing list that incorrectly uses a cover from a record that has the same ID, you must SQL query to change the `imageSource` of the existing list to `default` (e.g., `UPDATE bookcover_info SET imageSource = 'default' WHERE recordType = 'list' AND recordId = '664'`). This is because `BookCoverProcessor.php` will now properly check the source of the list's book cover before assuming its source and thus create a default cover image. Any future list creations that happen to have the same ID as an existing record will not need this additional step because of this patch.