### PR TITLE
DIS-416: Force debugging log ecommerce

### DIFF
--- a/code/web/release_notes/25.05.00.MD
+++ b/code/web/release_notes/25.05.00.MD
@@ -29,6 +29,8 @@
 // jacob
 
 // lucas
+### Other updates
+- Add option to enable forced debugging of eCommerce application responses (DIS-416) (*LM*)
 
 ## This release includes code contributions from
 ### ByWater Solutions

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -5037,18 +5037,21 @@ class MyAccount_AJAX extends JSON_Action {
 				"Accept-Language: en_US",
 				"Authorization: Basic $authInfo",
 			], true);
-			$postParams = ['grant_type' => 'client_credentials',];
+			$postParams = ['grant_type' => 'client_credentials'];
 
 			$accessTokenUrl = $baseUrl . "/v1/oauth2/token";
 			$accessTokenResults = $payPalAuthRequest->curlPostPage($accessTokenUrl, $postParams);
-			$accessTokenResults = json_decode($accessTokenResults);
-			if (empty($accessTokenResults->access_token)) {
+			$decodedAccessTokenResults = json_decode($accessTokenResults);
+
+			ExternalRequestLogEntry::logRequest('myaccount_ajax.createPayPalOrder', 'POST', $accessTokenUrl, $payPalAuthRequest->getHeaders(), json_encode($postParams), $payPalAuthRequest->getResponseCode(), $accessTokenResults, ['client_secret' => $clientSecret]);
+		
+			if (empty($decodedAccessTokenResults->access_token)) {
 				return [
 					'success' => false,
 					'message' => 'Unable to authenticate with PayPal, please try again in a few minutes.',
 				];
 			} else {
-				$accessToken = $accessTokenResults->access_token;
+				$accessToken = $decodedAccessTokenResults->access_token;
 			}
 
 			global $library;
@@ -5081,9 +5084,11 @@ class MyAccount_AJAX extends JSON_Action {
 			];
 
 			$paymentResponse = $payPalPaymentRequest->curlPostBodyData($paymentRequestUrl, $paymentRequestBody);
-			$paymentResponse = json_decode($paymentResponse);
-
-			if ($paymentResponse->status != 'CREATED') {
+			$decodedPaymentResponse = json_decode($paymentResponse);
+			
+			ExternalRequestLogEntry::logRequest('myaccount_ajax.createPayPalOrder', 'POST', $paymentRequestUrl, $payPalPaymentRequest->getHeaders(), json_encode($postParams), $payPalPaymentRequest->getResponseCode(), $paymentResponse, []);
+			
+			if ($decodedPaymentResponse->status != 'CREATED') {
 				return [
 					'success' => false,
 					'message' => 'Unable to create your order in PayPal.',
@@ -5091,13 +5096,13 @@ class MyAccount_AJAX extends JSON_Action {
 			}
 
 			//Log the request in the database so we can validate it on return
-			$payment->orderId = $paymentResponse->id;
+			$payment->orderId = $decodedPaymentResponse->id;
 			$payment->update();
 
 			return [
 				'success' => true,
 				'orderInfo' => $paymentResponse,
-				'orderID' => $paymentResponse->id,
+				'orderID' => $decodedPaymentResponse->id,
 			];
 		}
 	}
@@ -5176,18 +5181,21 @@ class MyAccount_AJAX extends JSON_Action {
 				"Accept-Language: en_US",
 				"Authorization: Basic $authInfo",
 			], true);
-			$postParams = ['grant_type' => 'client_credentials',];
+			$postParams = ['grant_type' => 'client_credentials'];
 
 			$accessTokenUrl = $baseUrl . "/v1/oauth2/token";
 			$accessTokenResults = $payPalAuthRequest->curlPostPage($accessTokenUrl, $postParams);
-			$accessTokenResults = json_decode($accessTokenResults);
-			if (empty($accessTokenResults->access_token)) {
+			$decodedAccessTokenResults = json_decode($accessTokenResults);
+			
+			ExternalRequestLogEntry::logRequest('myaccount_ajax.completePayPalOrder', 'POST', $accessTokenUrl, $payPalAuthRequest->getHeaders(), json_encode($postParams), $payPalAuthRequest->getResponseCode(), $accessTokenResults, ['client_secret' => $clientSecret]);
+			
+			if (empty($decodedAccessTokenResults->access_token)) {
 				return [
 					'success' => false,
 					'message' => 'Unable to authenticate with PayPal, please try again in a few minutes.',
 				];
 			} else {
-				$accessToken = $accessTokenResults->access_token;
+				$accessToken = $decodedAccessTokenResults->access_token;
 			}
 
 			$payPalPaymentRequest = new CurlWrapper();
@@ -5201,9 +5209,11 @@ class MyAccount_AJAX extends JSON_Action {
 			$paymentRequestUrl = $baseUrl . '/v2/checkout/orders/' . $payment->orderId;
 
 			$paymentResponse = $payPalPaymentRequest->curlGetPage($paymentRequestUrl);
-			$paymentResponse = json_decode($paymentResponse);
+			$decodedPaymentResponse = json_decode($paymentResponse);
 
-			$purchaseUnits = $paymentResponse->purchase_units;
+			ExternalRequestLogEntry::logRequest('myaccount_ajax.completePayPalOrder', 'GET', $paymentRequestUrl, $payPalPaymentRequest->getHeaders(),'', $payPalPaymentRequest->getResponseCode(), $paymentResponse, []);
+
+			$purchaseUnits = $decodedPaymentResponse->purchase_units;
 			if (!empty($purchaseUnits)) {
 				$firstItem = reset($purchaseUnits);
 				$payments = $firstItem->payments;
@@ -5406,9 +5416,12 @@ class MyAccount_AJAX extends JSON_Action {
 
 				$paymentUrl = $baseUrl . '/v2/payments';
 				$paymentRequestResults = $paymentRequest->curlPostBodyData($paymentUrl, $body);
-				$paymentRequestResults = json_decode($paymentRequestResults);
-				if ($paymentRequestResults->payment) {
-					$paymentResults = $paymentRequestResults->payment;
+				$decodedPaymentRequestResults = json_decode($paymentRequestResults);
+
+				ExternalRequestLogEntry::logRequest('myaccount_ajax.completeSquareOrder', 'POST', $paymentUrl, $paymentRequest->getHeaders(), json_encode($body), $paymentRequest->getResponseCode(), $paymentRequestResults, []);
+				
+				if ($decodedPaymentRequestResults->payment) {
+					$paymentResults = $decodedPaymentRequestResults->payment;
 					if ($paymentResults->status == 'COMPLETED' || $paymentResults->status == 'APPROVED') {
 						if ($transactionType == 'donation') {
 							$payment->completed = 1;
@@ -5459,7 +5472,7 @@ class MyAccount_AJAX extends JSON_Action {
 						}
 					}
 				} else {
-					$error = $paymentRequestResults->error;
+					$error = $decodedPaymentRequestResults->error;
 					$payment->error = 1;
 					$payment->message = $error->detail;
 					$payment->update();
@@ -5810,6 +5823,9 @@ class MyAccount_AJAX extends JSON_Action {
 					}
 
 					$createPayerResponse = $curlWrapper->curlSendPage($url, 'PUT', json_encode($createPayer));
+
+					ExternalRequestLogEntry::logRequest('myaccount_ajax.createpropayorder', 'PUT', $url, $curlWrapper->getHeaders(), json_encode($createPayer), $curlWrapper->getResponseCode(), $createPayerResponse, []);
+
 					if ($createPayerResponse && $curlWrapper->getResponseCode() == 200) {
 						$jsonResponse = json_decode($createPayerResponse);
 						if ($patron != null) {
@@ -5849,6 +5865,9 @@ class MyAccount_AJAX extends JSON_Action {
 					}
 
 					$createMerchantProfileResponse = $curlWrapper->curlSendPage($url, 'PUT', json_encode($createMerchantProfile));
+						
+					ExternalRequestLogEntry::logRequest('myaccount_ajax.createpropayorder', 'PUT', $url, $curlWrapper->getHeaders(), json_encode($createMerchantProfile), $curlWrapper->getResponseCode(), $createMerchantProfileResponse, []);
+
 					if ($createMerchantProfileResponse && $curlWrapper->getResponseCode() == 200) {
 						$jsonResponse = json_decode($createMerchantProfileResponse);
 						$proPaySetting->merchantProfileId = $jsonResponse->ProfileId;
@@ -5902,6 +5921,9 @@ class MyAccount_AJAX extends JSON_Action {
 					}
 
 					$response = $curlWrapper->curlSendPage($url, 'PUT', json_encode($requestElements));
+
+					ExternalRequestLogEntry::logRequest('myaccount_ajax.createpropayorder', 'PUT', $url, $curlWrapper->getHeaders(), json_encode($requestElements), $curlWrapper->getResponseCode(), $response, []);
+
 					if ($response && $curlWrapper->getResponseCode() == 200) {
 						$jsonResponse = json_decode($response);
 						$transactionIdentifier = $jsonResponse->HostedTransactionIdentifier;
@@ -6229,8 +6251,9 @@ class MyAccount_AJAX extends JSON_Action {
 
 				$resultJSON = $newRedirectRequest->curlPostBodyData($url, $postParams, true);
 				$result = json_decode($resultJSON);
-				ExternalRequestLogEntry::logRequest('ncr.createNCROrder', 'POST', $url, $newRedirectRequest->getHeaders(), json_encode($postParams), $newRedirectRequest->getResponseCode(), $resultJSON, []);
 
+				ExternalRequestLogEntry::logRequest('myaccount_ajax.createNCROrder', 'POST', $url, $newRedirectRequest->getHeaders(), json_encode($postParams), $newRedirectRequest->getResponseCode(), $resultJSON, []);
+			
 				if ($result->status != "ok") {
 					return [
 						'success' => false,
@@ -6482,8 +6505,9 @@ class MyAccount_AJAX extends JSON_Action {
 
 			$tokenResults = $payflowTokenRequest->curlSendPage($tokenRequestUrl, 'POST', $params);
 			$tokenResults = PayPalPayflowSetting::parsePayflowString($tokenResults);
+
 			if ($tokenResults['RESULT'] != 0) {
-				ExternalRequestLogEntry::logRequest('getPayflowToken', 'POST', $tokenRequestUrl, $payflowTokenRequest->getHeaders(), $params, $payflowTokenRequest->getResponseCode(), $tokenResults, []);
+				ExternalRequestLogEntry::logRequest('myaccount_ajax.getPayflowToken', 'POST', $tokenRequestUrl, $payflowTokenRequest->getHeaders(), $params, $payflowTokenRequest->getResponseCode(), $tokenResults, []);
 				return [
 					'success' => false,
 					'message' => 'Unable to authenticate with Payflow, please try again in a few minutes.',
@@ -6698,8 +6722,11 @@ class MyAccount_AJAX extends JSON_Action {
 
 				$url = 'https://www.invoicecloud.com/api/v1/biller/status';
 				$authResponse = $authRequest->curlGetPage($url);
-				$authResponse = json_decode($authResponse);
-				if (!$authResponse->Active) {
+				$decodedAuthResponse = json_decode($authResponse);
+
+				ExternalRequestLogEntry::logRequest('myaccount_ajax.createInvoiceCloudOrder','GET', $url, $authRequest->getHeaders(),'', $authRequest->getResponseCode(), $authResponse, []);
+
+				if (!$decodedAuthResponse->Active) {
 					return [
 						'success' => false,
 						'message' => 'Unable to create your order in InvoiceCloud. Library has an inactive account.'
@@ -6745,14 +6772,17 @@ class MyAccount_AJAX extends JSON_Action {
 
 				$url = 'https://www.invoicecloud.com/cloudpaymentsapi/v2';
 				$paymentResponse = $paymentRequest->curlPostBodyData($url, $postParams);
-				$paymentResponse = json_decode($paymentResponse);
-				if ($paymentResponse->Message != 'SUCCESS') {
+				$decodedPaymentResponse = json_decode($paymentResponse);
+
+				ExternalRequestLogEntry::logRequest('myaccount_ajax.createInvoiceCloudOrder','POST', $url, $paymentRequest->getHeaders(),json_encode($postParams), $paymentRequest->getResponseCode(), $paymentRegitsponse, []);
+
+				if ($decodedPaymentResponse->Message != 'SUCCESS') {
 					return [
 						'success' => false,
-						'message' => 'Unable to create your order in InvoiceCloud. ' . $paymentResponse->Message
+						'message' => 'Unable to create your order in InvoiceCloud. ' . $decodedPaymentResponse->Message
 					];
 				}
-				$paymentRequestUrl = $paymentResponse->Data->CloudPaymentURL;
+				$paymentRequestUrl = $decodedPaymentResponse->Data->CloudPaymentURL;
 
 				return [
 					'success' => true,

--- a/code/web/sys/Account/UserPayment.php
+++ b/code/web/sys/Account/UserPayment.php
@@ -248,7 +248,7 @@ class UserPayment extends DataObject {
 							if ($hostedTransactionResultsResponse && $curlWrapper->getResponseCode() == 200) {
 								$jsonResponse = json_decode($hostedTransactionResultsResponse);
 							}
-							ExternalRequestLogEntry::logRequest('ncr.completeNCROrder', 'GET', $url, $curlWrapper->getHeaders(), false, $curlWrapper->getResponseCode(), $hostedTransactionResultsResponse, []);
+							ExternalRequestLogEntry::logRequest('myaccount_ajax.completeNCROrder', 'GET', $url, $curlWrapper->getHeaders(), false, $curlWrapper->getResponseCode(), $hostedTransactionResultsResponse, []);
 
 							if ($jsonResponse->status == "ok") {
 								if($userPayment->transactionType == 'donation') {
@@ -506,6 +506,9 @@ class UserPayment extends DataObject {
 							'Authorization: ' . $authorization,
 						], true);
 						$hostedTransactionResultsResponse = $curlWrapper->curlGetPage($url);
+
+						ExternalRequestLogEntry::logRequest('myaccount_ajax.completeProPayPayment', 'GET', $url, $curlWrapper->getHeaders(),"", $curlWrapper->getResponseCode(), $hostedTransactionResultsResponse, []);
+						
 						$jsonResponse = null;
 						if ($hostedTransactionResultsResponse && $curlWrapper->getResponseCode() == 200) {
 							$jsonResponse = json_decode($hostedTransactionResultsResponse);

--- a/code/web/sys/DBMaintenance/version_updates/25.05.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.05.00.php
@@ -31,6 +31,20 @@ function getUpdates25_05_00(): array {
 		//James Staub - Nashville Public Library
 
 		//Lucas Montoya - Theke Solutions
+		'forceDebugLog' => [
+			'title' => 'Enable Forced Logging of Debugging Information for Paypal, PayPalPayflow, Propay, InvoiceCloud, Square, Stripe, and ACISpeedPay Payments',
+			'description' => 'Enable to show debugging information about Paypal payments',
+			'sql' => [
+				'ALTER TABLE paypal_settings ADD COLUMN forceDebugLog TINYINT(1) DEFAULT 1',
+				'ALTER TABLE square_settings ADD COLUMN forceDebugLog TINYINT(1) DEFAULT 1',
+				'ALTER TABLE stripe_settings ADD COLUMN forceDebugLog TINYINT(1) DEFAULT 1',
+				'ALTER TABLE propay_settings ADD COLUMN forceDebugLog TINYINT(1) DEFAULT 1',
+				'ALTER TABLE ncr_payments_settings ADD COLUMN forceDebugLog TINYINT(1) DEFAULT 1',
+				'ALTER TABLE paypal_payflow_settings ADD COLUMN forceDebugLog TINYINT(1) DEFAULT 1',
+				'ALTER TABLE aci_speedpay_settings ADD COLUMN forceDebugLog TINYINT(1) DEFAULT 1',
+				'ALTER TABLE invoice_cloud_settings ADD COLUMN forceDebugLog TINYINT(1) DEFAULT 1',
+			]
+		], //enable_payments_debugging
 
 		//other
 

--- a/code/web/sys/ECommerce/ACISpeedpaySetting.php
+++ b/code/web/sys/ECommerce/ACISpeedpaySetting.php
@@ -16,7 +16,7 @@ class ACISpeedpaySetting extends DataObject {
 	public $sdkApiAuthKey;
 	public $billerId;
 	public $billerAccountId;
-
+	public $forceDebugLog;
 	private $_libraries;
 
 	static function getObjectStructure($context = ''): array {
@@ -105,6 +105,14 @@ class ACISpeedpaySetting extends DataObject {
 				'values' => $billerAccount_options,
 				'description' => 'The identifier field used to connect payments to users.',
 				'hideInLists' => true,
+			],
+			'forceDebugLog' => [
+				'property' => 'forceDebugLog',
+				'type' => 'checkbox',
+				'label' => 'Force Debugging Logs',
+				'description' => 'Whether or not to allow users to get debugging information about payments either if the user IP is authorized or not',
+				'hideInLists' => false,
+				'default' => true,
 			],
 
 			'libraries' => [
@@ -392,6 +400,11 @@ class ACISpeedpaySetting extends DataObject {
 		], true);
 
 		$paymentTransaction = $paymentRequest->curlPostBodyData($url, $postData);
+
+		$forceDebugLog = $this->forceDebugLog;
+		if (IPAddress::showDebuggingInformation() || $forceDebugLog){
+			ExternalRequestLogEntry::logRequest('aciSpeedPaySetting', 'POST', $url, $paymentRequest->getHeaders(), json_encode($postData), $paymentRequest->getResponseCode(), $paymentTransaction, []);
+		}
 
 		$paymentResponse = json_decode($paymentTransaction, true);
 		if ($paymentRequest->getResponseCode() == 200) {

--- a/code/web/sys/ECommerce/ACISpeedpaySetting.php
+++ b/code/web/sys/ECommerce/ACISpeedpaySetting.php
@@ -401,10 +401,7 @@ class ACISpeedpaySetting extends DataObject {
 
 		$paymentTransaction = $paymentRequest->curlPostBodyData($url, $postData);
 
-		$forceDebugLog = $this->forceDebugLog;
-		if (IPAddress::showDebuggingInformation() || $forceDebugLog){
-			ExternalRequestLogEntry::logRequest('aciSpeedPaySetting', 'POST', $url, $paymentRequest->getHeaders(), json_encode($postData), $paymentRequest->getResponseCode(), $paymentTransaction, []);
-		}
+		ExternalRequestLogEntry::logRequest('myaccount_ajax.aciSpeedPaySetting', 'POST', $url, $paymentRequest->getHeaders(), json_encode($postData), $paymentRequest->getResponseCode(), $paymentTransaction, []);
 
 		$paymentResponse = json_decode($paymentTransaction, true);
 		if ($paymentRequest->getResponseCode() == 200) {

--- a/code/web/sys/ECommerce/InvoiceCloudSetting.php
+++ b/code/web/sys/ECommerce/InvoiceCloudSetting.php
@@ -10,6 +10,7 @@ class InvoiceCloudSetting extends DataObject {
 	public $apiKey;
 	public $invoiceTypeId;
 	public $ccServiceFee;
+	public $forceDebugLog;
 
 	private $_libraries;
 
@@ -58,6 +59,15 @@ class InvoiceCloudSetting extends DataObject {
 				'hideInLists' => true,
 				'maxLength' => 50,
 			],
+			'forceDebugLog' => [
+				'property' => 'forceDebugLog',
+				'type' => 'checkbox',
+				'label' => 'Force Debugging Logs',
+				'description' => 'Whether or not to allow users to get debugging information about payments either if the user IP is authorized or not',
+				'hideInLists' => false,
+				'default' => true,
+			],
+			
 			'libraries' => [
 				'property' => 'libraries',
 				'type' => 'multiSelect',

--- a/code/web/sys/ECommerce/NCRPaymentsSetting.php
+++ b/code/web/sys/ECommerce/NCRPaymentsSetting.php
@@ -8,7 +8,7 @@ class NCRPaymentsSetting extends DataObject {
 	public $webKey;
 	public $paymentTypeId;
 	public $lastTransactionNumber;
-
+	public $forceDebugLog;
 	private $_libraries;
 
 	static function getObjectStructure($context = ''): array {
@@ -52,6 +52,14 @@ class NCRPaymentsSetting extends DataObject {
 				'hideInLists' => false,
 				'default' => '0',
 				'maxLength' => 1,
+			],
+			'forceDebugLog' => [
+				'property' => 'forceDebugLog',
+				'type' => 'checkbox',
+				'label' => 'Force Debugging Logs',
+				'description' => 'Whether or not to allow users to get debugging information about payments either if the user IP is authorized or not',
+				'hideInLists' => false,
+				'default' => true,
 			],
 			'libraries' => [
 				'property' => 'libraries',

--- a/code/web/sys/ECommerce/PayPalPayflowSetting.php
+++ b/code/web/sys/ECommerce/PayPalPayflowSetting.php
@@ -10,6 +10,7 @@ class PayPalPayflowSetting extends DataObject {
 	public $vendor;
 	public $user;
 	public $password;
+	public $forceDebugLog;
 
 	private $_libraries;
 
@@ -75,7 +76,15 @@ class PayPalPayflowSetting extends DataObject {
 				'default' => '',
 				'size' => 72,
 			],
-
+			'forceDebugLog' => [
+				'property' => 'forceDebugLog',
+				'type' => 'checkbox',
+				'label' => 'Force Debugging Logs',
+				'description' => 'Whether or not to allow users to get debugging information about payments either if the user IP is authorized or not',
+				'hideInLists' => false,
+				'default' => true,
+			],
+			
 			'libraries' => [
 				'property' => 'libraries',
 				'type' => 'multiSelect',

--- a/code/web/sys/ECommerce/PayPalSetting.php
+++ b/code/web/sys/ECommerce/PayPalSetting.php
@@ -6,6 +6,7 @@ class PayPalSetting extends DataObject {
 	public $id;
 	public $name;
 	public $sandboxMode;
+	public $forceDebugLog;
 	public $showPayLater;
 	public $clientId;
 	public $clientSecret;
@@ -37,6 +38,14 @@ class PayPalSetting extends DataObject {
 				'description' => 'Whether or not to use PayPal in Sandbox mode',
 				'hideInLists' => false,
 				'note' => 'This is for testing only! No funds will be received by the library.',
+			],
+			'forceDebugLog' => [
+				'property' => 'forceDebugLog',
+				'type' => 'checkbox',
+				'label' => 'Force Debugging Logs',
+				'description' => 'Whether or not to allow users to get debugging information about payments either if the user IP is authorized or not',
+				'hideInLists' => false,
+				'default' => true,
 			],
 			'showPayLater' => [
 				'property' => 'showPayLater',

--- a/code/web/sys/ECommerce/ProPaySetting.php
+++ b/code/web/sys/ECommerce/ProPaySetting.php
@@ -8,6 +8,7 @@ class ProPaySetting extends DataObject {
 	public $id;
 	public $name;
 	public $useTestSystem;
+	public $forceDebugLog;
 	public $authenticationToken;
 	public $billerAccountId;
 	public $merchantProfileId;
@@ -40,6 +41,14 @@ class ProPaySetting extends DataObject {
 				'label' => 'Use Test System',
 				'description' => 'Whether or not users to use ProPay test system',
 				'hideInLists' => true,
+			],
+			'forceDebugLog' => [
+				'property' => 'forceDebugLog',
+				'type' => 'checkbox',
+				'label' => 'Force Debugging Logs',
+				'description' => 'Whether or not to allow users to get debugging information about payments either if the user IP is authorized or not',
+				'hideInLists' => false,
+				'default' => true,
 			],
 			'authenticationToken' => [
 				'property' => 'authenticationToken',

--- a/code/web/sys/ECommerce/SquareSetting.php
+++ b/code/web/sys/ECommerce/SquareSetting.php
@@ -6,6 +6,7 @@ class SquareSetting extends DataObject {
 	public $id;
 	public $name;
 	public $sandboxMode;
+	public $forceDebugLog;
 	public $applicationId;
 	public $accessToken;
 	public $locationId;
@@ -36,6 +37,14 @@ class SquareSetting extends DataObject {
 				'description' => 'Whether or not to use Square in Sandbox mode',
 				'hideInLists' => false,
 				'note' => 'This is for testing only! No funds will be received by the library.',
+			],
+			'forceDebugLog' => [
+				'property' => 'forceDebugLog',
+				'type' => 'checkbox',
+				'label' => 'Force Debugging Logs',
+				'description' => 'Whether or not to allow users to get debugging information about payments either if the user IP is authorized or not',
+				'hideInLists' => false,
+				'default' => true,
 			],
 			'applicationId' => [
 				'property' => 'applicationId',

--- a/code/web/sys/ECommerce/StripeSetting.php
+++ b/code/web/sys/ECommerce/StripeSetting.php
@@ -163,12 +163,9 @@ class StripeSetting extends DataObject {
 
 		$url = $baseUrl . '/v1/payment_intents';
 		$paymentIntent = $paymentIntentSetup->curlPostPage($url, $postParams);
-
-		$forceDebugLog = $this->forceDebugLog;
-		if (IPAddress::showDebuggingInformation() || $forceDebugLog){
-			ExternalRequestLogEntry::logRequest('stripeSettings.createPaymentIntent', 'POST', $url, $paymentIntentSetup->getHeaders(), json_encode($postParams), $paymentIntentSetup->getResponseCode(), $paymentIntent, []);
-		}
-
+	
+		ExternalRequestLogEntry::logRequest('myaccount_ajax.createPaymentIntent', 'POST', $url, $paymentIntentSetup->getHeaders(), json_encode($postParams), $paymentIntentSetup->getResponseCode(), $paymentIntent, []);
+		
 		return json_decode($paymentIntent, true);
 	}
 

--- a/code/web/sys/ECommerce/StripeSetting.php
+++ b/code/web/sys/ECommerce/StripeSetting.php
@@ -5,6 +5,7 @@ class StripeSetting extends DataObject {
 	public $__table = 'stripe_settings';
 	public $id;
 	public $name;
+	public $forceDebugLog;
 	public $stripePublicKey;
 	public $stripeSecretKey;
 
@@ -44,6 +45,14 @@ class StripeSetting extends DataObject {
 				'hideInLists' => true,
 				'default' => '',
 				'size' => 100,
+			],
+			'forceDebugLog' => [
+				'property' => 'forceDebugLog',
+				'type' => 'checkbox',
+				'label' => 'Force Debugging Logs',
+				'description' => 'Whether or not to allow users to get debugging information about payments either if the user IP is authorized or not',
+				'hideInLists' => false,
+				'default' => true,
 			],
 			'libraries' => [
 				'property' => 'libraries',
@@ -154,6 +163,12 @@ class StripeSetting extends DataObject {
 
 		$url = $baseUrl . '/v1/payment_intents';
 		$paymentIntent = $paymentIntentSetup->curlPostPage($url, $postParams);
+
+		$forceDebugLog = $this->forceDebugLog;
+		if (IPAddress::showDebuggingInformation() || $forceDebugLog){
+			ExternalRequestLogEntry::logRequest('stripeSettings.createPaymentIntent', 'POST', $url, $paymentIntentSetup->getHeaders(), json_encode($postParams), $paymentIntentSetup->getResponseCode(), $paymentIntent, []);
+		}
+
 		return json_decode($paymentIntent, true);
 	}
 
@@ -180,6 +195,11 @@ class StripeSetting extends DataObject {
 		], true);
 
 		$paymentTransaction = $paymentRequest->curlPostBodyData($url, null);
+
+		$forceDebugLog = $this->forceDebugLog;
+		if (IPAddress::showDebuggingInformation() || $forceDebugLog){
+			ExternalRequestLogEntry::logRequest('stripeSettings.createPaymentIntent', 'POST', $url, $paymentRequest->getHeaders(),'', $paymentRequest->getResponseCode(), $paymentTransaction, []);
+		}
 
 		$paymentResponse = json_decode($paymentTransaction, true);
 		if ($paymentRequest->getResponseCode() == 200) {

--- a/code/web/sys/SystemLogging/ExternalRequestLogEntry.php
+++ b/code/web/sys/SystemLogging/ExternalRequestLogEntry.php
@@ -95,7 +95,7 @@ class ExternalRequestLogEntry extends DataObject {
 	 */
 	static function logRequest(string $requestType, string $method, string $url, $headers, string $body, string $responseCode, ?string $response, array $dataToSanitize) {
 		try {
-			if (IPAddress::showDebuggingInformation()) {
+			if (IPAddress::showDebuggingInformation() || (self::getForceDebuggingLogStatus() && str_starts_with($requestType,"myaccount_ajax"))) {
 				require_once ROOT_DIR . '/sys/SystemLogging/ExternalRequestLogEntry.php';
 				$externalRequest = new ExternalRequestLogEntry();
 				$externalRequest->requestType = $requestType;
@@ -122,6 +122,88 @@ class ExternalRequestLogEntry extends DataObject {
 			global $logger;
 			$logger->log("Error logging request " . $e->getMessage(), Logger::LOG_ERROR);
 		}
+	}
+
+	/**
+	 * Get the status of the toggle 'Force Debugging Log' for a set ecommerce application.
+	 * 
+	 * @return  bool     True if 'Force Debugging Log' is enabled for that ecommerce or False if not.
+	 * @access  private
+	 */
+	private static function getForceDebuggingLogStatus(){
+		
+		global $library;
+		$finePaymentType = $library->finePaymentType;
+		$settings = null;
+		$status = false;
+
+		switch($finePaymentType){
+			case 2:
+				require_once ROOT_DIR . '/sys/ECommerce/PayPalSetting.php';
+				$settings = new PayPalSetting();
+				$settings->id = $library->payPalSettingId;
+				if($settings->find(true)){
+					$status = $settings->forceDebugLog;
+				}
+				break;
+			case 5:
+				require_once ROOT_DIR . '/sys/ECommerce/ProPaySetting.php';
+				$settings = new ProPaySetting();
+				$settings->id = $library->proPaySettingId;
+				if($settings->find(true)){
+					$status = $settings->forceDebugLog;
+				}
+				break;
+			case 8:
+				require_once ROOT_DIR . '/sys/ECommerce/ACISpeedpaySetting.php';
+				$settings = new ACISpeedpaySetting();
+				$settings->id = $library->aciSpeedpaySettingId;
+				if($settings->find(true)){
+					$status = $settings->forceDebugLog;
+				}
+				break;
+			case 9:
+				require_once ROOT_DIR . '/sys/ECommerce/InvoiceCloudSetting.php';
+				$settings = new InvoiceCloudSetting();
+				$settings->id = $library->invoiceCloudSettingId;
+				if($settings->find(true)){
+					$status = $settings->forceDebugLog;
+				};
+				break;
+			case 11:
+				require_once ROOT_DIR . '/sys/ECommerce/PayPalPayflowSetting.php';
+				$settings = new PayPalPayflowSetting();
+				$settings->id = $library->paypalPayflowSettingId;
+				if($settings->find(true)){
+					$status = $settings->forceDebugLog;
+				}
+				break;
+			case 12:
+				require_once ROOT_DIR . '/sys/ECommerce/SquareSetting.php';
+				$settings = new SquareSetting();
+				$settings->id = $library->squareSettingId;
+				if($settings->find(true)){
+					$status = $settings->forceDebugLog;
+				}
+				break;
+			case 13:
+				require_once ROOT_DIR . '/sys/ECommerce/StripeSetting.php';
+				$settings = new StripeSetting();
+				$settings->id = $library->stripeSettingId;
+				if($settings->find(true)){
+					$status = $settings->forceDebugLog;
+				}
+				break;
+			case 14:
+				require_once ROOT_DIR . '/sys/ECommerce/NCRPaymentsSetting';
+				$settings = new NCRPaymentsSetting();
+				$settings->id = $library->ncrSettingId;
+				if($settings->find(true)){
+					$status = $settings->forceDebugLog;
+				}
+				break;
+		}
+		return $status;
 	}
 
 	private static function sanitize($field, $dataToSanitize) {


### PR DESCRIPTION
Test plan :

Login as a staff user with permissions to manage ecommerce payments settings

Set your prefer ecommerce to manage your payments like Paypal, ProPay, NCR, PaypalPayflow with valid credentials

Go to Greenhouse -> External Log Entry

Login with a user who has fines to pay (use an incognito window for testing)

Pay the fines

The staff user should be able to watch debugging information about movements related with the ecommerce