### PR TITLE
DIS-352: fix: correct completed milestones count

### DIFF
--- a/code/web/release_notes/25.05.00.MD
+++ b/code/web/release_notes/25.05.00.MD
@@ -45,6 +45,7 @@
 - Added a leaderboard that can be viewed by user or by branch - configurable in Library Systems->Community Engagement - that is editable in Grapes JS (DIS-352) (*AB*)
 - Added the ability to opt in and out of appearing on campaign leaderboards when the library is displaying leaderboards by user. (DIS-352) (*AB*)
 - Added the ability to see the campaigns of linked users. (DIS-352) (*AB)
+- Updated the completed milestone count to enusre it includes those completed beyond 100%. (DIS-352) (*AB*)
 
 // chloe
 

--- a/code/web/sys/CommunityEngagement/Campaign.php
+++ b/code/web/sys/CommunityEngagement/Campaign.php
@@ -1065,7 +1065,7 @@ class Campaign extends DataObject {
 						$progressData = CampaignMilestoneProgressEntry::getUserProgressDataByMilestoneId($linkedUser->id, $milestone->id, $campaign->id);
 
 
-                        if ($milestoneProgress['progress'] == 100) {
+                        if ($milestoneProgress['progress'] >= 100) {
                             $numCompletedMilestones++;
                         }
 


### PR DESCRIPTION
Change to more than or equal to in order to account for milestones that can be completed beyond 100 percent