### PR TITLE
DIS-768: Incorrect Bypass Logic for Koha Reading History Updates

### DIFF
--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -8276,10 +8276,8 @@ class Koha extends AbstractIlsDriver {
 	}
 
 	public function bypassReadingHistoryUpdate($patron, $isNightlyUpdate) : bool {
-		//Last seen only updates once a day so only do this check if we're running the nightly update
+		// Last seen only updates once a day so only do this check if we're running the nightly update.
 		if (!$isNightlyUpdate) {
-			return false;
-		} else {
 			$this->initDatabaseConnection();
 			/** @noinspection SqlResolve */
 			$sql = "SELECT lastseen, dateexpiry FROM borrowers where borrowernumber = '" . mysqli_escape_string($this->dbConnection, $patron->unique_ils_id) . "'";
@@ -8289,26 +8287,26 @@ class Koha extends AbstractIlsDriver {
 			if ($results !== false) {
 				while ($curRow = $results->fetch_assoc()) {
 					if (!is_null($curRow['lastseen'])) {
-						$lastSeenDate =  strtotime($curRow['lastseen']);
+						$lastSeenDate = strtotime($curRow['lastseen']);
 					}
 					if (!is_null($curRow['dateexpiry'])) {
-						$expirationDate =  strtotime($curRow['dateexpiry']);
+						$expirationDate = strtotime($curRow['dateexpiry']);
 					}
 				}
 
 				$results->close();
 			}
 
-			//Don't update reading history if we've never seen the patron or the patron was last seen before we last updated reading history
+			// Don't update reading history if we've never seen the patron or the patron was last seen before we last updated reading history.
 			$lastReadingHistoryUpdate = $patron->lastReadingHistoryUpdate;
 			if ($lastSeenDate != null && ($lastSeenDate > $lastReadingHistoryUpdate)) {
-				//Also do not update if the patron's account expired more than 4 weeks ago.
+				// Do not update if the patron's account expired more than 4 weeks ago.
 				if ($expirationDate == null || ($expirationDate > (time() - 4 * 7 * 24 * 60 * 60))) {
-					return false;
+					return true;
 				}
 			}
-			return true;
 		}
+		return false;
 	}
 
 	public function hasAPICheckout() : bool {

--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -19,6 +19,7 @@
 
 ### Koha Updates
 - Resolved an issue that could prevent users with expired passwords from successfully resetting their password when prompted on the login screen. (DIS-744) (*LS*)
+- Patrons’ reading histories now update correctly each night, ensuring their recent check-outs and returns are always recorded, even if they haven’t signed in daily (DIS-768) (*LS*)
 
 // yanjun
 

--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -19,7 +19,7 @@
 
 ### Koha Updates
 - Resolved an issue that could prevent users with expired passwords from successfully resetting their password when prompted on the login screen. (DIS-744) (*LS*)
-- Patrons’ reading histories now update correctly each night, ensuring their recent check-outs and returns are always recorded, even if they haven’t signed in daily (DIS-768) (*LS*)
+- Patrons’ reading histories now update correctly each night, ensuring their recent check-outs and returns are always recorded, even if they haven’t signed in daily. (DIS-768) (*LS*)
 
 // yanjun
 


### PR DESCRIPTION
- Patrons’ reading histories now update correctly each night, ensuring their recent check-outs and returns are always recorded, even if they haven’t signed in daily.

Test Plan: Difficult to recreate for testing, but if you glance at the Cron Logs in the admin interface, large numbers of updates are skipped because of the incorrect logic.