### PR TITLE
DIS-759: Validate Before Removing Themes and Libraries from Themes

### DIFF
--- a/code/web/interface/themes/responsive/Admin/propertiesList.tpl
+++ b/code/web/interface/themes/responsive/Admin/propertiesList.tpl
@@ -273,7 +273,9 @@
 	<div class="row" style="padding-top: 1em">
 		<div class="btn-group btn-group-sm col-sm-12">
 			<button type='submit' value='batchDelete' class="btn btn-danger" onclick="return AspenDiscovery.Admin.showBatchDeleteForm('{$module}', '{$toolName}', 'selected')"><i class="fas fa-trash"></i> {translate text='Batch Delete Selected' isAdminFacing=true}</button>
+			{if $canDeleteAll}
 			<button type='submit' value='batchDelete' class="btn btn-danger" onclick="return AspenDiscovery.Admin.showBatchDeleteForm('{$module}', '{$toolName}', 'all')"><i class="fas fa-trash"></i> {translate text='Delete All' isAdminFacing=true}</button>
+			{/if}
 		</div>
 	</div>
 	{/if}

--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -15,6 +15,13 @@
 ### Koha Updates
 - Resolved an issue that could prevent users with expired passwords from successfully resetting their password when prompted on the login screen. (DIS-744) (*LS*)
 
+### Themes Updates
+- The essential default theme can no longer be deleted, as there must be at least one theme for site stability. (DIS-759) (*LS*)
+- If deleting a theme would leave a library with no theme, deletion is prevented. (DIS-759) (*LS*)
+- If deleting a parent theme on which other child themes depend, deletion is prevented. (DIS-759) (*LS*)
+- If a theme cannot be deleted because it's actively in use, there is a clear alert after saving that explains exactly why it cannot be removed. (DIS-759) (*LS*)
+- The "Delete All" button has been removed from the Themes administration page to prevent the deletion of all themes. (DIS-759) (*LS*)
+
 // yanjun
 
 // laura

