### PR TITLE
DIS-547 Create a new Driver Instance for reset PIN

### DIFF
--- a/code/web/CatalogConnection.php
+++ b/code/web/CatalogConnection.php
@@ -430,7 +430,9 @@ class CatalogConnection {
 			$userToResetPin->ils_barcode = $barcode;
 			if (!$userToResetPin->find(true)) {
 				$accountProfileDriver = $accountProfileInfo['driver'];
-				$userToResetPin = $accountProfileDriver->findNewUser($barcode, '');
+				require_once ROOT_DIR . '/CatalogFactory.php';
+				$catalogConnectionInstance = CatalogFactory::getCatalogConnectionInstance($accountProfileDriver, $accountProfile);
+				$userToResetPin = $catalogConnectionInstance->findNewUser($barcode, '');
 			}
 		}elseif ($accountProfile->authenticationMethod == 'db') {
 			//Check anything we do database authentication for

--- a/code/web/release_notes/25.03.01.MD
+++ b/code/web/release_notes/25.03.01.MD
@@ -3,6 +3,9 @@
 ### Sierra Updates
 - Add missing 'locations' field to Sierra export API request for updateMarcAndRegroupRecordId(). (DIS-571) (*YL*)
 
+### Other Updates
+- Create a new catalog connection instance when finding a new user to reset a PIN. (DIS-547) (*YL*)
+
 ## This release includes code contributions from
 
 ### ByWater Solutions


### PR DESCRIPTION
For libraries using Sierra, the patrons (including newly registered patrons and existing patrons) will see an error when they want to reset their PIN.
To replicate:

Click Reset PIN before logging in
Input library card number or username
See error Call to a member function findNewUser() on string
When it’s Sierra libraries,  $accountProfileInfo['driver'] is only a string (“Sierra”), To fix this, we need to create a new driver instance.

Submit this PR for 25.03.01