### PR TITLE
DIS-842: PHP Template Errors Cleanup V1

### DIFF
--- a/code/web/interface/themes/responsive/CollectionSpotlight/formattedHorizontalCarouselTitle.tpl
+++ b/code/web/interface/themes/responsive/CollectionSpotlight/formattedHorizontalCarouselTitle.tpl
@@ -15,7 +15,8 @@
 				</div>
 			{/if}
 		</a>
-		{* show ratings check in the template *}
-		{include file="GroupedWork/title-rating.tpl" showNotInterested=false}
+		{if !empty($showRatings)}
+			{include file="GroupedWork/title-rating.tpl" id=$id summId=$id ratingData=$ratingData showNotInterested=$showNotInterested}
+		{/if}
 	</div>
 {/strip}

--- a/code/web/interface/themes/responsive/CollectionSpotlight/formattedTitle.tpl
+++ b/code/web/interface/themes/responsive/CollectionSpotlight/formattedTitle.tpl
@@ -3,8 +3,9 @@
 		<a href="{$titleURL}" id="descriptionTrigger{$shortId}">
 		<img src="{$imageUrl}" class="scrollerTitleCover" alt="{translate text="%1% Cover" 1=$title isPublicFacing=true inAttribute=true}"/>
 		</a>
-		{* show ratings check in the template *}
-		{include file="GroupedWork/title-rating.tpl" showNotInterested=false}
+		{if !empty($showRatings)}
+			{include file="GroupedWork/title-rating.tpl" id=$id summId=$id ratingData=$ratingData showNotInterested=$showNotInterested}
+		{/if}
 	</div>
 	<div id="descriptionPlaceholder{$id}" style="display:none" class="loaded">
 		{include file="Record/ajax-description-popup.tpl"}

--- a/code/web/interface/themes/responsive/GroupedWork/copyDetails.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/copyDetails.tpl
@@ -5,9 +5,9 @@
 		<tr>
 			<th>{translate text="Available Copies" isPublicFacing=true}</th>
 			<th>{translate text="Location" isPublicFacing=true}</th>
-			{if !$isEContent}
+			{if empty($isEContent)}
 				<th>{translate text="Call #" isPublicFacing=true}</th>
-			{elseif $showEContentHoldCounts}
+			{elseif !empty($showEContentHoldCounts)}
 				<th>{translate text="Holds" isPublicFacing=true}</th>
 			{/if}
 		</tr>
@@ -35,7 +35,7 @@
 					<td class="notranslate">
 						{$item.callNumber}
 					</td>
-				{elseif $showEContentHoldCounts}
+				{elseif !empty($showEContentHoldCounts)}
 					<td class="notranslate">
 						{if $item.availableCopies <= 9999}
 							{$item.numHolds}

--- a/code/web/interface/themes/responsive/GroupedWork/copySummary.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/copySummary.tpl
@@ -1,5 +1,5 @@
 {strip}
-	{if $isEContent}
+	{if !empty($isEContent)}
 		<div class="itemSummary">
 			<a href="#" onclick="return AspenDiscovery.GroupedWork.showCopyDetails('{$workId}', '{if !empty($relatedManifestation)}{$relatedManifestation->format|urlencode}{else}{$format}{/if}', '{$itemSummaryId}');">
 				{translate text="where_is_it_button" defaultText="Where is it?" isPublicFacing=true}
@@ -11,10 +11,10 @@
 		{if $showQuickCopy != 3}
 		{foreach from=$summary item="item"}
 			{if !empty($item.displayByDefault) && $numRowsShown<3}
-				{if $item.isEContent == false}
+				{if empty($item.isEContent)}
 					<div class="itemSummary row" style="margin: 0">
 						<div class="col-lg-12 itemLocationDetails" data-shelfLocation="{$item.shelfLocation|escape:"javascript"}" data-subLocation="{$item.subLocation|escape:"javascript"}" data-callNumber="{$item.callNumber|escape:"javascript"}">
-							<span class="notranslate" >{if empty($item.isEContent)}<strong>{$item.shelfLocation}</strong>{/if}
+							<span class="notranslate" ><strong>{$item.shelfLocation}</strong>
 							<br>{$item.callNumber}
 								<br>{if $item.availableCopies < 999}
 									{translate text="%1% available" 1=$item.availableCopies isPublicFacing=true}

