### PR TITLE
DIS 188: duplicate series record fixes and cleanup script

### DIFF
--- a/code/web/release_notes/25.05.00.MD
+++ b/code/web/release_notes/25.05.00.MD
@@ -93,6 +93,7 @@
 - If a title belongs to multiple series, show them all, not just the first one. (DIS-188) (*KP*) 
 - Fix a bug where duplicate series members were being created if a title had multiple volume numbers in the same series. (DIS-188) (*KP*)
 - Fix a bug that created orphaned series titles if the original record was modified or removed. (DIS-188) (*KP*)
+- Remove existing duplicate series titles (DIS-188) (*KP*)
 
 // kirstien
 

--- a/code/web/release_notes/25.05.00.MD
+++ b/code/web/release_notes/25.05.00.MD
@@ -92,6 +92,7 @@
 - Fix problems with deleting series. Deleting a series will also delete series members. Reindexing will not add series members to deleted series or create duplicate series.  (DIS-188) (*KP*)
 - If a title belongs to multiple series, show them all, not just the first one. (DIS-188) (*KP*) 
 - Fix a bug where duplicate series members were being created if a title had multiple volume numbers in the same series. (DIS-188) (*KP*)
+- Fix a bug that created orphaned series titles if the original record was modified or removed. (DIS-188) (*KP*)
 
 // kirstien
 

--- a/code/web/sys/DBMaintenance/version_updates/25.05.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.05.00.php
@@ -57,6 +57,17 @@ function getUpdates25_05_00(): array {
 				"ALTER TABLE series_member ADD COLUMN deleted TINYINT(1) DEFAULT 0",
 			]
 		], //add_deleted_field_to_series_member
+		'remove_duplicate_series_titles' => [
+			'title' => 'Remove duplicate series titles',
+			'description' => 'Clean up series that have more than one copy of the same title unless it was manually added or has already been excluded',
+			'sql' => [
+				"DELETE t1 FROM series_member t1 INNER JOIN series_member t2
+				WHERE t1.groupedWorkPermanentId = t2.groupedWorkPermanentId	AND t1.seriesId = t2.seriesId
+				AND t1.userAdded = 0 AND t1.excluded = 0
+				AND t2.userAdded = 0 AND t2.excluded = 0
+				AND t1.id > t2.id;",
+			]
+		],
 
 		//kirstien - Grove
 


### PR DESCRIPTION
- During indexing, remove grouped works from series when the grouped work permanent ID no longer exists because the record has been edited or removed.  Not removing these was causing orphaned titles to show up on Series pages.
- Add script to remove duplicate records to 25.05.00 database maintenance.  This will only remove duplicates that were not manually added and haven't already been excluded.