### PR TITLE
DIS-698: using getMainLocation() in self registration because branchc…

### DIFF
--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -4699,7 +4699,7 @@ class Koha extends AbstractIlsDriver {
 			$postVariables = $this->setPostFieldWithDifferentName($postVariables, 'gender', 'borrower_sex', $library->useAllCapsWhenSubmittingSelfRegistration);
 			$postVariables = $this->setPostFieldWithDifferentName($postVariables, 'initials', 'borrower_initials', $library->useAllCapsWhenSubmittingSelfRegistration);
 			if (!isset($_REQUEST['borrower_branchcode']) || $_REQUEST['borrower_branchcode'] == -1) {
-				$postVariables['library_id'] = $library->code;
+				$postVariables['library_id'] = $library->getMainLocation()->code;
 			} else {
 				$postVariables = $this->setPostFieldWithDifferentName($postVariables, 'library_id', 'borrower_branchcode', $library->useAllCapsWhenSubmittingSelfRegistration);
 			}

--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -87,6 +87,7 @@
 // imani
 ### Koha Updates
 - getRenewErrorMessage returns the original code from Koha in addition to the "Unkown error" message when receiving unexpected error codes.
+- If no branchcode passed up to selfRegistration use getMainLocation() from our default library to grab a branchcode (DIS-698) (*IT*)
 
 // leo
 ### CloudLibrary Updates


### PR DESCRIPTION
* call /API/RegistrationAPI?method-processSelfRegistration (easiest way is via LiDA and the self register link) without sending up borrower_branchcode
* your registration should still go through and be associated with your default library's main location. 
* before this change you would get an error back from Koha about expecting a string but getting null. 