### PR TITLE
DIS-540 Sierra Contact Info State and ZIP handling

### DIFF
--- a/code/web/Drivers/Sierra.php
+++ b/code/web/Drivers/Sierra.php
@@ -2128,10 +2128,21 @@ class Sierra extends Millennium {
 				if (strpos($line2, ',')) {
 					$user->_city = substr($line2, 0, strrpos($line2, ','));
 					$stateZip = trim(substr($line2, strrpos($line2, ',') + 1));
-					$user->_state = substr($stateZip, 0, strrpos($stateZip, ' '));
-					$user->_zip = substr($stateZip, strrpos($stateZip, ' '));
+					if (strpos($stateZip, ' ')) {
+						$user->_state = substr($stateZip, 0, strrpos($stateZip, ' '));
+						$user->_zip = substr($stateZip, strrpos($stateZip, ' '));
+					} else {
+						$user->_state = trim($stateZip); 
+					}
 				} else {
-					$user->_city = $line2;
+					$parts = preg_split('/\s+/', $line2);
+					if (count($parts) >= 3) {
+						$user->_zip = array_pop($parts);
+						$user->_state = array_pop($parts);
+						$user->_city = implode(' ', $parts);
+					} else {
+						$user->_city = $line2;
+					}
 				}
 			}
 		}

--- a/code/web/release_notes/25.04.00.MD
+++ b/code/web/release_notes/25.04.00.MD
@@ -65,6 +65,8 @@
 //imani
 
 //yanjun
+### Sierra Updates
+- Add more flexible address state and zip format parsing for Sierra Patrons Contact Information. (DIS-540) (*YL*)
 
 //jason (equinox)
 


### PR DESCRIPTION
For libraries with Sierra, patrons' contact information, city, state, and zip are always displayed together. The current code splits city, state, and zip by checking commas. However, some libraries’ API responses for patron information don’t have the comma between city, state, and zip, but split them with only spaces, or missing ZIP. 

With this fix, different cases of address line 2 can be handled well. 
- City, State ZIP
- City, State
- City State ZIP