### PR TITLE
DIS-353: Sort Serials with the newest issue copy first in search results and in the place hold modal

### DIFF
--- a/code/web/RecordDrivers/MarcRecordDriver.php
+++ b/code/web/RecordDrivers/MarcRecordDriver.php
@@ -1624,25 +1624,7 @@ class MarcRecordDriver extends GroupedWorkSubDriver {
 		}
 
 		//If this is a periodical we may have additional information
-		$isPeriodical = false;
-		require_once ROOT_DIR . '/sys/Indexing/FormatMapValue.php';
-		foreach ($this->getFormats() as $format) {
-			if ($ils == 'sierra' || $ils == 'millennium') {
-				$formatValue = new FormatMapValue();
-				$formatValue->format = $format;
-				$formatValue->displaySierraCheckoutGrid = 1;
-				if ($formatValue->find(true)) {
-					$isPeriodical = true;
-					break;
-				}
-			}else{
-				if ($format == 'Journal' || $format == 'Newspaper' || $format == 'Print Periodical' || $format == 'Magazine') {
-					$isPeriodical = true;
-					break;
-				}
-			}
-		}
-		if ($isPeriodical) {
+		if ($this->isPeriodical()) {
 			global $library;
 			$interface->assign('showCheckInGrid', $library->getGroupedWorkDisplaySettings()->showCheckInGrid);
 			$issues = $this->loadPeriodicalInformation();
@@ -2395,6 +2377,34 @@ class MarcRecordDriver extends GroupedWorkSubDriver {
 	public function getCopies() {
 		$this->loadCopies();
 		return $this->holdings;
+	}
+
+	public function isPeriodical() {
+		$ils = 'Unknown';
+		if ($this->getIndexingProfile()->getAccountProfile() != null) {
+			$ils = $this->getIndexingProfile()->getAccountProfile()->ils;
+
+		}
+		//If this is a periodical we may have additional information
+		$isPeriodical = false;
+		require_once ROOT_DIR . '/sys/Indexing/FormatMapValue.php';
+		foreach ($this->getFormats() as $format) {
+			if ($ils == 'sierra' || $ils == 'millennium') {
+				$formatValue = new FormatMapValue();
+				$formatValue->format = $format;
+				$formatValue->displaySierraCheckoutGrid = 1;
+				if ($formatValue->find(true)) {
+					$isPeriodical = true;
+					break;
+				}
+			}else{
+				if ($format == 'Journal' || $format == 'Newspaper' || $format == 'Print Periodical' || $format == 'Magazine') {
+					$isPeriodical = true;
+					break;
+				}
+			}
+		}
+		return $isPeriodical;
 	}
 
 	public function loadPeriodicalInformation() {

--- a/code/web/release_notes/25.04.00.MD
+++ b/code/web/release_notes/25.04.00.MD
@@ -25,6 +25,8 @@
 //katherine
 
 //kodi
+### Serials Display Updates
+- Sort serials with the newest issue copy first in search results and the place hold modal. (DIS-353) (*KL*)
 
 //alexander
 

--- a/code/web/services/Record/AJAX.php
+++ b/code/web/services/Record/AJAX.php
@@ -426,7 +426,21 @@ class Record_AJAX extends Action {
 
 			//Figure out what types of holds to allow
 			$items = $marcRecord->getCopies();
-			array_multisort(array_column($items, 'description'), SORT_NATURAL, $items);
+			//sort things alphabetically and newest first for periodicals/serials
+			if ($marcRecord->isPeriodical()){
+				$sorter = function ($a, $b){
+					if ($a['shelfLocation'] == $b['shelfLocation']) {
+						if ($a['callNumber'] == $b['callNumber']) {
+							return 0;
+						}
+						return strnatcasecmp($b['callNumber'], $a['callNumber']);
+					}
+					return strnatcasecmp($a['shelfLocation'], $b['shelfLocation']);
+				};
+				uasort($items, $sorter);
+			} else {
+				array_multisort(array_column($items, 'description'), SORT_NATURAL, $items);
+			}
 			$relatedRecord = $marcRecord->getGroupedWorkDriver()->getRelatedRecord($marcRecord->getIdWithSource());
 			if (count($relatedRecord->recordVariations) > 1) {
 				foreach ($relatedRecord->recordVariations as $variation) {

--- a/code/web/sys/Grouping/Record.php
+++ b/code/web/sys/Grouping/Record.php
@@ -472,7 +472,41 @@ class Grouping_Record {
 	}
 
 	public function sortItemSummary($variationId): void {
-		ksort($this->_itemSummary[$variationId], SORT_NATURAL);
+		global $library;
+		$ils = 'Unknown';
+		if ($library->getAccountProfile() != null) {
+			$ils = $library->getAccountProfile()->ils;
+
+		}
+		$isPeriodical = false;
+		$format = $this->format;
+		require_once ROOT_DIR . '/sys/Indexing/FormatMapValue.php';
+		if ($ils == 'sierra' || $ils == 'millennium') {
+			$formatValue = new FormatMapValue();
+			$formatValue->format = $format;
+			$formatValue->displaySierraCheckoutGrid = 1;
+			if ($formatValue->find(true)) {
+				$isPeriodical = true;
+			}
+		} else {
+			if ($format == 'Journal' || $format == 'Newspaper' || $format == 'Print Periodical' || $format == 'Magazine') {
+				$isPeriodical = true;
+			}
+		}
+		if ($isPeriodical) {
+			$sorter = function ($a, $b){
+				if ($a['shelfLocation'] == $b['shelfLocation']) {
+					if ($a['callNumber'] == $b['callNumber']) {
+						return 0;
+					}
+					return strnatcasecmp($b['callNumber'], $a['callNumber']);
+				}
+				return strnatcasecmp($a['shelfLocation'], $b['shelfLocation']);
+			};
+			uasort($this->_itemSummary[$variationId], $sorter);
+		} else {
+			ksort($this->_itemSummary[$variationId], SORT_NATURAL);
+		}
 	}
 
 	/**


### PR DESCRIPTION
- Split out isPeriodical determination to its own function in MarcRecordDriver.php and in Manifestation.php 
- Update sorting  functionality in Record.php, Manifestation.php, and Record\AJAX.php to do a custom uasort for periodicals (custom sort will sort things alphabetically, while showing the most recently released items first, according to their call number)

- Update release notes

Tested on my local instance of Aspen