### PR TITLE
DIS-353: Sort Serials with the newest issue copy first in search results and in the place hold modal

### DIFF
--- a/code/web/Drivers/Sierra.php
+++ b/code/web/Drivers/Sierra.php
@@ -1161,6 +1161,16 @@ class Sierra extends Millennium {
 						'status' => $status,
 					];
 				}
+				$sorter = function ($a, $b){
+					if ($a['shelfLocation'] == $b['shelfLocation']) {
+						if ($a['callNumber'] == $b['callNumber']) {
+							return 0;
+						}
+						return strnatcasecmp($b['callNumber'], $a['callNumber']);
+					}
+					return strnatcasecmp($a['shelfLocation'], $b['shelfLocation']);
+				};
+				uasort($items, $sorter);
 				$hold_result['items'] = $items;
 			}
 		}

--- a/code/web/Drivers/Sierra.php
+++ b/code/web/Drivers/Sierra.php
@@ -1162,13 +1162,13 @@ class Sierra extends Millennium {
 					];
 				}
 				$sorter = function ($a, $b){
-					if ($a['shelfLocation'] == $b['shelfLocation']) {
+					if ($a['location'] == $b['location']) {
 						if ($a['callNumber'] == $b['callNumber']) {
 							return 0;
 						}
 						return strnatcasecmp($b['callNumber'], $a['callNumber']);
 					}
-					return strnatcasecmp($a['shelfLocation'], $b['shelfLocation']);
+					return strnatcasecmp($a['location'], $b['location']);
 				};
 				uasort($items, $sorter);
 				$hold_result['items'] = $items;


### PR DESCRIPTION
Fix issue where Sierra item level holds were not being sorted properly

Tested on my local instance of Aspen