### PR TITLE
DIS-785 Remove Inactive Boundless Records

### DIFF
--- a/code/axis_360_export/src/com/turning_leaf_technogies/axis360/Axis360Extractor.java
+++ b/code/axis_360_export/src/com/turning_leaf_technogies/axis360/Axis360Extractor.java
@@ -475,8 +475,9 @@ public class Axis360Extractor {
 			for (Axis360Title axis360Title : existingRecords.values()) {
 				if (!axis360Title.isDeleted() && !axis360Title.isProcessed()) {
 					//Remove Axis360 availability
-					deleteAxis360AvailabilityStmt.setString(1, axis360Title.getAxis360Id());
+					deleteAxis360AvailabilityStmt.setLong(1, axis360Title.getId());
 					deleteAxis360AvailabilityStmt.setLong(2, setting.getId());
+					deleteAxis360AvailabilityStmt.executeUpdate();
 
 					getExistingSettingsForAxis360TitleStmt.setLong(1, axis360Title.getId());
 					ResultSet getExistingSettingsForAxis360TitleRS = getExistingSettingsForAxis360TitleStmt.executeQuery();

--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -34,6 +34,8 @@
 - Added an 'X' button inside the search box to easily clear entered text; the button appears automatically when text is present. (DIS-778) (*LS*)
 
 // yanjun
+### Boundless Updates
+- Delete inactive Axis360 titles from database correctly. (DIS-785) (*YL*)
 
 // laura
 


### PR DESCRIPTION
Inactive Boundless records couldn't be removed from the database because records' related availability didn't get deleted successfully from the database. This patch corrected the query. 