### PR TITLE
DIS-803: Add Character Limit Feedback and Validation to Forms

### DIFF
--- a/code/web/interface/themes/responsive/DataObjectUtil/objectEditForm.tpl
+++ b/code/web/interface/themes/responsive/DataObjectUtil/objectEditForm.tpl
@@ -141,6 +141,14 @@
 				{include file="DataObjectUtil/validationRule.tpl"}
 			{/foreach}
 			objectEditorObject.data('serialize',objectEditorObject.serialize()); // On load save form current state
+			// Highlight fields in error upon input.
+			objectEditorObject.on('input', 'input[maxlength], textarea[maxlength]', function(){
+				const $field = $(this);
+				const max = parseInt($field.attr('maxlength'), 10);
+				$field.toggleClass('field-error', $field.val().length >= max);
+			});
+			// Initialize highlight state for all current fields.
+			objectEditorObject.find('input[maxlength], textarea[maxlength]').trigger('input');
 			{if !empty($initializationJs)}
 				{$initializationJs}
 			{/if}

--- a/code/web/interface/themes/responsive/DataObjectUtil/objectEditForm.tpl
+++ b/code/web/interface/themes/responsive/DataObjectUtil/objectEditForm.tpl
@@ -141,14 +141,7 @@
 				{include file="DataObjectUtil/validationRule.tpl"}
 			{/foreach}
 			objectEditorObject.data('serialize',objectEditorObject.serialize()); // On load save form current state
-			// Highlight fields in error upon input.
-			objectEditorObject.on('input', 'input[maxlength], textarea[maxlength]', function(){
-				const $field = $(this);
-				const max = parseInt($field.attr('maxlength'), 10);
-				$field.toggleClass('field-error', $field.val().length >= max);
-			});
-			// Initialize highlight state for all current fields.
-			objectEditorObject.find('input[maxlength], textarea[maxlength]').trigger('input');
+			AspenDiscovery.FormFields.initializeCharacterCounters(objectEditorObject);
 			{if !empty($initializationJs)}
 				{$initializationJs}
 			{/if}

--- a/code/web/interface/themes/responsive/DataObjectUtil/oneToMany.tpl
+++ b/code/web/interface/themes/responsive/DataObjectUtil/oneToMany.tpl
@@ -34,7 +34,7 @@
 								{assign var=subPropName value=$subProperty.property}
 								{assign var=subPropValue value=$subObject->$subPropName}
 								{if $subProperty.type=='text' || $subProperty.type=='regularExpression' || $subProperty.type=='integer' || $subProperty.type=='html'}
-									<input type="text" name="{$propName}_{$subPropName}[{$subObject->id}]" value="{$subPropValue|escape}" class="form-control{if $subProperty.type=="integer"} integer{/if}{if !empty($subProperty.required)} required{/if}" {if !empty($subProperty.onchange)}onchange="{$subProperty.onchange}"{/if} {if !empty($subProperty.readOnly) || !empty($property.readOnly)} readonly{/if} data-id="{$subObject->id}">
+									<input type="text" name="{$propName}_{$subPropName}[{$subObject->id}]" value="{$subPropValue|escape}" class="form-control{if $subProperty.type=="integer"} integer{/if}{if !empty($subProperty.required)} required{/if}" {if !empty($subProperty.onchange)}onchange="{$subProperty.onchange}"{/if} {if !empty($subProperty.readOnly) || !empty($property.readOnly)} readonly{/if}{if !empty($subProperty.maxLength)} maxlength="{$subProperty.maxLength}"{/if} data-id="{$subObject->id}">
 								{elseif $subProperty.type=='date'}
 									<input type="date" name="{$propName}_{$subPropName}[{$subObject->id}]" value="{$subPropValue|escape}" class="form-control{if !empty($subProperty.required)} required{/if}"{if !empty($subProperty.readOnly) || !empty($property.readOnly)} readonly disabled{/if} data-id="{$subObject->id}">
 								{elseif $subProperty.type=='time'}
