### PR TITLE
DIS-502: Fixed Null Type Error When Placing Volume Holds

### DIFF
--- a/code/web/RecordDrivers/MarcRecordDriver.php
+++ b/code/web/RecordDrivers/MarcRecordDriver.php
@@ -1241,13 +1241,13 @@ class MarcRecordDriver extends GroupedWorkSubDriver {
 	}
 
 	/**
-	 * @param array $items - The items to check
+	 * @param ?array $items - The items to check
 	 * @param HoldGroup[] $holdGroups - The valid hold groups for the patron's hold groups
 	 * @param int|string $variationId - The variation being loaded
 	 * @param string $patronHomeLocationCode - The location code for the patron's home location
 	 * @return bool
 	 */
-	public function oneOrMoreHoldableItemsOwnedByPatronHoldGroups(array $items, array $holdGroups, int|string $variationId, string $patronHomeLocationCode) : bool {
+	public function oneOrMoreHoldableItemsOwnedByPatronHoldGroups(?array $items, array $holdGroups, int|string $variationId, string $patronHomeLocationCode) : bool {
 		//If no hold groups exist, everything is valid
 		if (count($holdGroups) == 0) {
 			return true;

--- a/code/web/release_notes/25.03.00.MD
+++ b/code/web/release_notes/25.03.00.MD
@@ -217,6 +217,7 @@
 - Remove redundant code in `getInnReachResults` method (DIS-395) (*TC*)
 - Add logging to INN-Reach contents fetching (DIS-397) (*TC*)
 - Add Null Check for OverDrive getSubjects (DIS-473) (*YL*)
+- Added nullable type hint to `?array $items` parameter for `MarcRecordDriver::oneOrMoreHoldableItemsOwnedByPatronHoldGroups()`. (DIS-502) (*LS*)
 
 ## This release includes code contributions from
 ### ByWater Solutions


### PR DESCRIPTION
- Added nullable type hint to `?array $items` parameter for `MarcRecordDriver::oneOrMoreHoldableItemsOwnedByPatronHoldGroups()`. (DIS-502) (*LS*)