### PR TITLE
DIS-192: Use Aspen Event settings to set library scope instead of basing it on the event type

### DIFF
--- a/code/events_indexer/src/com/turning_leaf_technologies/events/AspenEventsIndexer.java
+++ b/code/events_indexer/src/com/turning_leaf_technologies/events/AspenEventsIndexer.java
@@ -20,6 +20,7 @@ import static java.util.Calendar.DAY_OF_YEAR;
 
 public class AspenEventsIndexer {
 	private final long settingsId;
+	private final String name;
 	private final int numberOfDaysToIndex;
 	private final boolean runFullUpdate;
 	private final long lastUpdateOfAllEvents;
@@ -27,6 +28,7 @@ public class AspenEventsIndexer {
 	private final Connection aspenConn;
 	private final EventsIndexerLogEntry logEntry;
 	private final HashMap<Long, AspenEvent> eventInstances = new HashMap<>();
+	private final HashSet<String> librariesToShowFor = new HashSet<>();
 	private final static CRC32 checksumCalculator = new CRC32();
 	private final String coverPath;
 
@@ -34,8 +36,9 @@ public class AspenEventsIndexer {
 
 	private final ConcurrentUpdateHttp2SolrClient solrUpdateServer;
 
-	AspenEventsIndexer(long settingsId, int numberOfDaysToIndex, boolean runFullUpdate, long lastUpdateOfAllEvents, long lastUpdateOfChangedEvents, ConcurrentUpdateHttp2SolrClient solrUpdateServer, Connection aspenConn, Logger logger, String serverName) {
+	AspenEventsIndexer(long settingsId, String name, int numberOfDaysToIndex, boolean runFullUpdate, long lastUpdateOfAllEvents, long lastUpdateOfChangedEvents, ConcurrentUpdateHttp2SolrClient solrUpdateServer, Connection aspenConn, Logger logger, String serverName) {
 		this.settingsId = settingsId;
+		this.name = name;
 		this.aspenConn = aspenConn;
 		this.solrUpdateServer = solrUpdateServer;
 		this.numberOfDaysToIndex = numberOfDaysToIndex;
@@ -43,7 +46,7 @@ public class AspenEventsIndexer {
 		this.lastUpdateOfAllEvents = lastUpdateOfAllEvents;
 		this.lastUpdateOfChangedEvents = lastUpdateOfChangedEvents;
 
-		logEntry = new EventsIndexerLogEntry("Aspen Events", aspenConn, logger);
+		logEntry = new EventsIndexerLogEntry("Aspen Events " + name, aspenConn, logger);
 
 		Ini configIni = ConfigUtil.loadConfigFile("config.ini", serverName, logger);
 		coverPath = configIni.get("Site","coverPath");
@@ -64,22 +67,32 @@ public class AspenEventsIndexer {
 			lastDateToIndex.add(DAY_OF_YEAR, this.numberOfDaysToIndex);
 
 			// Get total number of events for log
-			PreparedStatement eventCountStmt = aspenConn.prepareStatement("SELECT COUNT(*) FROM event_instance WHERE deleted = 0;");
+			PreparedStatement eventCountStmt = aspenConn.prepareStatement("SELECT COUNT(*) FROM event_instance LEFT JOIN event ON event_instance.eventId = event.id WHERE event_instance.deleted = 0 AND event.locationID IN (SELECT locationId from location_events_setting WHERE settingId = ?);");
+			eventCountStmt.setLong(1, settingsId);
 			ResultSet eventCountRS = eventCountStmt.executeQuery();
 			if (eventCountRS.next()) {
 				logEntry.incNumEvents(eventCountRS.getInt("COUNT(*)"));
+			}
+
+			PreparedStatement getLibraryScopesStmt = aspenConn.prepareStatement("SELECT subdomain from library inner join library_events_setting on library.libraryId = library_events_setting.libraryId WHERE settingSource = 'aspenEvents' AND settingId = ?");
+			getLibraryScopesStmt.setLong(1, settingsId);
+			ResultSet getLibraryScopesRS = getLibraryScopesStmt.executeQuery();
+			while (getLibraryScopesRS.next()){
+				librariesToShowFor.add(getLibraryScopesRS.getString("subdomain").toLowerCase());
 			}
 
 			PreparedStatement eventsStmt;
 			PreparedStatement deleteEventsStmt;
 			if (runFullUpdate) {
 				// Get event instance and event info
-				eventsStmt = aspenConn.prepareStatement("SELECT ei.*, e.title, e.description, e.eventTypeId, e.locationId, l.displayName, sl.name AS sublocationName, sl2.name AS sublocationOverride, e.sublocationId, e.cover, e.private FROM event_instance AS ei LEFT JOIN event as e ON e.id = ei.eventID LEFT JOIN location AS l ON e.locationId = l.locationId LEFT JOIN sublocation AS sl on e.sublocationId = sl.id LEFT JOIN sublocation AS sl2 ON ei.sublocationId = sl2.id WHERE ei.date < ? AND ei.deleted = 0;");
+				eventsStmt = aspenConn.prepareStatement("SELECT ei.*, e.title, e.description, e.eventTypeId, e.locationId, l.displayName, sl.name AS sublocationName, sl2.name AS sublocationOverride, e.sublocationId, e.cover, e.private FROM event_instance AS ei LEFT JOIN event as e ON e.id = ei.eventID LEFT JOIN location AS l ON e.locationId = l.locationId LEFT JOIN sublocation AS sl on e.sublocationId = sl.id LEFT JOIN sublocation AS sl2 ON ei.sublocationId = sl2.id WHERE ei.date < ? AND ei.deleted = 0 AND e.locationId IN (SELECT locationId from location_events_setting WHERE settingId = ?);");
+				eventsStmt.setLong(2, settingsId);
 			} else {
-				eventsStmt = aspenConn.prepareStatement("SELECT ei.*, e.title, e.description, e.eventTypeId, e.locationId, l.displayName, sl.name AS sublocationName, sl2.name AS sublocationOverride, e.sublocationId, e.cover, e.private FROM event_instance AS ei LEFT JOIN event as e ON e.id = ei.eventID LEFT JOIN location AS l ON e.locationId = l.locationId LEFT JOIN sublocation AS sl on e.sublocationId = sl.id LEFT JOIN sublocation AS sl2 ON ei.sublocationId = sl2.id WHERE ei.date < ? AND (e.dateUpdated > ? OR ei.dateUpdated > ?) AND ei.deleted = 0;");
+				eventsStmt = aspenConn.prepareStatement("SELECT ei.*, e.title, e.description, e.eventTypeId, e.locationId, l.displayName, sl.name AS sublocationName, sl2.name AS sublocationOverride, e.sublocationId, e.cover, e.private FROM event_instance AS ei LEFT JOIN event as e ON e.id = ei.eventID LEFT JOIN location AS l ON e.locationId = l.locationId LEFT JOIN sublocation AS sl on e.sublocationId = sl.id LEFT JOIN sublocation AS sl2 ON ei.sublocationId = sl2.id WHERE ei.date < ? AND (e.dateUpdated > ? OR ei.dateUpdated > ?) AND ei.deleted = 0 AND e.locationId IN (SELECT locationId from location_events_setting WHERE settingId = ?);");
 				deleteEventsStmt = aspenConn.prepareStatement("SELECT id FROM event_instance WHERE deleted = 1 AND dateUpdated > ?;");
 				eventsStmt.setLong(2, lastUpdateOfChangedEvents);
 				eventsStmt.setLong(3, lastUpdateOfChangedEvents);
+				eventsStmt.setLong(4, settingsId);
 				deleteEventsStmt.setLong(1, lastUpdateOfChangedEvents);
 				ResultSet deleteEventsRS = deleteEventsStmt.executeQuery();
 				while (deleteEventsRS.next()) {
@@ -87,8 +100,6 @@ public class AspenEventsIndexer {
 				}
 			}
 			eventsStmt.setString(1, dateFormat.format(lastDateToIndex.getTime()));
-			// Get libraries for this event type
-			PreparedStatement librariesStmt = aspenConn.prepareStatement("SELECT etl.libraryId, l.subdomain FROM event_type_library AS etl LEFT JOIN library as l ON etl.libraryId = l.libraryId WHERE eventTypeId = ?");
 			// Get custom fields
 			PreparedStatement eventFieldStmt = aspenConn.prepareStatement("SELECT ef.name, ef.allowableValues, ef.type, ef.facetName, eef.value from event_event_field AS eef LEFT JOIN event_field AS ef ON ef.id = eef.eventFieldId WHERE eef.eventId = ?;");
 
@@ -98,12 +109,6 @@ public class AspenEventsIndexer {
 
 			while (existingEventsRS.next()) {
 				AspenEvent event = new AspenEvent(existingEventsRS);
-				librariesStmt.clearParameters();
-				librariesStmt.setLong(1, event.getEventType());
-				ResultSet librariesFieldsRS = librariesStmt.executeQuery();
-				while (librariesFieldsRS.next()) {
-					event.addLibrary(librariesFieldsRS.getString("subdomain").toLowerCase());
-				}
 				eventFieldStmt.clearParameters();
 				eventFieldStmt.setLong(1, event.getParentEventId());
 				ResultSet eventFieldsRS = eventFieldStmt.executeQuery();
@@ -236,7 +241,7 @@ public class AspenEventsIndexer {
 				solrDocument.addField("description", eventInfo.getDescription());
 
 				// Libraries scopes
-				solrDocument.addField("library_scopes", eventInfo.getLibraries());
+				solrDocument.addField("library_scopes", librariesToShowFor);
 
 				solrDocument.addField("boost", boost);
 				solrUpdateServer.add(solrDocument);

--- a/code/events_indexer/src/com/turning_leaf_technologies/events/EventsIndexerMain.java
+++ b/code/events_indexer/src/com/turning_leaf_technologies/events/EventsIndexerMain.java
@@ -138,6 +138,7 @@ public class EventsIndexerMain {
 				while (eventsSitesRS.next()) {
 					AspenEventsIndexer indexer = new AspenEventsIndexer(
 						eventsSitesRS.getLong("id"),
+						eventsSitesRS.getString("name"),
 						eventsSitesRS.getInt("numberOfDaysToIndex"),
 						eventsSitesRS.getBoolean("runFullUpdate"),
 						eventsSitesRS.getLong("lastUpdateOfAllEvents"),

--- a/code/web/release_notes/25.04.00.MD
+++ b/code/web/release_notes/25.04.00.MD
@@ -44,6 +44,8 @@
 //kirstien
 
 //katherine
+### Aspen Events Updates
+- Add location options to Aspen Events Settings and update event indexing so that which event locations are visible from which library page can be controlled via these settings. (DIS-192) (*KP*)
 
 //kodi
 ### Indexing Updates

--- a/code/web/sys/DBMaintenance/version_updates/25.04.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.04.00.php
@@ -37,6 +37,17 @@ function getUpdates25_04_00(): array {
 		], //make_local_ill_form_note_optional
 
 		//katherine - Grove
+		'add_location_to_aspen_events_settings' => [
+			'title' => 'Add Location to Aspen Events Settings',
+			'description' => 'Add location_events_setting table so that settings can be linked to specific locations',
+			'sql' => [
+				"CREATE TABLE location_events_setting (
+					id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+					settingId INT NOT NULL,
+					locationId INT NOT NULL
+				) ENGINE INNODB CHARACTER SET utf8 COLLATE utf8_general_ci",
+			]
+		], //add_location_to_aspen_events_settings
 
 		//kirstien - Grove
 

--- a/code/web/sys/DBMaintenance/version_updates/25.04.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.04.00.php
@@ -46,6 +46,7 @@ function getUpdates25_04_00(): array {
 					settingId INT NOT NULL,
 					locationId INT NOT NULL
 				) ENGINE INNODB CHARACTER SET utf8 COLLATE utf8_general_ci",
+				"ALTER TABLE events_indexing_settings ADD COLUMN name VARCHAR(100)"
 			]
 		], //add_location_to_aspen_events_settings
 

--- a/code/web/sys/Events/EventsIndexingSetting.php
+++ b/code/web/sys/Events/EventsIndexingSetting.php
@@ -1,4 +1,5 @@
 <?php
+require_once ROOT_DIR . '/sys/Events/LocationEventsSetting.php';
 class EventsIndexingSetting extends DataObject {
 	public $__table = 'events_indexing_settings';    // table name
 	public $id;
@@ -6,10 +7,12 @@ class EventsIndexingSetting extends DataObject {
 	public $numberOfDaysToIndex;
 
 	private $_libraries;
+	private $_locations;
 //	public $lastUpdateOfAllEvents;
 //	public $lastUpdateOfChangedEvents;
 	public static function getObjectStructure($context = ''): array {
 		$libraryList = Library::getLibraryList(!UserAccount::userHasPermission('Administer Events for All Locations'));
+		$locationList = Location::getLocationList(!UserAccount::userHasPermission('Administer All Libraries') || UserAccount::userHasPermission('Administer Home Library Locations'));
 
 		return [
 			'id' => [
@@ -51,7 +54,14 @@ class EventsIndexingSetting extends DataObject {
 				'label' => 'Libraries',
 				'description' => 'Define libraries that use these settings',
 				'values' => $libraryList,
-				'hideInLists' => true,
+			],
+			'locations' => [
+				'property' => 'locations',
+				'type' => 'multiSelect',
+				'listStyle' => 'checkboxSimple',
+				'label' => 'Locations',
+				'description' => 'Define locations that use this type',
+				'values' => $locationList,
 			],
 		];
 	}
@@ -65,6 +75,7 @@ class EventsIndexingSetting extends DataObject {
 		$ret = parent::update();
 		if ($ret !== FALSE) {
 			$this->saveLibraries();
+			$this->saveLocations();
 		}
 		return $ret;
 	}
@@ -78,6 +89,7 @@ class EventsIndexingSetting extends DataObject {
 		$ret = parent::insert();
 		if ($ret !== FALSE) {
 			$this->saveLibraries();
+			$this->saveLocations();
 		}
 		return $ret;
 	}
@@ -85,6 +97,8 @@ class EventsIndexingSetting extends DataObject {
 	public function __get($name) {
 		if ($name == "libraries") {
 			return $this->getLibraries();
+		} else if ($name == "locations") {
+			return $this->getLocations();
 		} else {
 			return parent::__get($name);
 		}
@@ -93,6 +107,8 @@ class EventsIndexingSetting extends DataObject {
 	public function __set($name, $value) {
 		if ($name == "libraries") {
 			$this->_libraries = $value;
+		} else if ($name == "locations") {
+			$this->_locations = $value;
 		} else {
 			parent::__set($name, $value);
 		}
@@ -102,6 +118,7 @@ class EventsIndexingSetting extends DataObject {
 		$ret = parent::delete($useWhere);
 		if ($ret && !empty($this->id)) {
 			$this->clearLibraries();
+			$this->clearLocations();
 		}
 		return $ret;
 	}
@@ -139,7 +156,43 @@ class EventsIndexingSetting extends DataObject {
 	private function clearLibraries() {
 		//Delete links to the libraries
 		$libraryEventSetting = new LibraryEventsSetting();
-		$libraryEventSetting->settingSource = 'assabet';
+		$libraryEventSetting->settingSource = 'aspenEvents';
+		$libraryEventSetting->settingId = $this->id;
+		return $libraryEventSetting->delete(true);
+	}
+
+	public function getLocations() {
+		if (!isset($this->_locations) && $this->id) {
+			$this->_locations = [];
+			$location = new LocationEventsSetting();
+			$location->settingId = $this->id;
+			$location->find();
+			while ($location->fetch()) {
+				$this->_locations[$location->locationId] = $location->locationId;
+			}
+		}
+		return $this->_locations;
+	}
+
+	public function saveLocations() {
+		if (isset($this->_locations) && is_array($this->_locations)) {
+			$this->clearLocations();
+
+			foreach ($this->_locations as $locationId) {
+				$locationEventsSetting = new LocationEventsSetting();
+
+				$locationEventsSetting->settingId = $this->id;
+				$locationEventsSetting->locationId = $locationId;
+				$locationEventsSetting->insert();
+			}
+			unset($this->_locations);
+		}
+	}
+
+	private function clearLocations() {
+		//Delete links to the libraries
+		$libraryEventSetting = new LocationEventsSetting();
+		$libraryEventSetting->settingSource = 'aspenEvents';
 		$libraryEventSetting->settingId = $this->id;
 		return $libraryEventSetting->delete(true);
 	}

--- a/code/web/sys/Events/EventsIndexingSetting.php
+++ b/code/web/sys/Events/EventsIndexingSetting.php
@@ -3,6 +3,7 @@ require_once ROOT_DIR . '/sys/Events/LocationEventsSetting.php';
 class EventsIndexingSetting extends DataObject {
 	public $__table = 'events_indexing_settings';    // table name
 	public $id;
+	public $name;
 	public $runFullUpdate;
 	public $numberOfDaysToIndex;
 
@@ -20,6 +21,12 @@ class EventsIndexingSetting extends DataObject {
 				'type' => 'label',
 				'label' => 'Id',
 				'description' => 'The unique id',
+			],
+			'name' => [
+				'property' => 'name',
+				'type' => 'text',
+				'label' => 'Name',
+				'description' => 'A name for the settings',
 			],
 			'runFullUpdate' => [
 				'property' => 'runFullUpdate',

--- a/code/web/sys/Events/LocationEventsSetting.php
+++ b/code/web/sys/Events/LocationEventsSetting.php
@@ -1,0 +1,8 @@
+<?php
+
+class LocationEventsSetting extends DataObject {
+	public $__table = 'location_events_setting';
+	public $id;
+	public $settingId;
+	public $locationId;
+}


### PR DESCRIPTION
- Added two new fields to Aspen Events Settings: a settings name for keeping track of multiple settings and a locations field.
- Updated event indexing so that scopes are based on the libraries associated with the setting ID and only events at the locations in the setting are indexed.
- Updated event indexing logging so that the event count is correct for each setting and so that it includes the setting name.