### PR TITLE
DIS-635 Update Sierra User Agent

### DIFF
--- a/code/web/Drivers/Sierra.php
+++ b/code/web/Drivers/Sierra.php
@@ -25,6 +25,7 @@ class Sierra extends Millennium {
 			$authInfo = base64_encode($this->accountProfile->oAuthClientId . ":" . $this->accountProfile->oAuthClientSecret);
 			$headers = [
 				'Content-Type: application/x-www-form-urlencoded;charset=UTF-8',
+				'User-Agent: Aspen Discovery',
 				'Authorization: Basic ' . $authInfo,
 			];
 			curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);

--- a/code/web/release_notes/25.05.00.MD
+++ b/code/web/release_notes/25.05.00.MD
@@ -135,6 +135,9 @@
 
 </div>
 
+### Sierra Updates
+- Update the User-Agent header to identify Aspen Discovery in Sierra API requests. (DIS-635) (*YL*)
+
 // james
 ### Holds Updates
 - Fix invisible-to-user AJAX error when 'volume' not present in hold request. (*JStaub*)


### PR DESCRIPTION
Sierra.php  _connectToApi() is making the API request with User-Agent Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1) and such API got rejected because the User-Agent is outdated. We should use a more modern User-Agent or “Aspen Discovery”