### PR TITLE
DIS-574 Fix pickup Loc sync with Home Library if patrons can't customize pickup loc 

### DIFF
--- a/code/web/release_notes/25.04.00.MD
+++ b/code/web/release_notes/25.04.00.MD
@@ -78,6 +78,7 @@
 
 ### Other Updates
 - Create a new catalog connection instance when finding a new user to reset a PIN. (DIS-547) (*YL*)
+- For libraries that don't allow patrons to update their pickup locations, always use the home libraries as the pickup locations. (DIS-574) (*YL*)
 
 //jason (equinox)
 

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -3872,8 +3872,14 @@ class User extends DataObject {
 	}
 
 	function getPickupLocation() {
+		//Check if the library allows patrons to update their pickup locaton, if not, pickup location is always the home location
+		$allowCustomPickupLocation = false;
+		$homeLocation = $this->getHomeLocation();
+		if ($homeLocation != null && $homeLocation->getParentLibrary() != null) {
+			$allowCustomPickupLocation = $homeLocation->getParentLibrary()->allowPickupLocationUpdates;
+		}
 		//Always check if a preferred pickup location has been selected. If not, use the home location
-		if ($this->pickupLocationId > 0 && $this->pickupLocationId != $this->homeLocationId) {
+		if ($allowCustomPickupLocation && $this->pickupLocationId > 0 && $this->pickupLocationId != $this->homeLocationId) {
 			$pickupBranch = $this->pickupLocationId;
 			$locationLookup = new Location();
 			$locationLookup->locationId = $pickupBranch;
@@ -3881,10 +3887,10 @@ class User extends DataObject {
 			if ($locationLookup->find(true) && $locationLookup->validHoldPickupBranch != 2) {
 				$pickupBranch = $locationLookup;
 			} else {
-				$pickupBranch = $this->getHomeLocation();
+				$pickupBranch = $homeLocation;
 			}
 		} else {
-			$pickupBranch = $this->getHomeLocation();
+			$pickupBranch = $homeLocation;
 		}
 
 		return $pickupBranch;


### PR DESCRIPTION
For Libraries that don’t select Library System > Allow Patrons to Update Their Preferred Pickup Location, patrons’ pickup locations are always their home library. There’s a case where:
1) Patrons update their home library in the ILS
2) Log in to Aspen, in the My Preferences pages, Home Library, change to the new Home Library
3) Patrons try to place a hold 
4) The default pickup location in the modal still remains the old Home Library 
5) Go back to the My Preferences pages, click “Update My preferences” without making any changes 
6) Try to place a hold again, the default pickup location has changed to the new Hold Library 

In User.php, getPickupLocation(), we can check whether “Allow Patrons to Update Their Preferred Pickup Location” is selected or not, to help determine the patrons' pickup locations. 

This PR fixes the issue that pickup locations weren't properly syncing with the home library when the home library updated through ILS.