### PR TITLE
DIS-692: Record Variations Are Now Considered for Polaris ILS Item-Level Holds

### DIFF
--- a/code/web/release_notes/25.05.00.MD
+++ b/code/web/release_notes/25.05.00.MD
@@ -36,6 +36,8 @@
 // imani
 
 // leo
+### Polaris Updates
+- Corrected item‑level holds in the Polaris ILS driver to locate variation‑specific item barcodes and volume numbers properly. (DIS-692) (*LS*)
 
 // yanjun
 


### PR DESCRIPTION
- Corrected item‑level holds in the Polaris ILS driver to locate variation‑specific item barcodes and volume numbers properly.

Test Plan:
1. On an Aspen site that uses the Polaris ILS, locate a grouped work that contains two record manifestations, where each should contain variation records. One of the record manifestations should be a physical item (e.g., magazine) that contains multiple items (or volumes because Polaris handles volume-level holds as item-level holds).
   - If you inspect element the hold buttons, you should see variation IDs passed as arguments for the `showPlaceHold()` JS calls.
3. Place a hold on that record and select a valid item.
4. Navigate to your account where all of your current holds are listed. Notice that the incorrect volume has been put on hold. Any repeated attempts on holds on items _from the same library location_ will default to that hold, such that Polaris will send an error back notifying you that you already have a hold on that item.