### PR TITLE
DIS-640 Round Fines to 2 decimal

### DIFF
--- a/code/web/release_notes/25.05.00.MD
+++ b/code/web/release_notes/25.05.00.MD
@@ -135,6 +135,9 @@
 
 </div>
 
+### eCommerce Updates
+- Round the amount to pay for fines to 2 decimal places to prevent issues with floating point precision. (DIS-640) (*YL*)
+
 // james
 ### Holds Updates
 - Fix invisible-to-user AJAX error when 'volume' not present in hold request. (*JStaub*)

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -4905,7 +4905,7 @@ class MyAccount_AJAX extends JSON_Action {
 					if (isset($_REQUEST['amountToPay'][$fineId])) {
 						$fineAmount = $_REQUEST['amountToPay'][$fineId];
 						$maxFineAmount = $useOutstanding ? $fine['amountOutstandingVal'] : $fine['amountVal'];
-						if (!is_numeric($fineAmount) || $fineAmount <= 0 || $fineAmount > $maxFineAmount) {
+						if (!is_numeric($fineAmount) || $fineAmount <= 0 || round($fineAmount, 2) > round($maxFineAmount, 2)) {
 							return [
 								'success' => false,
 								'message' => translate([


### PR DESCRIPTION
When patrons pay their fines, they can select the amount they wish to pay. Recently, an issue was discovered where processing a fine with a small amount of $0.10 fails validation.

The problem is likely due to floating-point precision. When converting the string "0.10" to a floating-point number, PHP might internally represent it as something like 0.10000001

Rounding both $fineAmount and $maxFineAmount to 2 decimal places during the validation can help resolve this. 
