### PR TITLE
DIS-775: Improve Browse Category Page Load Speed for Accessible Mode & Fix Duplicate Items on Rapid Clicks

### DIFF
--- a/code/web/interface/themes/responsive/Search/browse-sub-category-tab.tpl
+++ b/code/web/interface/themes/responsive/Search/browse-sub-category-tab.tpl
@@ -23,7 +23,7 @@
 						<div class="swiper-button-prev"></div>
 					</div>
 					<div class="swiper-wrapper" id="swiper-sub-browse-category-{$subCategory.textId}">
-						{if $subCategory@iteration == 1 && !empty($subCategory.initialResults)}
+						{if $subCategory@iteration == 1}
 							<div class="swiper-slide" id="swiper-loading-{$subCategory.textId}" style="height: 200px">
 								<i class="fas fa-lg fa-spinner fa-spin"></i>
 							</div>

--- a/code/web/interface/themes/responsive/Search/browse-sub-category-tab.tpl
+++ b/code/web/interface/themes/responsive/Search/browse-sub-category-tab.tpl
@@ -23,22 +23,9 @@
 						<div class="swiper-button-prev"></div>
 					</div>
 					<div class="swiper-wrapper" id="swiper-sub-browse-category-{$subCategory.textId}">
-						{if $subCategory@iteration == 1}
-							<div class="swiper-slide" id="swiper-loading-{$subCategory.textId}" style="height: 200px">
-								<i class="fas fa-lg fa-spinner fa-spin"></i>
-							</div>
-							<script type="text/javascript">
-								{literal}
-								$(document).ready(function() {
-									AspenDiscovery.Browse.changeBrowseSubCategoryTab({/literal}'{$subCategory.textId}','{$parentTextId}'{literal});
-								});
-								{/literal}
-							</script>
-						{else}
-							<div class="swiper-slide" id="swiper-loading-{$subCategory.textId}" style="height: 200px">
-								<i class="fas fa-lg fa-spinner fa-spin"></i>
-							</div>
-						{/if}
+						<div class="swiper-slide" id="swiper-loading-{$subCategory.textId}" style="height: 200px">
+							<i class="fas fa-lg fa-spinner fa-spin"></i>
+						</div>
 					</div>
 					<div class="swiper-navigation-container">
 						<div class="swiper-button-next"></div>

--- a/code/web/interface/themes/responsive/Search/home.tpl
+++ b/code/web/interface/themes/responsive/Search/home.tpl
@@ -16,9 +16,12 @@
 						</button>
 					{/if}
 				</div>
-				{if !empty($browseCategory.subcategories)}
-					<div class="tabs">
-						{$browseCategory.subcategories nofilter}
+				{if $browseCategory.hasSubcategories}
+					<div class="tabs" id="tabs-{$browseCategory.textId}">
+						<div class="tabs-loading"
+							 style="height:200px;display:flex;align-items:center;justify-content:center;">
+							<i class="fas fa-lg fa-spinner fa-spin"></i>
+						</div>
 					</div>
 				{else}
 					<div class="swiper swiper-first swiper-browse-category-{$browseCategory.textId}" id="swiper-{$browseCategory.textId}">
@@ -29,9 +32,13 @@
 							<div class="swiper-slide" id="swiper-loading-{$browseCategory.textId}" style="height: 200px">
 								<i class="fas fa-lg fa-spinner fa-spin"></i>
 							</div>
-						   {literal} <script type="text/javascript">
-								setTimeout(() => AspenDiscovery.Browse.initializeBrowseCategorySwiper({/literal}'{$browseCategory.textId}'{literal}), 1000)
-							</script>{/literal}
+						   <script type="text/javascript">
+							   $(function() {
+								   setTimeout(function() {
+									   AspenDiscovery.Browse.initializeBrowseCategorySwiper("{$browseCategory.textId}");
+								   }, 1000);
+							   });
+						   </script>
 						</div>
 						<div class="swiper-navigation-container">
 							<div class="swiper-button-next"></div>
