### PR TITLE
DIS-558: Fixed Translation Mode for Reset Pin Buttons

### DIFF
--- a/code/web/interface/themes/responsive/MyAccount/aspenEmailResetPinLink.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/aspenEmailResetPinLink.tpl
@@ -13,7 +13,9 @@
 			</div>
 			<div class="form-group">
 				<div class="col-xs-12 col-sm-offset-4 col-sm-8">
-					<input id="emailPinSubmit" name="submit" class="btn btn-primary" type="submit" value="{translate text='Reset My PIN' isPublicFacing=true inAttribute=true}">
+					<button type="submit" id="emailPinSubmit" name="submit" class="btn btn-primary">
+						{translate text="Reset My PIN" isPublicFacing=true}
+					</button>
 				</div>
 			</div>
 		</form>

--- a/code/web/interface/themes/responsive/MyAccount/aspenEmailResetPinLink.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/aspenEmailResetPinLink.tpl
@@ -13,7 +13,7 @@
 			</div>
 			<div class="form-group">
 				<div class="col-xs-12 col-sm-offset-4 col-sm-8">
-					<input id="emailPinSubmit" name="submit" class="btn btn-primary" type="submit" value="{translate text='Reset My PIN' isPublicFacing=true}">
+					<input id="emailPinSubmit" name="submit" class="btn btn-primary" type="submit" value="{translate text='Reset My PIN' isPublicFacing=true inAttribute=true}">
 				</div>
 			</div>
 		</form>

--- a/code/web/interface/themes/responsive/MyAccount/evergreenEmailResetPinLink.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/evergreenEmailResetPinLink.tpl
@@ -22,7 +22,9 @@
 			</div>
 			<div class="form-group">
 				<div class="col-xs-12 col-sm-offset-4 col-sm-8">
-					<input id="emailPinSubmit" name="submit" class="btn btn-primary" type="submit" value="{translate text='Reset My PIN' isPublicFacing=true inAttribute=true}">
+					<button type="submit" id="emailPinSubmit" name="submit" class="btn btn-primary">
+						{translate text="Reset My PIN" isPublicFacing=true}
+					</button>
 					{if !empty($resendEmail)}
 						<input type="hidden" name="resendEmail" value="true">
 					{/if}

--- a/code/web/interface/themes/responsive/MyAccount/evergreenEmailResetPinLink.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/evergreenEmailResetPinLink.tpl
@@ -22,7 +22,7 @@
 			</div>
 			<div class="form-group">
 				<div class="col-xs-12 col-sm-offset-4 col-sm-8">
-					<input id="emailPinSubmit" name="submit" class="btn btn-primary" type="submit" value="{translate text='Reset My PIN' isPublicFacing=true}">
+					<input id="emailPinSubmit" name="submit" class="btn btn-primary" type="submit" value="{translate text='Reset My PIN' isPublicFacing=true inAttribute=true}">
 					{if !empty($resendEmail)}
 						<input type="hidden" name="resendEmail" value="true">
 					{/if}

--- a/code/web/interface/themes/responsive/MyAccount/kohaEmailResetPinLink.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/kohaEmailResetPinLink.tpl
@@ -22,8 +22,8 @@
 			</div>
 			<div class="form-group">
 				<div class="col-xs-12 col-sm-offset-4 col-sm-8">
-					<button id="emailPinSubmit" type="submit" name="submit" class="btn btn-primary">
-							{translate text='Reset My PIN' isPublicFacing=true}
+					<button type="submit" id="emailPinSubmit" name="submit" class="btn btn-primary">
+						{translate text="Reset My PIN" isPublicFacing=true}
 					</button>
 					{if !empty($resendEmail)}
 						<input type="hidden" name="resendEmail" value="true">

--- a/code/web/interface/themes/responsive/MyAccount/kohaEmailResetPinLink.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/kohaEmailResetPinLink.tpl
@@ -22,7 +22,9 @@
 			</div>
 			<div class="form-group">
 				<div class="col-xs-12 col-sm-offset-4 col-sm-8">
-					<input id="emailPinSubmit" name="submit" class="btn btn-primary" type="submit" value="{translate text='Reset My PIN' isPublicFacing=true}">
+					<button id="emailPinSubmit" type="submit" name="submit" class="btn btn-primary">
+							{translate text='Reset My PIN' isPublicFacing=true}
+					</button>
 					{if !empty($resendEmail)}
 						<input type="hidden" name="resendEmail" value="true">
 					{/if}

--- a/code/web/interface/themes/responsive/MyAccount/resetExpiredPin.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/resetExpiredPin.tpl
@@ -39,7 +39,7 @@
 			<div class="form-group">
 				<div class="col-xs-8 col-xs-offset-4">
 					<input id="resetPinSubmit" name="submit" class="btn btn-primary" type="submit"
-						   value="{translate text="Reset My PIN" isPublicFacing=true}">
+						   value="{translate text="Reset My PIN" isPublicFacing=true inAttribute=true}">
 				</div>
 			</div>
 		{/if}

