### PR TITLE
DIS-706: Refactored Events Indexing Log Page for Consistency and Filtering

### DIFF
--- a/code/web/interface/themes/responsive/Events/eventsIndexLog.tpl
+++ b/code/web/interface/themes/responsive/Events/eventsIndexLog.tpl
@@ -1,23 +1,8 @@
 {strip}
 	<div id="main-content" class="col-md-12">
 		<h1>{translate text='Events Indexing Log' isAdminFacing=true}</h1>
-		<hr>
 
-		<h4>{translate text="Filter by" isAdminFacing=true}</h4>
-
-		<form class="navbar form-inline row">
-			<div class="form-group col-xs-5">
-				<span class="pull-right">
-					<label for="pageSize" class="control-label">{translate text="Entries Per Page" isAdminFacing=true}&nbsp;</label>
-					<select id="pageSize" name="pageSize" class="pageSize form-control input-sm" onchange="AspenDiscovery.changePageSize()">
-						<option value="30"{if $recordsPerPage == 30} selected="selected"{/if}>30</option>
-						<option value="50"{if $recordsPerPage == 50} selected="selected"{/if}>50</option>
-						<option value="75"{if $recordsPerPage == 75} selected="selected"{/if}>75</option>
-						<option value="100"{if $recordsPerPage == 100} selected="selected"{/if}>100</option>
-					</select>
-				</span>
-			</div>
-		</form>
+		{include file='Admin/exportLogFilters.tpl'}
 		<div class="adminTableRegion fixed-height-table">
 			<table class="adminTable table table-condensed table-hover table-condensed smallText table-sticky">
 				<thead>

--- a/code/web/release_notes/25.05.00.MD
+++ b/code/web/release_notes/25.05.00.MD
@@ -46,6 +46,9 @@
 - Fixed incorrectly displaying successful checkout when checkout limit in CloudLibrary had been reached. (DIS-593) (*IT*)
 
 // leo
+### Events Updates
+- Enhanced the Events Indexing Log page by adding standard filtering controls (e.g., "Min Processed," "Show Errors Only") and refactoring the underlying code for consistency with other administrative log pages. (DIS-706) (*LS*)
+
 ### IP Address Updates
 - The `ip_lookup` table now supports IPv6 addresses, allowing administrators to manage access rules for IPv6 clients. (DIS-396) (*LS*)
 - API access can now be controlled for IPv6 addresses, enabling Aspen to work properly behind CloudFlare and other IPv6-enabled proxies. (DIS-396) (*LS*)

--- a/code/web/services/Events/IndexingLog.php
+++ b/code/web/services/Events/IndexingLog.php
@@ -1,39 +1,29 @@
 <?php
 
-require_once ROOT_DIR . '/Action.php';
-require_once ROOT_DIR . '/services/Admin/ObjectEditor.php';
-require_once ROOT_DIR . '/sys/Pager.php';
+require_once ROOT_DIR . '/services/Admin/IndexingLog.php';
 require_once ROOT_DIR . '/sys/Events/EventsIndexingLogEntry.php';
 
-class Events_IndexingLog extends Admin_Admin {
-	function launch() {
-		global $interface;
+class Events_IndexingLog extends Admin_IndexingLog {
+	function getIndexLogEntryObject(): BaseLogEntry {
+		return new EventsIndexingLogEntry();
+	}
 
-		$logEntries = [];
-		$logEntry = new EventsIndexingLogEntry();
-		$total = $logEntry->count();
-		$logEntry = new EventsIndexingLogEntry();
-		$logEntry->orderBy('startTime DESC');
-		$page = isset($_REQUEST['page']) ? $_REQUEST['page'] : 1;
-		$pageSize = isset($_REQUEST['pageSize']) ? $_REQUEST['pageSize'] : 30; // to adjust number of items listed on a page
-		$interface->assign('recordsPerPage', $pageSize);
-		$interface->assign('page', $page);
-		$logEntry->limit(($page - 1) * $pageSize, $pageSize);
-		$logEntry->find();
-		while ($logEntry->fetch()) {
-			$logEntries[] = clone($logEntry);
+	function getTemplateName(): string {
+		return 'eventsIndexLog.tpl';
+	}
+
+	function getTitle(): string {
+		return 'Events Indexing Log';
+	}
+
+	function getModule(): string {
+		return 'Events';
+	}
+
+	function applyMinProcessedFilter(DataObject $indexingObject, $minProcessed): void {
+		if ($indexingObject instanceof EventsIndexingLogEntry) {
+			$indexingObject->whereAdd('(numAdded + numDeleted + numUpdated) >= ' . intval($minProcessed));
 		}
-		$interface->assign('logEntries', $logEntries);
-
-		$options = [
-			'totalItems' => $total,
-			//'fileName' => '/Events/IndexingLog?page=%d' . (empty($_REQUEST['pageSize']) ? '' : '&pageSize=' . $_REQUEST['pageSize']),
-			'perPage' => $pageSize,
-		];
-		$pager = new Pager($options);
-		$interface->assign('pageLinks', $pager->getLinks());
-
-		$this->display('eventsIndexLog.tpl', 'Events Index Log');
 	}
 
 	function getBreadcrumbs(): array {

--- a/code/web/sys/Events/EventsIndexingLogEntry.php
+++ b/code/web/sys/Events/EventsIndexingLogEntry.php
@@ -1,7 +1,7 @@
 <?php
 
 
-class EventsIndexingLogEntry extends DataObject {
+class EventsIndexingLogEntry extends BaseLogEntry {
 	public $__table = 'events_indexing_log';
 	public $id;
 	public $startTime;
@@ -14,20 +14,4 @@ class EventsIndexingLogEntry extends DataObject {
 	public $numAdded;
 	public $numDeleted;
 	public $numUpdated;
-
-	function getElapsedTime() {
-		if (!isset($this->endTime) || is_null($this->endTime)) {
-			return "";
-		} else {
-			$elapsedTimeMin = ceil(($this->endTime - $this->startTime) / 60);
-			if ($elapsedTimeMin < 60) {
-				return $elapsedTimeMin . " min";
-			} else {
-				$hours = floor($elapsedTimeMin / 60);
-				$minutes = $elapsedTimeMin - (60 * $hours);
-				return "$hours hours, $minutes min";
-			}
-		}
-	}
-
 }


### PR DESCRIPTION
- Enhanced the Events Indexing Log page by adding standard filtering controls (e.g., "Min Processed," "Show Errors Only") and refactoring the underlying code for consistency with other administrative log pages.

Test Plan:
1. Navigate to the Events Indexing Log page of the admin interface. Notice that features are missing from other log pages (e.g., "Min Processed," "Show Errors Only").
2. Apply the patch and refresh the page.