### PR TITLE
DIS-789: Remove Undefined Smarty Parameters for List Entries

### DIFF
--- a/code/web/interface/themes/responsive/RecordDrivers/List/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/List/listEntry.tpl
@@ -82,7 +82,7 @@
 
 
 			<div class="resultActions row">
-				{include file='Lists/result-tools.tpl' id=$summId shortId=$shortId module=$summModule summTitle=$summTitle ratingData=$summRating recordUrl=$summUrl}
+				{include file='Lists/result-tools.tpl' recordUrl=$summUrl}
 			</div>
 		</div>
 

--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -38,6 +38,9 @@
 ### Searching Updates
 - Added an 'X' button inside the search box to easily clear entered text; the button appears automatically when text is present. (DIS-778) (*LS*)
 
+### Other Updates
+- List entries will no longer occasionally display confusing PHP warnings or broken layouts. (DIS-789) (*LS*)
+
 // yanjun
 
 // laura


### PR DESCRIPTION
- List entries will no longer occasionally display confusing PHP warnings or broken layouts.

Test Plan: Difficult to test because I have only seen one case of it. Regardless, those parameters are not used.