### PR TITLE
DIS-473 Add null check for OverDrive getSubjects()

### DIFF
--- a/code/web/RecordDrivers/OverDriveRecordDriver.php
+++ b/code/web/RecordDrivers/OverDriveRecordDriver.php
@@ -430,7 +430,7 @@ class OverDriveRecordDriver extends GroupedWorkSubDriver {
 
 	/** @noinspection PhpUnused */
 	public function getSubjects() : array {
-		return $this->getOverDriveMetaData()->getDecodedRawData()->subjects;
+		return $this->getOverDriveMetaData()->getDecodedRawData()->subjects ?? [];
 	}
 
 	/**

--- a/code/web/release_notes/25.03.00.MD
+++ b/code/web/release_notes/25.03.00.MD
@@ -208,6 +208,7 @@
 - Allow staff members to submit a masquerade login as a user using the Enter key (DIS-411) (*LM*)
 - Remove redundant code in `getInnReachResults` method (DIS-395) (*TC*)
 - Add logging to INN-Reach contents fetching (DIS-397) (*TC*)
+- Add Null Check for OverDrive getSubjects (DIS-473) (*YL*)
 
 ## This release includes code contributions from
 ### ByWater Solutions


### PR DESCRIPTION
Adding null check for `OverDriveRecordDriver.php`, `getSubjects() ` for preventing error: `OverDriveRecordDriver::getSubjects(): Return value must be of type array, null returned`