### PR TITLE
DIS-849: Add Static Location Selector for Hours & Locations Cells

### DIFF
--- a/code/web/interface/themes/responsive/AJAX/libraryHoursAndLocations.tpl
+++ b/code/web/interface/themes/responsive/AJAX/libraryHoursAndLocations.tpl
@@ -1,5 +1,5 @@
 {strip}
-	{if count($libraryLocations) > 1}
+	{if count($libraryLocations) > 1 && !isset($useStaticLocation)}}
 		<form role="form">
 			<div class="form-group">
 				<label for="selectLibraryHours">{translate text="Select a Location" isPublicFacing=true}</label>

--- a/code/web/interface/themes/responsive/js/aspen/web-builder.js
+++ b/code/web/interface/themes/responsive/js/aspen/web-builder.js
@@ -7,6 +7,8 @@ AspenDiscovery.WebBuilder = function () {
 		getPortalCellValuesForSource: function () {
 			var portalCellId = $("#id").val();
 			var sourceType = $("#sourceTypeSelect").val();
+			const $staticLocationSelector = $('#propertyRowstaticLocationId');
+			$($staticLocationSelector).hide();
 			if (sourceType === 'markdown') {
 				$('#propertyRowmarkdown').show();
 				$('#propertyRowsourceInfo').hide();
@@ -41,6 +43,7 @@ AspenDiscovery.WebBuilder = function () {
 				$('#propertyRowcustomImage').hide();
 				$('#propertyRowhideDescription').hide();
 			}else if (sourceType === 'hours_locations') {
+				$($staticLocationSelector).show();
 				$('#propertyRowmarkdown').hide();
 				$('#propertyRowsourceInfo').hide();
 				$("#propertyRowsourceId").hide();
@@ -52,6 +55,7 @@ AspenDiscovery.WebBuilder = function () {
 				$('#propertyRowcustomImage').hide();
 				$('#propertyRowhideDescription').hide();
 			}else {
+				$($staticLocationSelector).hide();
 				$('#propertyRowmarkdown').hide();
 				$('#propertyRowsourceInfo').hide();
 				$("#propertyRowsourceId").show();

--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -78,6 +78,9 @@
 - Discontinued use of TinyMCE's deprecated spellchecker plugin and enabled native browser spellcheck. (DIS-588) (*LS*)
 - List entries will no longer occasionally display confusing PHP warnings or broken layouts. (DIS-789) (*LS*)
 
+### Web Builder Updates
+- Added configuration to the "Library Hours and Locations" cell to always display a specific library's information if a location is selected under the new "Static Location" dropdown on the Portal Cells page. (DIS-849) (*LS*)
+
 // yanjun
 ### Boundless Updates
 - Delete inactive Axis360 titles from database correctly. (DIS-785) (*YL*)

--- a/code/web/sys/DBMaintenance/version_updates/25.06.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.06.00.php
@@ -64,6 +64,13 @@ function getUpdates25_06_00(): array {
 				"ALTER TABLE cloud_library_export_log ADD COLUMN IF NOT EXISTS numRegrouped int(11) DEFAULT 0 AFTER settingId",
 			]
 		], //add_num_regrouped_to_cloudlibrary_extract_logs
+		'add_static_location_id_to_portal_cell' => [
+			'title' => 'Add staticLocationId Column to Web Builder Portal Cells',
+			'description' => 'Adds a staticLocationId column to the web_builder_portal_cell table to represent the location ID of the static location chosen.',
+			'sql' => [
+				"ALTER TABLE web_builder_portal_cell ADD COLUMN IF NOT EXISTS staticLocationId int(11) NOT NULL DEFAULT -1",
+			]
+		], //add_num_regrouped_to_cloudlibrary_extract_logs
 
 		// Laura Escamilla - ByWater Solutions
 

--- a/code/web/sys/DBMaintenance/version_updates/25.06.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.06.00.php
@@ -70,7 +70,7 @@ function getUpdates25_06_00(): array {
 			'sql' => [
 				"ALTER TABLE web_builder_portal_cell ADD COLUMN IF NOT EXISTS staticLocationId int(11) NOT NULL DEFAULT -1",
 			]
-		], //add_num_regrouped_to_cloudlibrary_extract_logs
+		], //add_static_location_id_to_portal_cell
 
 		// Laura Escamilla - ByWater Solutions
 

--- a/code/web/sys/WebBuilder/PortalCell.php
+++ b/code/web/sys/WebBuilder/PortalCell.php
@@ -521,10 +521,9 @@ class PortalCell extends DataObject {
 				// Get all locations as before (dynamic selection).
 				$tmpLocation->libraryId = $library->libraryId;
 				$tmpLocation->showInLocationsAndHoursList = 1;
-				$tmpLocation->orderBy('isMainBranch DESC, displayName'); // List Main Branches first, then sort by name
+				$tmpLocation->orderBy('isMainBranch DESC, displayName');
 				$tmpLocation->find();
 				if ($tmpLocation->getNumResults() == 0) {
-					//Get all locations
 					$tmpLocation = new Location();
 					$tmpLocation->showInLocationsAndHoursList = 1;
 					$tmpLocation->orderBy('displayName');


### PR DESCRIPTION
- Added configuration to the "Library Hours and Locations" cell to always display a specific library's information if a location is selected under the new "Static Location" dropdown on the Portal Cells page.

Test Plan:
1. Apply the patch.
2. Navigate to the Custom Pages setting in the admin interface.
3. Create a new custom page or select an existing one.
4. Add or edit a row and add or edit an existing Portal Cell.
5. On the WebBuilder Portal Cells page, select “Library Hours and Locations” as the Source Type.
6. Select a location under the Static Location dropdown and click “Save Changes and Return.”
7. Navigate to the actual custom page you created (e.g., https://beta.aspendiscovery.org/hours_locations). Notice that users cannot select locations and that the static location’s information is displayed.