### PR TITLE
DIS-602: Fixed Password Reset Resend Email Link for Aspen-Koha Instances

### DIFF
--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -3437,15 +3437,28 @@ class Koha extends AbstractIlsDriver {
 
 		$username = isset($_REQUEST['username']) ? strip_tags($_REQUEST['username']) : '';
 		$email = isset($_REQUEST['email']) ? strip_tags($_REQUEST['email']) : '';
+		// Check if this is a resend email request from the form shown to the user.
+		$isResendRequest = isset($_REQUEST['op']) && $_REQUEST['op'] === 'cud-resendEmail';
+
 		if ($kohaVersion >= 24.05) {
-			$postVariables = [
-				'koha_login_context' => 'opac',
-				'username' => $username,
-				'email' => $email,
-				'op' => 'cud-sendEmail',
-				'csrf_token' => $csrfToken
-			];
-		}else{
+			if ($isResendRequest) {
+				$postVariables = [
+					'koha_login_context' => 'opac',
+					'username' => $username,
+					'email' => $email,
+					'op' => 'cud-resendEmail',
+					'csrf_token' => $csrfToken
+				];
+			} else {
+				$postVariables = [
+					'koha_login_context' => 'opac',
+					'username' => $username,
+					'email' => $email,
+					'op' => 'cud-sendEmail',
+					'csrf_token' => $csrfToken
+				];
+			}
+		} else {
 			$postVariables = [
 				'koha_login_context' => 'opac',
 				'username' => $username,
@@ -3458,7 +3471,6 @@ class Koha extends AbstractIlsDriver {
 		}
 
 		$postResults = $this->postToKohaPage($catalogUrl . '/cgi-bin/koha/opac-password-recovery.pl', $postVariables);
-
 		$messageInformation = [];
 		if ($postResults == 'Internal Server Error') {
 			if (isset($_REQUEST['resendEmail'])) {
@@ -3478,14 +3490,25 @@ class Koha extends AbstractIlsDriver {
 				$error = str_replace('<h3>', '<h4>', $error);
 				$error = str_replace('</h3>', '</h4>', $error);
 				$error = str_replace('/cgi-bin/koha/opac-password-recovery.pl', '/MyAccount/EmailResetPin', $error);
-				if ($kohaVersion >= 24.05) {
-					$error = str_replace('#', '/MyAccount/EmailResetPin', $error);
+
+				if (preg_match('/<a href="#" id="resendmail">Get new password recovery link<\/a>.*?<form method="post" id="resendform".*?<input type="hidden" name="email" value="(.*?)" \/>.*?<input type="hidden" name="username" value="(.*?)" \/>/s', $error, $resendMatches)) {
+					$email = $resendMatches[1];
+					$username = $resendMatches[2];
+					$resendLink = '/MyAccount/EmailResetPin?username=' . urlencode($username) . '&email=' . urlencode($email) . '&op=cud-resendEmail&submit=true';
+
+					// Replace both the link and the form so PHP does not interpret the hidden form inputs as a form submission.
+					$error = preg_replace('/<a href="#" id="resendmail">Get new password recovery link<\/a>.*?<\/form>/s',
+						'<a href="' . $resendLink . '">Get new password recovery link</a>',
+						$error);
 				}
 				$result['error'] = trim($error);
 			} elseif (preg_match('%<div id="password-recovery">\s+<div class="alert alert-info">(.*?)<a href="/cgi-bin/koha/opac-main.pl">Return to the main page</a>\s+</div>\s+</div>%s', $postResults, $messageInformation)) {
 				$message = $messageInformation[1];
 				$result['success'] = true;
-				$result['message'] = trim($message);
+				$result['message'] = translate([
+					'text' => trim($message),
+					'isPublicFacing' => true,
+				]);
 			}
 		}
 

--- a/code/web/interface/themes/responsive/MyAccount/emailResetPinResults.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/emailResetPinResults.tpl
@@ -10,6 +10,9 @@
 					</div>
 				{elseif !empty($result.message)}
 					<div class="alert alert-success">{$result.message}</div>{* Translation should be done prior to display *}
+					<p class="alert alert-warning">
+						{translate text="If you do not receive an email within a few minutes, please check any spam folder your email service may have.   If you do not receive any email, please contact your library to have them reset your pin." isPublicFacing=true}
+					</p>
 					<p>
 						<a class="btn btn-primary" role="button" href="/MyAccount/Login">{translate text='Sign in' isPublicFacing=true}</a>
 					</p>

--- a/code/web/release_notes/25.04.00.MD
+++ b/code/web/release_notes/25.04.00.MD
@@ -77,6 +77,10 @@
 - Added more extensive logging so users and developers alike understand what the exporter is doing. (DIS-505) (*LS*)
 - Disabled editing of the Last Update of Changed Records and Last Update of All Records fields because they are populated by the exporter. (DIS-505) (*LS*)
 
+### Password Recovery Updates
+- Fixed the "Get new password recovery link" so it attempts to send users a new email if one has already been sent for password recovery for Koha ILS. (DIS-602) (*LS*)
+- Enhanced messages upon successful password resets via email to properly display messages, if any exist, sent from the respective ILS. (DIS-602) (*LS*)
+
 ### Pickup Areas
 - Relabel pickup locations to pickup area for clarity and consistency. (DIS-526) (*MDN*)
 

--- a/code/web/services/MyAccount/EmailResetPin.php
+++ b/code/web/services/MyAccount/EmailResetPin.php
@@ -13,7 +13,7 @@ class MyAccount_EmailResetPin extends Action {
 		$catalog = CatalogFactory::getCatalogConnectionInstance(null, null);
 		if (isset($_REQUEST['submit'])) {
 			$emailResult = $catalog->processEmailResetPinForm();
-			header('Location: /MyAccount/EmailResetPinResults?success=' . $emailResult['success'] . '&error=' . urlencode($emailResult['error']) ?? '');
+			header('Location: /MyAccount/EmailResetPinResults?success=' . $emailResult['success'] . '&error=' . urlencode($emailResult['error'] ?? '') . '&message=' . urlencode($emailResult['message'] ?? ''));
 		} else {
 			$this->display($catalog->getEmailResetPinTemplate(), 'Reset ' . $interface->getVariable('passwordLabel'), '');
 		}

--- a/code/web/services/MyAccount/EmailResetPinResults.php
+++ b/code/web/services/MyAccount/EmailResetPinResults.php
@@ -12,12 +12,15 @@ class MyAccount_EmailResetPinResults extends Action {
 		$interface->assign('passwordLabel', str_replace('Your', '', $library->loginFormPasswordLabel ? $library->loginFormPasswordLabel : 'Library Card Number'));
 
 		$catalog = CatalogFactory::getCatalogConnectionInstance(null, null);
-		if($_REQUEST['success']) {
+		if(isset($_REQUEST['success']) && $_REQUEST['success']) {
 			$result['success'] = true;
+			if(!empty($_REQUEST['message'])) {
+				$result['message'] = $_REQUEST['message'];
+			}
 		} else {
 			$result['success'] = false;
 			$result['error'] = '';
-			if($_REQUEST['error']) {
+			if(isset($_REQUEST['error']) && $_REQUEST['error']) {
 				$result['error'] = $_REQUEST['error'];
 			}
 		}


### PR DESCRIPTION
- Fixed the "Get new password recovery link" so it attempts to send users a new email if one has already been sent for password recovery for Koha ILS.
- Enhanced messages upon successful password resets via email to properly display messages, if any exist, sent from the respective ILS.

Test Plan:
1. On an Aspen-Koha instance, navigate to the site's home page and click "Sign In." Then, click "Reset My PIN / Password."
2. Enter a patron's barcode and email and click "Reset My Pin." If this is your first attempt at a password/pin reset for that patron in the last two days, then a screen with a success message will be displayed.
3. Repeat steps 1-2. An error message will be displayed and click "Get new password recovery link."
4. You will be incorrectly redirected to the screen where you entered the patron's barcode and email in previous attempts.
5. Apply the patch and repeat step 3. Now, the link will take you to a new screen with a success message indicating the email has be resent.