### PR TITLE
DIS-454: Unable to load template 'file:Series/placeHolderListEntry.tpl'

### DIFF
--- a/code/web/sys/Series/Series.php
+++ b/code/web/sys/Series/Series.php
@@ -293,7 +293,7 @@ class Series extends DataObject {
 					$interface->assign('listEntrySource', "Series");
 					$interface->assign('seriesMemberId',$seriesMemberInfo['seriesMemberId']);
 					$interface->assign('placeholder', $seriesMemberInfo);
-					$listResults[$listPosition] = $interface->fetch('Series/placeHolderListEntry.tpl');
+					$listResults[$listPosition] = $interface->fetch('Series/placeholderListEntry.tpl');
 				}
 			}
 		}


### PR DESCRIPTION
- Fixed case typo; it should have been placeholderListEntry.tpl.
- To test: add a placeholder record to a series (add a record but don't include a grouped work ID) then view the series.  It should load correctly without an error.