--- a/code/web/interface/themes/responsive/MyAccount/readingHistoryEntry.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/readingHistoryEntry.tpl
@@ -80,8 +80,8 @@
 					</div>
 				</div>
 
-				{if $showRatings == 1}
-					{if !empty($record.existsInCatalog) && $record.ratingData}
+				{if !empty($showRatings)}
+					{if !empty($record.existsInCatalog) && !empty($record.ratingData)}
 						<div class="row">
 							<div class="result-label col-tn-3">{translate text="Rating" isPublicFacing=true}</div>
 							<div class="result-value col-tn-9">

--- a/code/web/interface/themes/responsive/RecordDrivers/Axis360/staff-view.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Axis360/staff-view.tpl
@@ -3,11 +3,13 @@
 		<div class="row">
 			<div class="col-xs-12">
 				<a href="/GroupedWork/{$recordDriver->getPermanentId()}" class="btn btn-sm btn-default">Go To Grouped Work</a>
-				<button onclick="return AspenDiscovery.GroupedWork.reloadCover('{$recordDriver->getPermanentId()}', '{$bookcoverInfo->recordType}', '{$bookcoverInfo->recordId}')" class="btn btn-sm btn-default">{translate text="Reload Cover" isAdminFacing=true}</button>
-				{if !empty($loggedIn) && in_array('Upload Covers', $userPermissions)}
-					<button onclick="return AspenDiscovery.GroupedWork.getUploadCoverForm('{$recordDriver->getPermanentId()}', '{$bookcoverInfo->recordType}', '{$bookcoverInfo->recordId}')" class="btn btn-sm btn-default">{translate text="Upload Cover by from Computer" isAdminFacing=true}</button>
-					<button onclick="return AspenDiscovery.GroupedWork.getUploadCoverFormByURL('{$recordDriver->getPermanentId()}', '{$bookcoverInfo->recordType}', '{$bookcoverInfo->recordId}')" class="btn btn-sm btn-default">{translate text="Upload Cover by URL" isAdminFacing=true}</button>
-					<button onclick="return AspenDiscovery.GroupedWork.clearUploadedCover('{$recordDriver->getPermanentId()}', '{$bookcoverInfo->recordType}', '{$bookcoverInfo->recordId}')" class="btn btn-sm btn-default">{translate text="Clear Uploaded Cover" isAdminFacing=true}</button>
+				{if !empty($bookcoverInfo)}
+					<button onclick="return AspenDiscovery.GroupedWork.reloadCover('{$recordDriver->getPermanentId()}', '{$bookcoverInfo->recordType}', '{$bookcoverInfo->recordId}')" class="btn btn-sm btn-default">{translate text="Reload Cover" isAdminFacing=true}</button>
+					{if !empty($loggedIn) && in_array('Upload Covers', $userPermissions)}
+						<button onclick="return AspenDiscovery.GroupedWork.getUploadCoverForm('{$recordDriver->getPermanentId()}', '{$bookcoverInfo->recordType}', '{$bookcoverInfo->recordId}')" class="btn btn-sm btn-default">{translate text="Upload Cover by from Computer" isAdminFacing=true}</button>
+						<button onclick="return AspenDiscovery.GroupedWork.getUploadCoverFormByURL('{$recordDriver->getPermanentId()}', '{$bookcoverInfo->recordType}', '{$bookcoverInfo->recordId}')" class="btn btn-sm btn-default">{translate text="Upload Cover by URL" isAdminFacing=true}</button>
+						<button onclick="return AspenDiscovery.GroupedWork.clearUploadedCover('{$recordDriver->getPermanentId()}', '{$bookcoverInfo->recordType}', '{$bookcoverInfo->recordId}')" class="btn btn-sm btn-default">{translate text="Clear Uploaded Cover" isAdminFacing=true}</button>
+					{/if}
 				{/if}
 				<button onclick="return AspenDiscovery.GroupedWork.reloadEnrichment('{$recordDriver->getPermanentId()}')" class="btn btn-sm btn-default" >{translate text="Reload Enrichment" isAdminFacing=true}</button>
 				{if !empty($loggedIn) && in_array('Force Reindexing of Records', $userPermissions)}

