### PR TITLE
DIS-820: Masquerade mode permissions issue

### DIFF
--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -75,6 +75,9 @@
 ### Searching Updates
 - To better handle searching words with apostrophe's (i.e. don't vs dont) the solr class for synonyms has been enabled and synonyms.txt updated (DIS-782) (*KL*)
 
+### Masquerade Mode Updates
+- Fix issue where if a user has "Masquerade as unrestricted patron types" and a permission that allows them to masquerade as restricted patron types in their home library or location, they were not able to masquerade as these restricted patrons. (DIS-820) (*KL*)
+
 // kyle
 ### Installer Updates
 - Fix script to update session.gc_probability. Update the script to dynamically determine the current PHP version, ensuring compatibility with the PHP version installed on the system. (*KMH*)

--- a/code/web/services/API/UserAPI.php
+++ b/code/web/services/API/UserAPI.php
@@ -5734,7 +5734,7 @@ class UserAPI extends AbstractAPI {
 							}
 							if (UserAccount::userHasPermission('Masquerade as any user')) {
 								//The user can masquerade as anyone, no additional checks needed
-							} elseif (UserAccount::userHasPermission('Masquerade as unrestricted patron types')) {
+							} elseif (UserAccount::userHasPermission('Masquerade as unrestricted patron types') && !UserAccount::userHasPermission('Masquerade as patrons with same home library') && !UserAccount::userHasPermission('Masquerade as patrons with same home location')) {
 								if ($isRestrictedUser) {
 									return [
 										'success' => false,
@@ -5765,7 +5765,7 @@ class UserAPI extends AbstractAPI {
 										]),
 									];
 								}
-								if ($guidingUserLibrary->libraryId != $masqueradedUserLibrary->libraryId) {
+								if ($guidingUserLibrary->libraryId != $masqueradedUserLibrary->libraryId && !UserAccount::userHasPermission('Masquerade as unrestricted patron types')) {
 									return [
 										'success' => false,
 										'error' => translate([
@@ -5774,7 +5774,7 @@ class UserAPI extends AbstractAPI {
 										]),
 									];
 								}
-								if ($isRestrictedUser && !UserAccount::userHasPermission('Masquerade as patrons with same home library')) {
+								if ($isRestrictedUser && (!UserAccount::userHasPermission('Masquerade as patrons with same home library') || $guidingUserLibrary->libraryId != $masqueradedUserLibrary->libraryId)) {
 									return [
 										'success' => false,
 										'error' => translate([
@@ -5802,7 +5802,7 @@ class UserAPI extends AbstractAPI {
 										]),
 									];
 								}
-								if ($user->homeLocationId != $masqueradedUser->homeLocationId) {
+								if ($user->homeLocationId != $masqueradedUser->homeLocationId && !UserAccount::userHasPermission('Masquerade as unrestricted patron types')) {
 									return [
 										'success' => false,
 										'error' => translate([
@@ -5811,7 +5811,7 @@ class UserAPI extends AbstractAPI {
 										]),
 									];
 								}
-								if ($isRestrictedUser && !UserAccount::userHasPermission('Masquerade as patrons with same home location')) {
+								if ($isRestrictedUser && (!UserAccount::userHasPermission('Masquerade as patrons with same home location') || $user->homeLocationId != $masqueradedUser->homeLocationId)) {
 									return [
 										'success' => false,
 										'error' => translate([


### PR DESCRIPTION
Add a check for the permissions "Masquerade as patrons with same home library" and "Masquerade as patrons with same home location" for users with the permission "Masquerade as unrestricted patron types"

These two permissions have more in-depth checking after this initial check

Update release notes

Tested on my local instance of Aspen