### PR TITLE
DIS-78: Added ID Property with Label to the Object Structure

### DIFF
--- a/code/web/release_notes/25.05.00.MD
+++ b/code/web/release_notes/25.05.00.MD
@@ -123,6 +123,7 @@
 - Added existence check for `'patronIdCheck'` when editing an object. (DIS-648) (*LS*)
 - Fixed duplicate alert boxes on the SSO Settings page. (DIS-652) (*LS*)
 - Ensured physical descriptions containing abbreviations of "p." display correctly without unintended word changes (e.g., "strap." no longer becomes "strapages."). (DIS-694) (*LS*)
+- Added edit-pencil icon for the Browse Category Groups table in the admin interface. (DIS-78) (*LS*)
 
 // yanjun
 ### Palace Project Updates

--- a/code/web/sys/Browse/BrowseCategoryGroup.php
+++ b/code/web/sys/Browse/BrowseCategoryGroup.php
@@ -32,6 +32,12 @@ class BrowseCategoryGroup extends DB_LibraryLocationLinkedObject {
 		unset($browseCategoryUserStructure['browseCategoryGroupId']);
 
 		$objectStructure = [
+			'id' => [
+				'property' => 'id',
+				'type' => 'label',
+				'label' => 'Id',
+				'description' => 'The unique id',
+			],
 			'name' => [
 				'property' => 'name',
 				'type' => 'text',


### PR DESCRIPTION
- Added edit-pencil icon for the Browse Category Groups table in the admin interface.

Test Plan:
1. Navigate to the Browse Category Groups page in the admin interface. Notice that there is no pencil-edit icon on the left side of each row.
2. Apply patch and repeat step 1.