### PR TITLE
DIS-580: fix Android Icon API request default (now with release notes!)

### DIFF
--- a/code/web/release_notes/25.04.00.MD
+++ b/code/web/release_notes/25.04.00.MD
@@ -129,11 +129,13 @@
 - Create a new catalog connection instance when finding a new user to reset a PIN. (DIS-547) (*YL*)
 - For libraries that don't allow patrons to update their pickup locations, always use the home libraries as the pickup locations. (DIS-574) (*YL*)
 - Assign default value to browseCategoryGroupId for Sierra when importing Libraries and Locations. (DIS-489) (*YL*)
+- Fix API requests for new Android Icon for LiDA to fall back to default app icon instead of using LoginLogo. (DIS-580) (*IW*)
 
 ## This release includes code contributions from
 ### ByWater Solutions
 - Leo Stoyanov (LS)
 - Yanjun Li (YL)
+- Ian Walls (IW)
 
 ### Grove For Libraries
 - Mark Noble (MDN)

--- a/code/web/services/API/SystemAPI.php
+++ b/code/web/services/API/SystemAPI.php
@@ -600,7 +600,7 @@ class SystemAPI extends AbstractAPI {
 				$fileName = $app->logoAppIcon;
 			} elseif ($type === "appIconAndroid") {
 				//Fall back to the app icon if an android-specific icon isn't provided
-				$fileName = $app->logoAppIconAndroid ?? $app->logoLogin;
+				$fileName = $app->logoAppIconAndroid ?? $app->logoAppIcon;
 			} elseif ($type === "appNotification") {
 				$fileName = $app->logoNotification;
 			} else {


### PR DESCRIPTION
If the Android-specific icon is not set for LiDA, return the Apple icon rather than the Login Logo
