### PR TITLE
DIS-857: Trim Trailing Space & Punctuation for LibCal JSON Fields

### DIFF
--- a/code/events_indexer/src/com/turning_leaf_technologies/events/SpringshareLibCalIndexer.java
+++ b/code/events_indexer/src/com/turning_leaf_technologies/events/SpringshareLibCalIndexer.java
@@ -157,17 +157,6 @@ class SpringshareLibCalIndexer {
 			return;
 		}
 
-		//We do not need to delete from the index proactively, because we delete existing records individually below
-//		try {
-//			solrUpdateServer.deleteByQuery("type:event_libcal AND source:" + this.settingsId);
-//			//3-19-2019 Don't commit so the index does not get cleared during run (but will clear at the end).
-//		} catch (BaseHttpSolrClient.RemoteSolrException rse) {
-//			logEntry.incErrors("Solr is not running properly, try restarting " + rse);
-//			System.exit(-1);
-//		} catch (Exception e) {
-//			logEntry.incErrors("Error deleting from index ", e);
-//		}
-
 		Date lastDateToIndex = new Date();
 		long numberOfDays = numberOfDaysToIndex * 24L;
 		lastDateToIndex.setTime(lastDateToIndex.getTime() + (numberOfDays * 60 * 60 * 1000));
@@ -427,6 +416,27 @@ class SpringshareLibCalIndexer {
 			logEntry.setFinished();
 			logEntry.saveResults();
 			System.exit(-3);
+		}
+
+		// Close prepared statements.
+		try {
+			if (addEventStmt != null) {
+				addEventStmt.close();
+			}
+			if (updateEventStmt != null) {
+				updateEventStmt.close();
+			}
+			if (deleteEventStmt != null) {
+				deleteEventStmt.close();
+			}
+			if (addRegistrantStmt != null) {
+				addRegistrantStmt.close();
+			}
+			if (deleteRegistrantStmt != null) {
+				deleteRegistrantStmt.close();
+			}
+		} catch (SQLException e) {
+			logEntry.incErrors("Error closing prepared statements: ", e);
 		}
 
 		logEntry.setFinished();

--- a/code/events_indexer/src/com/turning_leaf_technologies/events/SpringshareLibCalIndexer.java
+++ b/code/events_indexer/src/com/turning_leaf_technologies/events/SpringshareLibCalIndexer.java
@@ -458,15 +458,15 @@ class SpringshareLibCalIndexer {
 				if (curEvent.get(keyName) instanceof JSONObject){
 					JSONObject keyObj = curEvent.getJSONObject(keyName);
 					if (keyObj.has("name")) {
-						return keyObj.getString("name");
+						return AspenStringUtils.trimTrailingPunctuation(keyObj.getString("name"));
 					}else{
 						for (String objKey: keyObj.keySet()){
-							return keyObj.getString(objKey);
+							return AspenStringUtils.trimTrailingPunctuation(keyObj.getString(objKey));
 						}
 						return null;
 					}
 				}else{
-					return curEvent.get(keyName).toString();
+					return AspenStringUtils.trimTrailingPunctuation(curEvent.get(keyName).toString());
 				}
 			}
 		}else{
@@ -480,13 +480,13 @@ class SpringshareLibCalIndexer {
 			if (curEvent.get(keyName) instanceof JSONObject) {
 				JSONObject keyObj = curEvent.getJSONObject(keyName);
 				for (String keyValue : keyObj.keySet()) {
-					values.add(keyObj.getString(keyValue));
+					values.add(AspenStringUtils.trimTrailingPunctuation(keyObj.getString(keyValue)));
 				}
 			}else{
 				JSONArray keyArray = curEvent.getJSONArray(keyName);
 				for (int i = 0; i < keyArray.length(); i++){
 					if (keyArray.get(i) instanceof JSONObject && keyArray.getJSONObject(i).has("name")) {
-						values.add(keyArray.getJSONObject(i).getString("name"));
+						values.add(AspenStringUtils.trimTrailingPunctuation(keyArray.getJSONObject(i).getString("name")));
 					}
 				}
 			}

--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -119,6 +119,9 @@
 - Corrected logic in `RecordGroupingProcessor.java` to truncate any generated grouped-work title to a maximum of 500 characters. (DIS-810) (*LS*)
 - Fixed a Java compilation issue caused by ambiguity between `org.marc4j.marc.Record` and the new `java.lang.Record` class in Java 14+. (DIS-808) (*LS*)
 
+### SpringShare LibCal Updates
+- Strip trailing whitespace and punctuation from JSON‐sourced fields to allow for proper facet searching. (DIS-857) (*LS*)
+
 // yanjun
 ### Boundless Updates
 - Delete inactive Axis360 titles from database correctly. (DIS-785) (*YL*)


### PR DESCRIPTION
- Strip trailing whitespace and punctuation from JSON‐sourced fields to allow for proper facet searching.

Test Plan: Difficult to recreate unless your Springeshare LibCal integration sends Aspen JSON‐derived fields with trailing white-space and/or punctuation. Regardless, if you apply the patch, the events indexer will properly index events as before.