@@ -180,5 +187,9 @@
 		$('#'+AspenDiscovery.Browse.browseMode).addClass('active'); {* show user which one is selected *}
 
 		AspenDiscovery.Browse.toggleBrowseMode();
+
+		{if $accessibleBrowseCategories == '1'}
+			AspenDiscovery.Browse.loadAllBrowseCategoryTabsSequential();
+		{/if}
 	{rdelim});
 </script>

--- a/code/web/interface/themes/responsive/js/aspen/browse.js
+++ b/code/web/interface/themes/responsive/js/aspen/browse.js
@@ -13,6 +13,7 @@ AspenDiscovery.Browse = (function(){
 		browseStyle: 'masonry',
 		accessibleMode: false,
 		patronId: null,
+		subCategorySwipers: {},
 
 		addToHomePage: function(searchId){
 			AspenDiscovery.Account.ajaxLightbox(Globals.path + '/Browse/AJAX?method=getAddBrowseCategoryForm&searchId=' + searchId, true);
@@ -477,7 +478,7 @@ AspenDiscovery.Browse = (function(){
 						resultsPanel.fadeIn('slow');
 						AspenDiscovery.Ratings.initializeRaters();
 					});
-					
+
 					$('#selected-browse-search-link').attr('href', data.searchUrl); // update the search link
 
 					if (data.lastPage){
@@ -518,56 +519,115 @@ AspenDiscovery.Browse = (function(){
 
 		changeBrowseSubCategoryTab: function (subCategoryTextId, categoryId) {
 			AspenDiscovery.Browse.changingDisplay = true;
-			var url = Globals.path + '/Browse/AJAX';
-			var params = {
-				method : 'getBrowseSubCategoryInfo'
-				,textId : categoryId
-				,subCategoryTextId : subCategoryTextId
-				,browseMode : this.browseMode
+			const container = document.querySelector('.swiper-sub-browse-category-' + subCategoryTextId);
+			const self      = this;
+
+			// Accessibility: Make the container focusable so we can catch arrow-key navigation.
+			container.setAttribute('tabindex', '0');
+			container.addEventListener('keydown', function(e) {
+				const swiper = self.subCategorySwipers[subCategoryTextId];
+				if (!swiper) return;
+				if (e.key === 'ArrowLeft')  swiper.slidePrev();
+				if (e.key === 'ArrowRight') swiper.slideNext();
+			});
+
+			// Toggle the tab buttons and wire up aria-controls.
+			const $tabs = $('#tabs-' + categoryId);
+			$tabs.find('[role="tab"]').each(function(){
+				const $btn = $(this);
+				const thisId = $btn.attr('id');
+				const panelId = thisId.replace('tab-', 'panel-');
+				$btn.attr('aria-controls', panelId);
+
+				if (thisId === 'browse-sub-category-tab-' + subCategoryTextId) {
+					$btn.attr({ 'aria-selected': 'true', tabindex: 0 })
+						.addClass('selected');
+				} else {
+					$btn.attr({ 'aria-selected': 'false', tabindex: -1 })
+						.removeClass('selected');
+				}
+			});
+
+			// Hide all panels, then show the one we want, and manage aria-hidden.
+			$tabs.find('[role="tabpanel"]')
+				.addClass('is-hidden')
+				.attr('aria-hidden', 'true');
+
+			const $panel = $('#tabpanel-' + subCategoryTextId)
+				.removeClass('is-hidden')
+				.attr({
+					'aria-hidden': 'false',
+					'aria-live' : 'polite',
+					'aria-busy' : 'true'
+				});
+
+			const url = Globals.path + '/Browse/AJAX';
+			const params = {
+				method           : 'getBrowseSubCategoryInfo',
+				textId           : categoryId,
+				subCategoryTextId: subCategoryTextId,
+				browseMode       : this.browseMode
 			};
 
 			$.getJSON(url, params, function(data){
-				if (data.success === false){
-					AspenDiscovery.showMessage("Error loading browse information", "Sorry, we were not able to find titles for that category");
-				}else{
-					var resultsTabPanel = document.getElementById('swiper-sub-browse-category-' + subCategoryTextId) ;
-					resultsTabPanel.innerHTML = "";
-					var browseSwiper = new Swiper('.swiper-sub-browse-category-' + subCategoryTextId, {
+				if (!data.success) {
+					AspenDiscovery.showMessage(
+						"Error Loading Browse Information",
+						"Sorry, we were not able to find titles for that category."
+					);
+					$panel.attr('aria-busy','false');
+					return;
+				}
+
+				const slides = Object.values(data.records);
+
+				if (!self.subCategorySwipers[subCategoryTextId]) {
+					const wrapper = container.querySelector('.swiper-wrapper');
+					if (wrapper) wrapper.innerHTML = '';
+
+					const browseSwiper = new Swiper(container, {
 						slidesPerView: 5,
-						spaceBetween: 20,
-						direction: 'horizontal',
-
-						// Accessibility
-						a11y: {
-							enabled: true
+						spaceBetween : 20,
+						direction    : 'horizontal',
+						a11y         : { enabled: true },
+						navigation   : {
+							nextEl : container.querySelector('.swiper-button-next'),
+							prevEl : container.querySelector('.swiper-button-prev'),
 						},
-
-						// Navigation arrows
-						navigation: {
-							nextEl: '.swiper-button-next',
-							prevEl: '.swiper-button-prev'
-						},
-
 						virtual: {
 							enabled: true,
-							slides: Object.values(data.records)
+							slides : slides
 						}
 					});
-					// Fix keyboard navigation
-					$("#browse-category-feed .swiper-wrapper > .swiper-slide:not(.swiper-slide-visible) a").prop("tabindex", "-1");
-					$("#browse-category-feed .swiper-wrapper > .swiper-slide-visible a").removeProp("tabindex");
-					browseSwiper.on('slideChangeTransitionEnd', function () {
-						$("#browse-category-feed .swiper-wrapper > .swiper-slide:not(.swiper-slide-visible) a").prop("tabindex", "-1");
-						$("#browse-category-feed .swiper-wrapper > .swiper-slide-visible a").removeProp("tabindex");
+
+					// Keep off‑screen slides out of the tab order.
+					browseSwiper.on('slideChangeTransitionEnd', function(){
+						$("#browse-category-feed .swiper-wrapper > .swiper-slide:not(.swiper-slide-visible) a")
+							.prop("tabindex","-1");
+						$("#browse-category-feed .swiper-wrapper > .swiper-slide-visible a")
+							.removeAttr("tabindex");
 					});
 
+					self.subCategorySwipers[subCategoryTextId] = browseSwiper;
 				}
-			}).fail(function(){
+				else {
+					const swiper = self.subCategorySwipers[subCategoryTextId];
+					swiper.virtual.slides = slides;
+					swiper.virtual.update();
+					if (swiper.lazy) swiper.lazy.load();
+				}
+
+				$panel.attr('aria-busy','false');
+			})
+			.fail(function(){
 				AspenDiscovery.ajaxFail();
-				AspenDiscovery.Browse.changingDisplay = false;
-			}).done(function(){
+				$('#tabpanel-' + subCategoryTextId).attr('aria-busy','false');
+			})
+			.always(function(){
 				AspenDiscovery.Browse.changingDisplay = false;
 			});
+
+			return false;
 		},
 
 		updateBrowseCategory: function(){
@@ -656,6 +716,42 @@ AspenDiscovery.Browse = (function(){
 				}
 			}).fail(AspenDiscovery.ajaxFail);
 			return false;
+		},
+		// Load subcategory tabs and initial content for an accessible browse category.
+		loadBrowseCategoryTabs: function(categoryTextId) {
+			const url = Globals.path + '/Browse/AJAX';
+			const params = {
+				method: 'getBrowseCategoryInfo',
+				textId: categoryTextId,
+				browseMode: this.browseMode
+			};
+			return $.getJSON(url, params)
+			.done(function(data){
+				if (data.success === false) {
+					AspenDiscovery.showMessage('Error loading subcategories', 'Sorry, unable to load subcategories for that category');
+				} else {
+					// Replace placeholder with actual tabs
+					AspenDiscovery.Browse.changingDisplay = false;
+					$('#tabs-' + categoryTextId).html(data.subcategories);
+				}
+			}).fail(AspenDiscovery.ajaxFail).always(function() {
+				AspenDiscovery.Browse.changingDisplay = false;
+			});
+		},
+		// Load each browse category in order, from top to bottom.
+		loadAllBrowseCategoryTabsSequential: function() {
+			const self = this;
+			const ids = $('.tabs[id^="tabs-"]').map(function () {
+				return this.id.replace(/^tabs-/, '');
+			}).get();
+
+			function _next(){
+				if (!ids.length) return;
+				const id = ids.shift();
+				// Load this one, then when done, load the next.
+				self.loadBrowseCategoryTabs(id).done(_next);
+			}
+			_next();
 		}
 
 	}

--- a/code/web/interface/themes/responsive/js/aspen/browse.js
+++ b/code/web/interface/themes/responsive/js/aspen/browse.js
@@ -614,7 +614,6 @@ AspenDiscovery.Browse = (function(){
 					const swiper = self.subCategorySwipers[subCategoryTextId];
 					swiper.virtual.slides = slides;
 					swiper.virtual.update();
-					if (swiper.lazy) swiper.lazy.load();
 				}
 
 				$panel.attr('aria-busy','false');
@@ -755,7 +754,6 @@ AspenDiscovery.Browse = (function(){
 			function _next(){
 				if (!ids.length) return;
 				const id = ids.shift();
-				// Load this one, then when done, load the next.
 				self.loadBrowseCategoryTabs(id).done(_next);
 			}
 			_next();

--- a/code/web/interface/themes/responsive/js/aspen/browse.js
+++ b/code/web/interface/themes/responsive/js/aspen/browse.js
@@ -728,11 +728,18 @@ AspenDiscovery.Browse = (function(){
 			return $.getJSON(url, params)
 			.done(function(data){
 				if (data.success === false) {
-					AspenDiscovery.showMessage('Error loading subcategories', 'Sorry, unable to load subcategories for that category');
+					AspenDiscovery.showMessage('Error Loading Subcategories', 'Sorry, unable to load subcategories for that category.');
 				} else {
-					// Replace placeholder with actual tabs
-					AspenDiscovery.Browse.changingDisplay = false;
-					$('#tabs-' + categoryTextId).html(data.subcategories);
+					// Replace placeholder with actual tabs.
+					const $tabs = $('#tabs-' + categoryTextId);
+					$tabs.html(data.subcategories);
+
+					// Load the first subcategory.
+					const firstTabBtn = $tabs.find('[role="tab"]').first();
+					if (firstTabBtn.length) {
+						const subCategoryId = firstTabBtn.attr('id').replace('browse-sub-category-tab-', '');
+						AspenDiscovery.Browse.changeBrowseSubCategoryTab(subCategoryId, categoryTextId);
+					}
 				}
 			}).fail(AspenDiscovery.ajaxFail).always(function() {
 				AspenDiscovery.Browse.changingDisplay = false;

--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -38,6 +38,11 @@
 ### Searching Updates
 - Added an 'X' button inside the search box to easily clear entered text; the button appears automatically when text is present. (DIS-778) (*LS*)
 
+### Accessibility Updates
+- When using the accessible browse category display, the main browse category page will now load much faster. (DIS-775) (*LS*)
+  - Content within each browse category will now appear one by one from the top of the page to the bottom, rather than all at once. (DIS-775) (*LS*)
+  - Fixed an issue where quickly clicking through browse carousels could show repeated items. (DIS-775) (*LS*)
+
 // yanjun
 
 // laura

--- a/code/web/services/Search/Home.php
+++ b/code/web/services/Search/Home.php
@@ -201,26 +201,28 @@ class Search_Home extends Action {
 	 * @param BrowseCategoryGroup|null $localBrowseCategories
 	 * @return BrowseCategory[]
 	 */
-	private function getInitialBrowseCategoryFeed($localBrowseCategories = null) {
+	private function getInitialBrowseCategoryFeed($localBrowseCategories = null): array {
+		// Build basic list of categories, marking those with subcategories
 		require_once ROOT_DIR . '/services/API/SearchAPI.php';
-
+		$searchAPI = new SearchAPI();
 		$browseCategories = [];
 		if ($localBrowseCategories) {
-			foreach ($localBrowseCategories as $index => $localBrowseCategory) {
+			foreach ($localBrowseCategories as $localBrowseCategory) {
 				$browseCategory = new BrowseCategory();
 				$browseCategory->id = $localBrowseCategory->browseCategoryId;
 				$browseCategory->find(true);
-				if($browseCategory->isValidForDisplay()) {
-					$browseCategories[$browseCategory->id]['textId'] = $browseCategory->textId;
-					$browseCategories[$browseCategory->id]['label'] = $browseCategory->label;
-
-					require_once ROOT_DIR . '/services/Browse/AJAX.php';
-					$browseAJAX = new Browse_AJAX();
-					$browseCategories[$browseCategory->id] = $browseAJAX->getBrowseCategoryInfo($browseCategory->textId);
+				if ($browseCategory->isValidForDisplay()) {
+					$textId = $browseCategory->textId;
+					$subCatResult = $searchAPI->getSubCategories($textId);
+					$browseCategories[] = [
+						'textId' => $textId,
+						'label' => $browseCategory->label,
+						'searchUrl' => '#',
+						'hasSubcategories' => !empty($subCatResult['subCategories']),
+					];
 				}
 			}
 		}
-
 		return $browseCategories;
 	}
 

--- a/code/web/services/Search/Home.php
+++ b/code/web/services/Search/Home.php
@@ -198,11 +198,11 @@ class Search_Home extends Action {
 	}
 
 	/**
-	 * @param BrowseCategoryGroup|null $localBrowseCategories
+	 * @param BrowseCategoryGroupEntry[]|null $localBrowseCategories
 	 * @return BrowseCategory[]
 	 */
-	private function getInitialBrowseCategoryFeed($localBrowseCategories = null): array {
-		// Build basic list of categories, marking those with subcategories
+	private function getInitialBrowseCategoryFeed(array $localBrowseCategories = null): array {
+		// Build basic list of categories, marking those with subcategories.
 		require_once ROOT_DIR . '/services/API/SearchAPI.php';
 		$searchAPI = new SearchAPI();
 		$browseCategories = [];


### PR DESCRIPTION
- When using the accessible browse category display, the main browse category page will now load much faster.
  - Content within each browse category will now appear one by one from the top of the page to the bottom, rather than all at once.
  - Fixed an issue where quickly clicking through browse carousels could show repeated items.

Tested on 2 Aspen servers.

Test Plan:
1. Navigate to the Themes page in the admin interface and select the theme that your Aspen site is currently using for display.
2. Enable the “Use Accessible Layout” under the Browse Categories section.
3. Navigate to the browse page and notice how it takes a couple of seconds to load the page compared to before, especially if many of the browse categories are sourced from grouped-work searches.
   - Rapidly click through the browse subcategories to switch between sliders, and use the two corresponding arrows to move the slider. Notice that repeated grouped works may appear.
4. Apply the patch and repeat steps 1-3.
5. Hard reload the browse page and notice that it loads in around a second.
   - Repeat step 3.a. and notice that there are no longer repeated grouped works displaying.