### PR TITLE
DIS-741: Correct Browse Thumbnail to Use Display Block

### DIFF
--- a/code/web/interface/themes/responsive/css/browse-categories.less
+++ b/code/web/interface/themes/responsive/css/browse-categories.less
@@ -264,7 +264,7 @@
   .thumbnail;
   break-inside: avoid-column;
   -webkit-column-break-inside: avoid;
-  display: inline-flex;
+  display: block;
   .text-center();
   position: relative;
   //min-height: 200px;

--- a/code/web/interface/themes/responsive/css/main.css
+++ b/code/web/interface/themes/responsive/css/main.css
@@ -9473,7 +9473,7 @@ a.placard-link {
   transition: all 0.2s ease-in-out;
   break-inside: avoid-column;
   -webkit-column-break-inside: avoid;
-  display: inline-flex;
+  display: block;
   text-align: center;
   position: relative;
 }

--- a/code/web/release_notes/25.05.00.MD
+++ b/code/web/release_notes/25.05.00.MD
@@ -172,7 +172,7 @@
 
 ### Other Updates
 - Updated logic to ensure publication details, editions, and ISBNs/ISSNs display correctly under "More Details" when they are not set to be displayed in the top detail section. (DIS-622) (*LS*)
-- Changed `.browse-thumbnail` CSS rule from `display: inline-block` to `display: inline-flex` to properly align items within the grid without affecting masonry layouts. (DIS-114) (*LS*)
+- Changed `.browse-thumbnail` CSS rule from `display: inline-block` to `display: block` to properly align items within the grid without affecting masonry layouts. (DIS-114, 741) (*LS*)
 - Added existence check for `'patronIdCheck'` when editing an object. (DIS-648) (*LS*)
 - Fixed duplicate alert boxes on the SSO Settings page. (DIS-652) (*LS*)
 - Ensured physical descriptions containing abbreviations of "p." display correctly without unintended word changes (e.g., "strap." no longer becomes "strapages."). (DIS-694) (*LS*)

--- a/code/web/release_notes/25.05.00.MD
+++ b/code/web/release_notes/25.05.00.MD
@@ -172,7 +172,7 @@
 
 ### Other Updates
 - Updated logic to ensure publication details, editions, and ISBNs/ISSNs display correctly under "More Details" when they are not set to be displayed in the top detail section. (DIS-622) (*LS*)
-- Changed `.browse-thumbnail` CSS rule from `display: inline-block` to `display: block` to properly align items within the grid without affecting masonry layouts. (DIS-114, 741) (*LS*)
+- Changed `.browse-thumbnail` CSS rule from `display: inline-block` to `display: block` to properly align items within the grid without affecting masonry layouts. (DIS-114, DIS-741) (*LS*)
 - Added existence check for `'patronIdCheck'` when editing an object. (DIS-648) (*LS*)
 - Fixed duplicate alert boxes on the SSO Settings page. (DIS-652) (*LS*)
 - Ensured physical descriptions containing abbreviations of "p." display correctly without unintended word changes (e.g., "strap." no longer becomes "strapages."). (DIS-694) (*LS*)


### PR DESCRIPTION
- Changed `.browse-thumbnail` CSS rule from `display: inline-block` to `display: block` to properly align items within the grid without affecting masonry layouts.