### PR TITLE
DIS-192: QA Fixes for Aspen Events part 1

### DIFF
--- a/code/events_indexer/src/com/turning_leaf_technologies/events/AspenEvent.java
+++ b/code/events_indexer/src/com/turning_leaf_technologies/events/AspenEvent.java
@@ -228,7 +228,7 @@ class AspenEvent {
 		public String getValue() {
 			if (allowableValues.length > 0 && StringUtils.isNumeric(value)) {
 				try {
-					return allowableValues[Integer.parseInt(value)];
+					return allowableValues[Integer.parseInt(value)].trim();
 				}catch (ArrayIndexOutOfBoundsException e) {
 					//MDN 2/6/25 do additional handling and logging if we don't get a good value.
 					return "Unknown";

--- a/code/events_indexer/src/com/turning_leaf_technologies/events/AspenEventsIndexer.java
+++ b/code/events_indexer/src/com/turning_leaf_technologies/events/AspenEventsIndexer.java
@@ -108,7 +108,7 @@ public class AspenEventsIndexer {
 				eventFieldStmt.setLong(1, event.getParentEventId());
 				ResultSet eventFieldsRS = eventFieldStmt.executeQuery();
 				while (eventFieldsRS.next()) {
-					String[] allowableValues = eventFieldsRS.getString("allowableValues").split(", ");
+					String[] allowableValues = eventFieldsRS.getString("allowableValues").split("\n");
 					if (allowableValues[0].isEmpty()) {
 						allowableValues = new String[0];
 					}

--- a/code/web/interface/themes/responsive/Events/event-graph.tpl
+++ b/code/web/interface/themes/responsive/Events/event-graph.tpl
@@ -64,7 +64,7 @@
 					<label for="field_{$id}">{$select->name}: </label>
 					<select value="{$id}" id="field_{$id}" name="field_{$id}" class="form-control">
 						<option value="">No selection</option>
-						{foreach explode(",", $select->allowableValues) as $index => $option}
+						{foreach explode("\n", $select->allowableValues) as $index => $option}
 							<option {if array_key_exists("field_{$id}", $fields) && $fields["field_{$id}"] == $index}selected{/if} value="{$index}">{$option}</option>
 						{/foreach}
 					</select>

--- a/code/web/interface/themes/responsive/Events/event-graph.tpl
+++ b/code/web/interface/themes/responsive/Events/event-graph.tpl
@@ -30,7 +30,7 @@
 			<div class="form-group">
 				<label for="type">Location:</label>
 				<select name="location" id="location" class="form-control">
-					<option {if $locationValue == ''}selected{/if} value="">All Locations</option>
+					<option {if $locationValue == ''}selected{/if} value="">All Locations{$libraryRestriction}</option>
 					{foreach $locations as $id => $location}
 						<option {if $locationValue == $id}selected{/if} value="{$id}">{$location}</option>
 					{/foreach}

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -9645,7 +9645,7 @@ AspenDiscovery.Admin = (function () {
 			).fail(AspenDiscovery.ajaxFail);
 			return false;
 		},
-		/*showCopyEventsFacetGroupForm: function (id) {
+		showCopyEventsFacetGroupForm: function (id) {
 			var url = Globals.path + "/Admin/AJAX";
 			var params = {
 				method: 'getCopyEventsFacetGroupForm',
@@ -9681,7 +9681,7 @@ AspenDiscovery.Admin = (function () {
 				}
 			).fail(AspenDiscovery.ajaxFail);
 			return false;
-		},*/
+		},
 		showBatchDeleteForm: function (module, toolName, batchDeleteScope) {
 			var selectedObjects = $('.selectedObject:checked');
 			if (batchDeleteScope === 'all' || selectedObjects.length >= 1) {

--- a/code/web/interface/themes/responsive/js/aspen/admin.js
+++ b/code/web/interface/themes/responsive/js/aspen/admin.js
@@ -1161,7 +1161,7 @@ AspenDiscovery.Admin = (function () {
 			).fail(AspenDiscovery.ajaxFail);
 			return false;
 		},
-		/*showCopyEventsFacetGroupForm: function (id) {
+		showCopyEventsFacetGroupForm: function (id) {
 			var url = Globals.path + "/Admin/AJAX";
 			var params = {
 				method: 'getCopyEventsFacetGroupForm',
@@ -1197,7 +1197,7 @@ AspenDiscovery.Admin = (function () {
 				}
 			).fail(AspenDiscovery.ajaxFail);
 			return false;
-		},*/
+		},
 		showBatchDeleteForm: function (module, toolName, batchDeleteScope) {
 			var selectedObjects = $('.selectedObject:checked');
 			if (batchDeleteScope === 'all' || selectedObjects.length >= 1) {

--- a/code/web/release_notes/25.03.00.MD
+++ b/code/web/release_notes/25.03.00.MD
@@ -83,6 +83,8 @@
 - Use minutes instead of hours to set event length for Aspen Events. (*KP*) (DIS-192)
 - Users can export events in iCalendar format from both the search results page and the individual record page. (*KP*) (DIS-192)
 - Limit which private Aspen Events users can view, according to their permissions. (*KP*) (DIS-192)
+- Separate library events settings from library events facet settings so that different libraries can have different sets of facets (*KP*) (DIS-192)
+- Allow events facet groups to be copied. (*KP*) (DIS-192)
 
 <div markdown="1" class="settings">
 

--- a/code/web/services/Admin/AJAX.php
+++ b/code/web/services/Admin/AJAX.php
@@ -799,7 +799,7 @@ class Admin_AJAX extends JSON_Action {
 		}
 	}
     /** @noinspection PhpUnused */
-    /*function getCopyEventsFacetGroupForm() : array {
+    function getCopyEventsFacetGroupForm() : array {
         if (!empty($_REQUEST['facetGroupId'])) {
             global $interface;
             require_once ROOT_DIR . '/sys/Events/EventsFacetGroup.php';
@@ -843,10 +843,10 @@ class Admin_AJAX extends JSON_Action {
                 ])
             ];
         }
-    }*/
+    }
 
     /** @noinspection PhpUnused */
-    /*function doCopyEventsFacetGroup() : array {
+    function doCopyEventsFacetGroup() : array {
 
         if (!empty($_REQUEST['name'])) {
             $facetsProcessed = 0;
@@ -900,7 +900,7 @@ class Admin_AJAX extends JSON_Action {
                 'message' => "A name was not provided for the new facet group",
             ];
         }
-    }*/
+    }
 
 	/** @noinspection PhpUnused */
 	function getCopyDisplaySettingsForm() : array {

--- a/code/web/services/Events/EventGraphs.php
+++ b/code/web/services/Events/EventGraphs.php
@@ -260,7 +260,7 @@ class Events_EventGraphs extends Admin_Admin {
 					if ($fieldData[substr($key, -1)]->type == 2) {
 						$optionName = "true";
 					} else {
-						$values = explode(",", $fieldData[substr($key, -1)]->allowableValues);
+						$values = explode("\n", $fieldData[substr($key, -1)]->allowableValues);
 						$optionName = $values[$value];
 					}
 					$title .= $fieldData[substr($key, -1)]->name . ": " . $optionName . ", ";

--- a/code/web/services/Events/EventsFacets.php
+++ b/code/web/services/Events/EventsFacets.php
@@ -28,7 +28,7 @@ class Events_EventsFacets extends ObjectEditor {
 		$object->limit(($page - 1) * $recordsPerPage, $recordsPerPage);
 		$hasExistingObjects = true;
 		if (!UserAccount::userHasPermission('Administer Events Facet Settings')) {
-			$hasExistingObjects = $this->limitToObjectsForLibrary($object, 'LibraryEventsSetting', 'eventsFacetSettingsId');
+			$hasExistingObjects = $this->limitToObjectsForLibrary($object, 'LibraryEventsFacetSetting', 'eventsFacetGroupId');
 		}
 		$list = [];
 		if ($hasExistingObjects) {

--- a/code/web/services/Events/IndexingSettings.php
+++ b/code/web/services/Events/IndexingSettings.php
@@ -18,7 +18,7 @@ class Events_IndexingSettings extends ObjectEditor {
 	}
 
 	function getPageTitle(): string {
-		return 'Events Indexing Settings';
+		return 'Aspen Events Settings';
 	}
 
 	function getAllObjects($page, $recordsPerPage): array {

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -4605,7 +4605,7 @@ class User extends DataObject {
 					$aspenEventsAction->addSubAction(new AdminAction('Configure Event Fields', 'Define event fields for Aspen Events.', '/Events/EventFields'), 'Administer Field Sets');
 					$aspenEventsAction->addSubAction(new AdminAction('Configure Event Field Sets', 'Define sets of event fields to use for Aspen Events.', '/Events/EventFieldSets'), 'Administer Field Sets');
 					$aspenEventsAction->addSubAction(new AdminAction('Configure Event Types', 'Define event types to use for Aspen Events.', '/Events/EventTypes'), 'Administer Event Types');
-					$aspenEventsAction->addSubAction(new AdminAction('Indexing Settings', 'Aspen Events Indexing Settings.', '/Events/IndexingSettings'), 'Administer Events for All Locations');
+					$aspenEventsAction->addSubAction(new AdminAction('Aspen Events Settings', 'Aspen Events Settings including indexing and library scope.', '/Events/IndexingSettings'), 'Administer Events for All Locations');
 					$aspenEventsAction->addSubAction(new AdminAction('Event Reports', 'Aspen Events Reporting.', '/Events/EventGraphs'), [
 						'View Event Reports for All Libraries',
 						'View Event Reports for Home Library'

--- a/code/web/sys/DBMaintenance/version_updates/25.03.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.03.00.php
@@ -205,6 +205,18 @@ function getUpdates25_03_00(): array {
 				"ALTER TABLE event ADD COLUMN weekNumber TINYINT DEFAULT 1"
 			]
 		], //add_event_column_week_number
+		'separate_library_events_settings_and_library_events_facet_settings' => [
+			'title' => 'Separate library event settings from library event facet settings',
+			'description' => 'Create a separate table to store library event facet settings so that these can be controlled independently',
+			'sql' => [
+				"CREATE TABLE library_events_facet_setting (
+					id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+					libraryId INT NOT NULL,
+					eventsFacetGroupId INT NOT NULL
+				) ENGINE INNODB CHARACTER SET utf8 COLLATE utf8_general_ci",
+				"INSERT INTO library_events_facet_settings (libraryId, eventsFacetGroupId) SELECT DISTINCT libraryId, eventsFacetSettingsId FROM library_events_setting;"
+			]
+		], //separate_library_events_settings_and_library_events_facet_settings
 
 		//kirstien - Grove
 

--- a/code/web/sys/Events/Event.php
+++ b/code/web/sys/Events/Event.php
@@ -668,7 +668,8 @@ class Event extends DataObject {
 			'monthOffset',
 			'endOption',
 			'dateUpdated',
-			'sublocationId'
+			'sublocationId',
+			'weekNumber',
 		];
 	}
 

--- a/code/web/sys/Events/EventField.php
+++ b/code/web/sys/Events/EventField.php
@@ -49,9 +49,10 @@ class EventField extends DataObject {
 			],
 			'allowableValues' => [
 				'property' => 'allowableValues',
-				'type' => 'text',
+				'type' => 'textarea',
 				'label' => 'Allowable Values for Select Lists',
-				'description' => 'A comma-separated list of allowable values (only for select lists)',
+				'description' => 'A list of allowable values (only for select lists)',
+				'note' => 'Each value should be on a new line'
 			],
 			'defaultValue' => [
 				'property' => 'defaultValue',

--- a/code/web/sys/Events/EventFieldSet.php
+++ b/code/web/sys/Events/EventFieldSet.php
@@ -170,7 +170,7 @@ class EventFieldSet extends DataObject {
 					'facetName' => $field->facetName,
 				];
 				if ($type == 'enum') {
-					$structure[$field->id]['values'] = explode(",", $field->allowableValues);
+					$structure[$field->id]['values'] = explode("\n", $field->allowableValues);
 				}
 			}
 		}

--- a/code/web/sys/Events/EventsFacetGroup.php
+++ b/code/web/sys/Events/EventsFacetGroup.php
@@ -1,5 +1,6 @@
 <?php
 require_once ROOT_DIR . '/sys/Events/LibraryEventsSetting.php';
+require_once ROOT_DIR . '/sys/Events/LibraryEventsFacetSetting.php';
 require_once ROOT_DIR . '/sys/Events/EventsFacet.php';
 
 class EventsFacetGroup extends DataObject {
@@ -157,8 +158,8 @@ class EventsFacetGroup extends DataObject {
     public function getLibraries() {
         if (!isset($this->_libraries) && $this->id) {
             $this->_libraries = [];
-            $library = new LibraryEventsSetting();
-            $library->eventsFacetSettingsId = $this->id;
+            $library = new LibraryEventsFacetSetting();
+            $library->eventsFacetGroupId = $this->id;
             $library->find();
             while ($library->fetch()) {
                 $this->_libraries[$library->libraryId] = $library->libraryId;
@@ -168,11 +169,11 @@ class EventsFacetGroup extends DataObject {
     }
     private function clearLibraries() {
         //Delete links to the libraries
-        $libraryEventSetting = new LibraryEventsSetting();
-        $libraryEventSetting->eventsFacetSettingsId = $this->id;
+        $libraryEventSetting = new LibraryEventsFacetSetting();
+        $libraryEventSetting->eventsFacetGroupId = $this->id;
+		$libraryEventSetting->find();
         while ($libraryEventSetting->fetch()){
-            $libraryEventSetting->eventsFacetSettingsId = "0";
-            $libraryEventSetting->update();
+            $libraryEventSetting->delete();
         }
     }
     public function saveLibraries() {
@@ -180,27 +181,23 @@ class EventsFacetGroup extends DataObject {
             $this->clearLibraries();
 
             foreach ($this->_libraries as $libraryId) {
-                $libraryEventSetting = new LibraryEventsSetting();
+                $libraryEventSetting = new LibraryEventsFacetSetting();
                 $libraryEventSetting->libraryId = $libraryId;
-
-                while ($libraryEventSetting->fetch()){ //if there is no event setting for a library, that library won't save because there's nothing to update
-                    $libraryEventSetting->eventsFacetSettingsId = $this->id;
-                    $libraryEventSetting->update();
-                }
+				$libraryEventSetting->eventsFacetGroupId = $this->id;
+                $libraryEventSetting->update();
             }
             unset($this->_libraries);
         }
     }
 
 	function getAdditionalListJavascriptActions(): array {
-        /* Don't show copy facet button for now until saveLibraries is fixed */
-//		$objectActions[] = [
-//			'text' => 'Copy',
-//			'onClick' => "return AspenDiscovery.Admin.showCopyEventsFacetGroupForm('$this->id')",
-//			'icon' => 'fas fa-copy',
-//		];
-//
-//		return $objectActions;
-        return [];
+		$objectActions[] = [
+			'text' => 'Copy',
+			'onClick' => "return AspenDiscovery.Admin.showCopyEventsFacetGroupForm('$this->id')",
+			'icon' => 'fas fa-copy',
+		];
+
+		return $objectActions;
+//        return [];
 	}
 }

--- a/code/web/sys/Events/EventsIndexingSetting.php
+++ b/code/web/sys/Events/EventsIndexingSetting.php
@@ -4,9 +4,13 @@ class EventsIndexingSetting extends DataObject {
 	public $id;
 	public $runFullUpdate;
 	public $numberOfDaysToIndex;
+
+	private $_libraries;
 //	public $lastUpdateOfAllEvents;
 //	public $lastUpdateOfChangedEvents;
 	public static function getObjectStructure($context = ''): array {
+		$libraryList = Library::getLibraryList(!UserAccount::userHasPermission('Administer Events for All Locations'));
+
 		return [
 			'id' => [
 				'property' => 'id',
@@ -40,6 +44,103 @@ class EventsIndexingSetting extends DataObject {
 				'label' => 'Last Update Of Changed Events',
 				'readOnly' => 1,
 			],
+			'libraries' => [
+				'property' => 'libraries',
+				'type' => 'multiSelect',
+				'listStyle' => 'checkboxSimple',
+				'label' => 'Libraries',
+				'description' => 'Define libraries that use these settings',
+				'values' => $libraryList,
+				'hideInLists' => true,
+			],
 		];
+	}
+
+	/**
+	 * Override the update functionality to save related objects
+	 *
+	 * @see DB/DB_DataObject::update()
+	 */
+	public function update($context = '') {
+		$ret = parent::update();
+		if ($ret !== FALSE) {
+			$this->saveLibraries();
+		}
+		return $ret;
+	}
+
+	/**
+	 * Override the insert functionality to save the related objects
+	 *
+	 * @see DB/DB_DataObject::insert()
+	 */
+	public function insert($context = '') {
+		$ret = parent::insert();
+		if ($ret !== FALSE) {
+			$this->saveLibraries();
+		}
+		return $ret;
+	}
+
+	public function __get($name) {
+		if ($name == "libraries") {
+			return $this->getLibraries();
+		} else {
+			return parent::__get($name);
+		}
+	}
+
+	public function __set($name, $value) {
+		if ($name == "libraries") {
+			$this->_libraries = $value;
+		} else {
+			parent::__set($name, $value);
+		}
+	}
+
+	public function delete($useWhere = false) : int {
+		$ret = parent::delete($useWhere);
+		if ($ret && !empty($this->id)) {
+			$this->clearLibraries();
+		}
+		return $ret;
+	}
+
+	public function getLibraries() {
+		if (!isset($this->_libraries) && $this->id) {
+			$this->_libraries = [];
+			$library = new LibraryEventsSetting();
+			$library->settingSource = 'aspenEvents';
+			$library->settingId = $this->id;
+			$library->find();
+			while ($library->fetch()) {
+				$this->_libraries[$library->libraryId] = $library->libraryId;
+			}
+		}
+		return $this->_libraries;
+	}
+
+	public function saveLibraries() {
+		if (isset($this->_libraries) && is_array($this->_libraries)) {
+			$this->clearLibraries();
+
+			foreach ($this->_libraries as $libraryId) {
+				$libraryEventSetting = new LibraryEventsSetting();
+
+				$libraryEventSetting->settingSource = 'aspenEvents';
+				$libraryEventSetting->settingId = $this->id;
+				$libraryEventSetting->libraryId = $libraryId;
+				$libraryEventSetting->insert();
+			}
+			unset($this->_libraries);
+		}
+	}
+
+	private function clearLibraries() {
+		//Delete links to the libraries
+		$libraryEventSetting = new LibraryEventsSetting();
+		$libraryEventSetting->settingSource = 'assabet';
+		$libraryEventSetting->settingId = $this->id;
+		return $libraryEventSetting->delete(true);
 	}
 }

--- a/code/web/sys/Events/LibraryEventsFacetSetting.php
+++ b/code/web/sys/Events/LibraryEventsFacetSetting.php
@@ -1,0 +1,39 @@
+<?php
+require_once ROOT_DIR . '/sys/Events/EventsFacetGroup.php';
+
+class LibraryEventsFacetSetting extends DataObject {
+	public $__table = 'library_events_facet_setting';
+	public $id;
+	public $eventsFacetGroupId;
+	public $libraryId;
+
+	private $_facetGroup = false;
+
+	/** @return EventsFacet[] */
+	public function getFacets() {
+		try {
+			if (!is_null($this->getFacetGroup())) {
+				return $this->getFacetGroup()->getFacets();
+			} else {
+				return [];
+			}
+		} catch (Exception $e) {
+			return [];
+		}
+	}
+
+	public function getFacetGroup(): ?EventsFacetGroup {
+		try {
+			if ($this->_facetGroup === false) {
+				$this->_facetGroup = new EventsFacetGroup();
+				$this->_facetGroup->id = $this->eventsFacetGroupId;
+				if (!$this->_facetGroup->find(true)) {
+					$this->_facetGroup = null;
+				}
+			}
+			return $this->_facetGroup;
+		} catch (Exception $e) {
+			return null;
+		}
+	}
+}

--- a/code/web/sys/LibraryLocation/Library.php
+++ b/code/web/sys/LibraryLocation/Library.php
@@ -4989,11 +4989,11 @@ class Library extends DataObject {
 
 	protected $_eventFacetSettings = null;
 
-	public function getEventFacetSettings() : ?LibraryEventsSetting {
+	public function getEventFacetSettings() {
 		if ($this->_eventFacetSettings == null) {
 			try {
-				require_once ROOT_DIR . '/sys/Events/LibraryEventsSetting.php';
-				$eventsFacetSetting = new LibraryEventsSetting();
+				require_once ROOT_DIR . '/sys/Events/LibraryEventsFacetSetting.php';
+				$eventsFacetSetting = new LibraryEventsFacetSetting();
 				$eventsFacetSetting->libraryId = $this->libraryId;
 				if ($eventsFacetSetting->find(true)) {
 					$this->_eventFacetSettings = $eventsFacetSetting;

--- a/code/web/sys/Recommend/SideFacets.php
+++ b/code/web/sys/Recommend/SideFacets.php
@@ -97,37 +97,38 @@ class SideFacets implements RecommendationInterface {
 		$searchSource = $_REQUEST['searchSource'];
 		if ($searchSource == 'events') {
 			$facetSettings = $library->getEventFacetSettings();
+			if ($facetSettings) {
+				$interface->assign('facetCountsToShow', $facetSettings->getFacetGroup()->eventFacetCountsToShow);
 
-			$interface->assign('facetCountsToShow', $facetSettings->getFacetGroup()->eventFacetCountsToShow);
-
-			//if there are multiple integrations being used for one library, the first setting found will be used
-			if ($facetSettings->settingSource == 'communico'){
-				require_once ROOT_DIR . '/sys/Events/CommunicoSetting.php';
-				$eventSettings = new CommunicoSetting;
-				$eventSettings->id = $facetSettings->settingId;
-				if ($eventSettings->find(true)){
-					$interface->assign('maxEventDate', strtotime("+" . $eventSettings->numberOfDaysToIndex . " days"));
-				}
-			}else if ($facetSettings->settingSource == 'springshare'){
-				require_once ROOT_DIR . '/sys/Events/SpringshareLibCalSetting.php';
-				$eventSettings = new SpringshareLibCalSetting;
-				$eventSettings->id = $facetSettings->settingId;
-				if ($eventSettings->find(true)){
-					$interface->assign('maxEventDate', strtotime("+" . $eventSettings->numberOfDaysToIndex . " days"));
-				}
-			}else if ($facetSettings->settingSource == 'assabet'){
-				require_once ROOT_DIR . '/sys/Events/AssabetSetting.php';
-				$eventSettings = new AssabetSetting;
-				$eventSettings->id = $facetSettings->settingId;
-				if ($eventSettings->find(true)){
-					$interface->assign('maxEventDate', strtotime("+" . $eventSettings->numberOfDaysToIndex . " days"));
-				}
-			}else {
-				require_once ROOT_DIR . '/sys/Events/LMLibraryCalendarSetting.php';
-				$eventSettings = new LMLibraryCalendarSetting;
-				$eventSettings->id = $facetSettings->settingId;
-				if ($eventSettings->find(true)){
-					$interface->assign('maxEventDate', strtotime("+" . $eventSettings->numberOfDaysToIndex . " days"));
+				//if there are multiple integrations being used for one library, the first setting found will be used
+				if ($facetSettings->settingSource == 'communico') {
+					require_once ROOT_DIR . '/sys/Events/CommunicoSetting.php';
+					$eventSettings = new CommunicoSetting;
+					$eventSettings->id = $facetSettings->settingId;
+					if ($eventSettings->find(true)) {
+						$interface->assign('maxEventDate', strtotime("+" . $eventSettings->numberOfDaysToIndex . " days"));
+					}
+				} else if ($facetSettings->settingSource == 'springshare') {
+					require_once ROOT_DIR . '/sys/Events/SpringshareLibCalSetting.php';
+					$eventSettings = new SpringshareLibCalSetting;
+					$eventSettings->id = $facetSettings->settingId;
+					if ($eventSettings->find(true)) {
+						$interface->assign('maxEventDate', strtotime("+" . $eventSettings->numberOfDaysToIndex . " days"));
+					}
+				} else if ($facetSettings->settingSource == 'assabet') {
+					require_once ROOT_DIR . '/sys/Events/AssabetSetting.php';
+					$eventSettings = new AssabetSetting;
+					$eventSettings->id = $facetSettings->settingId;
+					if ($eventSettings->find(true)) {
+						$interface->assign('maxEventDate', strtotime("+" . $eventSettings->numberOfDaysToIndex . " days"));
+					}
+				} else {
+					require_once ROOT_DIR . '/sys/Events/LMLibraryCalendarSetting.php';
+					$eventSettings = new LMLibraryCalendarSetting;
+					$eventSettings->id = $facetSettings->settingId;
+					if ($eventSettings->find(true)) {
+						$interface->assign('maxEventDate', strtotime("+" . $eventSettings->numberOfDaysToIndex . " days"));
+					}
 				}
 			}
 		} else {


### PR DESCRIPTION
- Fixed permissions problem with event reports that wasn't limiting All Locations to be All Locations at their home library
- Added weekNumber to numeric columns so that it would not prevent creating new events by being empty.
- Separated library events facet settings and from library events settings.  This allows each library to have a different set of events facets independent from which event platform they are using.  
  - Also allows creating new sets of facets and copying them.
  - I didn't remove the old facet settings from the library events setting table out of an abundance of caution to make sure no data gets lost, but I'm pretty sure it could be removed.
- Added libraries field to Indexing Settings and changed the name to Aspen Event Settings.  This only determines whether or not the Events search is available for each library.  Indexing scope is still dependent on Event Type.  Further changes are needed here, but this fixes a problem where you could not search for events without manually adding settings to the database or turning on another events platform.
- Changed delimiter for event_field allowableValues from comma to newline.  This will allow values with commas and also fix an indexing problem that was preventing values from being parsed correctly.
  - Existing fields need to be updated to replace commas with line breaks.