### PR TITLE
DIS-568: Move All List Cover Images to the New Directory for Backwards Compatibility

### DIFF
--- a/code/web/release_notes/25.04.00.MD
+++ b/code/web/release_notes/25.04.00.MD
@@ -135,7 +135,7 @@
 - For libraries that don't allow patrons to update their pickup locations, always use the home libraries as the pickup locations. (DIS-574) (*YL*)
 - Assign default value to browseCategoryGroupId for Sierra when importing Libraries and Locations. (DIS-489) (*YL*)
 - Fix API requests for new Android Icon for LiDA to fall back to default app icon instead of using LoginLogo. (DIS-580) (*IW*)
-- All existing list cover images will be moved to their new directory to maintain backwards compatability. (DIS-568) (*LS*)
+- All existing list cover images will be moved to their new directory to maintain backwards compatibility. (DIS-568) (*LS*)
 
 ## This release includes code contributions from
 ### ByWater Solutions

--- a/code/web/release_notes/25.04.00.MD
+++ b/code/web/release_notes/25.04.00.MD
@@ -135,6 +135,7 @@
 - For libraries that don't allow patrons to update their pickup locations, always use the home libraries as the pickup locations. (DIS-574) (*YL*)
 - Assign default value to browseCategoryGroupId for Sierra when importing Libraries and Locations. (DIS-489) (*YL*)
 - Fix API requests for new Android Icon for LiDA to fall back to default app icon instead of using LoginLogo. (DIS-580) (*IW*)
+- All existing list cover images will be moved to their new directory to maintain backwards compatability. (DIS-568) (*LS*)
 
 ## This release includes code contributions from
 ### ByWater Solutions

--- a/code/web/sys/Covers/BookCoverProcessor.php
+++ b/code/web/sys/Covers/BookCoverProcessor.php
@@ -1952,12 +1952,6 @@ class BookCoverProcessor {
 		if (($source == 'upload' || $source == '') && file_exists($uploadedImage)) {
 			return $this->processImageURL($source, $uploadedImage);
 		}
-
-		// If not found, check the original directory as fallback (DIS-568).
-		$originalImage = $this->bookCoverPath . '/original/' . $id . '.png';
-		if (($source == 'upload' || $source == '') && file_exists($originalImage)) {
-			return $this->processImageURL($source, $originalImage);
-		}
 		return false;
 	}
 

--- a/code/web/sys/DBMaintenance/version_updates/25.03.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.03.00.php
@@ -494,7 +494,6 @@ function moveUploadedListImages(&$update) : void {
 	require_once ROOT_DIR . '/sys/Covers/BookCoverInfo.php';
 	$uploadedListCovers = new BookCoverInfo();
 	$uploadedListCovers->setRecordType('list');
-	$uploadedListCovers->setImageSource('upload');
 	$uploadedListCovers->find();
 	global $configArray;
 	$originalPath = $configArray['Site']['coverPath'] . '/original/';

--- a/code/web/sys/DBMaintenance/version_updates/25.04.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.04.00.php
@@ -83,6 +83,13 @@ function getUpdates25_04_00(): array {
 				"UPDATE user SET homeLocationId = -1 WHERE username = 'nyt_user' AND source = 'admin'",
 			],
 		], //fix_nyt_user_home_location
+		'move_list_images' => [
+			'title' => 'Properly Move All List Images',
+			'description' => "Move all list images to their own directory so they don't conflict with uploaded records' covers.",
+			'sql'=> [
+				'moveUploadedListImages'
+			]
+		], //move_list_images
 
 		//alexander - PTFS-Europe
 


### PR DESCRIPTION
- All existing list cover images will be moved to their new directory to maintain backwards compatibility.