### PR TITLE
DIS-313: Fix: amend wording and check selected user exists prior to filtering for exports

### DIFF
--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -3819,7 +3819,7 @@ class MyAccount_AJAX extends JSON_Action {
 		foreach ($allCheckedOut as $key => $checkout) {
 			$checkout->recordId = $this->normalizeRecordId($checkout->recordId);
 
-			if (!empty ($slectedUser) && $checkout->userId != $selectedUser) {
+			if (!empty ($selectedUser) && $checkout->userId != $selectedUser) {
 				continue;
 			}
 			$matchFound = false;

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -3819,7 +3819,7 @@ class MyAccount_AJAX extends JSON_Action {
 		foreach ($allCheckedOut as $key => $checkout) {
 			$checkout->recordId = $this->normalizeRecordId($checkout->recordId);
 
-			if ($checkout->userId != $selectedUser) {
+			if (!empty ($slectedUser) && $checkout->userId != $selectedUser) {
 				continue;
 			}
 			$matchFound = false;

--- a/code/web/sys/LibraryLocation/Library.php
+++ b/code/web/sys/LibraryLocation/Library.php
@@ -1346,7 +1346,7 @@ class Library extends DataObject {
 					'allowFilteringOfLinkedAccountsInCheckouts' => [
 						'property' => 'allowFilteringOfLinkedAccountsInCheckouts',
 						'type' => 'checkbox',
-						'label' => 'Allow Filtering of Linked Accounts in Check Out Titles',
+						'label' => 'Allow Filtering of Linked Accounts in Checked Out Titles',
 						'description' => 'Whether or not users can filter their checked out titles by linked accounts.',
 						'hideInLists' => true,
 						'default' => 0,


### PR DESCRIPTION
Amend wording of label 
Ensure selected user exists when filtering exports - if on "all" page filter by record only.