### PR TITLE
DIS-51: Fix Milestone Reward Status

### DIFF
--- a/code/web/services/CommunityEngagement/AJAX.php
+++ b/code/web/services/CommunityEngagement/AJAX.php
@@ -33,11 +33,12 @@ class CommunityEngagement_AJAX extends JSON_Action {
 		try {
 			$userId = $_GET['userId'];
 			$milestoneId = $_GET['milestoneId'];
+			$campaignId = $_GET['campaignId'];
 
 			$campaignMilestoneProgress = new CampaignMilestoneUsersProgress();
-			#TODO: Add a campaignId check
 			$campaignMilestoneProgress->userId = $userId;
 			$campaignMilestoneProgress->ce_milestone_id = $milestoneId;
+			$campaignMilestoneProgress->ce_campaign_id = $campaignId;
 
 			if ($campaignMilestoneProgress->find(true)) {
 				$campaignMilestoneProgress->rewardGiven = 1;

--- a/code/web/services/CommunityEngagement/AdminView.php
+++ b/code/web/services/CommunityEngagement/AdminView.php
@@ -62,7 +62,7 @@ class CommunityEngagement_AdminView extends Admin_Dashboard {
 					$milestoneComplete = $milestoneCompletionStatus[$milestone->id] ?? false;
 					$userProgress = CampaignMilestoneUsersProgress::getProgressByMilestoneId($milestone->id, $campaign->id, $user->id);
 					$totalGoals = CampaignMilestone::getMilestoneGoalCountByCampaign($campaign->id, $milestone->id);
-					$milestoneRewardGiven = CampaignMilestoneUsersProgress::getRewardGivenForMilestone($milestone->id, $user->id);
+					$milestoneRewardGiven = CampaignMilestoneUsersProgress::getRewardGivenForMilestone($milestone->id, $user->id, $campaign->id);
 					$userCampaigns[$campaign->id][$user->id]['milestones'][$milestone->id] = [
 						'milestoneComplete' => $milestoneComplete, 
 						'userProgress' => $userProgress,

--- a/code/web/services/CommunityEngagement/CampaignTable.php
+++ b/code/web/services/CommunityEngagement/CampaignTable.php
@@ -46,7 +46,7 @@ class CommunityEngagement_CampaignTable extends Admin_Dashboard {
 							$milestoneComplete = $milestoneCompletionStatus[$milestone->id] ?? false;
 							$userProgress = CampaignMilestoneUsersProgress::getProgressByMilestoneId($milestone->id, $campaignId, $user->id);
 							$totalGoals = CampaignMilestone::getMilestoneGoalCountByCampaign($campaignId, $milestone->id);
-							$milestoneRewardGiven = CampaignMilestoneUsersProgress::getRewardGivenForMilestone($milestone->id, $user->id);
+							$milestoneRewardGiven = CampaignMilestoneUsersProgress::getRewardGivenForMilestone($milestone->id, $user->id, $campaignId);
 
 							//Calculate percentage progress
 							$percentageProgress = $totalGoals > 0 ? ($userProgress / $totalGoals) * 100 : 0;

--- a/code/web/sys/CommunityEngagement/Campaign.php
+++ b/code/web/sys/CommunityEngagement/Campaign.php
@@ -578,7 +578,7 @@ class Campaign extends DataObject {
 							$milestoneProgress = CampaignMilestone::getMilestoneProgress($campaign->id, $userId, $milestone->id);
 							$milestone->userProgress = CampaignMilestoneUsersProgress::getProgressByMilestoneId($milestone->id, $campaign->id, $userId);
 							$milestone->isComplete = $milestoneCompletionStatus[$milestone->id] ?? false;
-							$milestone->rewardGiven = CampaignMilestoneUsersProgress::getRewardGivenForMilestone($milestone->id, $userId);
+							$milestone->rewardGiven = CampaignMilestoneUsersProgress::getRewardGivenForMilestone($milestone->id, $userId, $campaign->id);
 							$milestone->progress = $milestoneProgress['progress'];
 						}
 					}

--- a/code/web/sys/CommunityEngagement/CampaignMilestoneUsersProgress.php
+++ b/code/web/sys/CommunityEngagement/CampaignMilestoneUsersProgress.php
@@ -20,10 +20,11 @@ class CampaignMilestoneUsersProgress extends DataObject
 		return $milestoneProgress->progress ? $milestoneProgress->progress : 0;
 	}
 
-	public static function getRewardGivenForMilestone($milestoneId, $userId) {
+	public static function getRewardGivenForMilestone($milestoneId, $userId, $campaignId) {
 		$progress = new CampaignMilestoneUsersProgress();
 		$progress->ce_milestone_id = $milestoneId;
 		$progress->userId = $userId;
+		$progress->ce_campaign_id = $campaignId;
 
 		if ($progress->find(true)) {
 			return $progress->rewardGiven;


### PR DESCRIPTION
This fix ensures that the milestone reward status is only updated for the milestone scope to the particular campaign. 