### PR TITLE
DIS-786: Show List Titles & Descriptions When Printing Lists

### DIFF
--- a/code/web/interface/themes/responsive/css/main.css
+++ b/code/web/interface/themes/responsive/css/main.css
@@ -11368,4 +11368,36 @@ input[type="radio"][name="colorScheme"]:checked + label::after {
   height: 25px;
   position: relative;
 }
+@media print {
+  /* Make sure descriptions are visible when printing */
+  .hidden-xs {
+    display: block !important;
+  }
+  /* Make sure list title is prominently displayed */
+  #listTitle {
+    font-size: 24px;
+    margin-top: 20px;
+    margin-bottom: 10px;
+    display: block !important;
+  }
+  /* Hide buttons and controls that aren't needed for print */
+  .btn-toolbar,
+  .btn-group,
+  .resultActions {
+    display: none !important;
+  }
+  /* Prevent page breaks inside list items and their descriptions */
+  .result,
+  .resultsList.listEntry,
+  [id^="descriptionValue"],
+  .result-value,
+  .user-list-entry-note {
+    page-break-inside: avoid !important;
+    break-inside: avoid !important;
+  }
+  /* Hide mobile-only toggle rows (e.g. "Click to view") in print */
+  .visible-xs {
+    display: none !important;
+  }
+}
 /*# sourceMappingURL=main.css.map */

--- a/code/web/interface/themes/responsive/css/main.css
+++ b/code/web/interface/themes/responsive/css/main.css
@@ -11369,24 +11369,24 @@ input[type="radio"][name="colorScheme"]:checked + label::after {
   position: relative;
 }
 @media print {
-  /* Make sure descriptions are visible when printing */
+  /* Make sure descriptions are visible. */
   .hidden-xs {
     display: block !important;
   }
-  /* Make sure list title is prominently displayed */
+  /* Make sure list title is prominently displayed. */
   #listTitle {
     font-size: 24px;
     margin-top: 20px;
     margin-bottom: 10px;
     display: block !important;
   }
-  /* Hide buttons and controls that aren't needed for print */
+  /* Hide buttons and controls that aren't needed for print. */
   .btn-toolbar,
   .btn-group,
   .resultActions {
     display: none !important;
   }
-  /* Prevent page breaks inside list items and their descriptions */
+  /* Prevent page breaks inside list items and their descriptions. */
   .result,
   .resultsList.listEntry,
   [id^="descriptionValue"],
@@ -11395,9 +11395,16 @@ input[type="radio"][name="colorScheme"]:checked + label::after {
     page-break-inside: avoid !important;
     break-inside: avoid !important;
   }
-  /* Hide mobile-only toggle rows (e.g. "Click to view") in print */
+  /* Hide mobile-only toggle rows (e.g. "Click to view") in print. */
   .visible-xs {
     display: none !important;
+  }
+  /* Strip out any screen‐only height/overflow rules to allow landscape printing. */
+  html,
+  body {
+    height: auto !important;
+    max-height: none !important;
+    overflow: visible !important;
   }
 }
 /*# sourceMappingURL=main.css.map */

--- a/code/web/interface/themes/responsive/css/print.less
+++ b/code/web/interface/themes/responsive/css/print.less
@@ -1,10 +1,10 @@
 @media print {
-  /* Make sure descriptions are visible when printing */
+  /* Make sure descriptions are visible. */
   .hidden-xs {
     display: block !important;
   }
 
-  /* Make sure list title is prominently displayed */
+  /* Make sure list title is prominently displayed. */
   #listTitle {
     font-size: 24px;
     margin-top: 20px;
@@ -12,19 +12,26 @@
     display: block !important;
   }
 
-  /* Hide buttons and controls that aren't needed for print */
+  /* Hide buttons and controls that aren't needed for print. */
   .btn-toolbar, .btn-group, .resultActions {
     display: none !important;
   }
 
-  /* Prevent page breaks inside list items and their descriptions */
+  /* Prevent page breaks inside list items and their descriptions. */
   .result, .resultsList.listEntry, [id^="descriptionValue"], .result-value, .user-list-entry-note {
     page-break-inside: avoid !important;
     break-inside: avoid !important;
   }
 
-  /* Hide mobile-only toggle rows (e.g. "Click to view") in print */
+  /* Hide mobile-only toggle rows (e.g. "Click to view") in print. */
   .visible-xs {
     display: none !important;
+  }
+
+  /* Strip out any screen‐only height/overflow rules to allow landscape printing. */
+  html, body {
+    height: auto !important;
+    max-height: none !important;
+    overflow: visible !important;
   }
 }

--- a/code/web/interface/themes/responsive/css/print.less
+++ b/code/web/interface/themes/responsive/css/print.less
@@ -1,0 +1,30 @@
+@media print {
+  /* Make sure descriptions are visible when printing */
+  .hidden-xs {
+    display: block !important;
+  }
+
+  /* Make sure list title is prominently displayed */
+  #listTitle {
+    font-size: 24px;
+    margin-top: 20px;
+    margin-bottom: 10px;
+    display: block !important;
+  }
+
+  /* Hide buttons and controls that aren't needed for print */
+  .btn-toolbar, .btn-group, .resultActions {
+    display: none !important;
+  }
+
+  /* Prevent page breaks inside list items and their descriptions */
+  .result, .resultsList.listEntry, [id^="descriptionValue"], .result-value, .user-list-entry-note {
+    page-break-inside: avoid !important;
+    break-inside: avoid !important;
+  }
+
+  /* Hide mobile-only toggle rows (e.g. "Click to view") in print */
+  .visible-xs {
+    display: none !important;
+  }
+}

--- a/code/web/interface/themes/responsive/css/responsive_base.less
+++ b/code/web/interface/themes/responsive/css/responsive_base.less
@@ -392,3 +392,4 @@ div.striped {
 @import "ebsco.less";
 @import "cookie-consent.less";
 @import "talpa.less";
+@import "print.less";

--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -24,6 +24,10 @@
 - Resolved an issue that could prevent users with expired passwords from successfully resetting their password when prompted on the login screen. (DIS-744) (*LS*)
 - Patrons’ reading histories now update correctly each night, ensuring their recent check-outs and returns are always recorded, even if they haven’t signed in daily. (DIS-768) (*LS*)
 
+### User List Updates
+- Enhanced list printing to ensure the list's title is clearly displayed on the printout and all item descriptions are no longer hidden. (DIS-786) (*LS*)
+- Fixed an issue where printing lists in landscape mode would only print the first page; all items will now be included across multiple pages as needed. (DIS-786) (*LS*)
+
 // yanjun
 
 // laura


### PR DESCRIPTION
- Enhanced list printing to ensure the list's title is clearly displayed on the printout and all item descriptions are no longer hidden.
- Fixed an issue where printing lists in landscape mode would only print the first page; all items will now be included across multiple pages as needed.

Tested on Chrome, Mozilla, and Edge.

Test Plan:
1. Navigate to any list in the catalog and click the “Print List” button. Notice that the list title is not displayed and that list descriptions are hidden.
2. Switch to “Landscape” layout mode in the print preview. Notice that there is only one sheet and list items are cut off.
3. Apply the patch and repeat steps 1-2.