### PR TITLE
DIS-416: Debugging ecommerce applications

### DIFF
--- a/code/web/release_notes/25.04.00.MD
+++ b/code/web/release_notes/25.04.00.MD
@@ -27,6 +27,8 @@
 //jason (equinox)
 
 //lucas
+### Other Updates
+- Add an option to allow staff users to get debugging information about payments. (DIS-416) (*LM*)
 
 //tomas
 

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -6529,7 +6529,9 @@ class MyAccount_AJAX extends JSON_Action {
 
 			$tokenResults = $payflowTokenRequest->curlSendPage($tokenRequestUrl, 'POST', $params);
 			$tokenResults = PayPalPayflowSetting::parsePayflowString($tokenResults);
-			if ($tokenResults['RESULT'] != 0) {
+			$allowPaymentsDebugging = $payflowSettings->enablePaymentsDebugging;
+
+			if ($tokenResults['RESULT'] != 0 && $allowPaymentsDebugging) {
 				ExternalRequestLogEntry::logRequest('getPayflowToken', 'POST', $tokenRequestUrl, $payflowTokenRequest->getHeaders(), $params, $payflowTokenRequest->getResponseCode(), $tokenResults, []);
 				return [
 					'success' => false,

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -6747,8 +6747,14 @@ class MyAccount_AJAX extends JSON_Action {
 
 				$url = 'https://www.invoicecloud.com/api/v1/biller/status';
 				$authResponse = $authRequest->curlGetPage($url);
-				$authResponse = json_decode($authResponse);
-				if (!$authResponse->Active) {
+				$decodedAuthResponse = json_decode($authResponse);
+
+				$allowPaymentsDebugging = $invoiceCloudSetting->enablePaymentsDebugging;
+				if ($allowPaymentsDebugging){
+					ExternalRequestLogEntry::logRequest('myaccount_ajax.createInvoiceCloudOrder','GET', $url, $authRequest->getHeaders(),'', $authRequest->getResponseCode(), $authResponse, []);
+				}
+
+				if (!$decodedAuthResponse->Active) {
 					return [
 						'success' => false,
 						'message' => 'Unable to create your order in InvoiceCloud. Library has an inactive account.'
@@ -6794,14 +6800,19 @@ class MyAccount_AJAX extends JSON_Action {
 
 				$url = 'https://www.invoicecloud.com/cloudpaymentsapi/v2';
 				$paymentResponse = $paymentRequest->curlPostBodyData($url, $postParams);
-				$paymentResponse = json_decode($paymentResponse);
-				if ($paymentResponse->Message != 'SUCCESS') {
+				$decodedPaymentResponse = json_decode($paymentResponse);
+
+				if ($allowPaymentsDebugging){
+					ExternalRequestLogEntry::logRequest('myaccount_ajax.createInvoiceCloudOrder','POST', $url, $paymentRequest->getHeaders(),json_encode($postParams), $paymentRequest->getResponseCode(), $paymentRegitsponse, []);
+				}
+
+				if ($decodedPaymentResponse->Message != 'SUCCESS') {
 					return [
 						'success' => false,
-						'message' => 'Unable to create your order in InvoiceCloud. ' . $paymentResponse->Message
+						'message' => 'Unable to create your order in InvoiceCloud. ' . $decodedPaymentResponse->Message
 					];
 				}
-				$paymentRequestUrl = $paymentResponse->Data->CloudPaymentURL;
+				$paymentRequestUrl = $decodedPaymentResponse->Data->CloudPaymentURL;
 
 				return [
 					'success' => true,

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -5426,9 +5426,15 @@ class MyAccount_AJAX extends JSON_Action {
 
 				$paymentUrl = $baseUrl . '/v2/payments';
 				$paymentRequestResults = $paymentRequest->curlPostBodyData($paymentUrl, $body);
-				$paymentRequestResults = json_decode($paymentRequestResults);
-				if ($paymentRequestResults->payment) {
-					$paymentResults = $paymentRequestResults->payment;
+				$decodedPaymentRequestResults = json_decode($paymentRequestResults);
+
+				$allowPaymentsDebugging = $squareSettings->enablePaymentsDebugging;
+				if ($allowPaymentsDebugging){
+					ExternalRequestLogEntry::logRequest('myaccount_ajax.completeSquareOrder', 'POST', $paymentUrl, $paymentRequest->getHeaders(), json_encode($body), $paymentRequest->getResponseCode(), $paymentRequestResults, []);
+				}
+
+				if ($decodedPaymentRequestResults->payment) {
+					$paymentResults = $decodedPaymentRequestResults->payment;
 					if ($paymentResults->status == 'COMPLETED' || $paymentResults->status == 'APPROVED') {
 						if ($transactionType == 'donation') {
 							$payment->completed = 1;
@@ -5479,7 +5485,7 @@ class MyAccount_AJAX extends JSON_Action {
 						}
 					}
 				} else {
-					$error = $paymentRequestResults->error;
+					$error = $decodedPaymentRequestResults->error;
 					$payment->error = 1;
 					$payment->message = $error->detail;
 					$payment->update();

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -5820,6 +5820,8 @@ class MyAccount_AJAX extends JSON_Action {
 					'Accept-Encoding: gzip, deflate',
 					'Authorization: ' . $authorization,
 				], true);
+				
+				$allowPaymentsDebugging = $proPaySetting->enablePaymentsDebugging;
 
 				//Create the payer if one doesn't exist already.
 				if (empty($patron->proPayPayerAccountId)) {
@@ -5836,6 +5838,11 @@ class MyAccount_AJAX extends JSON_Action {
 					}
 
 					$createPayerResponse = $curlWrapper->curlSendPage($url, 'PUT', json_encode($createPayer));
+
+					if ($allowPaymentsDebugging){
+						ExternalRequestLogEntry::logRequest('myaccount_ajax.createpropayorder', 'PUT', $url, $curlWrapper->getHeaders(), json_encode($createPayer), $curlWrapper->getResponseCode(), $createPayerResponse, []);
+					}
+
 					if ($createPayerResponse && $curlWrapper->getResponseCode() == 200) {
 						$jsonResponse = json_decode($createPayerResponse);
 						if ($patron != null) {
@@ -5875,6 +5882,11 @@ class MyAccount_AJAX extends JSON_Action {
 					}
 
 					$createMerchantProfileResponse = $curlWrapper->curlSendPage($url, 'PUT', json_encode($createMerchantProfile));
+					
+					if ($allowPaymentsDebugging){
+						ExternalRequestLogEntry::logRequest('myaccount_ajax.createpropayorder', 'PUT', $url, $curlWrapper->getHeaders(), json_encode($createMerchantProfile), $curlWrapper->getResponseCode(), $createMerchantProfileResponse, []);
+					}
+
 					if ($createMerchantProfileResponse && $curlWrapper->getResponseCode() == 200) {
 						$jsonResponse = json_decode($createMerchantProfileResponse);
 						$proPaySetting->merchantProfileId = $jsonResponse->ProfileId;
@@ -5928,6 +5940,11 @@ class MyAccount_AJAX extends JSON_Action {
 					}
 
 					$response = $curlWrapper->curlSendPage($url, 'PUT', json_encode($requestElements));
+
+					if ($allowPaymentsDebugging){
+						ExternalRequestLogEntry::logRequest('myaccount_ajax.createpropayorder', 'PUT', $url, $curlWrapper->getHeaders(), json_encode($requestElements), $curlWrapper->getResponseCode(), $response, []);
+					}
+
 					if ($response && $curlWrapper->getResponseCode() == 200) {
 						$jsonResponse = json_decode($response);
 						$transactionIdentifier = $jsonResponse->HostedTransactionIdentifier;

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -5037,18 +5037,24 @@ class MyAccount_AJAX extends JSON_Action {
 				"Accept-Language: en_US",
 				"Authorization: Basic $authInfo",
 			], true);
-			$postParams = ['grant_type' => 'client_credentials',];
+			$postParams = ['grant_type' => 'client_credentials'];
 
 			$accessTokenUrl = $baseUrl . "/v1/oauth2/token";
 			$accessTokenResults = $payPalAuthRequest->curlPostPage($accessTokenUrl, $postParams);
-			$accessTokenResults = json_decode($accessTokenResults);
-			if (empty($accessTokenResults->access_token)) {
+			$decodedAccessTokenResults = json_decode($accessTokenResults);
+
+			$allowPaymentsDebugging = $payPalSettings->enablePaymentsDebugging;
+			if ($allowPaymentsDebugging){
+				ExternalRequestLogEntry::logRequest('myaccount_ajax.createPayPalOrder', 'POST', $accessTokenUrl, $payPalAuthRequest->getHeaders(), json_encode($postParams), $payPalAuthRequest->getResponseCode(), $accessTokenResults, ['client_secret' => $clientSecret]);
+			}
+
+			if (empty($decodedAccessTokenResults->access_token)) {
 				return [
 					'success' => false,
 					'message' => 'Unable to authenticate with PayPal, please try again in a few minutes.',
 				];
 			} else {
-				$accessToken = $accessTokenResults->access_token;
+				$accessToken = $decodedAccessTokenResults->access_token;
 			}
 
 			global $library;
@@ -5081,9 +5087,13 @@ class MyAccount_AJAX extends JSON_Action {
 			];
 
 			$paymentResponse = $payPalPaymentRequest->curlPostBodyData($paymentRequestUrl, $paymentRequestBody);
-			$paymentResponse = json_decode($paymentResponse);
+			$decodedPaymentResponse = json_decode($paymentResponse);
+			
+			if ($allowPaymentsDebugging){
+				ExternalRequestLogEntry::logRequest('myaccount.createPayPalOrder', 'POST', $paymentRequestUrl, $payPalPaymentRequest->getHeaders(), json_encode($postParams), $payPalPaymentRequest->getResponseCode(), $paymentResponse, []);
+			}
 
-			if ($paymentResponse->status != 'CREATED') {
+			if ($decodedPaymentResponse->status != 'CREATED') {
 				return [
 					'success' => false,
 					'message' => 'Unable to create your order in PayPal.',
@@ -5091,13 +5101,13 @@ class MyAccount_AJAX extends JSON_Action {
 			}
 
 			//Log the request in the database so we can validate it on return
-			$payment->orderId = $paymentResponse->id;
+			$payment->orderId = $decodedPaymentResponse->id;
 			$payment->update();
 
 			return [
 				'success' => true,
 				'orderInfo' => $paymentResponse,
-				'orderID' => $paymentResponse->id,
+				'orderID' => $decodedPaymentResponse->id,
 			];
 		}
 	}
@@ -5176,18 +5186,24 @@ class MyAccount_AJAX extends JSON_Action {
 				"Accept-Language: en_US",
 				"Authorization: Basic $authInfo",
 			], true);
-			$postParams = ['grant_type' => 'client_credentials',];
+			$postParams = ['grant_type' => 'client_credentials'];
 
 			$accessTokenUrl = $baseUrl . "/v1/oauth2/token";
 			$accessTokenResults = $payPalAuthRequest->curlPostPage($accessTokenUrl, $postParams);
-			$accessTokenResults = json_decode($accessTokenResults);
-			if (empty($accessTokenResults->access_token)) {
+			$decodedAccessTokenResults = json_decode($accessTokenResults);
+			
+			$allowPaymentsDebugging = $payPalSettings->enablePaymentsDebugging;
+			if ($allowPaymentsDebugging){
+				ExternalRequestLogEntry::logRequest('myaccount_ajax.completePayPalOrder', 'POST', $accessTokenUrl, $payPalAuthRequest->getHeaders(), json_encode($postParams), $payPalAuthRequest->getResponseCode(), $accessTokenResults, ['client_secret' => $clientSecret]);
+			}
+
+			if (empty($decodedAccessTokenResults->access_token)) {
 				return [
 					'success' => false,
 					'message' => 'Unable to authenticate with PayPal, please try again in a few minutes.',
 				];
 			} else {
-				$accessToken = $accessTokenResults->access_token;
+				$accessToken = $decodedAccessTokenResults->access_token;
 			}
 
 			$payPalPaymentRequest = new CurlWrapper();
@@ -5201,9 +5217,13 @@ class MyAccount_AJAX extends JSON_Action {
 			$paymentRequestUrl = $baseUrl . '/v2/checkout/orders/' . $payment->orderId;
 
 			$paymentResponse = $payPalPaymentRequest->curlGetPage($paymentRequestUrl);
-			$paymentResponse = json_decode($paymentResponse);
+			$decodedPaymentResponse = json_decode($paymentResponse);
 
-			$purchaseUnits = $paymentResponse->purchase_units;
+			if ($allowPaymentsDebugging){
+				ExternalRequestLogEntry::logRequest('myaccount_ajax.completePayPalOrder', 'GET', $paymentRequestUrl, $payPalPaymentRequest->getHeaders(),'', $payPalPaymentRequest->getResponseCode(), $paymentResponse, []);
+			}
+
+			$purchaseUnits = $decodedPaymentResponse->purchase_units;
 			if (!empty($purchaseUnits)) {
 				$firstItem = reset($purchaseUnits);
 				$payments = $firstItem->payments;

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -6272,8 +6272,12 @@ class MyAccount_AJAX extends JSON_Action {
 
 				$resultJSON = $newRedirectRequest->curlPostBodyData($url, $postParams, true);
 				$result = json_decode($resultJSON);
-				ExternalRequestLogEntry::logRequest('ncr.createNCROrder', 'POST', $url, $newRedirectRequest->getHeaders(), json_encode($postParams), $newRedirectRequest->getResponseCode(), $resultJSON, []);
 
+				$allowPaymentsDebugging = $NCRPaymentsSetting->enablePaymentsDebugging;
+				if ($allowPaymentsDebugging){
+					ExternalRequestLogEntry::logRequest('myaccount_ajax.createNCROrder', 'POST', $url, $newRedirectRequest->getHeaders(), json_encode($postParams), $newRedirectRequest->getResponseCode(), $resultJSON, []);
+				}
+				
 				if ($result->status != "ok") {
 					return [
 						'success' => false,

--- a/code/web/sys/Account/UserPayment.php
+++ b/code/web/sys/Account/UserPayment.php
@@ -506,6 +506,12 @@ class UserPayment extends DataObject {
 							'Authorization: ' . $authorization,
 						], true);
 						$hostedTransactionResultsResponse = $curlWrapper->curlGetPage($url);
+
+						$allowPaymentsDebugging = $proPaySetting->enablePaymentsDebugging;
+						if ($allowPaymentsDebugging){
+							ExternalRequestLogEntry::logRequest('userPayment.completeProPayPayment', 'GET', $url, $curlWrapper->getHeaders(),"", $curlWrapper->getResponseCode(), $hostedTransactionResultsResponse, []);
+						}
+
 						$jsonResponse = null;
 						if ($hostedTransactionResultsResponse && $curlWrapper->getResponseCode() == 200) {
 							$jsonResponse = json_decode($hostedTransactionResultsResponse);

--- a/code/web/sys/DBMaintenance/version_updates/25.03.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.03.00.php
@@ -371,21 +371,8 @@ function getUpdates25_03_00(): array {
 		//James Staub - Nashville Public Library
 
 		//Lucas Montoya - Theke Solutions
-		'enable_payments_debugging' => [
-			'title' => 'Enable to Show Debugging Information about Paypal Payments',
-			'description' => 'Enable to show debugging information about Paypal payments',
-			'sql' => [
-				'ALTER TABLE paypal_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 0',
-				'ALTER TABLE square_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 0',
-				'ALTER TABLE stripe_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 0',
-				'ALTER TABLE propay_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 0',
-				'ALTER TABLE ncr_payments_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 0',
-				'ALTER TABLE paypal_payflow_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 0',
-				'ALTER TABLE aci_speedpay_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 0',
-				'ALTER TABLE invoice_cloud_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 0',
-			]
-		], //enable_payments_debugging
 
+		
 		//Yanjun Li - ByWater
 		'sierra_self_reg_form_updates' => [
 			'title' => 'Sierra Self Reg updates',

--- a/code/web/sys/DBMaintenance/version_updates/25.03.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.03.00.php
@@ -376,6 +376,7 @@ function getUpdates25_03_00(): array {
 			'description' => 'Enable to show debugging information about Paypal payments',
 			'sql' => [
 				'ALTER TABLE paypal_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 0',
+				'ALTER TABLE square_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 0',
 			]
 		], //enable_payments_debugging
 

--- a/code/web/sys/DBMaintenance/version_updates/25.03.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.03.00.php
@@ -378,6 +378,7 @@ function getUpdates25_03_00(): array {
 				'ALTER TABLE paypal_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 0',
 				'ALTER TABLE square_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 0',
 				'ALTER TABLE stripe_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 0',
+				'ALTER TABLE propay_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 0',
 			]
 		], //enable_payments_debugging
 

--- a/code/web/sys/DBMaintenance/version_updates/25.03.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.03.00.php
@@ -377,6 +377,7 @@ function getUpdates25_03_00(): array {
 			'sql' => [
 				'ALTER TABLE paypal_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 0',
 				'ALTER TABLE square_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 0',
+				'ALTER TABLE stripe_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 0',
 			]
 		], //enable_payments_debugging
 

--- a/code/web/sys/DBMaintenance/version_updates/25.03.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.03.00.php
@@ -382,7 +382,7 @@ function getUpdates25_03_00(): array {
 				'ALTER TABLE ncr_payments_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 0',
 				'ALTER TABLE paypal_payflow_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 0',
 				'ALTER TABLE aci_speedpay_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 0',
-				
+				'ALTER TABLE invoice_cloud_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 0',
 			]
 		], //enable_payments_debugging
 

--- a/code/web/sys/DBMaintenance/version_updates/25.03.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.03.00.php
@@ -379,6 +379,8 @@ function getUpdates25_03_00(): array {
 				'ALTER TABLE square_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 0',
 				'ALTER TABLE stripe_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 0',
 				'ALTER TABLE propay_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 0',
+				'ALTER TABLE ncr_payments_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 0',
+
 			]
 		], //enable_payments_debugging
 

--- a/code/web/sys/DBMaintenance/version_updates/25.03.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.03.00.php
@@ -371,6 +371,13 @@ function getUpdates25_03_00(): array {
 		//James Staub - Nashville Public Library
 
 		//Lucas Montoya - Theke Solutions
+		'enable_payments_debugging' => [
+			'title' => 'Enable to Show Debugging Information about Paypal Payments',
+			'description' => 'Enable to show debugging information about Paypal payments',
+			'sql' => [
+				'ALTER TABLE paypal_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 0',
+			]
+		], //enable_payments_debugging
 
 		//Yanjun Li - ByWater
 		'sierra_self_reg_form_updates' => [

--- a/code/web/sys/DBMaintenance/version_updates/25.03.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.03.00.php
@@ -380,6 +380,7 @@ function getUpdates25_03_00(): array {
 				'ALTER TABLE stripe_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 0',
 				'ALTER TABLE propay_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 0',
 				'ALTER TABLE ncr_payments_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 0',
+				'ALTER TABLE paypal_payflow_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 0',
 
 			]
 		], //enable_payments_debugging

--- a/code/web/sys/DBMaintenance/version_updates/25.03.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.03.00.php
@@ -381,7 +381,8 @@ function getUpdates25_03_00(): array {
 				'ALTER TABLE propay_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 0',
 				'ALTER TABLE ncr_payments_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 0',
 				'ALTER TABLE paypal_payflow_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 0',
-
+				'ALTER TABLE aci_speedpay_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 0',
+				
 			]
 		], //enable_payments_debugging
 

--- a/code/web/sys/DBMaintenance/version_updates/25.04.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.04.00.php
@@ -31,6 +31,20 @@ function getUpdates25_04_00(): array {
 		//James Staub - Nashville Public Library
 
 		//Lucas Montoya - Theke Solutions
+		'enable_payments_debugging' => [
+			'title' => 'Enable to Show Debugging Information about Paypal Payments',
+			'description' => 'Enable to show debugging information about Paypal payments',
+			'sql' => [
+				'ALTER TABLE paypal_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 1',
+				'ALTER TABLE square_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 1',
+				'ALTER TABLE stripe_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 1',
+				'ALTER TABLE propay_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 1',
+				'ALTER TABLE ncr_payments_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 1',
+				'ALTER TABLE paypal_payflow_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 1',
+				'ALTER TABLE aci_speedpay_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 1',
+				'ALTER TABLE invoice_cloud_settings ADD COLUMN enablePaymentsDebugging TINYINT(1) DEFAULT 1',
+			]
+		], //enable_payments_debugging
 
 		//other
 

--- a/code/web/sys/ECommerce/ACISpeedpaySetting.php
+++ b/code/web/sys/ECommerce/ACISpeedpaySetting.php
@@ -16,7 +16,7 @@ class ACISpeedpaySetting extends DataObject {
 	public $sdkApiAuthKey;
 	public $billerId;
 	public $billerAccountId;
-
+	public $enablePaymentsDebugging;
 	private $_libraries;
 
 	static function getObjectStructure($context = ''): array {
@@ -105,6 +105,14 @@ class ACISpeedpaySetting extends DataObject {
 				'values' => $billerAccount_options,
 				'description' => 'The identifier field used to connect payments to users.',
 				'hideInLists' => true,
+			],
+			'enablePaymentsDebugging' => [
+				'property' => 'enablePaymentsDebugging',
+				'type' => 'checkbox',
+				'label' => 'Enable Payments Debugging',
+				'description' => 'Whether or not to allow staff users to get debugging information about payments',
+				'hideInLists' => false,
+				'default' => true,
 			],
 
 			'libraries' => [
@@ -392,6 +400,11 @@ class ACISpeedpaySetting extends DataObject {
 		], true);
 
 		$paymentTransaction = $paymentRequest->curlPostBodyData($url, $postData);
+
+		$allowPaymentsDebugging = $this->enablePaymentsDebugging;
+		if ($allowPaymentsDebugging){
+			ExternalRequestLogEntry::logRequest('aciSpeedPaySetting', 'POST', $url, $paymentRequest->getHeaders(), json_encode($postData), $paymentRequest->getResponseCode(), $paymentTransaction, []);
+		}
 
 		$paymentResponse = json_decode($paymentTransaction, true);
 		if ($paymentRequest->getResponseCode() == 200) {

--- a/code/web/sys/ECommerce/InvoiceCloudSetting.php
+++ b/code/web/sys/ECommerce/InvoiceCloudSetting.php
@@ -10,6 +10,7 @@ class InvoiceCloudSetting extends DataObject {
 	public $apiKey;
 	public $invoiceTypeId;
 	public $ccServiceFee;
+	public $enablePaymentsDebugging;
 
 	private $_libraries;
 
@@ -58,6 +59,15 @@ class InvoiceCloudSetting extends DataObject {
 				'hideInLists' => true,
 				'maxLength' => 50,
 			],
+			'enablePaymentsDebugging' => [
+				'property' => 'enablePaymentsDebugging',
+				'type' => 'checkbox',
+				'label' => 'Enable Payments Debugging',
+				'description' => 'Whether or not to allow staff users to get debugging information about payments',
+				'hideInLists' => false,
+				'default' => true,
+			],
+			
 			'libraries' => [
 				'property' => 'libraries',
 				'type' => 'multiSelect',

--- a/code/web/sys/ECommerce/NCRPaymentsSetting.php
+++ b/code/web/sys/ECommerce/NCRPaymentsSetting.php
@@ -8,7 +8,7 @@ class NCRPaymentsSetting extends DataObject {
 	public $webKey;
 	public $paymentTypeId;
 	public $lastTransactionNumber;
-
+	public $enablePaymentsDebugging;
 	private $_libraries;
 
 	static function getObjectStructure($context = ''): array {
@@ -52,6 +52,14 @@ class NCRPaymentsSetting extends DataObject {
 				'hideInLists' => false,
 				'default' => '0',
 				'maxLength' => 1,
+			],
+			'enablePaymentsDebugging' => [
+				'property' => 'enablePaymentsDebugging',
+				'type' => 'checkbox',
+				'label' => 'Enable Payments Debugging',
+				'description' => 'Whether or not to allow staff users to get debugging information about payments',
+				'hideInLists' => false,
+				'default' => true,
 			],
 			'libraries' => [
 				'property' => 'libraries',

--- a/code/web/sys/ECommerce/PayPalPayflowSetting.php
+++ b/code/web/sys/ECommerce/PayPalPayflowSetting.php
@@ -10,6 +10,7 @@ class PayPalPayflowSetting extends DataObject {
 	public $vendor;
 	public $user;
 	public $password;
+	public $enablePaymentsDebugging;
 
 	private $_libraries;
 
@@ -75,7 +76,15 @@ class PayPalPayflowSetting extends DataObject {
 				'default' => '',
 				'size' => 72,
 			],
-
+			'enablePaymentsDebugging' => [
+				'property' => 'enablePaymentsDebugging',
+				'type' => 'checkbox',
+				'label' => 'Enable Payments Debugging',
+				'description' => 'Whether or not to allow staff users to get debugging information about payments',
+				'hideInLists' => false,
+				'default' => true,
+			],
+			
 			'libraries' => [
 				'property' => 'libraries',
 				'type' => 'multiSelect',

--- a/code/web/sys/ECommerce/PayPalSetting.php
+++ b/code/web/sys/ECommerce/PayPalSetting.php
@@ -6,6 +6,7 @@ class PayPalSetting extends DataObject {
 	public $id;
 	public $name;
 	public $sandboxMode;
+	public $enablePaymentsDebugging;
 	public $showPayLater;
 	public $clientId;
 	public $clientSecret;
@@ -37,6 +38,14 @@ class PayPalSetting extends DataObject {
 				'description' => 'Whether or not to use PayPal in Sandbox mode',
 				'hideInLists' => false,
 				'note' => 'This is for testing only! No funds will be received by the library.',
+			],
+			'enablePaymentsDebugging' => [
+				'property' => 'enablePaymentsDebugging',
+				'type' => 'checkbox',
+				'label' => 'Enable Payments Debugging',
+				'description' => 'Whether or not to allow staff users to get debugging information about payments',
+				'hideInLists' => false,
+				'default' => true,
 			],
 			'showPayLater' => [
 				'property' => 'showPayLater',

--- a/code/web/sys/ECommerce/ProPaySetting.php
+++ b/code/web/sys/ECommerce/ProPaySetting.php
@@ -8,6 +8,7 @@ class ProPaySetting extends DataObject {
 	public $id;
 	public $name;
 	public $useTestSystem;
+	public $enablePaymentsDebugging;
 	public $authenticationToken;
 	public $billerAccountId;
 	public $merchantProfileId;
@@ -40,6 +41,14 @@ class ProPaySetting extends DataObject {
 				'label' => 'Use Test System',
 				'description' => 'Whether or not users to use ProPay test system',
 				'hideInLists' => true,
+			],
+			'enablePaymentsDebugging' => [
+				'property' => 'enablePaymentsDebugging',
+				'type' => 'checkbox',
+				'label' => 'Enable Payments Debugging',
+				'description' => 'Whether or not to allow staff users to get debugging information about payments',
+				'hideInLists' => false,
+				'default' => true,
 			],
 			'authenticationToken' => [
 				'property' => 'authenticationToken',

--- a/code/web/sys/ECommerce/SquareSetting.php
+++ b/code/web/sys/ECommerce/SquareSetting.php
@@ -6,6 +6,7 @@ class SquareSetting extends DataObject {
 	public $id;
 	public $name;
 	public $sandboxMode;
+	public $enablePaymentsDebugging;
 	public $applicationId;
 	public $accessToken;
 	public $locationId;
@@ -36,6 +37,14 @@ class SquareSetting extends DataObject {
 				'description' => 'Whether or not to use Square in Sandbox mode',
 				'hideInLists' => false,
 				'note' => 'This is for testing only! No funds will be received by the library.',
+			],
+			'enablePaymentsDebugging' => [
+				'property' => 'enablePaymentsDebugging',
+				'type' => 'checkbox',
+				'label' => 'Enable Payments Debugging',
+				'description' => 'Whether or not to allow staff users to get debugging information about payments',
+				'hideInLists' => false,
+				'default' => true,
 			],
 			'applicationId' => [
 				'property' => 'applicationId',

--- a/code/web/sys/ECommerce/StripeSetting.php
+++ b/code/web/sys/ECommerce/StripeSetting.php
@@ -5,6 +5,7 @@ class StripeSetting extends DataObject {
 	public $__table = 'stripe_settings';
 	public $id;
 	public $name;
+	public $enablePaymentsDebugging;
 	public $stripePublicKey;
 	public $stripeSecretKey;
 
@@ -44,6 +45,14 @@ class StripeSetting extends DataObject {
 				'hideInLists' => true,
 				'default' => '',
 				'size' => 100,
+			],
+			'enablePaymentsDebugging' => [
+				'property' => 'enablePaymentsDebugging',
+				'type' => 'checkbox',
+				'label' => 'Enable Payments Debugging',
+				'description' => 'Whether or not to allow staff users to get debugging information about payments',
+				'hideInLists' => false,
+				'default' => true,
 			],
 			'libraries' => [
 				'property' => 'libraries',
@@ -154,6 +163,12 @@ class StripeSetting extends DataObject {
 
 		$url = $baseUrl . '/v1/payment_intents';
 		$paymentIntent = $paymentIntentSetup->curlPostPage($url, $postParams);
+
+		$allowPaymentsDebugging = $this->enablePaymentsDebugging;
+		if ($allowPaymentsDebugging){
+			ExternalRequestLogEntry::logRequest('stripeSettings.createPaymentIntent', 'POST', $url, $paymentIntentSetup->getHeaders(), json_encode($postParams), $paymentIntentSetup->getResponseCode(), $paymentIntent, []);
+		}
+
 		return json_decode($paymentIntent, true);
 	}
 
@@ -180,6 +195,11 @@ class StripeSetting extends DataObject {
 		], true);
 
 		$paymentTransaction = $paymentRequest->curlPostBodyData($url, null);
+
+		$allowPaymentsDebugging = $this->enablePaymentsDebugging;
+		if ($allowPaymentsDebugging){
+			ExternalRequestLogEntry::logRequest('stripeSettings.createPaymentIntent', 'POST', $url, $paymentRequest->getHeaders(),'', $paymentRequest->getResponseCode(), $paymentTransaction, []);
+		}
 
 		$paymentResponse = json_decode($paymentTransaction, true);
 		if ($paymentRequest->getResponseCode() == 200) {


### PR DESCRIPTION
Test plan :

- Login as a staff user with permissions to manage ecommerce payments settings
- Set your prefer ecommerce to manage your payments like Paypal, ProPay, NCR, PaypalPayflow with valid credentials
- By default the option 'Enable Payments Debugging' is active
- Enable your IP to be able to log debugging information
- Go to Greenhouse -> External Log Entry
- Login with a user who has fines to pay (use an incognito window for testing)
- Pay the fines
- The staff user should be able to watch debugging information about movements related with the ecommerce