### PR TITLE
DIS-287 Debian PHP Installation / Upgrade via Scheduled Update

### DIFF
--- a/code/web/cron/runScheduledUpdate.php
+++ b/code/web/cron/runScheduledUpdate.php
@@ -59,7 +59,7 @@ if (count($updatesToRun) == 0) {
 					//Prepare the system to be updated
 					if ($operatingSystem == 'linux' && $scheduledUpdate->updateType === 'complete') {
 						if ($linuxDistribution == 'debian') {
-							executeCommand('Stopping cron', 'cron stop', $scheduledUpdate);
+							executeCommand('Stopping cron', '/usr/bin/systemctl stop cron', $scheduledUpdate);
 						} else {
 							executeCommand('Stopping cron', '/usr/sbin/service crond stop', $scheduledUpdate);
 							executeCommand('Running system updates', 'yum -y update', $scheduledUpdate);
@@ -115,7 +115,7 @@ if (count($updatesToRun) == 0) {
 						sleep(2);
 						//Start cron
 						if ($linuxDistribution == 'debian') {
-							executeCommand('Starting cron', '/usr/sbin/service cron start', $scheduledUpdate);
+							executeCommand('Starting cron', '/usr/bin/systemctl start cron', $scheduledUpdate);
 						} else {
 							executeCommand('Starting cron', '/usr/sbin/service crond start', $scheduledUpdate);
 						}

--- a/install/debian_install_php.sh
+++ b/install/debian_install_php.sh
@@ -18,15 +18,23 @@ if ! [ -s "$keyrings/sury.gpg" ] || ! [ -s /etc/apt/sources.list.d/sury.list ]; 
   echo "deb [signed-by=$keyrings/sury.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" >/etc/apt/sources.list.d/sury.list
 fi
 
+# disable older version of php apache module if present
+# will be empty on new installs
+curr_php=$(/usr/sbin/a2query -m | grep -Eo php...)
+curr_php=${curr_php#php}
+
+if [ -n "$curr_php" ] && [ "$curr_php" != "$php_vers" ]; then
+	/usr/sbin/a2dismod "php${curr_php}"
+fi
+
 # install new package versions
 apt-get update -q
-apt-get install -y -q "libapache2-mod-php${php_vers}" "php${php_vers}" "php${php_vers}-mcrypt" "php${php_vers}-gd" "php${php_vers}-imagick" "php${php_vers}-curl" "php${php_vers}-mysql" "php${php_vers}-zip" "php${php_vers}-xml" "php${php_vers}-intl" "php${php_vers}-mbstring" "php${php_vers}-soap" "php${php_vers}-pgsql" "php${php_vers}-ssh2" "php${php_vers}-ldap"
+DEBIAN_FRONTEND=noninteractive apt-get install -y -q "libapache2-mod-php${php_vers}" "php${php_vers}" "php${php_vers}-mcrypt" "php${php_vers}-gd" "php${php_vers}-imagick" "php${php_vers}-curl" "php${php_vers}-mysql" "php${php_vers}-zip" "php${php_vers}-xml" "php${php_vers}-intl" "php${php_vers}-mbstring" "php${php_vers}-soap" "php${php_vers}-pgsql" "php${php_vers}-ssh2" "php${php_vers}-ldap"
 
 # Make sure the active apache module has the correct settings
 cp php.ini "/etc/php/$php_vers/apache2/"
 
 # and turn it on
-rm /etc/apache2/mods-enabled/php*
-a2enmod "php${php_vers}"
+/usr/sbin/a2enmod "php${php_vers}"
 systemctl restart apache2
 


### PR DESCRIPTION
Differences in PATH when manually running an upgrade vs default cron path require changes to debian_install_php.sh to operate in either situation. Also use systemctl in runScheduledUpdates.php to properly stop / start cron on Debian systems.