### PR TITLE
DIS-571 Sierra API fix the missing locations field

### DIFF
--- a/code/web/release_notes/25.03.01.MD
+++ b/code/web/release_notes/25.03.01.MD
@@ -1,5 +1,9 @@
 ## Aspen Discovery Updates
 
+### Sierra Updates
+- Add missing 'locations' field to Sierra export API request for updateMarcAndRegroupRecordId(). (DIS-571) (*YL*)
 
 ## This release includes code contributions from
 
+### ByWater Solutions
+- Yanjun Li (YL)


### PR DESCRIPTION
For Sierra Libraries,  if in Indexing profiles > Sierra Field Mappings > Bib Level Locations Destination Subfield has a value, then the exporter will look for the “locations” array in the API response. Adding the “locations” field in the API call to fix this bug. 
Also add a "marc" field check for better error handling. 