### PR TITLE
Dis 593 cloud library item limit

### DIFF
--- a/code/web/Drivers/CloudLibraryDriver.php
+++ b/code/web/Drivers/CloudLibraryDriver.php
@@ -695,6 +695,13 @@ class CloudLibraryDriver extends AbstractEContentDriver {
 					'isPublicFacing' => true,
 				]);
 				$result['api']['message'] = translate(['text' => 'Sorry, we could not checkout this cloudLibrary title to you.', 'isPublicFacing' => true,]);
+			} elseif (str_contains($checkoutXml->Message, 'Patron cannot loan more than')) {
+				$result['message'] = translate(['text' => 'Borrow limit reached. You have reached the maximum number of books you can borrow. Return some before borrowing more.', 'isPublicFacing' => true,]);
+				$result['api']['title'] = translate([
+					'text' => 'Borrow limit reached',
+					'isPublicFacing' => true,
+				]);
+				$result['api']['message'] = translate(['text' => 'Borrow limit reached. You have reached the maximum number of books you can borrow. Return some before borrowing more.', 'isPublicFacing' => true,]);
 			} else {
 				$this->trackUserUsageOfCloudLibrary($patron);
 				$this->trackRecordCheckout($titleId);

--- a/code/web/release_notes/25.04.00.MD
+++ b/code/web/release_notes/25.04.00.MD
@@ -17,6 +17,7 @@
 
 ### CloudLibrary Updates
 - Fixed renewals of CloudLibrary titles and updated the UI during the renewal process to be more responsive and user-friendly. (DIS-491) (*LS*)
+- Fixed incorrectly displaying successful checkout when checkout limit in CloudLibrary had been reached. (DIS-593) (*IT*)
 
 ### Course Reserves Updates
 - Fixed an error that a "facet does not exist" for Course Reserve facets which have a sufficiently large number of options due to a missing case in `SearchObjectFactory.php`. (DIS-523) (*LS*)
@@ -134,6 +135,7 @@
 ### ByWater Solutions
 - Leo Stoyanov (LS)
 - Yanjun Li (YL)
+- Imani Thomas (IT)
 
 ### Grove For Libraries
 - Mark Noble (MDN)


### PR DESCRIPTION
If a cloudLibrary item limit has been set previously attempting to check out a cloudLibrary item from aspen while at the limit would give a successfull checkout message despite nothing being checked out. After this change you will get a Borrow limit reached message instead correctly indicating the failed checkout.

