### PR TITLE
DIS-744: Fixed Koha Password Reset Failure for Expired Passwords

### DIFF
--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -1083,7 +1083,7 @@ class Koha extends AbstractIlsDriver {
 						$user->unique_ils_id = $patronId;
 						if (!$user->find(true)) {
 							$cardNumber = $passwordExpirationRow['cardnumber'];
-							$this->findNewUser($cardNumber, '');
+							$user = $this->findNewUser($cardNumber, '');
 						}
 
 						require_once ROOT_DIR . '/sys/Account/PinResetToken.php';
@@ -1094,6 +1094,9 @@ class Koha extends AbstractIlsDriver {
 						$resetToken = '';
 						if ($pinResetToken->insert()) {
 							$resetToken = $pinResetToken->token;
+						} else {
+							global $logger;
+							$logger->log("Failed to insert PinResetToken for user ID: {$user->id} (ILS ID: {$patronId}). DB Error: {$pinResetToken->getLastError()}", Logger::LOG_ERROR);
 						}
 						require_once ROOT_DIR . '/sys/Account/ExpiredPasswordError.php';
 						$result = new ExpiredPasswordError($patronId, $passwordExpirationRow['password_expiration_date'], $resetToken);

--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -12,6 +12,8 @@
 // imani
 
 // leo
+### Koha Updates
+- Resolved an issue that could prevent users with expired passwords from successfully resetting their password when prompted on the login screen. (DIS-744) (*LS*)
 
 // yanjun
 


### PR DESCRIPTION
- Resolved an issue that could prevent users with expired passwords from successfully resetting their password when prompted on the login screen.

Test Plan:
1. In any Koha version greater than or equal to 24.11.0, the `ForcePasswordResetWhenSetByStaff` system preference must be enabled.
2. Create a new patron account in Koha.
3. Navigate to Aspen and attempt to log in. You will see a notification display that the password/pin must be reset.
4. In the password-reset pop-up modal, input a new password and submit it. You will see a "Token not found" error display on a new page.
5. Apply the patch and repeat steps 1-4 _but with another, new patron account_. You may delete the initial one created for this test and subsequently recreate it. Now, your password reset in Aspen will be successful.