### PR TITLE
Dis 586 incorrect location code

### DIFF
--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -8155,7 +8155,7 @@ class Koha extends AbstractIlsDriver {
 
 					$this->apiCurlWrapper->addCustomHeaders([
 						'Authorization: Bearer ' . $oAuthToken,
-						'x-koha-library: ' . $checkoutLocation->code,
+						'x-koha-library: ' . $checkoutLocation,
 						'User-Agent: Aspen Discovery',
 						'Accept: */*',
 						'Cache-Control: no-cache',

--- a/code/web/release_notes/25.04.00.MD
+++ b/code/web/release_notes/25.04.00.MD
@@ -50,6 +50,7 @@
 - Add alert error messages handling to Koha update Contact Information. (DIS-570) (*YL*)
 - Correctly handle marc data for authorities depending on Koha's version. (DIS-553) (*LM*)
 - Filter notices according to system preferences in the ils (Koha). (DIS-504) (*LM*)
+- Send Location code instead of null in CheckoutByAPI. (DIS-586) (*IT*)
 
 ### Local ILL
 - Allow Local ILL to be restricted by Patron Type. (DIS-527) (*MDN*)
@@ -134,6 +135,7 @@
 ### ByWater Solutions
 - Leo Stoyanov (LS)
 - Yanjun Li (YL)
+- Imani Thomas (IT)
 
 ### Grove For Libraries
 - Mark Noble (MDN)


### PR DESCRIPTION
If you activate Lida and self checkout with a Koha ILS the assign checkout to setting should now properly change where the current library of a book checkouted out via self checkout is changed to. 

ILS/SelfCheckTester to easily test the checkouts.