--- a/code/web/interface/themes/responsive/RecordDrivers/Hoopla/staff-view.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Hoopla/staff-view.tpl
@@ -3,11 +3,13 @@
 		<div class="row">
 			<div class="col-xs-12">
 				<a href="/GroupedWork/{$recordDriver->getPermanentId()}" class="btn btn-sm btn-default">Go To Grouped Work</a>
-				<button onclick="return AspenDiscovery.GroupedWork.reloadCover('{$recordDriver->getPermanentId()}', '{$bookcoverInfo->recordType}', '{$bookcoverInfo->recordId}')" class="btn btn-sm btn-default">{translate text="Reload Cover" isAdminFacing=true}</button>
-				{if !empty($loggedIn) && in_array('Upload Covers', $userPermissions)}
-					<button onclick="return AspenDiscovery.GroupedWork.getUploadCoverForm('{$recordDriver->getPermanentId()}', '{$bookcoverInfo->recordType}', '{$bookcoverInfo->recordId}')" class="btn btn-sm btn-default">{translate text="Upload Cover by from Computer" isAdminFacing=true}</button>
-					<button onclick="return AspenDiscovery.GroupedWork.getUploadCoverFormByURL('{$recordDriver->getPermanentId()}', '{$bookcoverInfo->recordType}', '{$bookcoverInfo->recordId}')" class="btn btn-sm btn-default">{translate text="Upload Cover by URL" isAdminFacing=true}</button>
-					<button onclick="return AspenDiscovery.GroupedWork.clearUploadedCover('{$recordDriver->getPermanentId()}', '{$bookcoverInfo->recordType}', '{$bookcoverInfo->recordId}')" class="btn btn-sm btn-default">{translate text="Clear Uploaded Cover" isAdminFacing=true}</button>
+				{if !empty($bookcoverInfo)}
+					<button onclick="return AspenDiscovery.GroupedWork.reloadCover('{$recordDriver->getPermanentId()}', '{$bookcoverInfo->recordType}', '{$bookcoverInfo->recordId}')" class="btn btn-sm btn-default">{translate text="Reload Cover" isAdminFacing=true}</button>
+					{if !empty($loggedIn) && in_array('Upload Covers', $userPermissions)}
+						<button onclick="return AspenDiscovery.GroupedWork.getUploadCoverForm('{$recordDriver->getPermanentId()}', '{$bookcoverInfo->recordType}', '{$bookcoverInfo->recordId}')" class="btn btn-sm btn-default">{translate text="Upload Cover by from Computer" isAdminFacing=true}</button>
+						<button onclick="return AspenDiscovery.GroupedWork.getUploadCoverFormByURL('{$recordDriver->getPermanentId()}', '{$bookcoverInfo->recordType}', '{$bookcoverInfo->recordId}')" class="btn btn-sm btn-default">{translate text="Upload Cover by URL" isAdminFacing=true}</button>
+						<button onclick="return AspenDiscovery.GroupedWork.clearUploadedCover('{$recordDriver->getPermanentId()}', '{$bookcoverInfo->recordType}', '{$bookcoverInfo->recordId}')" class="btn btn-sm btn-default">{translate text="Clear Uploaded Cover" isAdminFacing=true}</button>
+					{/if}
 				{/if}
 				<button onclick="return AspenDiscovery.GroupedWork.reloadEnrichment('{$recordDriver->getPermanentId()}')" class="btn btn-sm btn-default" >{translate text="Reload Enrichment" isAdminFacing=true}</button>
 				{if !empty($loggedIn) && in_array('Force Reindexing of Records', $userPermissions)}

--- a/code/web/interface/themes/responsive/RecordDrivers/PalaceProject/staff-view.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/PalaceProject/staff-view.tpl
@@ -3,11 +3,13 @@
 		<div class="row">
 			<div class="col-xs-12">
 				<a href="/GroupedWork/{$recordDriver->getPermanentId()}" class="btn btn-sm btn-default">Go To Grouped Work</a>