--- a/code/web/services/Admin/AJAX.php
+++ b/code/web/services/Admin/AJAX.php
@@ -1034,7 +1034,6 @@ class Admin_AJAX extends JSON_Action {
 		$toolName = $_REQUEST['toolName'];
 		$batchDeleteScope = $_REQUEST['batchDeleteScope'];
 
-		/** @noinspection PhpIncludeInspection */
 		require_once ROOT_DIR . '/services/' . $moduleName . '/' . $toolName . '.php';
 		$fullToolName = $moduleName . '_' . $toolName;
 		/** @var ObjectEditor $tool */
@@ -1055,7 +1054,7 @@ class Admin_AJAX extends JSON_Action {
 						if (!$deletionBlockInfo['preventDeletion']) {
 							$ret = $dataObject->delete();
 							if ($ret == 0) {
-								$allErrors[] = "Unable to delete {$tool->getObjectType()} with id of {$dataObject->getPrimaryKeyValue()}";
+								$allErrors[] = "Unable to delete {$tool->getObjectType()} with id of {$dataObject->getPrimaryKeyValue()}.";
 							}
 						}else{
 							$allErrors[] = $deletionBlockInfo['message'];
@@ -1064,7 +1063,7 @@ class Admin_AJAX extends JSON_Action {
 				}
 				if (!empty($allErrors)) {
 					$user = UserAccount::getActiveUserObj();
-					$user->updateMessage = implode(',', $allErrors);
+					$user->updateMessage = implode('<br/>', $allErrors);
 					$user->updateMessageIsError = true;
 					$user->update();
 					$errorOccurred = true;
@@ -1073,13 +1072,13 @@ class Admin_AJAX extends JSON_Action {
 					return [
 						'success' => true,
 						'title' => 'Error',
-						'message' => "One or more {$tool->getPageTitle()} objects could not be deleted",
+						'message' => "One or more {$tool->getPageTitle()} objects could not be deleted.",
 					];
 				}else{
 					return [
 						'success' => true,
 						'title' => 'Success',
-						'message' => "Deleted all {$tool->getPageTitle()} objects",
+						'message' => "Deleted all {$tool->getPageTitle()} objects.",
 					];
 				}
 
@@ -1094,7 +1093,7 @@ class Admin_AJAX extends JSON_Action {
 						if (!$deletionBlockInfo['preventDeletion']) {
 							$ret = $dataObject->delete();
 							if ($ret == 0) {
-								$allErrors[] = "Unable to delete {$tool->getObjectType()} with id of {$dataObject->getPrimaryKeyValue()}";
+								$allErrors[] = "Unable to delete {$tool->getObjectType()} with id of {$dataObject->getPrimaryKeyValue()}.";
 							}
 						}else{
 							$allErrors[] = $deletionBlockInfo['message'];
@@ -1103,7 +1102,7 @@ class Admin_AJAX extends JSON_Action {
 				}
 				if (!empty($allErrors)) {
 					$user = UserAccount::getActiveUserObj();
-					$user->updateMessage = implode(',', $allErrors);
+					$user->updateMessage = implode('<br/>', $allErrors);
 					$user->updateMessageIsError = true;
 					$user->update();
 					$errorOccurred = true;
@@ -1112,13 +1111,13 @@ class Admin_AJAX extends JSON_Action {
 					return [
 						'success' => true,
 						'title' => 'Error',
-						'message' => "One or more {$tool->getPageTitle()} objects could not be deleted",
+						'message' => "One or more {$tool->getPageTitle()} objects could not be deleted.",
 					];
 				}else{
 					return [
 						'success' => true,
 						'title' => 'Success',
-						'message' => "Deleted selected {$tool->getPageTitle()} objects",
+						'message' => "Deleted selected {$tool->getPageTitle()} objects.",
 					];
 				}
 			}
@@ -1127,7 +1126,7 @@ class Admin_AJAX extends JSON_Action {
 			return [
 				'success' => false,
 				'title' => 'Error Processing Update',
-				'message' => "Sorry, you don't have permission to batch delete",
+				'message' => "Sorry, you don't have permission to batch delete.",
 			];
 		}
 	}

--- a/code/web/services/Admin/ObjectEditor.php
+++ b/code/web/services/Admin/ObjectEditor.php
@@ -43,6 +43,7 @@ abstract class ObjectEditor extends Admin_Admin {
 		}
 		$interface->assign('canCompare', $this->canCompare());
 		$interface->assign('canDelete', $this->canDelete());
+		$interface->assign('canDeleteAll', $this->canDeleteAll());
 		$interface->assign('canSort', $this->canSort());
 		$interface->assign('canFilter', $this->canFilter($structure));
 		$interface->assign('canBatchUpdate', $this->canBatchEdit());
@@ -742,8 +743,18 @@ abstract class ObjectEditor extends Admin_Admin {
 		return true;
 	}
 
-	public function canBatchDelete() {
+	public function canBatchDelete(): bool {
 		return $this->getNumObjects() > 1 && UserAccount::userHasPermission('Batch Delete');
+	}
+
+	/**
+	 * Determines if the user can delete all objects of this type at once based upon batch delete.
+	 * Purpose: Override it in the deriving class to prevent the display of the "Delete All" button.
+	 * @return bool True if the user is allowed to delete all objects, false otherwise.
+	 */
+	public function canDeleteAll(): bool
+	{
+		return $this->canBatchDelete();
 	}
 
 	public function canBatchEdit() {

--- a/code/web/services/Admin/Themes.php
+++ b/code/web/services/Admin/Themes.php
@@ -17,8 +17,13 @@ class Admin_Themes extends ObjectEditor {
 		return 'Themes';
 	}
 
-	function canDelete() {
+	function canDelete(): bool {
 		return UserAccount::userHasPermission('Administer All Themes');
+	}
+
+	public function canDeleteAll(): bool {
+		// Never allow Delete All for themes because the default theme should never be deleted.
+		return false;
 	}
 
 	function getAllObjects($page, $recordsPerPage): array {
@@ -123,12 +128,10 @@ class Admin_Themes extends ObjectEditor {
 	}
 
 	public function canShareToCommunity() {
-		//TODO: This needs a permission
 		return $this->hasCommunityConnection() && UserAccount::userHasPermission('Share Content with Community');
 	}
 
 	public function canFetchFromCommunity() {
-		//TODO: This needs a permission
 		return $this->hasCommunityConnection() && UserAccount::userHasPermission('Import Content from Community');
 	}
 

--- a/code/web/services/Greenhouse/ScheduledUpdates.php
+++ b/code/web/services/Greenhouse/ScheduledUpdates.php
@@ -90,7 +90,7 @@ class Greenhouse_ScheduledUpdates extends ObjectEditor {
 		return false;
 	}
 
-	function canBatchDelete() {
+	function canBatchDelete(): bool {
 		return true;
 	}
 

--- a/code/web/sys/LibraryLocation/Library.php
+++ b/code/web/sys/LibraryLocation/Library.php
@@ -4972,8 +4972,52 @@ class Library extends DataObject {
 		return $this->_themes;
 	}
 
+	/**
+	 * Checks if this library has multiple themes assigned to it.
+	 *
+	 * @return bool True if the library has more than one theme, false otherwise.
+	 */
+	public function hasMultipleThemes(): bool {
+		$themes = $this->getThemes();
+		return count($themes) > 1;
+	}
+
 	public function saveThemes() : void {
 		if (isset ($this->_themes) && is_array($this->_themes)) {
+			// First, check if all themes are being deleted.
+			$themesToDelete = 0;
+			$totalThemes = count($this->getThemes());
+
+			foreach ($this->_themes as $obj) {
+				/** @var LibraryTheme $obj */
+				if ($obj->_deleteOnSave) {
+					$themesToDelete++;
+				}
+			}
+
+			// If all themes would be deleted, prevent it.
+			if ($themesToDelete > 0 && $themesToDelete >= $totalThemes) {
+				$preventionMessage = translate([
+					'text' => 'Cannot delete all themes from a library. Each library must have at least one theme assigned to it.',
+					'isAdminFacing' => true
+				]);
+
+				$user = UserAccount::getActiveUserObj();
+				if ($user) {
+					$user->updateMessage = $preventionMessage;
+					$user->updateMessageIsError = true;
+					$user->update();
+				}
+
+				// Prevent the deletion by unsetting the deleteOnSave flag.
+				foreach ($this->_themes as $obj) {
+					if ($obj->_deleteOnSave) {
+						$obj->_deleteOnSave = false;
+						break; // Only need to preserve at least one theme.
+					}
+				}
+			}
+
 			foreach ($this->_themes as $obj) {
 				/** @var LibraryTheme $obj */
 				if ($obj->_deleteOnSave) {
@@ -4991,7 +5035,7 @@ class Library extends DataObject {
 							}
 						}
 					} else {
-						// set appropriate weight for new theme
+						// Set the appropriate weight for the new theme.
 						$weight = 0;
 						$existingThemesForLibrary = new LibraryTheme();
 						$existingThemesForLibrary->libraryId = $this->libraryId;

--- a/code/web/sys/Theming/Theme.php
+++ b/code/web/sys/Theming/Theme.php
@@ -3244,7 +3244,6 @@ class Theme extends DataObject {
 
 			// If any libraries would be left without themes, show error message and abort.
 			if ($preventDeletion) {
-				// Create a single error message listing all libraries
 				if (count($librariesWithOnlyThisTheme) == 1) {
 					$preventionMessage = translate([
 						'text' => 'Library %1% cannot be removed from this theme because it is the only theme for the library. Before proceeding, please assign another theme to this library.',

--- a/code/web/sys/Theming/Theme.php
+++ b/code/web/sys/Theming/Theme.php
@@ -3218,10 +3218,64 @@ class Theme extends DataObject {
 		}
 	}
 
-	public function saveLibraries() {
+	public function saveLibraries(): void {
 		if (isset ($this->_libraries) && is_array($this->_libraries)) {
+			// First, check if any libraries would be left without themes if removed.
+			require_once ROOT_DIR . '/sys/LibraryLocation/Library.php';
+			$librariesToDelete = [];
+			$librariesWithOnlyThisTheme = [];
+			$preventDeletion = false;
+
 			foreach($this->_libraries as $obj) {
-				/** @var DataObject $obj */
+				/** @var LibraryTheme $obj */
+				if($obj->_deleteOnSave) {
+					$librariesToDelete[] = $obj;
+					// Check if this is the library's only theme.
+					$library = new Library();
+					$library->libraryId = $obj->libraryId;
+					if ($library->find(true)) {
+						if (!$library->hasMultipleThemes()) {
+							$preventDeletion = true;
+							$librariesWithOnlyThisTheme[] = $library->displayName;
+						}
+					}
+				}
+			}
+
+			// If any libraries would be left without themes, show error message and abort.
+			if ($preventDeletion) {
+				// Create a single error message listing all libraries
+				if (count($librariesWithOnlyThisTheme) == 1) {
+					$preventionMessage = translate([
+						'text' => 'Library %1% cannot be removed from this theme because it is the only theme for the library. Before proceeding, please assign another theme to this library.',
+						'isAdminFacing' => true,
+						1 => $librariesWithOnlyThisTheme[0]
+					]);
+				} else {
+					$libraryList = implode('", "', $librariesWithOnlyThisTheme);
+					$preventionMessage = translate([
+						'text' => 'The following libraries cannot be removed from this theme because it is their only theme: %1%. Before proceeding, please assign another theme to these libraries.',
+						'isAdminFacing' => true,
+						1 => $libraryList
+					]);
+				}
+
+				$user = UserAccount::getActiveUserObj();
+				if ($user) {
+					$user->updateMessage = $preventionMessage;
+					$user->updateMessageIsError = true;
+					$user->update();
+				}
+
+				// Remove the libraries marked for deletion from the _deleteOnSave list.
+				foreach($librariesToDelete as $obj) {
+					$obj->_deleteOnSave = false;
+				}
+			}
+
+			// Continue with normal save procedure for non-deleted libraries.
+			foreach($this->_libraries as $obj) {
+				/** @var LibraryTheme $obj */
 				if($obj->_deleteOnSave) {
 					$obj->delete();
 				} else {
@@ -3235,7 +3289,7 @@ class Theme extends DataObject {
 							}
 						}
 					} else {
-						// set appropriate weight for new theme
+						// Set the appropriate weight for the new theme.
 						$weight = 0;
 						$existingThemesForLibrary = new LibraryTheme();
 						$existingThemesForLibrary->libraryId = $obj->libraryId;
@@ -3294,8 +3348,8 @@ class Theme extends DataObject {
 		}
 	}
 
-	/** @return Library[]
-	 * @noinspection PhpUnused
+	/**
+	 * @return array|null
 	 */
 	public function getLibraries() : ?array {
 		if (!isset($this->_libraries) && $this->id) {
@@ -3310,8 +3364,8 @@ class Theme extends DataObject {
 		return $this->_libraries;
 	}
 
-	/** @return Location[]
-	 * @noinspection PhpUnused
+	/**
+	 * @return array|null
 	 */
 	public function getLocations() : ?array {
 		if (!isset($this->_locations) && $this->id) {
@@ -3404,15 +3458,150 @@ class Theme extends DataObject {
 	}
 
 	/**
-	 * Validates the `extendsTheme` property to ensure it references a valid, non-self theme.
+	 * Return appropriate warning messages about why a theme can't be deleted.
 	 *
+	 * @return array
+	 */
+	public function getAdditionalListActions(): array {
+		$actions = [];
+		$deletionInfo = $this->checkDeletionDependencies();
+		if ($deletionInfo['preventDeletion']) {
+			$actions[] = [
+				'text' => 'Warning',
+				'url' => '#',
+				'onclick' => "alert('" . str_replace("'", "\\'", strip_tags($deletionInfo['message'])) . "'); return false;",
+				'class' => 'btn-danger'
+			];
+		}
+		return $actions;
+	}
+
+	/**
+	 * Check to see if this object should not be deleted because it will cause inconsistencies in other objects.
+	 * Prevent deletion of the default theme (ID: 1) and handle relationships with dependent objects.
+	 *
+	 * @param array $structure The object structure of this object.
+	 * @return array
+	 */
+	public function getDeletionBlockInformation(array $structure) : array {
+		return $this->checkDeletionDependencies();
+	}
+
+	/**
+	 * Checks if the theme can be deleted based on dependencies.
+	 * - Prevents deletion of the default theme (ID: 1).
+	 * - Prevents deletion if the theme is extended by child themes.
+	 * - Prevents deletion if the theme is the only theme for any library.
+	 *
+	 * @return array ['preventDeletion' => bool, 'message' => string]
+	 */
+	private function checkDeletionDependencies() : array {
+		// Check if this is the default theme (ID: 1) and prevent its deletion.
+		if ($this->id == 1) {
+			return [
+				'preventDeletion' => true,
+				'message' => translate(['text' => 'The default theme ' . $this->themeName . ' (ID: 1) cannot be deleted.', 'isAdminFacing'=>true])
+			];
+		}
+
+		$objectDependencyInfo = [
+			'preventDeletion' => false,
+			'message' => ''
+		];
+		$errorMessages = [];
+
+		// Check for child themes to prevent orphaned themes.
+		$childThemesWithThisParent = [];
+		$childTheme = new Theme();
+		$childTheme->extendsTheme = $this->themeName;
+		$childTheme->find();
+		while ($childTheme->fetch()) {
+			if ($childTheme->id != $this->id) {
+				$childThemesWithThisParent[] = $childTheme->displayName;
+			}
+		}
+		if (count($childThemesWithThisParent) > 0) {
+			$objectDependencyInfo['preventDeletion'] = true;
+			if (count($childThemesWithThisParent) == 1) {
+				$errorMessages[] = translate([
+					'text' => 'It is extended by the child theme: %1%. Before proceeding, please update the child theme to extend a different theme or "None".',
+					'isAdminFacing' => true,
+					1 => $childThemesWithThisParent[0]
+				]);
+			} else {
+				$childThemesList = implode(', ', $childThemesWithThisParent);
+				$errorMessages[] = translate([
+					'text' => 'It is extended by the child themes: %1%. Before proceeding, please update the child themes to extend a different theme or "None".',
+					'isAdminFacing' => true,
+					1 => $childThemesList
+				]);
+			}
+		}
+
+		// Custom handling for library themes to only prevent deletion
+		// if removing this theme would leave a library without any themes.
+		// There is no need to prevent the deletion of locations that would be left
+		// without any themes because their fallback is their respective library's theme.
+		require_once ROOT_DIR . '/sys/LibraryLocation/LibraryTheme.php';
+		$librariesWithOnlyThisTheme = [];
+		$libraryTheme = new LibraryTheme();
+		$libraryTheme->themeId = $this->id;
+		$libraryTheme->find();
+		while ($libraryTheme->fetch()) {
+			// For each library using this theme, check if it has other themes.
+			$otherThemeCheck = new LibraryTheme();
+			$otherThemeCheck->libraryId = $libraryTheme->libraryId;
+			$otherThemeCheck->whereAdd("themeId != {$this->id}");
+			if ($otherThemeCheck->count() == 0) {
+				require_once ROOT_DIR . '/sys/LibraryLocation/Library.php';
+				$library = new Library();
+				$library->libraryId = $libraryTheme->libraryId;
+				if ($library->find(true)) {
+					$librariesWithOnlyThisTheme[] = $library->displayName;
+				}
+			}
+		}
+		if (count($librariesWithOnlyThisTheme) > 0) {
+			$objectDependencyInfo['preventDeletion'] = true;
+			if (count($librariesWithOnlyThisTheme) == 1) {
+				$errorMessages[] = translate([
+					'text' => 'It is the only theme for the library: %1%. Before proceeding, please assign another theme to this library.',
+					'isAdminFacing' => true,
+					1 => $librariesWithOnlyThisTheme[0]
+				]);
+			} else {
+				$librariesList = implode(', ', $librariesWithOnlyThisTheme);
+				$errorMessages[] = translate([
+					'text' => 'It is the only theme for the libraries: %1%. Before proceeding, please assign another theme to these libraries.',
+					'isAdminFacing' => true,
+					1 => $librariesList
+				]);
+			}
+		}
+
+		if ($objectDependencyInfo['preventDeletion']) {
+			$objectDependencyInfo['message'] = translate([
+				'text' => 'The theme %1% cannot be deleted because:',
+				'isAdminFacing' => true,
+				1 => $this->themeName
+			]) . '<ul>';
+			foreach ($errorMessages as $msg) {
+				$objectDependencyInfo['message'] .= '<li>' . $msg . '</li>';
+			}
+			$objectDependencyInfo['message'] .= '</ul>';
+		}
+
+		return $objectDependencyInfo;
+	}
+
+	/**
+	 * Validates the `extendsTheme` property to ensure it references a valid, non-self theme.
 	 * - If `extendsTheme` is set but does not point to an existing theme, it resets the value and logs an error.
 	 * - If `extendsTheme` references the current theme itself, it removes the self-reference and logs the correction.
 	 *
 	 * @return bool Returns true if the `extendsTheme` value was invalid and had to be reset (non-existent or self-referential), false otherwise.
 	 */
-	private function validateExtendsTheme(): bool
-	{
+	private function validateExtendsTheme(): bool {
 		if (!empty($this->extendsTheme)) {
 			$parentTheme = new Theme();
 			$parentTheme->themeName = $this->extendsTheme;


### PR DESCRIPTION
- The essential default theme can no longer be deleted, as there must be at least one theme for site stability.
- If deleting a theme would leave a library with no theme, deletion is prevented.
- If deleting a parent theme on which other child themes depend, deletion is prevented.
- If a theme cannot be deleted because it's actively in use, there is a clear alert after saving that explains exactly why it cannot be removed.
- The "Delete All" button has been removed from the Themes administration page to prevent the deletion of all themes.

Test Plan:
1. Navigate to the Themes admin interface and delete a Theme that is the parent theme of another theme (i.e., another themes extends the about-to-be-deleted theme). I recommend creating backup tables of the following tables so they can be re-inserted after testing: `themes`, `library_themes`, and `location_themes`. 
2. If you navigate to the catalog that the orphaned theme is responsible for displaying, the catalog will pop up AJAX request errors and template errors and be generally unusable.
3. If you created backups, re-insert the data from the backup tables into the original tables. If you did not create backups, run SQL statements to remove the deleted theme’s ID from the `library_themes` and `location_themes` tables because these dependencies will cause conflicts.
4. Apply the patch and redo steps 1-3. Notice that an error will display if you attempt to delete themes with child and library dependencies.
   - In terms of library dependencies, if a library from Library Systems has no associated themes, its catalog will contain template errors. After the patch, you cannot delete themes from a library, or delete libraries from a theme, if that library has no other associated themes; it must have at least one theme.