### PR TITLE
DIS-188: Series fixes

### DIFF
--- a/code/reindexer/src/org/aspen_discovery/reindexer/GroupedWorkIndexer.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/GroupedWorkIndexer.java
@@ -1443,6 +1443,11 @@ public class GroupedWorkIndexer {
 						long seriesId;
 						if (seriesRS.next()) { // Should only be one match
 							seriesId = seriesRS.getLong("id");
+							// Check if the series has been deleted
+							int seriesDeleted = seriesRS.getInt("deleted");
+							if (seriesDeleted == 1) {
+								continue;
+							}
 							// Check to see if we need to add additional authors
 							String authors = seriesRS.getString("author");
 							String newAuthor = groupedWork.getPrimaryAuthor();

--- a/code/web/RecordDrivers/GroupedWorkDriver.php
+++ b/code/web/RecordDrivers/GroupedWorkDriver.php
@@ -2224,7 +2224,8 @@ class GroupedWorkDriver extends IndexRecordDriver {
 				$seriesMember->groupedWorkPermanentId = $this->getPermanentId();
 				$seriesMember->excluded = 0;
 				$seriesInfo = null;
-				if ($seriesMember->find(true)) {
+				$seriesMember->find();
+				if ($seriesMember->fetch()) {
 					$series = $seriesMember->getSeries();
 					if ($series != null) {
 						$seriesInfo = [
@@ -2235,6 +2236,16 @@ class GroupedWorkDriver extends IndexRecordDriver {
 							'fromSeriesIndex' => true
 						];
 					}
+				}
+				while ($seriesMember->fetch()) {
+					$series = $seriesMember->getSeries();
+					$seriesInfo['additionalSeries'][] = [
+						'seriesTitle' => $series->displayName,
+						'seriesId' => $series->id,
+						'volume' => $seriesMember->volume,
+						'fromNovelist' => false,
+						'fromSeriesIndex' => true
+					];
 				}
 				$this->seriesData = $seriesInfo;
 			}else{

--- a/code/web/interface/themes/responsive/GroupedWork/series-summary.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/series-summary.tpl
@@ -6,10 +6,24 @@
 			<a href="/GroupedWork/{$recordDriver->getPermanentId()}/Series">{$summSeries.seriesTitle}</a>{if !empty($summSeries.volume)}<strong> {translate text="volume %1%" 1=$summSeries.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}
 		{elseif !empty($summSeries.fromSeriesIndex)}
 			<a href="/Series/{$summSeries.seriesId}">{$summSeries.seriesTitle}</a>{if !empty($summSeries.volume)}<strong> {translate text="volume %1%" 1=$summSeries.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}
+			{if !empty($summSeries.additionalSeries)}
+				{assign var=numSeriesShown value=1}
+				{foreach from=$summSeries.additionalSeries item=additional}
+					{assign var=numSeriesShown value=$numSeriesShown+1}
+					{if $numSeriesShown == 4}
+						<a onclick="$('#moreSeries_{$summId}').show();$('#moreSeriesLink_{$summId}').hide();" id="moreSeriesLink_{$summId}">{translate text='More Series...' isPublicFacing=true}</a>
+						<div id="moreSeries_{$summId}" style="display:none">
+					{/if}
+					<br><a href="/Series/{$additional.seriesId}">{$additional.seriesTitle}</a>{if !empty($additional.volume)}<strong> {translate text="volume %1%" 1=$additional.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}
+				{/foreach}
+				{if $numSeriesShown >= 4}
+					</div>
+				{/if}
+			{/if}
 		{else}
 			<a href="/Search/Results?searchIndex=Series&lookfor={$summSeries.seriesTitle}&sort=year+asc%2Ctitle+asc">{$summSeries.seriesTitle}</a>{if !empty($summSeries.volume)}<strong> {translate text="volume %1%" 1=$summSeries.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}
 		{/if}
-		{if !empty($indexedSeries)}
+		{if !empty($indexedSeries) && empty($summSeries.fromSeriesIndex)}
 			{if !empty($summSeries)}
 				<br/>
 			{/if}

--- a/code/web/interface/themes/responsive/GroupedWork/work-details.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/work-details.tpl
@@ -18,6 +18,20 @@
 							<a href="/GroupedWork/{$recordDriver->getPermanentId()}/Series">{$summSeries.seriesTitle}</a>{if !empty($summSeries.volume)}<strong> {translate text="volume %1%" 1=$summSeries.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}
 						{elseif !empty($summSeries.fromSeriesIndex)}
 							<a href="/Series/{$summSeries.seriesId}">{$summSeries.seriesTitle}</a>{if !empty($summSeries.volume)}<strong> {translate text="volume %1%" 1=$summSeries.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}
+							{if !empty($summSeries.additionalSeries)}
+								{assign var=numSeriesShown value=1}
+								{foreach from=$summSeries.additionalSeries item=additional}
+									{assign var=numSeriesShown value=$numSeriesShown+1}
+									{if $numSeriesShown == 4}
+										<a onclick="$('#moreSeries_{$summId}').show();$('#moreSeriesLink_{$summId}').hide();" id="moreSeriesLink_{$summId}">{translate text='More Series...' isPublicFacing=true}</a>
+										<div id="moreSeries_{$summId}" style="display:none">
+									{/if}
+									<br><a href="/Series/{$additional.seriesId}">{$additional.seriesTitle}</a>{if !empty($additional.volume)}<strong> {translate text="volume %1%" 1=$additional.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}
+								{/foreach}
+								{if $numSeriesShown >= 4}
+									</div>
+								{/if}
+							{/if}
 						{else}
 							<a href="/Search/Results?searchIndex=Series&lookfor={$summSeries.seriesTitle}&sort=year+asc%2Ctitle+asc">{$summSeries.seriesTitle}</a>{if !empty($summSeries.volume)}<strong> {translate text="volume %1%" 1=$summSeries.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}
 						{/if}

--- a/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/result.tpl
@@ -66,11 +66,25 @@
 										<a href="/GroupedWork/{$summId}/Series">{$summSeries.seriesTitle}</a>{if !empty($summSeries.volume)} <strong>{translate text=volume isPublicFacing=true} {$summSeries.volume|format_float_with_min_decimals}</strong>{/if}<br>
 									{elseif !empty($summSeries.fromSeriesIndex)}
 										<a href="/Series/{$summSeries.seriesId}">{$summSeries.seriesTitle}</a>{if !empty($summSeries.volume)}<strong> {translate text="volume %1%" 1=$summSeries.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}<br>
+										{if !empty($summSeries.additionalSeries)}
+											{assign var=numSeriesShown value=1}
+											{foreach from=$summSeries.additionalSeries item=additional}
+												{assign var=numSeriesShown value=$numSeriesShown+1}
+												{if $numSeriesShown == 4}
+													<a onclick="$('#moreSeries_{$summId}').show();$('#moreSeriesLink_{$summId}').hide();" id="moreSeriesLink_{$summId}">{translate text='More Series...' isPublicFacing=true}</a>
+													<div id="moreSeries_{$summId}" style="display:none">
+												{/if}
+												<a href="/Series/{$additional.seriesId}">{$additional.seriesTitle}</a>{if !empty($additional.volume)}<strong> {translate text="volume %1%" 1=$additional.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}<br>
+											{/foreach}
+											{if $numSeriesShown >= 4}
+												</div>
+											{/if}
+										{/if}
 									{else}
 										<a href="/Search/Results?searchIndex=Series&lookfor={$summSeries.seriesTitle}&sort=year+asc%2Ctitle+asc">{$summSeries.seriesTitle}</a>{if !empty($summSeries.volume)}<strong> {translate text="volume %1%" 1=$summSeries.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}<br>
 									{/if}
 								{/if}
-								{if !empty($indexedSeries)}
+								{if !empty($indexedSeries) && empty($summSeries.fromSeriesIndex)}
 									{assign var=numSeriesShown value=0}
 									{foreach from=$indexedSeries item=seriesItem name=loop}
 										{if !isset($summSeries.seriesTitle) || ((strpos(strtolower($seriesItem.seriesTitle), strtolower($summSeries.seriesTitle)) === false) && (strpos(strtolower($summSeries.seriesTitle), strtolower($seriesItem.seriesTitle)) === false))}

--- a/code/web/release_notes/25.05.00.MD
+++ b/code/web/release_notes/25.05.00.MD
@@ -47,6 +47,8 @@
 </div>
 
 // katherine
+#### Series Updates
+- Fix problems with deleting series. Deleting a series will also delete series members. Reindexing will not add series members to deleted series or create duplicate series.  (DIS-188) (*KP*)
 
 // kirstien
 

--- a/code/web/release_notes/25.05.00.MD
+++ b/code/web/release_notes/25.05.00.MD
@@ -49,6 +49,7 @@
 // katherine
 #### Series Updates
 - Fix problems with deleting series. Deleting a series will also delete series members. Reindexing will not add series members to deleted series or create duplicate series.  (DIS-188) (*KP*)
+- If a title belongs to multiple series, show them all, not just the first one. (DIS-188) (*KP*) 
 
 // kirstien
 

--- a/code/web/services/Series/AdministerSeries.php
+++ b/code/web/services/Series/AdministerSeries.php
@@ -23,6 +23,7 @@ class Series_AdministerSeries extends ObjectEditor {
 
 	function getAllObjects($page, $recordsPerPage): array {
 		$object = new Series();
+		$object->deleted = 0;
 		$object->limit(($page - 1) * $recordsPerPage, $recordsPerPage);
 		$this->applyFilters($object);
 		$object->orderBy($this->getSort());

--- a/code/web/sys/DBMaintenance/version_updates/25.05.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.05.00.php
@@ -38,6 +38,13 @@ function getUpdates25_05_00(): array {
 		], //axis360_setting_name
 
 		//katherine - Grove
+		'add_deleted_field_to_series_member' => [
+			'title' => 'Add a deleted field to Series Member table',
+			'description' => 'Add a deleted field so that Series Members can be deleted',
+			'sql' => [
+				"ALTER TABLE series_member ADD COLUMN deleted TINYINT(1) DEFAULT 0",
+			]
+		], //add_deleted_field_to_series_member
 
 		//kirstien - Grove
 

--- a/code/web/sys/Series/SeriesMember.php
+++ b/code/web/sys/Series/SeriesMember.php
@@ -17,6 +17,7 @@ class SeriesMember extends DataObject {
 	public $cover;
 	public $userAdded;
 	public $excluded;
+	public $deleted;
 
 	public static function getObjectStructure($context = ''): array {
 		global $configArray;


### PR DESCRIPTION
- Fix problems with deleting series.  When deleting a series, also delete its series members.  Titles will not get added to deleted series during reindexing and deleted series won't get re-added.  Added a deleted field to the series_member table.
- If a title belongs to multiple series, show them all, not just the first one.  