### PR TITLE
DIS-453: Stalling NYT List Updater Due to Missing Include Statement

### DIFF
--- a/code/web/cron/updateNYTLists.php
+++ b/code/web/cron/updateNYTLists.php
@@ -9,6 +9,7 @@ require_once ROOT_DIR . '/sys/NYTApi.php';
 
 require_once ROOT_DIR . '/sys/Enrichment/NewYorkTimesSetting.php';
 require_once ROOT_DIR . '/sys/UserLists/NYTUpdateLogEntry.php';
+require_once ROOT_DIR . '/sys/Grouping/GroupedWork.php';
 
 //Create a NYTUpdateLogEntry
 $nytUpdateLog = new NYTUpdateLogEntry();

--- a/code/web/release_notes/25.02.01.MD
+++ b/code/web/release_notes/25.02.01.MD
@@ -8,8 +8,11 @@
 ### Symphony Updates
 - Do not allow changing pickup location, canceling, or freezing holds that have a status of ILLSHIPPED. (DIS-34) (*MDN*)
 
-#### Cover Images Updates
+### Cover Images Updates
 - Added check to `BookCoverProcessor::getUploadedListCover()` to make sure the list's cover is actually from an 'upload' source. (DIS-364) (*LS*)
+
+### New York Times List Updates
+- NYT List updater was stalling due to a missing include statement for `GroupedWork.php`. (DIS-453) (*LS*)
 
 ## This release includes code contributions from
 ### Grove For Libraries


### PR DESCRIPTION
- NYT List updater was stalling due to a missing include statement for `GroupedWork.php`.