### PR TITLE
DIS-287 Debian Installer Followup

### DIFF
--- a/code/web/release_notes/25.03.00.MD
+++ b/code/web/release_notes/25.03.00.MD
@@ -48,7 +48,7 @@
 ### Install Updates
 - Properly install the logrotate configuration file on debian systems. (DIS-366) (*MDN*)
 - Increase max_input_vars for php to 5000 on debian systems. (DIS-431) (*MDN*)
-- Update Debian installer to incoporate the above, upgrade Debian systems to PHP 8.4, optionally install ClamAV, and use a Debian-specific logrotate config (DIS-287) (*JBoyer*)
+- Update Debian installer and upgrader to incoporate the above, upgrade Debian systems to PHP 8.4, optionally install ClamAV, and use a Debian-specific logrotate config (DIS-287) (*JBoyer*)
 
 ### IP Address Usage
 - Make IP Address usage updates atomic to ensure they update accurately when multiple pages load at the same time from the same IP. (DIS-378) (*MDN*)

--- a/install/debian_install_php.sh
+++ b/install/debian_install_php.sh
@@ -16,25 +16,17 @@ fi
 if ! [ -s "$keyrings/sury.gpg" ] || ! [ -s /etc/apt/sources.list.d/sury.list ]; then
   wget -q -O - https://packages.sury.org/php/apt.gpg | gpg -o "$keyrings/sury.gpg" --dearmor
   echo "deb [signed-by=$keyrings/sury.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" >/etc/apt/sources.list.d/sury.list
-  apt-get update -q
-fi
-
-# disable older version of php apache module if present
-# will be empty on new installs
-curr_php=$(a2query -m | grep -Eo php...)
-curr_php=${curr_php#php}
-
-if [ -n "$curr_php" ] && [ "$curr_php" != "$php_vers" ]; then
-	a2dismod "php${curr_php}"
 fi
 
 # install new package versions
-apt-get install -y -q "php${php_vers}" "php${php_vers}-mcrypt" "php${php_vers}-gd" "php${php_vers}-imagick" "php${php_vers}-curl" "php${php_vers}-mysql" "php${php_vers}-zip" "php${php_vers}-xml" "php${php_vers}-intl" "php${php_vers}-mbstring" "php${php_vers}-soap" "php${php_vers}-pgsql" "php${php_vers}-ssh2" "php${php_vers}-ldap"
+apt-get update -q
+apt-get install -y -q "libapache2-mod-php${php_vers}" "php${php_vers}" "php${php_vers}-mcrypt" "php${php_vers}-gd" "php${php_vers}-imagick" "php${php_vers}-curl" "php${php_vers}-mysql" "php${php_vers}-zip" "php${php_vers}-xml" "php${php_vers}-intl" "php${php_vers}-mbstring" "php${php_vers}-soap" "php${php_vers}-pgsql" "php${php_vers}-ssh2" "php${php_vers}-ldap"
 
 # Make sure the active apache module has the correct settings
 cp php.ini "/etc/php/$php_vers/apache2/"
 
 # and turn it on
+rm /etc/apache2/mods-enabled/php*
 a2enmod "php${php_vers}"
 systemctl restart apache2
 

--- a/install/upgrade_debian.sh
+++ b/install/upgrade_debian.sh
@@ -11,7 +11,7 @@ if [ -z "$2" ]
     exit 1
 fi
 
-service cron stop
+systemctl stop cron
 pkill -9 java
 
 apt-get update
@@ -23,7 +23,7 @@ git pull origin $2
 cd /usr/local/aspen-discovery/install
 if [ -f "/usr/local/aspen-discovery/install/upgrade_debian_$2.sh" ]; then
   echo "Running version updates"
-  /usr/local/aspen-discovery/install/upgrade_debian_$2.sh
+  /usr/local/aspen-discovery/install/upgrade_debian_$2.sh $1
 fi
 
 if [ -f "/usr/local/aspen-discovery/install/updateCron_$2.php" ]; then
@@ -35,15 +35,14 @@ echo "Run database maintenance, and then press return when done"
 # shellcheck disable=SC2034
 read waitOver
 
-service mysqld restart
-apachectl restart
+systemctl restart apache2 mysql
 cd /usr/local/aspen-discovery/data_dir_setup
 /usr/local/aspen-discovery/data_dir_setup/update_solr_files_debian.sh $1
 
 cd /usr/local/aspen-discovery
 git gc
 
-service cron start
+systemctl start cron
 
 echo "Upgrade completed."
 


### PR DESCRIPTION
Update upgrade_debian.sh script to call upgrade_debian_X.Y.Z.sh scripts correctly and always force correct php version to be enabled in debian_install_php.sh.