### PR TITLE
DIS-634: Set Account Profiles for Imported Patron Types from Koha

### DIFF
--- a/code/koha_export/src/com/turning_leaf_technologies/koha_export/KohaExportMain.java
+++ b/code/koha_export/src/com/turning_leaf_technologies/koha_export/KohaExportMain.java
@@ -928,9 +928,9 @@ public class KohaExportMain {
 			//go through pTypes
 			ResultSet kohaPTypes = kohaPatronTypeStmt.executeQuery();
 			while (kohaPTypes.next()) {
-				existingAspenPatronTypesStmt.setString(1, kohaPTypes.getString("categorycode"));
-				ResultSet existingAspenPatronTypesRS = existingAspenPatronTypesStmt.executeQuery();
 				String ptype = kohaPTypes.getString("categorycode");
+				existingAspenPatronTypesStmt.setString(1, ptype);
+				ResultSet existingAspenPatronTypesRS = existingAspenPatronTypesStmt.executeQuery();
 
 				if (!existingAspenPatronTypesRS.next()) {
 					// Get the account profile ID using the indexing profile name.
@@ -942,7 +942,7 @@ public class KohaExportMain {
 					}
 					accountProfileRS.close();
 
-					addAspenPatronTypeStmt.setString(1, kohaPTypes.getString("categorycode"));
+					addAspenPatronTypeStmt.setString(1, ptype);
 					// If an account profile was found, set the import patron type's account profile to it.
 					if (accountProfileId != -1) {
 						addAspenPatronTypeStmt.setString(2, String.valueOf(accountProfileId));
@@ -952,7 +952,7 @@ public class KohaExportMain {
 
 				//if 22.11, check if the current pType is in kohaPSLimits
 				if(kohaVersion >= 22.11 ){
-					getPatronTypeSuggestLimit.setString(1, kohaPTypes.getString("categorycode"));
+					getPatronTypeSuggestLimit.setString(1, ptype);
 					ResultSet currentSetting = getPatronTypeSuggestLimit.executeQuery();
 
 					if (currentSetting.next()) {
@@ -971,6 +971,14 @@ public class KohaExportMain {
 				existingAspenPatronTypesRS.close();
 			}
 			kohaPTypes.close();
+			kohaPatronTypeStmt.close();
+			existingAspenPatronTypesStmt.close();
+			addAspenPatronTypeStmt.close();
+			getAccountProfileIdStmt.close();
+			getKohaPSLimits.close();
+			getPatronTypeSuggestLimit.close();
+			updatePatronTypeCannotSuggest.close();
+			updatePatronTypeCanSuggest.close();
 		} catch (Exception e) {
 			logger.error("Error updating patron type information from Koha", e);
 		}

--- a/code/web/release_notes/25.05.00.MD
+++ b/code/web/release_notes/25.05.00.MD
@@ -25,6 +25,8 @@
 // imani
 
 // leo
+### Koha Updates
+- Enhanced patron type importation to automatically set the account profile of the new patron type based on the existing indexing profile. (DIS-634) (*LS*)
 
 // yanjun
 


### PR DESCRIPTION
- Enhanced patron type importation to automatically set the account profile of the new patron type based on the existing indexing profile.

Test Plan:
1. Create a patron type (i.e., patron category) in Koha. Wait a couple of minutes for the Koha exporter to pull it.
2. Notice that the new patron type has no associated account profile.
3. Apply the patch and repeat step 1. Now, notice that the patron type is associated with the account profile declared in the `name` field in the respective indexing profile (e.g., likely "ils").