### PR TITLE
DIS-792: Clarify Auto-Correction Replacement Term When Searching

### DIFF
--- a/code/web/interface/themes/responsive/Search/list.tpl
+++ b/code/web/interface/themes/responsive/Search/list.tpl
@@ -10,9 +10,9 @@
 	{* Information about the search *}
 	<div class="result-head">
 		{if !empty($replacementTerm)}
-			<div id="replacement-search-info-block">
-				<div id="replacement-search-info"><span class="replacement-search-info-text">{translate text="Showing Results for" isPublicFacing=true}</span> {$replacementTerm}</div>
-				<div id="original-search-info"><span class="replacement-search-info-text">{translate text="Search instead for" isPublicFacing=true} </span><a href="{$oldSearchUrl}">{$oldTerm}</a></div>
+			<div id="replacement-search-info-block" class="alert alert-info" role="alert">
+				<p>{translate text="No results were found for \"%1%\". Showing results for \"%2%\" instead." isPublicFacing=true 1=$oldTerm 2=$replacementTerm}</p>
+				<p><a href="{$oldSearchUrl}">{translate text="Search for \"%1%\" instead." isPublicFacing=true 1=$oldTerm}</a></p>
 			</div>
 		{/if}
 

--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -48,6 +48,7 @@
 
 ### Searching Updates
 - Added an 'X' button inside the search box to easily clear entered text; the button appears automatically when text is present. (DIS-778) (*LS*)
+- When a catalog search doesn't match any results, there will be a message explaining that it's displaying results for a similar term, with a link to retry the original search if preferred. (DIS-792) (*LS*)
 
 ### Other Updates
 - Resolved a JavaScript loading issue by reordering script tags to ensure `tinymce.min.js` loads before plugins. (DIS-592) (*LS*) 


### PR DESCRIPTION
- When a catalog search doesn't match any results, there will be a message explaining that it's displaying results for a similar term, with a link to retry the original search if preferred.

Test Plan:
1. Search for “Looshkin” in the catalog because it is a good example of a case where Aspen auto-corrects the term, thinking it is a spelling mistake. Notice that Aspen will auto-correct the search term to “lookin” and display results for that term, if any.
2. Apply the patch and repeat step 1. Notice an information alert box explaining the auto-correction.