-				<button onclick="return AspenDiscovery.GroupedWork.reloadCover('{$recordDriver->getPermanentId()}', '{$bookcoverInfo->recordType}', '{$bookcoverInfo->recordId}')" class="btn btn-sm btn-default">{translate text="Reload Cover" isAdminFacing=true}</button>
-				{if !empty($loggedIn) && in_array('Upload Covers', $userPermissions)}
-					<button onclick="return AspenDiscovery.GroupedWork.getUploadCoverForm('{$recordDriver->getPermanentId()}', '{$bookcoverInfo->recordType}', '{$bookcoverInfo->recordId}')" class="btn btn-sm btn-default">{translate text="Upload Cover by from Computer" isAdminFacing=true}</button>
-					<button onclick="return AspenDiscovery.GroupedWork.getUploadCoverFormByURL('{$recordDriver->getPermanentId()}', '{$bookcoverInfo->recordType}', '{$bookcoverInfo->recordId}')" class="btn btn-sm btn-default">{translate text="Upload Cover by URL" isAdminFacing=true}</button>
-					<button onclick="return AspenDiscovery.GroupedWork.clearUploadedCover('{$recordDriver->getPermanentId()}', '{$bookcoverInfo->recordType}', '{$bookcoverInfo->recordId}')" class="btn btn-sm btn-default">{translate text="Clear Uploaded Cover" isAdminFacing=true}</button>
+				{if !empty($bookcoverInfo)}
+					<button onclick="return AspenDiscovery.GroupedWork.reloadCover('{$recordDriver->getPermanentId()}', '{$bookcoverInfo->recordType}', '{$bookcoverInfo->recordId}')" class="btn btn-sm btn-default">{translate text="Reload Cover" isAdminFacing=true}</button>
+					{if !empty($loggedIn) && in_array('Upload Covers', $userPermissions)}
+						<button onclick="return AspenDiscovery.GroupedWork.getUploadCoverForm('{$recordDriver->getPermanentId()}', '{$bookcoverInfo->recordType}', '{$bookcoverInfo->recordId}')" class="btn btn-sm btn-default">{translate text="Upload Cover by from Computer" isAdminFacing=true}</button>
+						<button onclick="return AspenDiscovery.GroupedWork.getUploadCoverFormByURL('{$recordDriver->getPermanentId()}', '{$bookcoverInfo->recordType}', '{$bookcoverInfo->recordId}')" class="btn btn-sm btn-default">{translate text="Upload Cover by URL" isAdminFacing=true}</button>
+						<button onclick="return AspenDiscovery.GroupedWork.clearUploadedCover('{$recordDriver->getPermanentId()}', '{$bookcoverInfo->recordType}', '{$bookcoverInfo->recordId}')" class="btn btn-sm btn-default">{translate text="Clear Uploaded Cover" isAdminFacing=true}</button>
+					{/if}
 				{/if}
 				<button onclick="return AspenDiscovery.GroupedWork.reloadEnrichment('{$recordDriver->getPermanentId()}')" class="btn btn-sm btn-default" >{translate text="Reload Enrichment" isAdminFacing=true}</button>
 				{if !empty($loggedIn) && in_array('Force Reindexing of Records', $userPermissions)}

--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -62,6 +62,8 @@
 - Fixed a typo in `Theme.php` where the default key for `primaryButtonHoverBorderColor` was incorrectly set as 'primary' instead of 'default'. (DIS-592) (*LS*)
 - Discontinued use of TinyMCE's deprecated spellchecker plugin and enabled native browser spellcheck. (DIS-588) (*LS*)
 - List entries will no longer occasionally display confusing PHP warnings or broken layouts. (DIS-789) (*LS*)
+- Added guards and default filters across multiple Smarty templates to eliminate PHP notices for undefined keys and properties. (DIS-842) (*LS*)
+- Updated `formattedTitle.tpl` and `formattedHorizontalCarouselTitle.tpl` to pass required variables, fixing missing-data issues in horizontal and carousel spotlights. (DIS-842) (*LS*)
 
 // yanjun
 ### Boundless Updates


### PR DESCRIPTION
- Added guards and default filters across multiple Smarty templates to eliminate PHP notices for undefined keys and properties.
- Updated `formattedTitle.tpl` and `formattedHorizontalCarouselTitle.tpl` to pass required variables, fixing missing-data issues in horizontal and carousel spotlights.