@@ -42,7 +42,7 @@
 								{elseif $subProperty.type=='dynamic_label'}
 									<span id="{$propName}_{$subPropName}_{$subObject->id}" data-id="{$subObject->id}">{$subPropValue|escape}<span>
 								{elseif $subProperty.type=='textarea' || $subProperty.type=='multilineRegularExpression'}
-									<textarea name="{$propName}_{$subPropName}[{$subObject->id}]" class="form-control{if !empty($subProperty.autoResizeTextArea)} auto-grow-textarea{/if}"{if !empty($subProperty.readOnly) || !empty($property.readOnly)} readonly{/if} data-id="{$subObject->id}">{$subPropValue|escape}</textarea>
+									<textarea name="{$propName}_{$subPropName}[{$subObject->id}]" class="form-control{if !empty($subProperty.autoResizeTextArea)} auto-grow-textarea{/if}"{if !empty($subProperty.readOnly) || !empty($property.readOnly)} readonly{/if}{if !empty($subProperty.maxLength)} maxlength="{$subProperty.maxLength}"{/if} data-id="{$subObject->id}">{$subPropValue|escape}</textarea>
 								{elseif $subProperty.type=='checkbox'}
 									{if !empty($subProperty.readOnly) || !empty($property.readOnly)}
 										{if $subPropValue == 1}{translate text='Yes' isAdminFacing=true}{else}{translate text='No' isAdminFacing=true}{/if}
@@ -208,10 +208,24 @@
 						{assign var=subPropName value=$subProperty.property}
 						{if $subProperty.type=='text' || $subProperty.type=='regularExpression' || $subProperty.type=='multilineRegularExpression' || $subProperty.type=='integer' || $subProperty.type=='textarea'|| $subProperty.type=='html'}
 							{if ($subProperty.type=='textarea' || $subProperty.type=='multilineRegularExpression')}
-								const autoGrowClass = '{if !empty($subProperty.autoResizeTextArea)} auto-grow-textarea{/if}';
-								newRow += "<textarea name='{$propName}_{$subPropName}[" + numAdditional{$propName} + "]' class='form-control" + autoGrowClass + "' data-id='" + numAdditional{$propName} + "'>{if !empty($subProperty.default)}{$subProperty.default}{/if}</textarea>";
+								newRow +=
+								"<textarea " +
+									"name='{$propName}_{$subPropName}[" + numAdditional{$propName} + "]' " +
+									"class='form-control" +
+									'{if !empty($subProperty.autoResizeTextArea)} auto-grow-textarea{/if}' +
+									'{if !empty($subProperty.maxLength)} maxlength="{$subProperty.maxLength}"{/if}' +
+									" data-id='" + numAdditional{$propName} + "'>" +
+									'{if !empty($subProperty.default)}{$subProperty.default}{/if}' +
+								"</textarea>";
 							{else}
-								newRow += "<input type='text' name='{$propName}_{$subPropName}[" + numAdditional{$propName} + "]' value='{if !empty($subProperty.default)}{$subProperty.default}{/if}' class='form-control{if $subProperty.type=="integer"} integer{/if}{if !empty($subProperty.required)} required{/if}' data-id='" + numAdditional{$propName} + "'>";
+								newRow +=
+								"<input type='text' " +
+									"name='{$propName}_{$subPropName}[" + numAdditional{$propName} + "]' " +
+									"value='{if !empty($subProperty.default)}{$subProperty.default}{/if}' " +
+									"class='form-control{if $subProperty.type=="integer"} integer{/if}{if !empty($subProperty.required)} required{/if}'" +
+									'{if !empty($subProperty.maxLength)} maxlength="{$subProperty.maxLength}"{/if}' +
+									" data-id='" + numAdditional{$propName}
+								+ "'>";
 							{/if}
 						{elseif $subProperty.type=='date'}
 							newRow += "<input type='date' name='{$propName}_{$subPropName}[" + numAdditional{$propName} + "]' value='{if !empty($subProperty.default)}{$subProperty.default}{/if}' class='form-control{if !empty($subProperty.required)} required{/if}' data-id='" + numAdditional{$propName} + "'>";

