### PR TITLE
DIS-752: Palace Project Grouped Work Language Not Properly Set

### DIFF
--- a/code/reindexer/src/org/aspen_discovery/reindexer/PalaceProjectProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/PalaceProjectProcessor.java
@@ -154,6 +154,7 @@ public class PalaceProjectProcessor {
 					String threeLetterLanguage = indexer.translateSystemValue("two_to_three_character_language_codes", languageCode, identifier);
 					String language = indexer.translateSystemValue("language", threeLetterLanguage, identifier);
 					palaceProjectRecord.setPrimaryLanguage(language);
+					groupedWork.addLanguage(language);
 					if (language.equalsIgnoreCase("English")){
 						groupedWork.setLanguageBoost(10L);
 					}else if (language.equalsIgnoreCase("Spanish")){

--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -12,6 +12,8 @@
 // imani
 
 // leo
+### Palace Project Updates
+- Palace Project titles will now display the correct language more reliably, so language filters and searches better match the actual content. (DIS-752) (*LS*)
 
 // yanjun
 


### PR DESCRIPTION
- Palace Project titles will now display the correct language more reliably, so language filters and searches better match the actual content.

Test Plan:
1. Find a grouped work with only a Palace Project record whose language displayed is correct, but when you view the language set in the Staff View (i.e., the language stored in Solr), it is different, likely “English.”
2. Apply the patch. Force reindex the grouped work and wait a couple of minutes. Notice that the language in the Staff View (and in Solr) matches the displayed language next to the grouped work’s cover.