### PR TITLE
DIS-570 Add alert-error handling for Koha Contact Info Update

### DIFF
--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -391,6 +391,11 @@ class Koha extends AbstractIlsDriver {
 						$error = str_replace('</h3>', '</h4>', $error);
 						$result['success'] = true;
 						$result['messages'][] = trim($error);
+					} elseif (preg_match('%<div class="alert alert-error">(.*?)</div>%s', $postResults, $messageInformation)) {
+						$error = $messageInformation[1];
+						$error = str_replace('<h3>', '<h4>', $error);
+						$error = str_replace('</h3>', '</h4>', $error);
+						$result['messages'][] = trim($error);
 					} elseif (preg_match('%<div class="alert">(.*?)</div>%s', $postResults, $messageInformation)) {
 						$error = $messageInformation[1];
 						$result['messages'][] = trim($error);

--- a/code/web/release_notes/25.04.00.MD
+++ b/code/web/release_notes/25.04.00.MD
@@ -65,6 +65,8 @@
 //imani
 
 //yanjun
+### Koha Updates
+- Add alert error messages handling to Koha update Contact Information. (DIS-570) (*YL*)
 
 //jason (equinox)
 


### PR DESCRIPTION
For Koha libraries, in Contact Information, patrons would get “Unknown error updating your account” when trying to update the contact information or save contact information without editing any info. While `/cgi-bin/koha/opac-memberentry.pl?DISABLE_SYSPREF_OPACUserCSS=1` has `class="alert alert-error"`, the message is not being handled correctly. This fix can display the alert-error message correctly. 