### PR TITLE
DIS-452 Boundless: Pass email during Checkout-to-placeHolds transition

### DIFF
--- a/code/web/Drivers/Axis360Driver.php
+++ b/code/web/Drivers/Axis360Driver.php
@@ -597,10 +597,6 @@ class Axis360Driver extends AbstractEContentDriver {
 						'text' => 'Place a Hold',
 						'isPublicFacing' => true,
 					]);
-					$email = empty($patron->axis360Email) ? $patron->email : $patron->axis360Email;
-					$result['api']['holdParams'] = [
-						'email' => $email
-					];
 				} else {
 					$result['message'] .= '&nbsp;' . (string)$status->statusMessage;
 					$this->incrementStat('numApiErrors');

--- a/code/web/Drivers/Axis360Driver.php
+++ b/code/web/Drivers/Axis360Driver.php
@@ -597,6 +597,10 @@ class Axis360Driver extends AbstractEContentDriver {
 						'text' => 'Place a Hold',
 						'isPublicFacing' => true,
 					]);
+					$email = empty($patron->axis360Email) ? $patron->email : $patron->axis360Email;
+					$result['api']['holdParams'] = [
+						'email' => $email
+					];
 				} else {
 					$result['message'] .= '&nbsp;' . (string)$status->statusMessage;
 					$this->incrementStat('numApiErrors');

--- a/code/web/interface/themes/responsive/js/aspen/axis360.js
+++ b/code/web/interface/themes/responsive/js/aspen/axis360.js
@@ -55,7 +55,7 @@ AspenDiscovery.Axis360 = (function () {
 								AspenDiscovery.closeLightbox(function (){
 									var ret = confirm(data.message);
 									if (ret === true) {
-										AspenDiscovery.Axis360.doHold(patronId, id);
+										AspenDiscovery.Axis360.doHold(patronId, id, data.api.holdParams.email, 0);
 									}
 								});
 							} else {

--- a/code/web/interface/themes/responsive/js/aspen/axis360.js
+++ b/code/web/interface/themes/responsive/js/aspen/axis360.js
@@ -55,7 +55,7 @@ AspenDiscovery.Axis360 = (function () {
 								AspenDiscovery.closeLightbox(function (){
 									var ret = confirm(data.message);
 									if (ret === true) {
-										AspenDiscovery.Axis360.doHold(patronId, id, data.api.holdParams.email, 0);
+										AspenDiscovery.Axis360.placeHold(id);
 									}
 								});
 							} else {

--- a/code/web/release_notes/25.03.00.MD
+++ b/code/web/release_notes/25.03.00.MD
@@ -123,6 +123,7 @@
 // yanjun
 ### Boundless Updates
 - Fix Boundless incorrect API request for canceling holds. (DIS-432) (*YL*)
+- Pass the email to Boundless doHold while transitioning from Checkout to Place hold. (DIS-452) (*YL*)
 
 // james
 


### PR DESCRIPTION
When a Boundless record is showing “available” in Aspen, but actually “waitlist” on Boundless website, if a patron wants to checkout the record, Aspen will redirect to place holds. But it will fail and shows “invalid email address”.

To replicate the bug:
1. Find a Boundless record that “available” in Aspen but “waitlist” on Boundless. 
2. Checkout the record 
3. A pop-up displaying “Sorry, we could not checkout this Boundless title to you. Would you like to place a hold instead?”
4. Click Ok and place a hold 
5. Get the error “Could not place Boundless hold, Invalid Email Address” 

The error comes from when redirecting from Checkout to Placeholds, the email is not being passed, so, add the parameters to the doHold method. 