### PR TITLE
DIS-629: Fix paths for tunnel and solr Dockerfiles on gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,7 @@ build:aspen:
 build:solr:
   stage: build
   script:
-    - docker build . -f docker/solr/Dockerfile -t $BASEIMAGE/solr:$CI_COMMIT_TAG
+    - docker build . -f docker/files/solr/Dockerfile -t $BASEIMAGE/solr:$CI_COMMIT_TAG
     - docker tag $BASEIMAGE/solr:$CI_COMMIT_TAG $BASEIMAGE/solr:latest
     - docker push $BASEIMAGE/solr:$CI_COMMIT_TAG
     - docker push $BASEIMAGE/solr:latest
@@ -36,7 +36,7 @@ build:solr:
 build:tunnel:
   stage: build
   script:
-    - docker build . -f docker/tunnel/Dockerfile -t $BASEIMAGE/tunnel:$CI_COMMIT_TAG
+    - docker build . -f docker/files/tunnel/Dockerfile -t $BASEIMAGE/tunnel:$CI_COMMIT_TAG
     - docker tag $BASEIMAGE/tunnel:$CI_COMMIT_TAG $BASEIMAGE/tunnel:latest
     - docker push $BASEIMAGE/tunnel:$CI_COMMIT_TAG
     - docker push $BASEIMAGE/tunnel:latest

--- a/code/web/release_notes/25.05.00.MD
+++ b/code/web/release_notes/25.05.00.MD
@@ -37,6 +37,8 @@
 // jacob
 
 // lucas
+### Docker Updates
+- Fix : The paths of both solr and tunnel Dockerfiles have been updated in the gitlab-ci.yml (DIS-629) (*LM*)
 
 ## This release includes code contributions from
 ### ByWater Solutions


### PR DESCRIPTION
The paths for solr and tunnel services have been corrected.