--- a/code/web/interface/themes/responsive/css/main.css
+++ b/code/web/interface/themes/responsive/css/main.css
@@ -7557,11 +7557,30 @@ a.bg-overdue:focus {
 .goog-te-gadget {
   display: inline-block;
 }
-input.field-error,
-textarea.field-error {
-  border: 1px solid #d9534f !important;
-  box-shadow: 0 0 4px rgba(217, 83, 79, 0.8) !important;
-  transition: background-color 0.3s, box-shadow 0.3s;
+.field-wrapper {
+  position: relative;
+  display: block;
+}
+.field-wrapper.outside {
+  padding-bottom: 1.6em;
+}
+.char-counter {
+  position: absolute;
+  right: 0.5em;
+  font-size: 0.85em;
+  color: #666;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s ease, bottom 0.2s ease;
+}
+.char-counter.visible {
+  opacity: 1;
+}
+.char-counter.inside {
+  bottom: 0.3em;
+}
+.char-counter.outside {
+  bottom: 0;
 }
 .ui-rater > span {
   vertical-align: top;

--- a/code/web/interface/themes/responsive/css/main.css
+++ b/code/web/interface/themes/responsive/css/main.css
@@ -7557,6 +7557,12 @@ a.bg-overdue:focus {
 .goog-te-gadget {
   display: inline-block;
 }
+input.field-error,
+textarea.field-error {
+  border: 1px solid #d9534f !important;
+  box-shadow: 0 0 4px rgba(217, 83, 79, 0.8) !important;
+  transition: background-color 0.3s, box-shadow 0.3s;
+}
 .ui-rater > span {
   vertical-align: top;
 }

--- a/code/web/interface/themes/responsive/css/responsive_base.less
+++ b/code/web/interface/themes/responsive/css/responsive_base.less
@@ -362,11 +362,35 @@ div.striped {
   display: inline-block;
 }
 
-input.field-error, textarea.field-error {
-  border: 1px solid #d9534f !important;
-  box-shadow: 0 0 4px rgba(217,83,79,0.8) !important;
-  transition: background-color 0.3s, box-shadow 0.3s;
+.field-wrapper {
+  position: relative;
+  display: block;
 }
+.field-wrapper.outside {
+  padding-bottom: 1.6em;
+}
+
+.char-counter {
+  position: absolute;
+  right: 0.5em;
+  font-size: 0.85em;
+  color: #666;
+  pointer-events: none;
+
+  opacity: 0;
+  transition: opacity 0.2s ease, bottom 0.2s ease;
+}
+.char-counter.visible {
+  opacity: 1;
+}
+
+.char-counter.inside {
+  bottom: 0.3em;
+}
+.char-counter.outside {
+  bottom: 0;
+}
+
 
 // Third party imports
 @import "ratings.less";

--- a/code/web/interface/themes/responsive/css/responsive_base.less
+++ b/code/web/interface/themes/responsive/css/responsive_base.less
@@ -362,6 +362,12 @@ div.striped {
   display: inline-block;
 }
 
+input.field-error, textarea.field-error {
+  border: 1px solid #d9534f !important;
+  box-shadow: 0 0 4px rgba(217,83,79,0.8) !important;
+  transition: background-color 0.3s, box-shadow 0.3s;
+}
+
 // Third party imports
 @import "ratings.less";
 @import "jcarousel.responsive.less";

--- a/code/web/interface/themes/responsive/js/aspen/form-fields.js
+++ b/code/web/interface/themes/responsive/js/aspen/form-fields.js
@@ -14,7 +14,7 @@ AspenDiscovery.FormFields = (function() {
 		const $container = $(container);
 		if (!$container.length) return;
 
-		// Canvas for text-width measuring (reuse for all fields)
+		// Canvas for text-width measuring (reuse for all fields).
 		const ccCanvas = document.createElement('canvas');
 		const ccCtx = ccCanvas.getContext('2d');
 		const buffer = 8;
@@ -52,7 +52,7 @@ AspenDiscovery.FormFields = (function() {
 		});
 		observer.observe($container[0], { childList: true, subtree: true });
 
-		// Handle input events on fields with maxlength
+		// Handle input events on fields with maxlength.
 		$container.on('input', 'input[maxlength], textarea[maxlength]', function() {
 			const $f = $(this);
 			const fld = $f[0];
@@ -71,7 +71,7 @@ AspenDiscovery.FormFields = (function() {
 			const ls = style.letterSpacing === 'normal' ? 0 : parseFloat(style.letterSpacing);
 			const textW = rawW + ls * Math.max(0, val.length - 1);
 
-			// Compute truly available width inside the field
+			// Compute truly available width inside the field.
 			const paddingLeft = parseFloat(style.paddingLeft);
 			const paddingRight = parseFloat(style.paddingRight);
 			const avail = fld.clientWidth - paddingLeft - paddingRight - $ctr[0].offsetWidth - buffer;

--- a/code/web/interface/themes/responsive/js/aspen/form-fields.js
+++ b/code/web/interface/themes/responsive/js/aspen/form-fields.js
@@ -1,0 +1,128 @@
+/**
+ * Javascript for enhancing form fields:
+ * - Character counter for maxlength attributes.
+ * - Others could be added later....
+**/
+
+AspenDiscovery.FormFields = (function() {
+	/**
+	 * Initialize character counters on elements with maxLength in the specified container.
+	 *
+	 * @param {jQuery|HTMLElement|string} container
+	 */
+	function initializeCharacterCounters(container) {
+		const $container = $(container);
+		if (!$container.length) return;
+
+		// Canvas for text-width measuring (reuse for all fields)
+		const ccCanvas = document.createElement('canvas');
+		const ccCtx = ccCanvas.getContext('2d');
+		const buffer = 8;
+
+		// Helper to wrap and inject the counter.
+		function initCharCounterField($f) {
+			if (!$f.parent().hasClass('field-wrapper')) {
+				$f.wrap('<div class="field-wrapper"></div>');
+			}
+			if (!$f.next('.char-counter').length) {
+				$f.after('<span class="char-counter"></span>');
+			}
+		}
+
+		// Initialize on page-load for all existing fields.
+		$container.find('input[maxlength], textarea[maxlength]').each(function() {
+			initCharCounterField($(this));
+		});
+
+		// Observe DOM for any new fields added under container.
+		// Needed otherwise the dynamic injection of the counter will
+		// cause the user to lose focus on the field.
+		const observer = new MutationObserver(function (mutations) {
+			mutations.forEach(function (mutation) {
+				Array.prototype.forEach.call(mutation.addedNodes, function (node) {
+					let $n = $(node);
+					if ($n.is('input[maxlength], textarea[maxlength]')) {
+						initCharCounterField($n);
+					}
+					$n.find('input[maxlength], textarea[maxlength]').each(function () {
+						initCharCounterField($(this));
+					});
+				});
+			});
+		});
+		observer.observe($container[0], { childList: true, subtree: true });
+
+		// Handle input events on fields with maxlength
+		$container.on('input', 'input[maxlength], textarea[maxlength]', function() {
+			const $f = $(this);
+			const fld = $f[0];
+			const $ctr = $f.next('.char-counter');
+			const max = parseInt($f.attr('maxlength'), 10);
+			if (isNaN(max) || max <= 0) return;
+			const val = $f.val();
+
+			$ctr.text(val.length + '/' + max).addClass('visible');
+			$f.toggleClass('field-error', val.length >= max);
+
+			// Measure rendered text width.
+			const style = window.getComputedStyle(fld);
+			ccCtx.font = style.font;
+			const rawW = ccCtx.measureText(val).width;
+			const ls = style.letterSpacing === 'normal' ? 0 : parseFloat(style.letterSpacing);
+			const textW = rawW + ls * Math.max(0, val.length - 1);
+
+			// Compute truly available width inside the field
+			const paddingLeft = parseFloat(style.paddingLeft);
+			const paddingRight = parseFloat(style.paddingRight);
+			const avail = fld.clientWidth - paddingLeft - paddingRight - $ctr[0].offsetWidth - buffer;
+
+			// Switch between "inside" vs "outside" modes.
+			const $wrap = $f.parent();
+			if (textW < avail) {
+				$wrap.removeClass('outside');
+				$ctr.removeClass('outside').addClass('inside');
+			} else {
+				$wrap.addClass('outside');
+				$ctr.removeClass('inside').addClass('outside');
+			}
+
+			// Setup timer to hide counter after delay.
+			clearTimeout($f.data('ccTimer'));
+			const tid = setTimeout(function () {
+				if (val.length < max) {
+					$ctr.removeClass('visible');
+				}
+			}, 2000);
+			$f.data('ccTimer', tid);
+		});
+
+		// On focus: if already at max, show the counter; otherwise, hide it immediately.
+		$container.on('focus', 'input[maxlength], textarea[maxlength]', function() {
+			const $f   = $(this);
+			const max  = parseInt($f.attr('maxlength'), 10);
+			const len  = $f.val().length;
+			const $ctr = $f.next('.char-counter');
+
+			if (len >= max) {
+				$ctr.text(len + '/' + max).addClass('visible');
+			} else {
+				$ctr.removeClass('visible');
+			}
+		});
+
+		// On blur: always hide the counter after a short interval.
+		$container.on('blur', 'input[maxlength], textarea[maxlength]', function() {
+			const $f   = $(this);
+			const $ctr = $f.next('.char-counter');
+			clearTimeout($f.data('ccTimer'));
+			const tid = setTimeout(function() {
+				$ctr.removeClass('visible');
+			}, 2000);
+			$f.data('ccTimer', tid);
+		});
+	}
+
+	return {
+		initializeCharacterCounters: initializeCharacterCounters
+	};
+}());

--- a/code/web/interface/themes/responsive/js/javascript_files.txt
+++ b/code/web/interface/themes/responsive/js/javascript_files.txt
@@ -62,3 +62,4 @@ aspen/tab-switcher.js
 aspen/cookieConsent.js
 aspen/palace-project.js
 aspen/communityEngagement.js
+aspen/form-fields.js

--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -57,6 +57,10 @@
 - Discontinued use of TinyMCE's deprecated spellchecker plugin and enabled native browser spellcheck. (DIS-588) (*LS*)
 - List entries will no longer occasionally display confusing PHP warnings or broken layouts. (DIS-789) (*LS*)
 
+### Interface Updates
+- Added front-end validation for fields with character limits to prevent users from inputting beyond the defined character limit. (DIS-803) (*LS*)
+- Character counters display when users type in fields or interact with fields nearing their maximum length. (DIS-803) (*LS*)
+
 // yanjun
 ### Boundless Updates
 - Delete inactive Axis360 titles from database correctly. (DIS-785) (*YL*)


### PR DESCRIPTION
- Added front-end validation for fields with character limits to prevent users from inputting beyond the defined character limit.
- Character counters display when users type in fields or interact with fields nearing their maximum length.

Test Plan:
1. Locate any field that has a character limit set by a `maxLength` attribute within its property declaration (e.g., “Collections to include” field in Library System settings).
2. Input a number of characters larger than the field’s set `maxLength` and save the form. Notice that the field will not save because it exceeded the number of characters its respective database column could accept.
3. Apply the patch.
4. Input a couple of characters and notice that the character counter will display at the rightmost side of the input field.
5. Input a sufficient number of characters such that the counter moves below the input field.
6. Attempt to input more characters than the field’s set `maxLength` and the field will prevent you from doing so.