### PR TITLE
DIS-703: Add Palace Project Library ID in Library

### DIFF
--- a/code/web/Drivers/PalaceProjectDriver.php
+++ b/code/web/Drivers/PalaceProjectDriver.php
@@ -53,7 +53,23 @@ class PalaceProjectDriver extends AbstractEContentDriver {
 		}
 
 		$headers = $this->getPalaceProjectHeaders($patron);
-		$checkoutsUrl = $settings->apiUrl . "/" . $settings->libraryId . "/loans?refresh=false";
+		$homeLibrary = $patron->getHomeLibrary();
+		if (!empty($homeLibrary)) {
+			$homePalaceProjectLibraryId = $homeLibrary->palaceProjectLibraryId;
+			global $logger;
+			$logger->log('patron Home Library ' . $homeLibrary, Logger::LOG_ERROR);
+			$logger->log('homePalaceProjectLibraryId ' . $homePalaceProjectLibraryId, Logger::LOG_ERROR);
+
+			if (!empty($homePalaceProjectLibraryId)) {
+				$checkoutsUrl = $settings->apiUrl . "/" . $homePalaceProjectLibraryId . "/loans?refresh=false";
+			} else {
+				$checkoutsUrl = $settings->apiUrl . "/" . $settings->libraryId . "/loans?refresh=false";
+			}
+		} else {
+			$checkoutsUrl = $settings->apiUrl . "/" . $settings->libraryId . "/loans?refresh=false";
+		}
+		global $logger;
+		$logger->log('loadCirculationInformation URL ' . $checkoutsUrl, Logger::LOG_ERROR);
 
 		$this->initCurlWrapper();
 		$this->curlWrapper->addCustomHeaders($headers, true);
