### PR TITLE
DIS-844: Show Item Status on Copy Summary

### DIFF
--- a/code/web/interface/themes/responsive/GroupedWork/copySummary.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/copySummary.tpl
@@ -16,8 +16,8 @@
 						<div class="col-lg-12 itemLocationDetails" data-shelfLocation="{$item.shelfLocation|escape:"javascript"}" data-subLocation="{$item.subLocation|escape:"javascript"}" data-callNumber="{$item.callNumber|escape:"javascript"}">
 							<span class="notranslate" >{if empty($item.isEContent)}<strong>{$item.shelfLocation}</strong>{/if}
 							<br>{$item.callNumber}
-								<br>{if $item.availableCopies < 999}
-									{translate text="%1% available" 1=$item.availableCopies isPublicFacing=true}
+							<br>{if $item.availableCopies < 999}
+									{translate text="%1% available" 1=$item.availableCopies isPublicFacing=true}{if !empty($item.statusFull)} &mdash; {translate text=$item.statusFull isPublicFacing=true}{/if}
 								{/if}
 							</span>
 						</div>

--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -62,6 +62,7 @@
 - Fixed a typo in `Theme.php` where the default key for `primaryButtonHoverBorderColor` was incorrectly set as 'primary' instead of 'default'. (DIS-592) (*LS*)
 - Discontinued use of TinyMCE's deprecated spellchecker plugin and enabled native browser spellcheck. (DIS-588) (*LS*)
 - List entries will no longer occasionally display confusing PHP warnings or broken layouts. (DIS-789) (*LS*)
+- Copy summary rows now show each item's status next to its availability count (e.g. "1 available — On Shelf"). (DIS-844) (*LS*)
 
 // yanjun
 ### Boundless Updates


### PR DESCRIPTION
- Copy summary rows now show each item's status next to its availability count (e.g. "1 available — On Shelf").