### PR TITLE
DIS-631: Fixed Incorrect SSO Page Redirection

### DIFF
--- a/code/web/release_notes/25.05.00.MD
+++ b/code/web/release_notes/25.05.00.MD
@@ -19,6 +19,10 @@
 // imani
 
 // leo
+### SSO Updates
+- Fixed an issue where users were not properly redirected back to the page they were viewing before a successful SSO. (DIS-631) (*LS*)
+- Enhanced session handling to maintain state during AJAX operations when setting return-to locations. (DIS-631) (*LS*)
+- Improved SSO redirect behavior to preserve the exact search parameters and page position when logging in from search results. (DIS-631) (*LS*)
 
 // yanjun
 

--- a/code/web/services/Admin/Admin.php
+++ b/code/web/services/Admin/Admin.php
@@ -6,6 +6,9 @@ abstract class Admin_Admin extends Action {
 	function __construct($isStandalonePage = false) {
 		parent::__construct($isStandalonePage);
 
+		$_SESSION['returnToModule'] = 'Admin';
+		$_SESSION['returnToAction'] = 'Home';
+
 		$user = UserAccount::getLoggedInUser();
 
 		//If the user isn't logged in, take them to the login page

--- a/code/web/services/Authentication/SAML2.php
+++ b/code/web/services/Authentication/SAML2.php
@@ -28,19 +28,6 @@ class Authentication_SAML2 extends Action {
 				if ($followupModule == 'Search' && $followupAction == 'Results' && isset($_SESSION['lastSearchURL'])) {
 					$returnTo = $_SESSION['lastSearchURL'];
 					unset($_SESSION['lastSearchURL']);
-				} elseif($followupModule == 'WebBuilder' && $followupAction == 'PortalPage' && $followupPageId) {
-					require_once ROOT_DIR . '/sys/WebBuilder/PortalPage.php';
-					$portalPage = new PortalPage();
-					$portalPage->id = $followupPageId;
-					if ($portalPage->find(true)) {
-						if ($portalPage->urlAlias) {
-							$returnTo = $portalPage->urlAlias;
-						} else {
-							$returnTo = $configArray['Site']['url'] . '/' . $followupModule . '/' . $followupAction . '?id=' . $followupPageId;
-						}
-					} else {
-						$returnTo = $configArray['Site']['url'] . '/' . $followupModule . '/' . $followupAction . '?id=' . $followupPageId;
-					}
 				} else {
 					$returnTo = $configArray['Site']['url'] . '/' . $followupModule . '/' . $followupAction;
 					if ($followupPageId) {

--- a/code/web/services/Authentication/SAML2.php
+++ b/code/web/services/Authentication/SAML2.php
@@ -3,9 +3,10 @@ require_once ROOT_DIR . '/sys/Authentication/SAMLAuthentication.php';
 
 class Authentication_SAML2 extends Action {
 	/**
-	 * @throws UnknownAuthenticationMethodException
+	 * @throws UnknownAuthenticationMethodException|OneLogin_Saml2_Error
 	 */
-	public function launch() {
+	public function launch(): void
+	{
 		global $configArray;
 
 		if(isset($_GET['init'])) {
@@ -18,16 +19,14 @@ class Authentication_SAML2 extends Action {
 			$followupAction = $_SESSION['returnToAction'] ?? $action;
 			$followupModule = $_SESSION['returnToModule'] ?? $module;
 			$followupPageId = $_SESSION['returnToId'] ?? null;
-			$logger->log("SSO: " .
-				($_SESSION['returnToAction'] ?? 'not set') . ', ' .
-				($_SESSION['returnToModule'] ?? 'not set') . ', ' .
-				($_SESSION['returnToId'] ?? 'not set'),
-				Logger::LOG_ERROR
-			);
+
 			if($followupModule && $followupAction) {
 				if ($followupModule == 'Search' && $followupAction == 'Results' && isset($_SESSION['lastSearchURL'])) {
 					$returnTo = $_SESSION['lastSearchURL'];
 					unset($_SESSION['lastSearchURL']);
+				}
+				elseif ($followupModule == 'MyAccount' && $followupPageId) {
+					$returnTo = $configArray['Site']['url'] . '/' . $followupModule . '/' . $followupAction . '/' . $followupPageId;
 				} else {
 					$returnTo = $configArray['Site']['url'] . '/' . $followupModule . '/' . $followupAction;
 					if ($followupPageId) {

--- a/code/web/services/Authentication/SAML2.php
+++ b/code/web/services/Authentication/SAML2.php
@@ -15,9 +15,15 @@ class Authentication_SAML2 extends Action {
 			$returnTo = $configArray['Site']['url'];
 			$action = isset($_REQUEST['followupAction']) ? strip_tags($_REQUEST['followupAction']) : 'Home';
 			$module = isset($_REQUEST['followupModule']) ? strip_tags($_REQUEST['followupModule']) :  'MyAccount';
-			$followupAction = isset($_SESSION['returnToAction']) ?? $action;
-			$followupModule = isset($_SESSION['returnToModule']) ?? $module;
-			$followupPageId = isset($_SESSION['returnToId']) ?? null;
+			$followupAction = $_SESSION['returnToAction'] ?? $action;
+			$followupModule = $_SESSION['returnToModule'] ?? $module;
+			$followupPageId = $_SESSION['returnToId'] ?? null;
+			$logger->log("SSO: " .
+				($_SESSION['returnToAction'] ?? 'not set') . ', ' .
+				($_SESSION['returnToModule'] ?? 'not set') . ', ' .
+				($_SESSION['returnToId'] ?? 'not set'),
+				Logger::LOG_ERROR
+			);
 			if($followupModule && $followupAction) {
 				if($followupModule == 'WebBuilder' && $followupAction == 'PortalPage' && $followupPageId) {
 					require_once ROOT_DIR . '/sys/WebBuilder/PortalPage.php';
@@ -27,17 +33,21 @@ class Authentication_SAML2 extends Action {
 						if ($portalPage->urlAlias) {
 							$returnTo = $portalPage->urlAlias;
 						} else {
-							$returnTo = $configArray['Site']['url'] . '/' . $followupModule . '/' . $followupAction . '?id=' . $followupAction;
+							$returnTo = $configArray['Site']['url'] . '/' . $followupModule . '/' . $followupAction . '?id=' . $followupPageId;
 						}
 					} else {
-						$returnTo = $configArray['Site']['url'] . '/' . $followupModule . '/' . $followupAction . '?id=' . $followupAction;
+						$returnTo = $configArray['Site']['url'] . '/' . $followupModule . '/' . $followupAction . '?id=' . $followupPageId;
 					}
 				} else {
 					$returnTo = $configArray['Site']['url'] . '/' . $followupModule . '/' . $followupAction;
+					if ($followupPageId) {
+						$returnTo .= '?id=' . $followupPageId;
+					}
 				}
 			}
 			unset($_SESSION['returnToAction']);
 			unset($_SESSION['returnToModule']);
+			unset($_SESSION['returnToId']);
 			unset($_REQUEST['followupAction']);
 			unset($_REQUEST['followupModule']);
 			$auth->login($returnTo);

--- a/code/web/services/Authentication/SAML2.php
+++ b/code/web/services/Authentication/SAML2.php
@@ -25,7 +25,10 @@ class Authentication_SAML2 extends Action {
 				Logger::LOG_ERROR
 			);
 			if($followupModule && $followupAction) {
-				if($followupModule == 'WebBuilder' && $followupAction == 'PortalPage' && $followupPageId) {
+				if ($followupModule == 'Search' && $followupAction == 'Results' && isset($_SESSION['lastSearchURL'])) {
+					$returnTo = $_SESSION['lastSearchURL'];
+					unset($_SESSION['lastSearchURL']);
+				} elseif($followupModule == 'WebBuilder' && $followupAction == 'PortalPage' && $followupPageId) {
 					require_once ROOT_DIR . '/sys/WebBuilder/PortalPage.php';
 					$portalPage = new PortalPage();
 					$portalPage->id = $followupPageId;

--- a/code/web/services/Axis360/Home.php
+++ b/code/web/services/Axis360/Home.php
@@ -61,6 +61,7 @@ class Axis360_Home extends GroupedWorkSubRecordHomeAction {
 			$interface->assign('semanticData', json_encode($this->recordDriver->getSemanticData()));
 
 			$_SESSION['returnToAction'] = $this->id;
+			$_SESSION['returnToModule'] = 'Axis360';
 
 			// Display Page
 			$this->display('full-record.tpl', $this->recordDriver->getTitle(), '', false);

--- a/code/web/services/CloudLibrary/Home.php
+++ b/code/web/services/CloudLibrary/Home.php
@@ -62,6 +62,7 @@ class CloudLibrary_Home extends GroupedWorkSubRecordHomeAction {
 
 
 			$_SESSION['returnToAction'] = $this->id;
+			$_SESSION['returnToModule'] = 'CloudLibrary';
 
 			// Display Page
 			$this->display('full-record.tpl', $this->recordDriver->getTitle(), '', false);

--- a/code/web/services/CloudLibrary/Home.php
+++ b/code/web/services/CloudLibrary/Home.php
@@ -60,7 +60,6 @@ class CloudLibrary_Home extends GroupedWorkSubRecordHomeAction {
 
 			$interface->assign('semanticData', json_encode($this->recordDriver->getSemanticData()));
 
-
 			$_SESSION['returnToAction'] = $this->id;
 			$_SESSION['returnToModule'] = 'CloudLibrary';
 

--- a/code/web/services/GroupedWork/AJAX.php
+++ b/code/web/services/GroupedWork/AJAX.php
@@ -477,6 +477,9 @@ class GroupedWork_AJAX extends JSON_Action {
 
 		require_once ROOT_DIR . '/RecordDrivers/GroupedWorkDriver.php';
 		$id = $_REQUEST['id'];
+		$_SESSION['returnToModule'] = 'GroupedWork';
+		$_SESSION['returnToAction'] = $id;
+
 		$recordDriver = new GroupedWorkDriver($id);
 
 		if (!empty($_REQUEST['browseCategoryId'])) { // TODO need to check for $_REQUEST['subCategory'] ??

--- a/code/web/services/GroupedWork/Home.php
+++ b/code/web/services/GroupedWork/Home.php
@@ -13,7 +13,8 @@ class GroupedWork_Home extends Action {
 		global $logger;
 
 		$id = strip_tags($_REQUEST['id']);
-		$_SESSION['returnToAction'] = $id;
+		$_SESSION['returnToAction'] = $id . "?showPlaceHold=true";
+		$_SESSION['returnToModule'] = 'GroupedWork';
 
 		require_once ROOT_DIR . '/RecordDrivers/GroupedWorkDriver.php';
 		$this->recordDriver = new GroupedWorkDriver($id);

--- a/code/web/services/GroupedWork/Home.php
+++ b/code/web/services/GroupedWork/Home.php
@@ -13,7 +13,7 @@ class GroupedWork_Home extends Action {
 		global $logger;
 
 		$id = strip_tags($_REQUEST['id']);
-		$_SESSION['returnToAction'] = $id . "?showPlaceHold=true";
+		$_SESSION['returnToAction'] = $id;
 		$_SESSION['returnToModule'] = 'GroupedWork';
 
 		require_once ROOT_DIR . '/RecordDrivers/GroupedWorkDriver.php';

--- a/code/web/services/Hoopla/Home.php
+++ b/code/web/services/Hoopla/Home.php
@@ -16,6 +16,7 @@ class Hoopla_Home extends GroupedWorkSubRecordHomeAction {
 		$id = strip_tags($_REQUEST['id']);
 		$interface->assign('id', $id);
 		$_SESSION['returnToAction'] = $id;
+		$_SESSION['returnToModule'] = 'Hoopla';
 		$this->recordDriver = new HooplaRecordDriver($id);
 
 		global $enabledModules;

--- a/code/web/services/MyAccount/MyList.php
+++ b/code/web/services/MyAccount/MyList.php
@@ -37,6 +37,9 @@ class MyAccount_MyList extends MyAccount {
 
 		// Fetch List object
 		$listId = $_REQUEST['id'];
+		$_SESSION['returnToModule'] = 'MyAccount';
+		$_SESSION['returnToAction'] = 'MyList';
+		$_SESSION['returnToId'] = $listId;
 		require_once ROOT_DIR . '/sys/UserLists/UserList.php';
 		require_once ROOT_DIR . '/sys/UserLists/UserListEntry.php';
 		$list = new UserList();

--- a/code/web/services/OverDrive/Home.php
+++ b/code/web/services/OverDrive/Home.php
@@ -61,6 +61,9 @@ class OverDrive_Home extends GroupedWorkSubRecordHomeAction {
 
 			$interface->assign('semanticData', json_encode($this->recordDriver->getSemanticData()));
 
+			$_SESSION['returnToAction'] = $this->id;
+			$_SESSION['returnToModule'] = 'OverDrive';
+
 			// Display Page
 			$this->display('full-record.tpl', $this->recordDriver->getTitle(), '', false);
 

--- a/code/web/services/PalaceProject/Home.php
+++ b/code/web/services/PalaceProject/Home.php
@@ -61,6 +61,7 @@ class PalaceProject_Home extends GroupedWorkSubRecordHomeAction {
 			$interface->assign('semanticData', json_encode($this->recordDriver->getSemanticData()));
 
 			$_SESSION['returnToAction'] = $this->id;
+			$_SESSION['returnToModule'] = 'PalaceProject';
 
 			// Display Page
 			$this->display('full-record.tpl', $this->recordDriver->getTitle(), '', false);

--- a/code/web/services/Person/Home.php
+++ b/code/web/services/Person/Home.php
@@ -28,6 +28,7 @@ class Person_Home extends Action {
 		//Load basic information needed in subclasses
 		$id = $_GET['id'];
 		$_SESSION['returnToAction'] = $id;
+		$_SESSION['returnToModule'] = 'Person';
 
 		// Setup Search Engine Connection
 		// Include Search Engine Class

--- a/code/web/services/Record/Home.php
+++ b/code/web/services/Record/Home.php
@@ -227,6 +227,7 @@ class Record_Home extends GroupedWorkSubRecordHomeAction {
 		}
 
 		$_SESSION['returnToAction'] = $this->id;
+		$_SESSION['returnToModule'] = 'Record';
 
 		// Retrieve User Search History
 		$this->lastSearch = isset($_SESSION['lastSearchURL']) ? $_SESSION['lastSearchURL'] : false;

--- a/code/web/services/Search/Results.php
+++ b/code/web/services/Search/Results.php
@@ -402,11 +402,13 @@ class Search_Results extends ResultsAction {
 			}
 		}
 
-		// Save the ID of this search to the session so we can return to it easily:
+		// Save the ID of this search to the session so we can return to it easily.
 		$_SESSION['lastSearchId'] = $searchObject->getSearchId();
 
-		// Save the URL of this search to the session so we can return to it easily:
+		// Save the URL of this search to the session so we can return to it easily.
 		$_SESSION['lastSearchURL'] = $searchObject->renderSearchUrl();
+		$_SESSION['returnToModule'] = 'Search';
+		$_SESSION['returnToAction'] = 'Results';
 
 		//Always get spelling suggestions to account for cases where something is misspelled, but still gets results
 		$spellingSuggestions = $searchObject->getSpellingSuggestions();

--- a/code/web/services/WebBuilder/BasicPage.php
+++ b/code/web/services/WebBuilder/BasicPage.php
@@ -13,6 +13,9 @@ class WebBuilder_BasicPage extends Action {
 		global $interface;
 
 		$id = strip_tags($_REQUEST['id']);
+		$_SESSION['returnToId'] = $id;
+		$_SESSION['returnToModule'] = 'WebBuilder';
+		$_SESSION['returnToAction'] = 'BasicPage';
 		$this->basicPage = new BasicPage();
 		$this->basicPage->id = $id;
 

--- a/code/web/services/WebBuilder/CustomWebResourcePage.php
+++ b/code/web/services/WebBuilder/CustomWebResourcePage.php
@@ -12,6 +12,9 @@ class WebBuilder_CustomWebResourcePage extends Action {
 		global $interface;
 
 		$id = strip_tags($_REQUEST['id']);
+		$_SESSION['returnToId'] = $id;
+		$_SESSION['returnToModule'] = 'WebBuilder';
+		$_SESSION['returnToAction'] = 'CustomWebResourcePage';
 		$this->customWebResourcePage = new CustomWebResourcePage();
 		$this->customWebResourcePage->id = $id;
 

--- a/code/web/services/WebBuilder/Form.php
+++ b/code/web/services/WebBuilder/Form.php
@@ -8,6 +8,9 @@ class WebBuilder_Form extends Action {
 		global $interface;
 
 		$id = strip_tags($_REQUEST['id']);
+		$_SESSION['returnToId'] = $id;
+		$_SESSION['returnToModule'] = 'WebBuilder';
+		$_SESSION['returnToAction'] = 'Form';
 		$interface->assign('id', $id);
 
 		require_once ROOT_DIR . '/sys/WebBuilder/CustomForm.php';

--- a/code/web/services/WebBuilder/GrapesPage.php
+++ b/code/web/services/WebBuilder/GrapesPage.php
@@ -13,6 +13,9 @@ class WebBuilder_GrapesPage extends Action {
 		global $interface;
 
 		$id = strip_tags($_REQUEST['id']);
+		$_SESSION['returnToId'] = $id;
+		$_SESSION['returnToModule'] = 'WebBuilder';
+		$_SESSION['returnToAction'] = 'GrapesPage';
 		$this->grapesPage = new GrapesPage();
 		$this->grapesPage->id = $id;
 

--- a/code/web/services/WebBuilder/PortalPage.php
+++ b/code/web/services/WebBuilder/PortalPage.php
@@ -13,6 +13,8 @@ class WebBuilder_PortalPage extends Action {
 		$this->portalPage = new PortalPage();
 		$id = strip_tags($_REQUEST['id']);
 		$_SESSION['returnToId'] = $_REQUEST['id'];
+		$_SESSION['returnToModule'] = 'WebBuilder';
+		$_SESSION['returnToAction'] = 'PortalPage';
 		$this->portalPage->id = $id;
 		$this->portalPageFound = $this->portalPage->find(true);
 

--- a/code/web/services/WebBuilder/PortalPage.php
+++ b/code/web/services/WebBuilder/PortalPage.php
@@ -12,7 +12,7 @@ class WebBuilder_PortalPage extends Action {
 		require_once ROOT_DIR . '/sys/WebBuilder/PortalPage.php';
 		$this->portalPage = new PortalPage();
 		$id = strip_tags($_REQUEST['id']);
-		$_SESSION['returnToId'] = $_REQUEST['id'];
+		$_SESSION['returnToId'] = $id;
 		$_SESSION['returnToModule'] = 'WebBuilder';
 		$_SESSION['returnToAction'] = 'PortalPage';
 		$this->portalPage->id = $id;

--- a/code/web/services/WebBuilder/QuickPoll.php
+++ b/code/web/services/WebBuilder/QuickPoll.php
@@ -8,6 +8,9 @@ class WebBuilder_QuickPoll extends Action {
 		global $interface;
 
 		$id = strip_tags($_REQUEST['id']);
+		$_SESSION['returnToId'] = $id;
+		$_SESSION['returnToModule'] = 'WebBuilder';
+		$_SESSION['returnToAction'] = 'QuickPoll';
 		$interface->assign('id', $id);
 
 		require_once ROOT_DIR . '/sys/WebBuilder/QuickPoll.php';

--- a/code/web/services/WebBuilder/StaffDirectory.php
+++ b/code/web/services/WebBuilder/StaffDirectory.php
@@ -6,6 +6,9 @@ class StaffDirectory extends Action {
 		global $interface;
 		global $library;
 
+		$_SESSION['returnToModule'] = 'WebBuilder';
+		$_SESSION['returnToAction'] = 'StaffDirectory';
+
 		require_once ROOT_DIR . '/sys/WebBuilder/StaffMember.php';
 		$staffMember = new StaffMember();
 		$staffMember->orderBy('name');

--- a/code/web/services/WebBuilder/WebResource.php
+++ b/code/web/services/WebBuilder/WebResource.php
@@ -7,6 +7,9 @@ class WebBuilder_WebResource extends Action {
 		global $interface;
 
 		$id = strip_tags($_REQUEST['id']);
+		$_SESSION['returnToId'] = $id;
+		$_SESSION['returnToModule'] = 'WebBuilder';
+		$_SESSION['returnToAction'] = 'WebResource';
 		$interface->assign('id', $id);
 
 		require_once ROOT_DIR . '/sys/WebBuilder/WebResource.php';

--- a/code/web/sys/Session/MySQLSession.php
+++ b/code/web/sys/Session/MySQLSession.php
@@ -43,7 +43,18 @@ class MySQLSession extends SessionInterface {
 			//Don't update sessions on AJAX and JSON calls
 			if (isset($_REQUEST['method'])) {
 				$method = $_REQUEST['method'];
-				if ($method != 'loginUser' && $method != 'login' && $method != 'initiateMasquerade' && $method != 'endMasquerade' && $method != 'lockFacet' && $method != 'unlockFacet' && $method != 'updateDisplaySettings' && !isset($_REQUEST['showCovers']) && !isset($_REQUEST['sort']) && !isset($_REQUEST['availableHoldSort']) && !isset($_REQUEST['unavailableHoldSort']) && !isset($_REQUEST['autologout'])) {
+				$skipWrite = (
+					$method != 'loginUser' && $method != 'login' &&
+					$method != 'initiateMasquerade' && $method != 'endMasquerade' &&
+					$method != 'lockFacet' && $method != 'unlockFacet' &&
+					$method != 'updateDisplaySettings' && !isset($_REQUEST['showCovers']) &&
+					!isset($_REQUEST['sort']) && !isset($_REQUEST['availableHoldSort']) &&
+					!isset($_REQUEST['unavailableHoldSort']) && !isset($_REQUEST['autologout']) &&
+					// Do not skip session writes for AJAX calls that have set returnToModule or returnToAction.
+					!(isset($_SESSION['returnToModule']) || isset($_SESSION['returnToAction']))
+				);
+
+				if ($skipWrite) {
 					//$logger->log("Not updating session $sess_id $module $action $method", Logger::LOG_DEBUG);
 					return true;
 				}


### PR DESCRIPTION
**This patch only considers SAML; the same issue may occur for other SSO types.**
- Fixed an issue where users were not properly redirected back to the page they were viewing before a successful SSO. (DIS-631) (*LS*)
- Enhanced session handling to maintain state during AJAX operations when setting return-to locations. (DIS-631) (*LS*)
- Improved SSO redirect behavior to preserve the exact search parameters and page position when logging in from search results. (DIS-631) (*LS*)

Test Plan:
1. Pick any of the above pages (i.e., modules) to view and navigate to it.
2. Click the “Sign In” button and use SSO.
3. You will be incorrectly redirected to the home page where you see all browse categories after a successful sign-in.
4. Apply the patch and repeat steps 1-2. You will be redirected back to the page you were viewing before successfully signing in.