@@ -375,6 +391,20 @@ class PalaceProjectDriver extends AbstractEContentDriver {
 		$recordDriver = new PalaceProjectRecordDriver($recordId);
 		if ($recordDriver->isValid()) {
 			$borrowLink = $recordDriver->getBorrowLink();
+			$settings = $this->getActiveSettings();
+			$homeLibrary = $patron->getHomeLibrary();
+			if (!empty($homeLibrary)) {
+				$homePalaceProjectLibraryId = $homeLibrary->palaceProjectLibraryId;
+				if (!empty($homePalaceProjectLibraryId)) {
+					$borrowLink = preg_replace(
+						'~/[^/]+/works/~',
+					'/' . $homePalaceProjectLibraryId . '/works/',
+						$borrowLink
+					);
+				}
+			}
+			global $logger;
+			$logger->log('placeHold URL ' . $borrowLink, Logger::LOG_ERROR);
 
 			$headers = $this->getPalaceProjectHeaders($patron);
 			$this->initCurlWrapper();
@@ -600,6 +630,20 @@ class PalaceProjectDriver extends AbstractEContentDriver {
 		$recordDriver = new PalaceProjectRecordDriver($titleId);
 		if ($recordDriver->isValid()) {
 			$borrowLink = $recordDriver->getBorrowLink();
+			$settings = $this->getActiveSettings();
+			$homeLibrary = $patron->getHomeLibrary();
+			if (!empty($homeLibrary)) {
+				$homePalaceProjectLibraryId = $homeLibrary->palaceProjectLibraryId;
+				if (!empty($homePalaceProjectLibraryId)) {
+					$borrowLink = preg_replace(
+						'~/[^/]+/works/~',
+					'/' . $homePalaceProjectLibraryId . '/works/',
+						$borrowLink
+					);
+				}
+			}
+			global $logger;
+			$logger->log('checkout  URL ' . $borrowLink, Logger::LOG_ERROR);
 
 			$headers = $this->getPalaceProjectHeaders($patron);
 			$this->initCurlWrapper();

--- a/code/web/Drivers/PalaceProjectDriver.php
+++ b/code/web/Drivers/PalaceProjectDriver.php
@@ -56,10 +56,6 @@ class PalaceProjectDriver extends AbstractEContentDriver {
 		$homeLibrary = $patron->getHomeLibrary();
 		if (!empty($homeLibrary)) {
 			$homePalaceProjectLibraryId = $homeLibrary->palaceProjectLibraryId;
-			global $logger;
-			$logger->log('patron Home Library ' . $homeLibrary, Logger::LOG_ERROR);
-			$logger->log('homePalaceProjectLibraryId ' . $homePalaceProjectLibraryId, Logger::LOG_ERROR);
-
 			if (!empty($homePalaceProjectLibraryId)) {
 				$checkoutsUrl = $settings->apiUrl . "/" . $homePalaceProjectLibraryId . "/loans?refresh=false";
 			} else {
@@ -68,8 +64,6 @@ class PalaceProjectDriver extends AbstractEContentDriver {
 		} else {
 			$checkoutsUrl = $settings->apiUrl . "/" . $settings->libraryId . "/loans?refresh=false";
 		}
-		global $logger;
-		$logger->log('loadCirculationInformation URL ' . $checkoutsUrl, Logger::LOG_ERROR);
 
 		$this->initCurlWrapper();
 		$this->curlWrapper->addCustomHeaders($headers, true);
@@ -403,9 +397,6 @@ class PalaceProjectDriver extends AbstractEContentDriver {
 					);
 				}
 			}
-			global $logger;
-			$logger->log('placeHold URL ' . $borrowLink, Logger::LOG_ERROR);
-
 			$headers = $this->getPalaceProjectHeaders($patron);
 			$this->initCurlWrapper();
 			$this->curlWrapper->addCustomHeaders($headers, true);
@@ -642,8 +633,6 @@ class PalaceProjectDriver extends AbstractEContentDriver {
 					);
 				}
 			}
-			global $logger;
-			$logger->log('checkout  URL ' . $borrowLink, Logger::LOG_ERROR);
 
 			$headers = $this->getPalaceProjectHeaders($patron);
 			$this->initCurlWrapper();

--- a/code/web/release_notes/25.05.00.MD
+++ b/code/web/release_notes/25.05.00.MD
@@ -78,6 +78,15 @@
 - Fixed duplicate alert boxes on the SSO Settings page. (DIS-652) (*LS*)
 
 // yanjun
+### Palace Project Updates
+- Add a field to store the palace project library id in Library systems for patron circulations. (DIS-703) (*YL*)
+
+<div markdown="1" class="settings">
+
+#### New Settings
+- Library Settings > Palace Project > Palace Project Library ID
+
+</div>
 
 // james
 

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -865,7 +865,7 @@ class User extends DataObject {
 				} elseif ($source == 'axis360') {
 					return array_key_exists('Axis 360', $enabledModules) && ($userHomeLibrary->axis360ScopeId > 0);
 				} elseif ($source == 'palace_project') {
-					return array_key_exists('Palace Project', $enabledModules) && ($userHomeLibrary->palaceProjectScopeId > 0);
+					return array_key_exists('Palace Project', $enabledModules) && ($userHomeLibrary->palaceProjectLibraryId > 0 || $userHomeLibrary->palaceProjectScopeId > 0);
 				}
 			}
 		}

--- a/code/web/sys/DBMaintenance/version_updates/25.05.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.05.00.php
@@ -37,6 +37,14 @@ function getUpdates25_05_00(): array {
 		//kodi - Grove
 
 		//Yanjun Li - ByWater
+		'library_add_palace_project_library_id' => [
+			'title' => 'library_add_palace_project_library_id',
+			'description' => 'Add a field to store the palace project library id for the library',
+			'continueOnError' => false,
+			'sql' => [
+				"ALTER TABLE library add column palaceProjectLibraryId VARCHAR(50) DEFAULT NULL",
+			]
+		], //library_add_palace_project_library_id
 
 		// Leo Stoyanov - BWS
 		'custom_form_field_enums_to_text' => [

--- a/code/web/sys/LibraryLocation/Library.php
+++ b/code/web/sys/LibraryLocation/Library.php
@@ -173,6 +173,7 @@ class Library extends DataObject {
 		$hooplaScopeId;
 	public /** @noinspection PhpUnused */
 		$axis360ScopeId;
+	public $palaceProjectLibraryId;
 	public $palaceProjectScopeId;
 	public /** @noinspection PhpUnused */
 		$systemsToRepeatIn;
@@ -3926,6 +3927,14 @@ class Library extends DataObject {
 				'renderAsHeading' => true,
 				'permissions' => ['Library Records included in Catalog'],
 				'properties' => [
+					'palaceProjectLibraryId' => [
+						'property' => 'palaceProjectLibraryId',
+						'type' => 'text',
+						'label' => 'Palace Project Library ID',
+						'description' => 'The ID Number Palace Project uses for this library',
+						'hideInLists' => true,
+						'forcesReindex' => true,
+					],
 					'palaceProjectScopeId' => [
 						'property' => 'palaceProjectScopeId',
 						'type' => 'enum',


### PR DESCRIPTION
Usually, libraries that use the Palace Project will have their own collections even if they are in the same consortium, so with the individual Palace Project setting and scope, it’s working well with circulation. 

But here is a case where one consortium has multiple member libraries that share the same Palace Project collections, but every member library has a unique Palace Project ID. And patrons need to circulate with their Home Library Palace project ID so their accounts in the Palace Project can sync well and correctly with Aspen, since Palace Project manages patrons at the library level. Adding multiple unnecessary settings is not an ideal solution.

With this PR, one setting for collection feeding can apply to different member libraries with different Palace Library Id