### PR TITLE
DIS-551: Block actions for expired patrons

### DIFF
--- a/code/web/CatalogConnection.php
+++ b/code/web/CatalogConnection.php
@@ -1495,6 +1495,13 @@ class CatalogConnection {
 		return $this->driver->getNewMaterialsRequestForm($user);
 	}
 
+	function patronEligibleForILLRequests(User $user){
+		if( empty($this->driver)){
+			return false;
+		}
+		return $this->driver->patronEligibleForILLRequests($user);
+	}
+
 	function processMaterialsRequestForm($user) {
 		return $this->driver->processMaterialsRequestForm($user);
 	}

--- a/code/web/CatalogConnection.php
+++ b/code/web/CatalogConnection.php
@@ -1578,6 +1578,13 @@ class CatalogConnection {
 		return $this->driver->patronEligibleForHolds($patron);
 	}
 
+	public function patronEligibleForRenewals($patron){
+		if( empty($this->driver)){
+			return false;
+		}
+		return $this->driver->patronEligibleForHolds($patron);
+	}
+	
 	public function getShowAutoRenewSwitch(User $patron) {
 		if (empty($this->driver)) {
 			return false;

--- a/code/web/Drivers/AbstractIlsDriver.php
+++ b/code/web/Drivers/AbstractIlsDriver.php
@@ -276,6 +276,14 @@ abstract class AbstractIlsDriver extends AbstractDriver {
 		];
 	}
 
+	public function patronEligibleForRenewals($patron){
+		$result = [
+			'isEligible' => true,
+			'message' => '',
+		];
+		return $result;
+	}
+
 	public function getShowAutoRenewSwitch(User $patron) {
 		return false;
 	}

--- a/code/web/Drivers/AbstractIlsDriver.php
+++ b/code/web/Drivers/AbstractIlsDriver.php
@@ -166,6 +166,14 @@ abstract class AbstractIlsDriver extends AbstractDriver {
 		return 'not supported';
 	}
 
+	function patronEligibleForILLRequests(User $user) {
+		$result = [
+			'isEligible' => false,
+			'message' => '',
+		];
+		return $result;
+	}
+
 	/**
 	 * @param User $user
 	 * @return string[]

--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -86,6 +86,7 @@
 
 ### Koha Updates
 - Ensure that users with frozen accounts in Koha are unable to place holds in Aspen. (DIS-599) (*LM*) 
+- Ensure that users with expired accounts in Koha are unable to place holds, place ILL requests or renew items in Aspen. (DIS-551) (*LM*)
 
 ## This release includes code contributions from
 ### ByWater Solutions

--- a/code/web/services/MaterialsRequest/NewRequestIls.php
+++ b/code/web/services/MaterialsRequest/NewRequestIls.php
@@ -12,11 +12,23 @@ class MaterialsRequest_NewRequestIls extends MyAccount {
 		$user = UserAccount::getActiveUserObj();
 		$patronId = empty($_REQUEST['patronId']) ? $user->id : $_REQUEST['patronId'];
 		$patron = $user->getUserReferredTo($patronId);
+		
 		$interface->assign('patronId', $patronId);
 
 		$interface->assign('newMaterialsRequestSummary', $library->newMaterialsRequestSummary);
 
 		$catalogConnection = CatalogFactory::getCatalogConnectionInstance();
+
+		$isElegible = $catalogConnection->patronEligibleForILLRequests($patron)['isEligible'];
+		if (!$isElegible) {
+			$interface->assign('module', 'Error');
+			$interface->assign('action', 'Handle403');
+			require_once ROOT_DIR . "/services/Error/Handle403.php";
+			$actionClass = new Error_Handle403();
+			$actionClass->launch();
+			die();
+		}
+		
 		if (isset($_REQUEST['submit'])) {
 			$result = $catalogConnection->processMaterialsRequestForm($patron);
 			if ($result['success']) {


### PR DESCRIPTION
Test plan

**Before the patch** 

In koha: 
 - Set BlockExpiredPatronOpacActions system preference to 'All Selected' : 'Placing a hold on an item', 'Placing an ILL request' and 'Renewing an item'

In Aspen: 
- With an expired account try to do any of those actions
- You will be able to perform it ignoring Koha's system preferences

**After the patch**

In koha:
- Set BlockExpiredPatronOpacActions system preference to 'All Selected' : 'Placing a hold on an item', 'Placing an ILL request' and 'Renewing an item'

In Aspen:
- With an expired account try to do any of those actions
- If you try to place a hold or renew an item you will get an error message
- If you try to make a new material request you will be redirected to a 403 page.
