### PR TITLE
DIS-834: Add In-Processing Facet

### DIFF
--- a/code/java_shared_libraries/src/com/turning_leaf_technologies/dates/DateUtils.java
+++ b/code/java_shared_libraries/src/com/turning_leaf_technologies/dates/DateUtils.java
@@ -35,8 +35,10 @@ public class DateUtils {
 	static LinkedHashSet<String> timeSinceAddedSixMonths = new LinkedHashSet<>();
 	static LinkedHashSet<String> timeSinceAddedYear = new LinkedHashSet<>();
 	static LinkedHashSet<String> timeSinceAddedNone = new LinkedHashSet<>();
+	static LinkedHashSet<String> timeSinceAddedInProcess = new LinkedHashSet<>();
 	static {
 		timeSinceAddedOnOrder.add("On Order");
+		timeSinceAddedInProcess.add("In Processing");
 		timeSinceAddedUnderConsideration.add("Under Consideration");
 		timeSinceAddedYear.add("Year");
 		timeSinceAddedSixMonths.add("Six Months");
@@ -56,24 +58,26 @@ public class DateUtils {
 		// System.out.println("Time Difference Days: " + timeDifferenceDays);
 		if (timeDifferenceDays == Integer.MAX_VALUE) {
 			return timeSinceAddedUnderConsideration;
-		}else if (timeDifferenceDays < 0) {
+		} else if (timeDifferenceDays == -2) {
+			return timeSinceAddedInProcess;
+		} else if (timeDifferenceDays < 0) {
 			return timeSinceAddedOnOrder;
-		}else {
+		} else {
 			if (timeDifferenceDays <= 1) {
 				return timeSinceAddedDay;
-			}else if (timeDifferenceDays <= 7) {
+			} else if (timeDifferenceDays <= 7) {
 				return timeSinceAddedWeek;
-			}else if (timeDifferenceDays <= 30) {
+			} else if (timeDifferenceDays <= 30) {
 				return timeSinceAddedMonth;
-			}else if (timeDifferenceDays <= 60) {
+			} else if (timeDifferenceDays <= 60) {
 				return timeSinceAdded2Months;
-			}else if (timeDifferenceDays <= 90) {
+			} else if (timeDifferenceDays <= 90) {
 				return timeSinceAddedQuarter;
-			}else if (timeDifferenceDays <= 180) {
+			} else if (timeDifferenceDays <= 180) {
 				return timeSinceAddedSixMonths;
-			}else if (timeDifferenceDays <= 365) {
+			} else if (timeDifferenceDays <= 365) {
 				return timeSinceAddedYear;
-			}else{
+			} else {
 				return timeSinceAddedNone;
 			}
 		}

--- a/code/reindexer/src/org/aspen_discovery/reindexer/GroupedWorkSolr2.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/GroupedWorkSolr2.java
@@ -176,6 +176,7 @@ public class GroupedWorkSolr2 extends AbstractGroupedWorkSolr implements Cloneab
 			//Check to see if all items are on order.  If so, add on order keywords
 			boolean allItemsOnOrder = true;
 			boolean allItemsUnderConsideration = true;
+			boolean allItemsInProcess = true;
 			int numItems = 0;
 			HashSet<String> uniqueFormatCategories = new HashSet<>();
 			HashSet<String> uniqueFormats = new HashSet<>();
@@ -187,7 +188,10 @@ public class GroupedWorkSolr2 extends AbstractGroupedWorkSolr implements Cloneab
 							if (!(item.getGroupedStatus().equals("On Order") || item.getDetailedStatus().equals("On Order") || item.getDetailedStatus().equals("Coming Soon"))) {
 								allItemsOnOrder = false;
 							}
-							if (!item.getDetailedStatus().equals("Under Consideration")) {
+							if (!(item.getGroupedStatus().equals("In Processing") || item.getDetailedStatus().equals("In-Process"))) {
+								allItemsInProcess = false;
+							}
+							if (!(item.getGroupedStatus().equals("Under Consideration") || item.getDetailedStatus().equals("Under Consideration"))) {
 								allItemsUnderConsideration = false;
 							}
 						}else{
@@ -227,6 +231,10 @@ public class GroupedWorkSolr2 extends AbstractGroupedWorkSolr implements Cloneab
 				addKeywords("Coming Soon");
 				doc.addField("days_since_added", -1);
 				doc.addField("time_since_added", "On Order");
+			} else if (allItemsInProcess) {
+				addKeywords("In Processing");
+				doc.addField("days_since_added", -2);
+				doc.addField("time_since_added", "In Processing");
 			} else if (allItemsUnderConsideration) {
 				addKeywords("Under Consideration");
 				doc.addField("days_since_added", Integer.MAX_VALUE);
@@ -633,10 +641,18 @@ public class GroupedWorkSolr2 extends AbstractGroupedWorkSolr implements Cloneab
 	private Long daysAddedSincePubDate = null;
 	private Long loadScopedDaysAdded(ItemInfo curItem) {
 		Long daysSinceAdded;
-		if (curItem.isOrderItem() || (curItem.getStatusCode() != null && (curItem.getGroupedStatus().equals("On Order") || curItem.getDetailedStatus().equals("On Order") || curItem.getDetailedStatus().equals("Coming Soon") || curItem.getDetailedStatus().equals("Under Consideration")))) {
-			if (curItem.getDetailedStatus().equals("Under Consideration")) {
+		if (curItem.isOrderItem() ||
+				curItem.getStatusCode() != null &&
+						(curItem.getGroupedStatus().equals("On Order") ||
+								curItem.getGroupedStatus().equals("In Processing") ||
+								curItem.getDetailedStatus().equals("Coming Soon") || // Falls under the "On Order" facet, so only consider the item's status to find it.
+								curItem.getGroupedStatus().equals("Under Consideration")))
+		{
+			if (curItem.getGroupedStatus().equals("Under Consideration")) {
 				daysSinceAdded = (long)Integer.MAX_VALUE;
-			}else{
+			} else if (curItem.getGroupedStatus().equals("In Processing")) {
+				daysSinceAdded = -2L;
+			} else {
 				daysSinceAdded = -1L;
 			}
 		} else {

--- a/code/reindexer/src/org/aspen_discovery/reindexer/GroupedWorkSolr2.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/GroupedWorkSolr2.java
@@ -642,11 +642,11 @@ public class GroupedWorkSolr2 extends AbstractGroupedWorkSolr implements Cloneab
 	private Long loadScopedDaysAdded(ItemInfo curItem) {
 		Long daysSinceAdded;
 		if (curItem.isOrderItem() ||
-				curItem.getStatusCode() != null &&
-						(curItem.getGroupedStatus().equals("On Order") ||
-								curItem.getGroupedStatus().equals("In Processing") ||
-								curItem.getDetailedStatus().equals("Coming Soon") || // Falls under the "On Order" facet, so only consider the item's status to find it.
-								curItem.getGroupedStatus().equals("Under Consideration")))
+			curItem.getStatusCode() != null &&
+			(curItem.getGroupedStatus().equals("On Order") ||
+			curItem.getGroupedStatus().equals("In Processing") ||
+			curItem.getDetailedStatus().equals("Coming Soon") || // Falls under the "On Order" facet, so only consider the item's status to find it.
+			curItem.getGroupedStatus().equals("Under Consideration")))
 		{
 			if (curItem.getGroupedStatus().equals("Under Consideration")) {
 				daysSinceAdded = (long)Integer.MAX_VALUE;

--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -63,6 +63,10 @@
 - Discontinued use of TinyMCE's deprecated spellchecker plugin and enabled native browser spellcheck. (DIS-588) (*LS*)
 - List entries will no longer occasionally display confusing PHP warnings or broken layouts. (DIS-789) (*LS*)
 
+### Facet Updates
+- Added a dedicated "In Processing" option within the "Added in the Last" facet group. (DIS-834) (*LS*)
+- Extended the indexing logic in `GroupedWorkSolr2` to use an item’s grouped status (e.g., "On Order," "In Processing," "Under Consideration") for building all related facets, no longer relying solely on the detailed status. (DIS-834) (*LS*)
+
 // yanjun
 ### Boundless Updates
 - Delete inactive Axis360 titles from database correctly. (DIS-785) (*YL*)

--- a/code/web/sys/Recommend/SideFacets.php
+++ b/code/web/sys/Recommend/SideFacets.php
@@ -222,6 +222,7 @@ class SideFacets implements RecommendationInterface {
 //			}
 			$sortOrder = [
 				'On Order' => null,
+				'In Processing' => null,
 				'Day' => null,
 				'Week' => null,
 				'Month' => null,


### PR DESCRIPTION
- Added a dedicated "In Processing" option within the "Added in the Last" facet group.
- Extended the indexing logic in `GroupedWorkSolr2` to use an item’s grouped status (e.g., "On Order," "In Processing," "Under Consideration") for building all related facets, no longer relying solely on the detailed status.

Tested on GMILCS Test server.

Test Plan:
1. Locate grouped works that have a grouped status of “In Processing.”
2. Apply the patch and reindex those grouped works.
   - Note: I’m not sure if this is a general bug, but after rebuilding and uploading the `reindexer.jar`, if I click “Force Reindex” under the Staff View, the `local_days_since_added_{library}` field under Solr Details will properly display `-2`, but the `local_time_since_added_{library}` will display `On Order`. If I run a single extraction from the CLI, the `local_time_since_added_{library}` properly changes to `In Processing`. My only theory is that the reloading process still uses an outdated version of the JAR for some reason.
3. Select the “In Processing” facet under the grouped facet “Added in the Last”. Select it and you will see the reindexed grouped works.