### PR TITLE
DIS-580: Fix default value for appIconAndroid API call

### DIFF
--- a/code/web/services/API/SystemAPI.php
+++ b/code/web/services/API/SystemAPI.php
@@ -597,7 +597,7 @@ class SystemAPI extends AbstractAPI {
 				$fileName = $app->logoAppIcon;
 			} elseif ($type === "appIconAndroid") {
 				//Fall back to the app icon if an android-specific icon isn't provided
-				$fileName = $app->logoAppIconAndroid ?? $app->logoLogin;
+				$fileName = $app->logoAppIconAndroid ?? $app->logoAppIcon;
 			} elseif ($type === "appNotification") {
 				$fileName = $app->logoNotification;
 			} else {


### PR DESCRIPTION
If the Android-specific icon is not set for LiDA, return the Apple icon rather than the Login Logo