### PR TITLE
DIS-192: Events editing bug fixes

### DIFF
--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -12478,6 +12478,7 @@ AspenDiscovery.Events = (function(){
 				$("#endDate").val(startDate.format("YYYY-MM-DD"));
 				$("#endTime").val(startDate.format("HH:mm"));
 			}
+			AspenDiscovery.Events.calculateRecurrenceDates();
 			return false;
 		},
 

--- a/code/web/interface/themes/responsive/js/aspen/events.js
+++ b/code/web/interface/themes/responsive/js/aspen/events.js
@@ -139,6 +139,7 @@ AspenDiscovery.Events = (function(){
 				$("#endDate").val(startDate.format("YYYY-MM-DD"));
 				$("#endTime").val(startDate.format("HH:mm"));
 			}
+			AspenDiscovery.Events.calculateRecurrenceDates();
 			return false;
 		},
 

--- a/code/web/sys/DBMaintenance/version_updates/25.03.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.03.00.php
@@ -198,6 +198,13 @@ function getUpdates25_03_00(): array {
 				) ENGINE INNODB CHARACTER SET utf8 COLLATE utf8_general_ci",
 			]
 		], //event_calendar_display_settings
+		'add_event_column_week_number' => [
+			'title' => 'Add weekNumber column to Event table',
+			'description' => 'Add weekNumber column to Event table',
+			'sql' => [
+				"ALTER TABLE event ADD COLUMN weekNumber TINYINT DEFAULT 1"
+			]
+		], //add_event_column_week_number
 
 		//kirstien - Grove
 

--- a/code/web/sys/Events/Event.php
+++ b/code/web/sys/Events/Event.php
@@ -533,6 +533,7 @@ class Event extends DataObject {
 
 	public function update($context = '') {
 		$this->dateUpdated = time();
+		$this->setStartDate();
 		$ret = parent::update();
 		if ($ret !== FALSE) {
 			$this->saveLibraries();
@@ -547,6 +548,7 @@ class Event extends DataObject {
 		if (empty($this->dateUpdated)) {
 			$this->dateUpdated = time(); // Set to 0 for new events
 		}
+		$this->setStartDate();
 		$ret = parent::insert();
 		if ($ret !== FALSE) {
 			$this->saveLibraries();
@@ -617,6 +619,12 @@ class Event extends DataObject {
 			return $this->calculateEnd($name);
 		} else {
 			return parent::__get($name);
+		}
+	}
+
+	public function setStartDate() {
+		if ($this->recurrenceOption != 1 && isset($this->startDate) && isset($this->_dates[0]) && strtotime($this->startDate) != strtotime($this->_dates[0])) {
+			$this->startDate = $this->_dates[0];
 		}
 	}
 

--- a/code/web/sys/Events/Event.php
+++ b/code/web/sys/Events/Event.php
@@ -860,6 +860,7 @@ class Event extends DataObject {
 			$this->_datesPreview = '';
 			$instance = new EventInstance();
 			$instance->eventId = $this->id;
+			$instance->deleted = 0;
 			$instance->find();
 			while ($instance->fetch()) {
 				$date = strtotime($instance->date);

--- a/code/web/sys/Events/Event.php
+++ b/code/web/sys/Events/Event.php
@@ -534,6 +534,10 @@ class Event extends DataObject {
 	public function update($context = '') {
 		$this->dateUpdated = time();
 		$this->setStartDate();
+		if (isset($this->weekDays) && is_array($this->weekDays)) {
+			// convert the array to string before storing in the database
+			$this->weekDays = implode(",", $this->weekDays);
+		}
 		$ret = parent::update();
 		if ($ret !== FALSE) {
 			$this->saveLibraries();
@@ -549,6 +553,10 @@ class Event extends DataObject {
 			$this->dateUpdated = time(); // Set to 0 for new events
 		}
 		$this->setStartDate();
+		if (isset($this->weekDays) && is_array($this->weekDays)) {
+			// convert the array to string before storing in the database
+			$this->weekDays = implode( ",", $this->weekDays);
+		}
 		$ret = parent::insert();
 		if ($ret !== FALSE) {
 			$this->saveLibraries();
@@ -620,6 +628,23 @@ class Event extends DataObject {
 		} else {
 			return parent::__get($name);
 		}
+	}
+
+	public function fetch(): bool|DataObject|null {
+		$return = parent::fetch();
+		if ($return) {
+			if (!empty($this->weekDays) && is_string($this->weekDays) ) {
+				// convert to array retrieving from the database
+				$weekdays= [];
+				foreach (explode(",", $this->weekDays) as $weekDay) {
+					$weekdays[$weekDay] = $weekDay;
+				}
+				$this->weekDays = $weekdays;
+			} else {
+				$this->weekDays = [];
+			}
+		}
+		return $return;
 	}
 
 	public function setStartDate() {

--- a/code/web/sys/Events/Event.php
+++ b/code/web/sys/Events/Event.php
@@ -28,6 +28,7 @@ class Event extends DataObject {
 	public $recurrenceFrequency;
 	public $weekDays;
 	public $monthlyOption;
+	public $weekNumber;
 	public $monthDay;
 	public $monthDate;
 	public $monthOffset;

--- a/code/web/sys/Events/EventInstance.php
+++ b/code/web/sys/Events/EventInstance.php
@@ -83,7 +83,7 @@ class EventInstance extends DataObject {
 
 	public function update($context = '') {
 		$this->dateUpdated = time();
-		if (count($this->_changedFields) > 0) {
+		if (isset($htis->_changedFields) && count($this->_changedFields) > 0) {
 			$this->_changedFields[] = 'dateUpdated';
 		}
 		return parent::update();

--- a/code/web/sys/Events/EventInstance.php
+++ b/code/web/sys/Events/EventInstance.php
@@ -83,7 +83,7 @@ class EventInstance extends DataObject {
 
 	public function update($context = '') {
 		$this->dateUpdated = time();
-		if (isset($htis->_changedFields) && count($this->_changedFields) > 0) {
+		if (isset($this->_changedFields) && count($this->_changedFields) > 0) {
 			$this->_changedFields[] = 'dateUpdated';
 		}
 		return parent::update();


### PR DESCRIPTION
- Fixed problem where just changing the time or length of repeating events didn't update event instances
- Fixed problem with logic in clearFutureInstances() that was causing an error
- Fixed problem with weekly repeats where weekdays weren't getting saved because they needed to be converted from an array to a string.
- Fixed problem with monthly repeats where week number wasn't saved because it wasn't in the database.
- When saving a repeating event, the event start date will be updated to match the date of the first event.