### PR TITLE
DIS-808: Fix Ambiguous Record Reference in New Java

### DIFF
--- a/code/reindexer/src/org/aspen_discovery/grouping/RecordGroupingProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/grouping/RecordGroupingProcessor.java
@@ -922,7 +922,7 @@ public class RecordGroupingProcessor {
 				if (rawResponse != null && !rawResponse.isEmpty()) {
 					try {
 						MarcReader reader = new MarcPermissiveStreamReader(new ByteArrayInputStream(rawResponse.getBytes(StandardCharsets.UTF_8)), true, false, "UTF-8");
-						Record marcRecord;
+						org.marc4j.marc.Record marcRecord;
 						if (reader.hasNext()) {
 							marcRecord = reader.next();
 							return groupCloudLibraryRecord(cloudLibraryId, marcRecord);

--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -56,6 +56,7 @@
 - Fixed a typo in `Theme.php` where the default key for `primaryButtonHoverBorderColor` was incorrectly set as 'primary' instead of 'default'. (DIS-592) (*LS*)
 - Discontinued use of TinyMCE's deprecated spellchecker plugin and enabled native browser spellcheck. (DIS-588) (*LS*)
 - List entries will no longer occasionally display confusing PHP warnings or broken layouts. (DIS-789) (*LS*)
+- Fixed a Java compilation issue caused by ambiguity between `org.marc4j.marc.Record` and the new `java.lang.Record` class in Java 14+. (DIS-808) (*LS*)
 
 // yanjun
 ### Boundless Updates


### PR DESCRIPTION
- Fixed a Java compilation issue caused by ambiguity between `org.marc4j.marc.Record` and the new `java.lang.Record` class in Java 14+.