--- a/code/web/interface/themes/responsive/MyAccount/resetExpiredPin.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/resetExpiredPin.tpl
@@ -38,8 +38,9 @@
 		{if !isset($showSubmitButton) || $showSubmitButton == true}
 			<div class="form-group">
 				<div class="col-xs-8 col-xs-offset-4">
-					<input id="resetPinSubmit" name="submit" class="btn btn-primary" type="submit"
-						   value="{translate text="Reset My PIN" isPublicFacing=true inAttribute=true}">
+					<button type="submit" id="resetPinSubmit" name="submit" class="btn btn-primary">
+						{translate text="Reset My PIN" isPublicFacing=true}
+					</button>
 				</div>
 			</div>
 		{/if}

--- a/code/web/interface/themes/responsive/MyAccount/resetPin.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/resetPin.tpl
@@ -26,7 +26,7 @@
 				<input type="password" name="pin2" id="pin2" value="" minlength="{$pinValidationRules.minLength}" maxlength="{$pinValidationRules.maxLength}" class="form-control required {if !empty($pinValidationRules.onlyDigitsAllowed)}digits{/if}">
 			</div>
 			<div class="form-group propertyRow">
-				<input id="resetPinSubmit" name="submit" class="btn btn-primary" type="submit" value="{translate text="Reset My Pin" isPublicFacing=true}">
+				<input id="resetPinSubmit" name="submit" class="btn btn-primary" type="submit" value="{translate text="Reset My Pin" isPublicFacing=true inAttribute=true}">
 			</div>
 		</form>
 	</div>

--- a/code/web/interface/themes/responsive/MyAccount/resetPin.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/resetPin.tpl
@@ -26,7 +26,9 @@
 				<input type="password" name="pin2" id="pin2" value="" minlength="{$pinValidationRules.minLength}" maxlength="{$pinValidationRules.maxLength}" class="form-control required {if !empty($pinValidationRules.onlyDigitsAllowed)}digits{/if}">
 			</div>
 			<div class="form-group propertyRow">
-				<input id="resetPinSubmit" name="submit" class="btn btn-primary" type="submit" value="{translate text="Reset My Pin" isPublicFacing=true inAttribute=true}">
+				<button type="submit" id="resetPinSubmit" name="submit" class="btn btn-primary">
+					{translate text="Reset My PIN" isPublicFacing=true}
+				</button>
 			</div>
 		</form>
 	</div>

--- a/code/web/interface/themes/responsive/MyAccount/sirsiROAEmailResetPinLink.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/sirsiROAEmailResetPinLink.tpl
@@ -13,7 +13,9 @@
 			</div>
 			<div class="form-group">
 				<div class="col-xs-12 col-sm-offset-4 col-sm-8">
-					<input id="emailPinSubmit" name="submit" class="btn btn-primary" type="submit" value="{translate text='Reset My PIN' isPublicFacing=true inAttribute=true}">
+					<button type="submit" id="emailPinSubmit" name="submit" class="btn btn-primary">
+						{translate text="Reset My PIN" isPublicFacing=true}
+					</button>
 				</div>
 			</div>
 		</form>

--- a/code/web/interface/themes/responsive/MyAccount/sirsiROAEmailResetPinLink.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/sirsiROAEmailResetPinLink.tpl
@@ -13,7 +13,7 @@
 			</div>
 			<div class="form-group">
 				<div class="col-xs-12 col-sm-offset-4 col-sm-8">
-					<input id="emailPinSubmit" name="submit" class="btn btn-primary" type="submit" value="{translate text='Reset My PIN' isPublicFacing=true}">
+					<input id="emailPinSubmit" name="submit" class="btn btn-primary" type="submit" value="{translate text='Reset My PIN' isPublicFacing=true inAttribute=true}">
 				</div>
 			</div>
 		</form>

--- a/code/web/release_notes/25.04.00.MD
+++ b/code/web/release_notes/25.04.00.MD
@@ -44,6 +44,8 @@
 //nick
 
 //leo
+### Other Updates
+- Added missing `inAttribute=true` for `Reset My Pin` buttons in many reset-pin related template files to prevent malformed HTML during translation mode. (DIS-558) (*LS*)
 
 //imani
 

--- a/code/web/release_notes/25.04.00.MD
+++ b/code/web/release_notes/25.04.00.MD
@@ -45,7 +45,7 @@
 
 //leo
 ### Other Updates
-- Added missing `inAttribute=true` for `Reset My Pin` buttons in many reset-pin related template files to prevent malformed HTML during translation mode. (DIS-558) (*LS*)
+- Changed `Reset My Pin` inputs to buttons in many reset-pin related template files to prevent malformed HTML and allow the use of the Translation Button. (DIS-558) (*LS*)
 
 //imani
 


### PR DESCRIPTION
- Changed `Reset My Pin` inputs to buttons in many reset-pin related template files to prevent malformed HTML and allow the use of the Translation Button.

Note: When using translation mode, the embedded span elements inside buttons initially triggered Cloudflare's WAF security protections, which were then addressed with a custom WAF rule allowing these form submissions. If you encounter similar Cloudflare blocking issues with form submissions containing translated content, consider adding a WAF exception rule to allow the specific submission pattern.