### PR TITLE
DIS-336 : Updates to Aspen Web Resources - QA Updates

### DIFF
--- a/code/web/services/WebBuilder/CustomWebResourcePage.php
+++ b/code/web/services/WebBuilder/CustomWebResourcePage.php
@@ -38,6 +38,7 @@ class WebBuilder_CustomWebResourcePage extends Action {
 	function launch() {
 		global $interface;
 		global $activeLanguage;
+		global $library;
 
 		require_once ROOT_DIR . '/sys/WebBuilder/CustomWebResourcePageAudience.php';
 		require_once ROOT_DIR . '/sys/WebBuilder/CustomWebResourcePageCategory.php';
@@ -79,8 +80,13 @@ class WebBuilder_CustomWebResourcePage extends Action {
 					$resourcesForAudience->audienceId = $audienceId;
 					$resourcesForAudience->find();
 					while ($resourcesForAudience->fetch()) {
-						if (!array_key_exists("WebResource:" . $resourcesForAudience->webResourceId, $audienceWebResourceIds)) {
-							$audienceWebResourceIds["\"WebResource:" . $resourcesForAudience->webResourceId . "\""] = "WebResource:" . $resourcesForAudience->webResourceId;
+						$webResourceLibrary = new libraryWebResource();
+						$webResourceLibrary->webResourceId = $resourcesForAudience->webResourceId;
+						$webResourceLibrary->libraryId = $library->libraryId;
+						if ($webResourceLibrary->find()) {
+							if (!array_key_exists("WebResource:" . $resourcesForAudience->webResourceId, $audienceWebResourceIds)) {
+								$audienceWebResourceIds["\"WebResource:" . $resourcesForAudience->webResourceId . "\""] = "WebResource:" . $resourcesForAudience->webResourceId;
+							}
 						}
 					}
 				}
@@ -91,8 +97,13 @@ class WebBuilder_CustomWebResourcePage extends Action {
 					$resourcesForCategory->categoryId = $categoryId;
 					$resourcesForCategory->find();
 					while ($resourcesForCategory->fetch()) {
-						if (!array_key_exists("WebResource:" . $resourcesForCategory->webResourceId, $categoryWebResourceIds)) {
-							$categoryWebResourceIds["\"WebResource:" . $resourcesForCategory->webResourceId . "\""] = "WebResource:" . $resourcesForCategory->webResourceId;
+						$webResourceLibrary = new libraryWebResource();
+						$webResourceLibrary->webResourceId = $resourcesForCategory->webResourceId;
+						$webResourceLibrary->libraryId = $library->libraryId;
+						if ($webResourceLibrary->find()) {
+							if (!array_key_exists("WebResource:" . $resourcesForCategory->webResourceId, $categoryWebResourceIds)) {
+								$categoryWebResourceIds["\"WebResource:" . $resourcesForCategory->webResourceId . "\""] = "WebResource:" . $resourcesForCategory->webResourceId;
+							}
 						}
 					}
 				}

--- a/code/web/services/WebBuilder/CustomWebResourcePages.php
+++ b/code/web/services/WebBuilder/CustomWebResourcePages.php
@@ -26,7 +26,7 @@ class WebBuilder_CustomWebResourcePages extends ObjectEditor {
 		$object->limit(($page - 1) * $recordsPerPage, $recordsPerPage);
 		$userHasExistingObjects = true;
 		if (!UserAccount::userHasPermission('Administer All Custom Web Resource Pages')) {
-			$userHasExistingObjects = $this->limitToObjectsForLibrary($object, 'LibraryCustomWebResourcePage', 'customWebResourcePageId');
+			$userHasExistingObjects = $this->limitToObjectsForLibrary($object, 'LibraryCustomWebResourcePage', 'customResourcePageId');
 		}
 		$objectList = [];
 		if ($userHasExistingObjects) {

--- a/code/web/services/WebBuilder/WebResourceSettings.php
+++ b/code/web/services/WebBuilder/WebResourceSettings.php
@@ -25,9 +25,6 @@ class WebBuilder_WebResourceSettings extends ObjectEditor {
 		$this->applyFilters($object);
 		$object->limit(($page - 1) * $recordsPerPage, $recordsPerPage);
 		$userHasExistingObjects = true;
-		if (!UserAccount::userHasPermission('Administer All Web Resources')) {
-			$userHasExistingObjects = $this->limitToObjectsForLibrary($object, 'LibraryWebResource', 'webResourceId');
-		}
 		$objectList = [];
 		if ($userHasExistingObjects) {
 			$object->find();
@@ -73,7 +70,6 @@ class WebBuilder_WebResourceSettings extends ObjectEditor {
 	function canView(): bool {
 		return UserAccount::userHasPermission([
 			'Administer All Web Resources',
-			'Administer Library Web Resources',
 		]);
 	}
 

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -4184,7 +4184,6 @@ class User extends DataObject {
 			]);
 			$sections['web_builder']->addAction(new AdminAction('Web Resource Settings', 'Settings for Web Resources including which custom pages get indexed.', '/WebBuilder/WebResourceSettings'), [
 				'Administer All Web Resources',
-				'Administer Library Web Resources',
 			]);
 			$sections['web_builder']->addAction(new AdminAction('Custom Web Resource Pages', 'Create custom web resource pages to display web resources belonging to specific categories and audiences.', '/WebBuilder/CustomWebResourcePages'), [
 				'Administer All Custom Web Resource Pages',

--- a/code/web/sys/DBMaintenance/version_updates/25.03.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.03.00.php
@@ -398,6 +398,13 @@ function getUpdates25_03_00(): array {
 				"ALTER TABLE web_builder_resource ADD COLUMN generatePlacard TINYINT(1) DEFAULT 0",
 			],
 		], //web_resource_generate_placard
+		'alter_web_builder_custom_web_resource_page_table' => [
+			'title' => 'Alter Custom Web Resource Page Table',
+			'description' => 'Remove addToIndex column - this is handled in the web_builder_web_resources_to_index table.',
+			'sql' => [
+				"ALTER TABLE web_builder_custom_web_resource_page DROP COLUMN addToIndex",
+			],
+		], //alter_web_builder_custom_web_resource_page_table
 
 		// Leo Stoyanov - BWS
 		'use_original_cover_urls_settings' => [

--- a/code/web/sys/WebBuilder/CustomWebResourcePage.php
+++ b/code/web/sys/WebBuilder/CustomWebResourcePage.php
@@ -12,7 +12,6 @@ class CustomWebResourcePage extends DB_LibraryLinkedObject {
 	public $id;
 	public $title;
 	public $urlAlias;
-	public $addToIndex;
 	public $requireLogin;
 	public $requireLoginUnlessInLibrary;
 	public $lastUpdate;
@@ -60,13 +59,6 @@ class CustomWebResourcePage extends DB_LibraryLinkedObject {
 				'description' => 'The url of the page (no domain name)',
 				'size' => '40',
 				'maxLength' => 100,
-			],
-			'addToIndex' => [
-				'property' => 'addToIndex',
-				'type' => 'checkbox',
-				'label' => 'Add to Website Index',
-				'description' => 'Adds resource page to indexed websites',
-				'default' => 0,
 			],
 			'customWebResourceDescription' => [
 				'property' => 'customWebResourceDescription',

--- a/code/web/sys/WebBuilder/WebResourcesSetting.php
+++ b/code/web/sys/WebBuilder/WebResourcesSetting.php
@@ -8,7 +8,6 @@ class WebResourcesSetting extends DataObject
 	public $__table = 'web_builder_web_resources_settings';    // table name
 	public $id;
 	public $name;
-	public $webResourceSettingId;
 	public $indexAtoZ;
 
 	private $_libraries;


### PR DESCRIPTION
Fix issue when viewing Custom Web Resource Pages list without the "Administer All Custom Web Resource Pages"
Limit Web Resource Settings page access to those with the "Administer All Web Resources" permission
Remove "Add To Index" checkbox for object edit pages for Custom Web Resource Pages - this functionality is tied to Web Resource Settings only for now
Only show web resources for the active library on custom web resource pages