### PR TITLE
DIS-458: Added Bluesky and Threads Social Media links

### DIFF
--- a/code/web/interface/themes/responsive/footer_responsive.tpl
+++ b/code/web/interface/themes/responsive/footer_responsive.tpl
@@ -75,6 +75,12 @@
 					{if !empty($tiktokLink)}
 						<a href="{$tiktokLink}" class="connect-icon" target="_blank" title="{translate text="Follow us on TikTok" inAttribute=true isPublicFacing=true}" aria-label="{translate text="Follow us on TikTok" inAttribute=true isPublicFacing=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})"><i class='fab fa-tiktok fa-lg' role="presentation"></i></a>
 					{/if}
+                                        {if !empty($blueskyLink)}
+                                                <a href="{$blueskyLink}" class="connect-icon" target="_blank" title="{translate text="Follow us on BlueSky" inAttribute= isPublicFacing=true}" aria-label="{translate text="Follow us on BlueSky" inAttribute=true isPublicFacing=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})"><i class='fab fa-bluesky fa-lg' role="presentation"></i></a>
+                                        {/if}
+                                        {if !empty($threadsLink)}
+                                                <a href="{threadsLink)}" class="connect-icon" target="_blank" title="{translate text="Follow us on Threads" inAttribute= isPublicFacing=true}" aria-label="{translate text="Follow us on Threads" inAttribute=true isPublicFacing=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})"><i class='fab fa-threads fa-lg' role="presentation"></i></a>
+                                        {/if}
 					{if !empty($generalContactLink)}
 						<a href="{$generalContactLink}" class="connect-icon" target="_blank" title="{translate text="Contact Us" inAttribute=true isPublicFacing=true}" aria-label="{translate text="Contact Us" inAttribute=true isPublicFacing=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})"><i class='fas fa-envelope-open fa-lg' role="presentation"></i></a>
 					{/if}

--- a/code/web/release_notes/25.05.00.MD
+++ b/code/web/release_notes/25.05.00.MD
@@ -82,6 +82,10 @@
 
 // yanjun
 
+// laura
+### Other Updates
+- Included options to add both Bluesky and Threads URL links within Contact Links. (DIS-458) (*LE*)
+
 // james
 
 // alexander
@@ -143,6 +147,7 @@
 - Yanjun Li (YL)
 - Imani Thomas (IT)
 - Ian Walls (IW)
+- Laura Escamilla (LE)
 
 ### Grove For Libraries
 - Mark Noble (MDN)

--- a/code/web/sys/DBMaintenance/version_updates/25.05.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.05.00.php
@@ -56,6 +56,26 @@ function getUpdates25_05_00(): array {
 			],
 		], //ip_lookup_ipv6_support
 
+		// Laura Escamilla - ByWater Solutions
+
+               'blueskyLink' => [
+                      'title' => 'Bluesky Link', 
+                      'description' => 'The URL to Bluesky (leave blank if the library does not have a Bluesky account)',
+                      'continueOnError' => true,
+                      'sql' => [
+                               "ALTER TABLE library ADD COLUMN blueskyLink VARCHAR(255)",
+                               ], 
+                ], // blueskyLink
+
+               'threadsLink' => [
+                      'title' => 'Threads Link',
+                      'description' => 'The URL to Threads (leave blank if the library does not have a Threads account)',
+                      'continueOnError' => true,
+                      'sql' => [
+                               "ALTER TABLE library ADD COLUMN threadsLink VARCHAR(255)",
+                               ],
+                ], // threadsLink
+
 		//alexander - Open Fifth
 		'allow_filtering_of_linked_users_in_checkouts' => [
 			'title' => 'Allow Filtering of Linked Users in Checkouts',

--- a/code/web/sys/Interface.php
+++ b/code/web/sys/Interface.php
@@ -616,6 +616,8 @@ class UInterface extends Smarty {
 		$this->assign('pinterestLink', $library->pinterestLink);
 		$this->assign('goodreadsLink', $library->goodreadsLink);
 		$this->assign('tiktokLink', $library->tiktokLink);
+		$this->assign('blueskyLink', $library->blueskyLink);
+		$this->assign('threadsLink', $library->threadsLink);
 		$this->assign('generalContactLink', $library->generalContactLink);
 		$this->assign('showLoginButton', $library->showLoginButton && ($offlineMode == false || $this->getVariable('enableEContentWhileOffline')));
 		$this->assign('showAdvancedSearchbox', $library->showAdvancedSearchbox);

--- a/code/web/sys/LibraryLocation/Library.php
+++ b/code/web/sys/LibraryLocation/Library.php
@@ -272,6 +272,8 @@ class Library extends DataObject {
 	public $pinterestLink;
 	public $goodreadsLink;
 	public $tiktokLink;
+	public $blueskyLink;
+	public $threadsLink;
 	public $generalContactLink;
 	public $contactEmail;
 
@@ -1214,6 +1216,24 @@ class Library extends DataObject {
 						'type' => 'text',
 						'label' => 'TikTok Link URL',
 						'description' => 'The URL to TikTok (leave blank if the library does not have a TikTok account)',
+						'size' => '40',
+						'maxLength' => 255,
+						'hideInLists' => true,
+					],
+					'blueskyLink' => [
+						'property' => 'blueskyLink',
+						'type' => 'text',
+						'label' => 'BlueSky Link URL',
+						'description' => 'The URL to BlueSky (leave blank if the library does not have a BlueSky account)',
+						'size' => '40',
+						'maxLength' => 255,
+						'hideInLists' => true,
+					],
+					'threadsLink' => [
+						'property' => 'threadsLink',
+						'type' => 'text',
+						'label' => 'Threads Link URL',
+						'description' => 'The URL to Threads (leave blank if the library does not have a Threads account)',
 						'size' => '40',
 						'maxLength' => 255,
 						'hideInLists' => true,


### PR DESCRIPTION
To test: 

1. Apply the patch
2. Navigate to Primary Configuration > Library Systems > and select a library system. 
3. Scroll down to Contact Links and expand the menu. You should see the options to add a BlueSky link and a Threads URL. 
4. Add a general URL to both options for testing. 
5. Notice that both URLs are functioning in the footer. 