### PR TITLE
DIS-575: Add latest tag to github actions for docker image push 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,9 @@ jobs:
           file: docker/Dockerfile
           push: ${{ startsWith(github.ref, 'refs/tags/') }}
           tags: |
+            aspendiscovery/aspen:latest
+            ghcr.io/aspen-discovery/aspen:latest
+            quay.io/aspen-discovery/aspen:latest
             aspendiscovery/aspen:${{ env.GIT_TAG }}
             ghcr.io/aspen-discovery/aspen:${{ env.GIT_TAG }}
             quay.io/aspen-discovery/aspen:${{ env.GIT_TAG }}
@@ -103,6 +106,9 @@ jobs:
           file: docker/files/solr/Dockerfile
           push: ${{ startsWith(github.ref, 'refs/tags/') }}
           tags: |
+            aspendiscovery/solr:latest
+            ghcr.io/aspen-discovery/solr:latest
+            quay.io/aspen-discovery/solr:latest
             aspendiscovery/solr:${{ env.GIT_TAG }}
             ghcr.io/aspen-discovery/solr:${{ env.GIT_TAG }}
             quay.io/aspen-discovery/solr:${{ env.GIT_TAG }}
@@ -155,6 +161,9 @@ jobs:
           file: docker/files/tunnel/Dockerfile
           push: ${{ startsWith(github.ref, 'refs/tags/') }}
           tags: |
+            aspendiscovery/tunnel:latest
+            ghcr.io/aspen-discovery/tunnel:latest
+            quay.io/aspen-discovery/tunnel:latest
             aspendiscovery/tunnel:${{ env.GIT_TAG }}
             ghcr.io/aspen-discovery/tunnel:${{ env.GIT_TAG }}
             quay.io/aspen-discovery/tunnel:${{ env.GIT_TAG }}

--- a/code/web/release_notes/25.04.00.MD
+++ b/code/web/release_notes/25.04.00.MD
@@ -87,6 +87,10 @@
 ### Other Updates
 - Prevent search filters (facets) from resetting the search index to its default (commonly, 'Text') for EBSCO EDS and Summon searches. (DIS-477) (*CZ*)
 
+//jacob
+### Other Updates
+- Amend Github Actions to additionally push docker images to latest tag. (*JOM*)
+
 //nick
 
 //leo
@@ -149,9 +153,10 @@
 ### Nasville Public Library
   - James Staub (JStaub)
 
-### PTFS-Europe
+### Open Fifth
   - Alexander Blanchard (AB)
   - Chloe Zermatten (CZ)
+  - Jacob O'Mara (JOM)
 
 ### Theke Solutions
   - Lucas Montoya (LM)


### PR DESCRIPTION
This bug is causing indexing to fail on all ADB instances. Since there is no 'latest' tag, the development environments (which rely on moving images and not static ones) have been getting outdated for a while. This means that the SOLR schema has now become out of date, causing the indexing to fail for any users of an image without a specified tag. Docker is designed to automatically pull 'latest' if no tags are given but this image is not updated when a static tag is pushed (as we do currently). We need to do this separately in the github actions and push both to the static tag and latest.

Since this is such a small patch that doesn't touch or affect the codebase at large, I have not updated the release notes here. Let me know if you would prefer this to be included in there and I can get a quick commit pushed.