### PR TITLE
DIS-568: Fix List Cover Image Migration and Display Issues

### DIFF
--- a/code/web/release_notes/25.03.01.MD
+++ b/code/web/release_notes/25.03.01.MD
@@ -1,5 +1,9 @@
 ## Aspen Discovery Updates
 
+### Cover Images Updates
+- Added a directory creation step to ensure the target `/original/lists/` directory exists before attempting to copy files into it. (DIS-568) (*LS*)
+- Implemented a fallback mechanism in `getUploadedListCover()` that checks both the new and old directories for list cover images, ensuring covers remain visible during the migration process. (DIS-568) (*LS*)
 
 ## This release includes code contributions from
-
+### ByWater Solutions
+- Leo Stoyanov (LS)

--- a/code/web/sys/Covers/BookCoverProcessor.php
+++ b/code/web/sys/Covers/BookCoverProcessor.php
@@ -1942,9 +1942,15 @@ class BookCoverProcessor {
 
 	private function getUploadedListCover($id) {
 		$uploadedImage = $this->bookCoverPath . '/original/lists/' . $id . '.png';
-		$source = $this->bookCoverInfo->imageSource;
+		$source = $this->bookCoverInfo->imageSource ?? '';
 		if (($source == 'upload' || $source == '') && file_exists($uploadedImage)) {
 			return $this->processImageURL($source, $uploadedImage);
+		}
+
+		// If not found, check the original directory as fallback (DIS-568).
+		$originalImage = $this->bookCoverPath . '/original/' . $id . '.png';
+		if (($source == 'upload' || $source == '') && file_exists($originalImage)) {
+			return $this->processImageURL($source, $originalImage);
 		}
 		return false;
 	}

--- a/code/web/sys/DBMaintenance/version_updates/25.03.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.03.00.php
@@ -500,6 +500,10 @@ function moveUploadedListImages(&$update) : void {
 	$originalPath = $configArray['Site']['coverPath'] . '/original/';
 	$newPath = $configArray['Site']['coverPath'] . '/original/lists/';
 
+	if (!file_exists($newPath)) {
+		mkdir($newPath, 0755, true);
+	}
+
 	$numCoversCopied = 0;
 	while($uploadedListCovers->fetch()) {
 		$listId = $uploadedListCovers->getRecordId();

--- a/code/web/sys/DBMaintenance/version_updates/25.03.01.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.03.01.php
@@ -22,6 +22,15 @@ function getUpdates25_03_01(): array {
 
 		//kodi
 
+		// Leo Stoyanov - BWS
+		'move_uploaded_list_images_again' => [
+			'title' => 'Properly Move Uploaded List Images',
+			'description' => "Rerun move of uploaded list images to their own directory so they don't conflict with uploaded records' covers.",
+			'sql'=> [
+				'moveUploadedListImages'
+			]
+		], //move_uploaded_list_images_again
+
 		//alexander - PTFS-Europe
 
 		//chloe - PTFS-Europe


### PR DESCRIPTION
- Added a directory creation step to ensure the target `/original/lists/` directory exists before attempting to copy files into it.
- Implemented a fallback mechanism in `getUploadedListCover()` that checks both the new and old directories for list cover images, ensuring covers remain visible during the migration process.