### PR TITLE
DIS-763: Solr Search Error When Query Contains Double Hyphens

### DIFF
--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -18,6 +18,9 @@
 ### Koha Updates
 - Resolved an issue that could prevent users with expired passwords from successfully resetting their password when prompted on the login screen. (DIS-744) (*LS*)
 
+### Searching Updates
+- Fixed an issue where searching for terms containing double hyphens (e.g., "Subject--Subdivision") would result in an error message. (DIS-763) (*LS*)
+
 // yanjun
 
 // laura

--- a/code/web/sys/SolrConnector/Solr.php
+++ b/code/web/sys/SolrConnector/Solr.php
@@ -1907,6 +1907,9 @@ abstract class Solr {
 		//Remove any semi-colons that Solr will handle incorrectly.
 		$input = str_replace(';', ' ', $input);
 
+		// Remove any double hyphens that Solr will handle incorrectly.
+		$input = str_replace('--', ' ', $input);
+
 		//Remove slashes occur in the middle of a word that Solr will handle incorrectly.
 		$input = preg_replace("/([0-9a-zA-Z])([\/])([0-9a-zA-Z])/", "$1 $3", $input);
 		$input = preg_replace("/([0-9a-zA-Z])([\\\\])([0-9a-zA-Z])/", "$1 $3", $input);


### PR DESCRIPTION
- Fixed an issue where searching for terms containing double hyphens (e.g., "Subject--Subdivision") would result in an error message.

Test Plan: Difficult to replicate because the Solr error occurs when clicking on a recommendation that contains the double hyphens in the query. An example error is under the Testing Notes of the Jira due to its length.