### PR TITLE
DIS-389 Allow users use special characters in their password

### DIFF
--- a/code/web/CatalogConnection.php
+++ b/code/web/CatalogConnection.php
@@ -169,8 +169,6 @@ class CatalogConnection {
 				$invalidUser = true;
 			} elseif (!empty($user->ils_barcode) && (strip_tags($user->ils_barcode) != $user->ils_barcode)) {
 				$invalidUser = true;
-			} elseif (!empty($user->ils_password) && (strip_tags($user->ils_password) != $user->ils_password)) {
-				$invalidUser = true;
 			} elseif (!empty($user->displayName) && (strip_tags($user->displayName) != $user->displayName)) {
 				$invalidUser = true;
 			} elseif (!empty($user->phone) && (strip_tags($user->phone) != $user->phone)) {

--- a/code/web/release_notes/25.03.00.MD
+++ b/code/web/release_notes/25.03.00.MD
@@ -124,6 +124,9 @@
 ### Boundless Updates
 - Fix Boundless incorrect API request for canceling holds. (DIS-432) (*YL*)
 
+### Other Updates
+- Remove the strip_tags() check for ils_password, to allow users to use special characters for their passwords. (DIS-389) (*YL*)
+
 // james
 
 // alexander


### PR DESCRIPTION
The library reported that patrons can’t log in if their password contains ‘<' ‘&’ while we can masquerade the patron account. 

Found that in CatalogConnection.php `patronLogin()`, we use `strip_tags()` for passwords, which is not necessary since patrons want to use special characters in passwords and passwords usually won’t be displayed. 
