### PR TITLE
DIS-859: Update and Fix Generated Citations

### DIFF
--- a/code/web/interface/themes/responsive/Citation/ama.tpl
+++ b/code/web/interface/themes/responsive/Citation/ama.tpl
@@ -1,5 +1,5 @@
 {if !empty($citeDetails.authors)}{$citeDetails.authors|escape} {/if}
-<span style="font-style:italic;">{$citeDetails.title|escape} </span> 
+<span style="font-style:italic;">{$citeDetails.title|escape}</span>
 {if !empty($citeDetails.edition)}{$citeDetails.edition|escape} {/if}
 {if !empty($citeDetails.publisher)}{$citeDetails.publisher|escape}; {/if}
 {if !empty($citeDetails.year)}{$citeDetails.year|escape}. {/if}

--- a/code/web/interface/themes/responsive/Citation/apa.tpl
+++ b/code/web/interface/themes/responsive/Citation/apa.tpl
@@ -1,5 +1,5 @@
 {if !empty($apaDetails.authors)}{$apaDetails.authors|escape} {/if}
 {if !empty($apaDetails.year)}({$apaDetails.year|escape}). {/if}
-<span style="font-style:italic;">{$apaDetails.title|escape}</span> 
-{if !empty($apaDetails.edition)}({$apaDetails.edition|escape}){/if}.
-{if !empty($apaDetails.publisher)}{$apaDetails.publisher|escape}.{/if}
+<span style="font-style:italic;">{$apaDetails.title|escape}</span>
+{if !empty($apaDetails.edition)}({$apaDetails.edition|escape}).{/if}
+{if !empty($apaDetails.publisher)} {$apaDetails.publisher|escape}.{/if}

--- a/code/web/interface/themes/responsive/Citation/chicago-authdate.tpl
+++ b/code/web/interface/themes/responsive/Citation/chicago-authdate.tpl
@@ -1,4 +1,4 @@
 {if !empty($citeDetails.authors)}{$citeDetails.authors|escape}. {/if}
 {if !empty($citeDetails.year)}{$citeDetails.year|escape}. {/if}
-<span style="font-style:italic;">{$citeDetails.title|escape}</span>.
-{if !empty($citeDetails.publisher)}{$citeDetails.publisher|escape}{/if}.
+<span style="font-style:italic;">{$citeDetails.title|escape}</span>
+{if !empty($citeDetails.publisher)} {$citeDetails.publisher|escape}.{/if}

--- a/code/web/interface/themes/responsive/Citation/chicago-humanities.tpl
+++ b/code/web/interface/themes/responsive/Citation/chicago-humanities.tpl
@@ -1,4 +1,4 @@
 {if !empty($citeDetails.authors)}{$citeDetails.authors|escape}. {/if}
-<span style="font-style:italic;">{$citeDetails.title|escape} </span> 
+<span style="font-style:italic;">{$citeDetails.title|escape}</span>
 {if !empty($citeDetails.publisher)}{$citeDetails.publisher|escape}{/if}
 {if !empty($citeDetails.year)}, {$citeDetails.year|escape}{/if}.

--- a/code/web/interface/themes/responsive/Citation/harvard.tpl
+++ b/code/web/interface/themes/responsive/Citation/harvard.tpl
@@ -2,4 +2,4 @@
 {if !empty($harvardDetails.year)}({$harvardDetails.year|escape}). {/if}
 <span style="font-style:italic;">{$harvardDetails.title|escape}</span>
 {if !empty($harvardDetails.edition)} {$harvardDetails.edition|escape} {/if}
-{if !empty($harvardDetails.publisher)}{$harvardDetails.publisher|escape}. {/if}
+{if !empty($harvardDetails.publisher)}{$harvardDetails.publisher|escape}.{/if}

--- a/code/web/interface/themes/responsive/Citation/mla.tpl
+++ b/code/web/interface/themes/responsive/Citation/mla.tpl
@@ -1,5 +1,5 @@
 {if !empty($mlaDetails.authors)}{$mlaDetails.authors|escape}. {/if}
-<span style="font-style: italic;">{$mlaDetails.title|escape}</span> 
+<span style="font-style: italic;">{$mlaDetails.title|escape}</span>
 {if !empty($mlaDetails.edition)}{$mlaDetails.edition|escape}, {/if}
 {if !empty($mlaDetails.publisher)}{$mlaDetails.publisher|escape}, {/if}
-{if !empty($mlaDetails.year)}{$mlaDetails.year|escape}. {/if}
+{if !empty($mlaDetails.year)}{$mlaDetails.year|escape}.{/if}

--- a/code/web/interface/themes/responsive/ExternalEContent/cite.tpl
+++ b/code/web/interface/themes/responsive/ExternalEContent/cite.tpl
@@ -18,42 +18,42 @@
 		{/if}
 
 		{if !empty($apa)}
-			<b>{translate text="APA Citation, 7th Edition" isPublicFacing=true}</b> {if !empty($showCitationStyleGuides)}<span class="styleGuide"><a href="https://owl.purdue.edu/owl/research_and_citation/apa_style/apa_formatting_and_style_guide/general_format.html" target="_blank"  aria-label="{translate text='style guide' isPublicFacing=true} ({translate text='opens in new window' isPublicFacing=true})">({translate text="style guide" isPublicFacing=true})</a></span>{/if}
+			<b>{translate text="APA Citation, 7th Edition" isPublicFacing=true}</b> {if !empty($showCitationStyleGuides)}<span class="styleGuide"><a href="https://owl.purdue.edu/owl/research_and_citation/apa_style/apa_formatting_and_style_guide/general_format.html" target="_blank"  aria-label="{translate text='Style Guide' isPublicFacing=true} ({translate text='opens in new window' isPublicFacing=true})">({translate text="Style Guide" isPublicFacing=true})</a></span>{/if}
 			<p style="width: 95%; padding-left: 25px; text-indent: -25px;">
 				{include file=$apa}
 			</p>
 		{/if}
 
 		{if !empty($chicagoauthdate)}
-			<b>{translate text="Chicago / Turabian - Author Date Citation, 17th Edition" isPublicFacing=true}</b> {if !empty($showCitationStyleGuides)}<span class="styleGuide"><a href="https://www.chicagomanualofstyle.org/tools_citationguide/citation-guide-2.html" target="_blank" aria-label="{translate text='style guide' isPublicFacing=true} ({translate text='opens in new window' isPublicFacing=true})">({translate text="style guide" isPublicFacing=true})</a></span>{/if}
+			<b>{translate text="Chicago / Turabian - Author Date Citation, 18th Edition" isPublicFacing=true}</b> {if !empty($showCitationStyleGuides)}<span class="styleGuide"><a href="https://www.chicagomanualofstyle.org/tools_citationguide/citation-guide-2.html" target="_blank" aria-label="{translate text='Style Guide' isPublicFacing=true} ({translate text='opens in new window' isPublicFacing=true})">({translate text="Style Guide" isPublicFacing=true})</a></span>{/if}
 			<p style="width: 95%; padding-left: 25px; text-indent: -25px;">
 				{include file=$chicagoauthdate}
 			</p>
 		{/if}
 
 		{if !empty($chicagohumanities)}
-			<b>{translate text="Chicago / Turabian - Humanities (Notes and Bibliography) Citation, 17th Edition" isPublicFacing=true}</b> {if !empty($showCitationStyleGuides)}<span class="styleGuide"><a href="https://www.chicagomanualofstyle.org/tools_citationguide/citation-guide-1.html" target="_blank" aria-label="{translate text='style guide' isPublicFacing=true} ({translate text='opens in new window' isPublicFacing=true})">({translate text="style guide" isPublicFacing=true})</a></span>{/if}
+			<b>{translate text="Chicago / Turabian - Humanities (Notes and Bibliography) Citation, 18th Edition" isPublicFacing=true}</b> {if !empty($showCitationStyleGuides)}<span class="styleGuide"><a href="https://www.chicagomanualofstyle.org/tools_citationguide/citation-guide-1.html" target="_blank" aria-label="{translate text='Style Guide' isPublicFacing=true} ({translate text='opens in new window' isPublicFacing=true})">({translate text="Style Guide" isPublicFacing=true})</a></span>{/if}
 			<p style="width: 95%; padding-left: 25px; text-indent: -25px;">
 				{include file=$chicagohumanities}
 			</p>
 		{/if}
 
 		{if !empty($harvard)}
-			<b>{translate text="Harvard Citation" isPublicFacing=true}</b> {if !empty($showCitationStyleGuides)}<span class="styleGuide"><a href="https://library-guides.ucl.ac.uk/harvard/a-z" target="_blank" aria-label="{translate text='style guide' isPublicFacing=true} ({translate text='opens in new window' isPublicFacing=true})">({translate text="style guide" isPublicFacing=true})</a></span>{/if}
+			<b>{translate text="UCL Harvard Citation" isPublicFacing=true}</b> {if !empty($showCitationStyleGuides)}<span class="styleGuide"><a href="https://library-guides.ucl.ac.uk/harvard/a-z" target="_blank" aria-label="{translate text='Style Guide' isPublicFacing=true} ({translate text='opens in new window' isPublicFacing=true})">({translate text="Style Guide" isPublicFacing=true})</a></span>{/if}
 			<p style="width: 95%; padding-left: 25px; text-indent: -25px;">
 				{include file=$harvard}
 			</p>
 		{/if}
 
 		{if !empty($mla)}
-			<b>{translate text="MLA Citation, 9th Edition" isPublicFacing=true}</b> {if !empty($showCitationStyleGuides)}<span class="styleGuide"><a href="https://owl.purdue.edu/owl/research_and_citation/mla_style/mla_formatting_and_style_guide/mla_general_format.html" target="_blank" aria-label="{translate text='style guide' isPublicFacing=true} ({translate text='opens in new window' isPublicFacing=true})">({translate text="style guide" isPublicFacing=true})</a></span>{/if}
+			<b>{translate text="MLA Citation, 9th Edition" isPublicFacing=true}</b> {if !empty($showCitationStyleGuides)}<span class="styleGuide"><a href="https://owl.purdue.edu/owl/research_and_citation/mla_style/mla_formatting_and_style_guide/mla_formatting_and_style_guide.html" target="_blank" aria-label="{translate text='Style Guide' isPublicFacing=true} ({translate text='opens in new window' isPublicFacing=true})">({translate text="Style Guide" isPublicFacing=true})</a></span>{/if}
 			<p style="width: 95%; padding-left: 25px; text-indent: -25px;">
 				{include file=$mla}
 			</p>
 		{/if}
 	</div>
-	<div class="alert alert-warning">
-		<strong>{translate text="Note!" isPublicFacing=true}</strong> {translate text="Citations contain only title, author, edition, publisher, and year published. Citations should be used as a guideline and should be double checked for accuracy. Citation formats are based on standards as of August 2021." isPublicFacing=true}
+	<div class="alert alert-info">
+		<strong>{translate text="Note:" isPublicFacing=true}</strong> {translate text=": Citations contain only title, author, edition, and publisher. Only UCL Harvard citations contain the year published. Citations should be used as a guideline and should be double checked for accuracy. Citation formats are based on standards as of May 2025." isPublicFacing=true}
 	</div>
 {/if}
 {if !empty($lightbox)}

--- a/code/web/interface/themes/responsive/MyAccount/listCitations.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/listCitations.tpl
@@ -22,8 +22,7 @@
 	{translate text='This list does not have any titles to build citations for.' isPublicFacing=true}
 {/if}
 <div class="alert alert-info">
-	<p>{translate text="Citation formats are based on standards as of August 2021.  Citations contain only title, author, edition, publisher, and year published." isPublicFacing=true}</p>
-	<p>{translate text="Citations should be used as a guideline and should be double checked for accuracy." isPublicFacing=true}</p>
-	<p>{translate text="For titles that are available in multiple formats you can view more detailed citations by viewing the record for the specific format." isPublicFacing=true}</p>
+	<p>{translate text="Citations contain only title, author, edition, and publisher. Only UCL Harvard citations contain the year published. Citations should be used as a guideline and should be double checked for accuracy. Citation formats are based on standards as of May 2025." isPublicFacing=true}</p>
+	<p>{translate text="For titles that are available in multiple formats, you can view more detailed citations by navigating to the record for the specific format." isPublicFacing=true}</p>
 </div>
 

--- a/code/web/interface/themes/responsive/Record/cite.tpl
+++ b/code/web/interface/themes/responsive/Record/cite.tpl
@@ -18,43 +18,43 @@
 		{/if}
 
 		{if !empty($apa)}
-			<b>{translate text="APA Citation, 7th Edition" isPublicFacing=true}</b> {if !empty($showCitationStyleGuides)}<span class="styleGuide"><a href="https://owl.purdue.edu/owl/research_and_citation/apa_style/apa_formatting_and_style_guide/general_format.html" target="_blank">({translate text="style guide" isPublicFacing=true})</a></span>{/if}
+			<b>{translate text="APA Citation, 7th Edition" isPublicFacing=true}</b> {if !empty($showCitationStyleGuides)}<span class="styleGuide"><a href="https://owl.purdue.edu/owl/research_and_citation/apa_style/apa_formatting_and_style_guide/reference_list_books.html" target="_blank">({translate text="Style Guide" isPublicFacing=true})</a></span>{/if}
 			<p style="width: 95%; padding-left: 25px; text-indent: -25px;">
 				{include file=$apa}
 			</p>
 		{/if}
 
 		{if !empty($chicagoauthdate)}
-			<b>{translate text="Chicago / Turabian - Author Date Citation, 17th Edition" isPublicFacing=true}</b> {if !empty($showCitationStyleGuides)}<span class="styleGuide"><a href="https://www.chicagomanualofstyle.org/tools_citationguide/citation-guide-2.html" target="_blank">({translate text="style guide" isPublicFacing=true})</a></span>{/if}
+			<b>{translate text="Chicago / Turabian - Author Date Citation, 18th Edition" isPublicFacing=true}</b> {if !empty($showCitationStyleGuides)}<span class="styleGuide"><a href="https://www.chicagomanualofstyle.org/tools_citationguide/citation-guide-2.html" target="_blank">({translate text="Style Guide" isPublicFacing=true})</a></span>{/if}
 			<p style="width: 95%; padding-left: 25px; text-indent: -25px;">
 				{include file=$chicagoauthdate}
 			</p>
 		{/if}
 
 		{if !empty($chicagohumanities)}
-			<b>{translate text="Chicago / Turabian - Humanities (Notes and Bibliography) Citation, 17th Edition" isPublicFacing=true}</b> {if !empty($showCitationStyleGuides)}<span class="styleGuide"><a href="https://www.chicagomanualofstyle.org/tools_citationguide/citation-guide-1.html" target="_blank">({translate text="style guide" isPublicFacing=true})</a></span>{/if}
+			<b>{translate text="Chicago / Turabian - Humanities (Notes and Bibliography) Citation, 18th Edition" isPublicFacing=true}</b> {if !empty($showCitationStyleGuides)}<span class="styleGuide"><a href="https://www.chicagomanualofstyle.org/tools_citationguide/citation-guide-1.html" target="_blank">({translate text="Style Guide" isPublicFacing=true})</a></span>{/if}
 			<p style="width: 95%; padding-left: 25px; text-indent: -25px;">
 				{include file=$chicagohumanities}
 			</p>
 		{/if}
 
 		{if !empty($harvard)}
-			<b>{translate text="Harvard Citation" isPublicFacing=true}</b> {if !empty($showCitationStyleGuides)}<span class="styleGuide"><a href="https://library-guides.ucl.ac.uk/harvard/a-z" target="_blank" aria-label="{translate text='style guide' isPublicFacing=true} ({translate text='opens in new window' isPublicFacing=true})">({translate text="style guide" isPublicFacing=true})</a></span>{/if}
+			<b>{translate text="UCL Harvard Citation" isPublicFacing=true}</b> {if !empty($showCitationStyleGuides)}<span class="styleGuide"><a href="https://library-guides.ucl.ac.uk/harvard/a-z" target="_blank" aria-label="{translate text='Style Guide' isPublicFacing=true} ({translate text='opens in new window' isPublicFacing=true})">({translate text="Style Guide" isPublicFacing=true})</a></span>{/if}
 			<p style="width: 95%; padding-left: 25px; text-indent: -25px;">
 				{include file=$harvard}
 			</p>
 		{/if}
 
 		{if !empty($mla)}
-			<b>{translate text="MLA Citation, 9th Edition" isPublicFacing=true}</b> {if !empty($showCitationStyleGuides)}<span class="styleGuide"><a href="https://owl.purdue.edu/owl/research_and_citation/mla_style/mla_formatting_and_style_guide/mla_general_format.html" target="_blank">({translate text="style guide" isPublicFacing=true})</a></span>{/if}
+			<b>{translate text="MLA Citation, 9th Edition" isPublicFacing=true}</b> {if !empty($showCitationStyleGuides)}<span class="styleGuide"><a href="https://owl.purdue.edu/owl/research_and_citation/mla_style/mla_formatting_and_style_guide/mla_formatting_and_style_guide.html" target="_blank">({translate text="Style Guide" isPublicFacing=true})</a></span>{/if}
 			<p style="width: 95%; padding-left: 25px; text-indent: -25px;">
 				{include file=$mla}
 			</p>
 		{/if}
 
 	</div>
-	<div class="alert alert-warning">
-		<strong>{translate text="Note!" isPublicFacing=true}</strong> {translate text="Citations contain only title, author, edition, publisher, and year published. Citations should be used as a guideline and should be double checked for accuracy. Citation formats are based on standards as of August 2021." isPublicFacing=true}
+	<div class="alert alert-info">
+		<strong>{translate text="Note:" isPublicFacing=true}</strong> {translate text="Citations contain only title, author, edition, and publisher. Only UCL Harvard citations contain the year published. Citations should be used as a guideline and should be double checked for accuracy. Citation formats are based on standards as of May 2025." isPublicFacing=true}
 	</div>
 {/if}
 {if !empty($lightbox)}

--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -129,7 +129,6 @@
 - Added a dedicated "In Processing" option within the "Added in the Last" facet group. (DIS-834) (*LS*)
 - Extended the indexing logic in `GroupedWorkSolr2` to use an item’s grouped status (e.g., "On Order," "In Processing," "Under Consideration") for building all related facets, no longer relying solely on the detailed status. (DIS-834) (*LS*)
 
-
 ### SpringShare LibCal Updates
 - Strip trailing whitespace and punctuation from JSON‐sourced fields to allow for proper facet searching. (DIS-857) (*LS*)
 
@@ -147,6 +146,13 @@
 - Updated `formattedTitle.tpl` and `formattedHorizontalCarouselTitle.tpl` to pass required variables, fixing missing-data issues in horizontal and carousel spotlights. (DIS-842) (*LS*)
 - Corrected logic in `RecordGroupingProcessor.java` to truncate any generated grouped-work title to a maximum of 500 characters. (DIS-810) (*LS*)
 - Fixed a Java compilation issue caused by ambiguity between `org.marc4j.marc.Record` and the new `java.lang.Record` class in Java 14+. (DIS-808) (*LS*)
+
+### Generated Citations Updates
+- Fixed missing or extra punctuation in titles, editions, and publisher fields. (DIS-859) (*LS*)
+- Cleaned up author formatting by removing full names in parentheses before abbreviating initials. (DIS-859) (*LS*)
+- Updated Chicago/Turabian citations to follow the 18th edition, removing place-of-publication details. (DIS-859) (*LS*)
+- Restored proper punctuation at the end of titles, adding a period only when needed. (DIS-859) (*LS*)
+- Refactored internal code structure and documentation for better maintainability. (DIS-859) (*LS*)
 
 // yanjun
 ### Boundless Updates

--- a/code/web/sys/CitationBuilder.php
+++ b/code/web/sys/CitationBuilder.php
@@ -6,16 +6,13 @@
  * This class builds APA and MLA citations.
  *
  * @author      Demian Katz <demian.katz@villanova.edu>
- * @access      public
  */
 class CitationBuilder {
-	private $details;
+	private array $details;
 
 	/**
-	 * Constructor
-	 *
-	 * Load the base data needed to build the citations.  The $details parameter
-	 * should contain as many of the following keys as possible:
+	 * Load the base data needed to build the citations.
+	 * The $details parameter should contain as many of the following keys as possible:
 	 *
 	 *  authors         => Array of authors in "Last, First, Title, Dates" format.
 	 *                     i.e. King, Martin Luther, Jr., 1929-1968.
@@ -28,16 +25,14 @@ class CitationBuilder {
 	 *
 	 * Unless noted as an array, each field should be a string.
 	 *
-	 * @param array $details An array of details used to build
-	 *                                      the citations.  See above for a full
-	 *                                      list of keys to populate.
-	 * @access  public
+	 * @param array $details An array of details used to build the citations.
+	 *                       See above for a full list of keys to populate.
 	 */
-	public function __construct($details) {
+	public function __construct(array $details) {
 		$this->details = $details;
 	}
 
-	public static function getCitationFormats() {
+	public static function getCitationFormats(): array {
 		return [
 			//'AMA' => 'AMA',
 			'APA' => 'APA',
@@ -51,19 +46,17 @@ class CitationBuilder {
 	/**
 	 * Get APA citation.
 	 *
-	 * This function assigns all the necessary variables and then returns a template
+	 * Assign all the necessary variables and then returns a template
 	 * name to display an APA citation.
 	 *
-	 * @access  public
-	 * @return  string                      Path to a Smarty template to display
-	 *                                      the citation.
+	 * @return string Path to a Smarty template to display the citation.
 	 */
-	public function getAPA() {
+	public function getAPA(): string {
 		global $interface;
 		$apa = [
-			'title' => $this->getAPATitle(),
+			'title' => $this->getTitle(),
 			'authors' => $this->getAPAAuthors(),
-			'publisher' => $this->getAPAPublisher(),
+			'publisher' => $this->getPublisher(),
 			'year' => $this->getYear(),
 			'edition' => $this->getEdition(),
 		];
@@ -74,19 +67,17 @@ class CitationBuilder {
 	/**
 	 * Get MLA citation.
 	 *
-	 * This function assigns all the necessary variables and then returns a template
+	 * Assign all the necessary variables and then returns a template
 	 * name to display an MLA citation.
 	 *
-	 * @access  public
-	 * @return  string                      Path to a Smarty template to display
-	 *                                      the citation.
+	 * @return string Path to a Smarty template to display the citation.
 	 */
-	public function getMLA() {
+	public function getMLA(): string {
 		global $interface;
 		$mla = [
-			'title' => $this->getMLATitle(),
+			'title' => $this->getCapitalizedTitle(),
 			'authors' => $this->getMLAAuthors(),
-			'publisher' => $this->getMLAPublisher(),
+			'publisher' => $this->getPublisher(),
 			'year' => $this->getYear(),
 			'edition' => $this->getEdition(),
 		];
@@ -94,7 +85,7 @@ class CitationBuilder {
 		return 'Citation/mla.tpl';
 	}
 
-	private function getMLAFormat() {
+	private function getMLAFormat(): string {
 		$formats = $this->details['format'];
 		if (is_array($formats)) {
 			foreach ($formats as $format) {
@@ -104,7 +95,7 @@ class CitationBuilder {
 					return 'DVD';
 				} elseif ($format == 'Book' || $format == 'Large Print' || $format == 'Serial' || $format == 'Musical Score' || $format == 'Journal' || $format == 'Manuscript' || $format == 'Newspaper') {
 					return 'Print';
-				} elseif ($format == 'Internet Link' || $format == 'eBook' || $format == 'eBook' || $format == 'EPUB EBook' || $format == 'Kindle Book' || $format == 'Kindle' || $format == 'Plucker' || $format == 'Adobe PDF eBook' || $format == 'overdrive' || $format == 'Adobe PDF') {
+				} elseif ($format == 'Internet Link' || $format == 'eBook' || $format == 'EPUB EBook' || $format == 'Kindle Book' || $format == 'Kindle' || $format == 'Plucker' || $format == 'Adobe PDF eBook' || $format == 'overdrive' || $format == 'Adobe PDF') {
 					return 'Web';
 				}
 			}
@@ -115,7 +106,7 @@ class CitationBuilder {
 				return 'DVD';
 			} elseif ($formats == 'Book' || $formats == 'Large Print' || $formats == 'Serial' || $formats == 'Musical Score' || $formats == 'Journal' || $formats == 'Manuscript' || $formats == 'Newspaper') {
 				return 'Print';
-			} elseif ($formats == 'Internet Link' || $formats == 'eBook' || $formats == 'eBook' || $formats == 'EPUB EBook' || $formats == 'Kindle Book' || $formats == 'Kindle' || $formats == 'Plucker' || $formats == 'Adobe PDF eBook' || $formats == 'overdrive' || $formats == 'Adobe PDF') {
+			} elseif ($formats == 'Internet Link' || $formats == 'eBook' || $formats == 'EPUB EBook' || $formats == 'Kindle Book' || $formats == 'Kindle' || $formats == 'Plucker' || $formats == 'Adobe PDF eBook' || $formats == 'overdrive' || $formats == 'Adobe PDF') {
 				return 'Web';
 			}
 		}
@@ -126,19 +117,17 @@ class CitationBuilder {
 	/**
 	 * Get AMA citation.
 	 *
-	 * This function assigns all the necessary variables and then returns a template
+	 * Assign all the necessary variables and then returns a template
 	 * name to display an AMA citation.
 	 *
-	 * @access  public
-	 * @return  string                      Path to a Smarty template to display
-	 *                                      the citation.
+	 * @return string Path to a Smarty template to display the citation.
 	 */
-	public function getAMA() {
+	public function getAMA(): string {
 		global $interface;
 		$citeDetails = [
-			'title' => $this->getMLATitle(),
+			'title' => $this->getCapitalizedTitle(),
 			'authors' => $this->getAMAAuthors(),
-			'publisher' => $this->getPublisher(),
+			'publisher' => $this->getPublisherWithPlace(),
 			'year' => $this->getYear(),
 			'edition' => $this->getEdition(),
 		];
@@ -149,17 +138,15 @@ class CitationBuilder {
 	/**
 	 * Get Chicago Humanities citation.
 	 *
-	 * This function assigns all the necessary variables and then returns a template
+	 * Assign all the necessary variables and then returns a template
 	 * name to display a Chicago Humanities citation.
 	 *
-	 * @access  public
-	 * @return  string                      Path to a Smarty template to display
-	 *                                      the citation.
+	 * @return string Path to a Smarty template to display the citation.
 	 */
-	public function getChicagoHumanities() {
+	public function getChicagoHumanities(): string {
 		global $interface;
 		$citeDetails = [
-			'title' => $this->getMLATitle(),
+			'title' => $this->getCapitalizedTitle(),
 			'authors' => $this->getChicagoAuthors(),
 			'publisher' => $this->getPublisher(),
 			'year' => $this->getYear(),
@@ -169,18 +156,17 @@ class CitationBuilder {
 	}
 
 	/**
-	 * This function assigns all the necessary variables and then returns a template
-	 * name to display a Harvard citation.
-	 * 
-	 * @access public
-	 * @return string
+	 * Assign all the necessary variables and then returns a template
+	 * name to display a UCL Harvard citation.
+	 *
+	 * @return string Path to a Smarty template to display the citation.
 	 */
-	public function getHarvard() {
+	public function getHarvard(): string {
 		global $interface;
 		$harvard = [
 			'title' => $this->getHarvardTitle(),
 			'authors' => $this->getHarvardAuthors(),
-			'publisher' => $this->getPublisher(),
+			'publisher' => $this->getPublisherWithPlace(),
 			'year' => $this->getHarvardYear(),
 			'edition' => $this->getHarvardEdition(),
 		];
@@ -191,17 +177,15 @@ class CitationBuilder {
 	/**
 	 * Get Chicago Auth Date citation.
 	 *
-	 * This function assigns all the necessary variables and then returns a template
+	 * Assign all the necessary variables and then returns a template
 	 * name to display a Chicago Auth Datemanities citation.
 	 *
-	 * @access  public
-	 * @return  string                      Path to a Smarty template to display
-	 *                                      the citation.
+	 * @return string Path to a Smarty template to display the citation.
 	 */
-	public function getChicagoAuthDate() {
+	public function getChicagoAuthDate(): string {
 		global $interface;
 		$citeDetails = [
-			'title' => $this->getMLATitle(),
+			'title' => $this->getCapitalizedTitle(),
 			'authors' => $this->getChicagoAuthors(),
 			'publisher' => $this->getPublisher(),
 			'year' => $this->getYear(),
@@ -213,11 +197,10 @@ class CitationBuilder {
 	/**
 	 * Is the string a valid name suffix?
 	 *
-	 * @access  private
 	 * @param string $str The string to check.
-	 * @return  bool                        True if it's a name suffix.
+	 * @return bool True if it's a name suffix.
 	 */
-	private function isNameSuffix($str) {
+	private function isNameSuffix(string $str): bool {
 		$str = $this->stripPunctuation($str);
 
 		// Is it a standard suffix?
@@ -242,11 +225,10 @@ class CitationBuilder {
 	/**
 	 * Is the string a date range?
 	 *
-	 * @access  private
 	 * @param string $str The string to check.
-	 * @return  bool                        True if it's a date range.
+	 * @return bool True if it's a date range.
 	 */
-	private function isDateRange($str) {
+	private function isDateRange(string $str): bool {
 		$str = trim($str);
 		return preg_match('/^([0-9]+)-([0-9]*)\.?$/', $str);
 	}
@@ -254,16 +236,17 @@ class CitationBuilder {
 	/**
 	 * Abbreviate a first name.
 	 *
-	 * @access  private
-	 * @param string $name The name to abbreviate
-	 * @return  string                      The abbreviated name.
+	 * @param string $name The name to abbreviate.
+	 * @return string The abbreviated name.
 	 */
-	private function abbreviateName($name) {
+	private function abbreviateName(string $name): string {
+		// Remove parenthetical full names before abbreviation.
+		$name = preg_replace('/\s*\([^)]*\)/', '', $name);
 		$parts = explode(', ', $name);
 		$name = $parts[0];
 
-		// Attach initials... but if we encountered a date range, the name
-		// ended earlier than expected, and we should stop now.
+		// Append initials if the second part is not a date range.
+		// If a date range is encountered instead, it indicates the end of the name and processing should stop.
 		if (isset($parts[1]) && !$this->isDateRange($parts[1])) {
 			$fnameParts = explode(' ', $parts[1]);
 			for ($i = 0; $i < count($fnameParts); $i++) {
@@ -283,11 +266,10 @@ class CitationBuilder {
 	/**
 	 * Strip the dates off the end of a name.
 	 *
-	 * @access  private
-	 * @param string $str Name to reverse.
-	 * @return  string                      Reversed name.
+	 * @param string $str The name to reverse.
+	 * @return string The reversed name.
 	 */
-	private function cleanNameDates($str) {
+	private function cleanNameDates(string $str): string {
 		$arr = explode(', ', $str);
 		$name = $arr[0];
 		if (isset($arr[1]) && !$this->isDateRange($arr[1])) {
@@ -304,13 +286,12 @@ class CitationBuilder {
 	/**
 	 * Strip unwanted punctuation from the right side of a string.
 	 *
-	 * @access  private
-	 * @param string $text Text to clean up.
-	 * @return  string                      Cleaned up text.
+	 * @param string $text The text to clean up.
+	 * @return string The cleaned up text.
 	 */
-	private function stripPunctuation($text) {
+	private function stripPunctuation(string $text): string {
 		$text = trim($text);
-		if ((substr($text, -1) == '.') || (substr($text, -1) == ',') || (substr($text, -1) == ':') || (substr($text, -1) == ';') || (substr($text, -1) == '/')) {
+		if ((str_ends_with($text, '.')) || (str_ends_with($text, ',')) || (str_ends_with($text, ':')) || (str_ends_with($text, ';')) || (str_ends_with($text, '/'))) {
 			$text = substr($text, 0, -1);
 		}
 		return trim($text);
@@ -319,11 +300,10 @@ class CitationBuilder {
 	/**
 	 * Turn a "Last, First" name into a "First Last" name.
 	 *
-	 * @access  private
-	 * @param string $str Name to reverse.
-	 * @return  string                      Reversed name.
+	 * @param string $str The name to reverse.
+	 * @return string The reversed name.
 	 */
-	private function reverseName($str) {
+	private function reverseName(string $str): string {
 		$arr = explode(', ', $str);
 
 		// If the second chunk is a date range, there is nothing to reverse!
@@ -341,11 +321,10 @@ class CitationBuilder {
 	/**
 	 * Capitalize all words in a title, except for a few common exceptions.
 	 *
-	 * @access  private
-	 * @param string $str Title to capitalize.
-	 * @return  string                      Capitalized title.
+	 * @param string $str The title to capitalize.
+	 * @return string The capitalized title.
 	 */
-	private function capitalizeTitle($str) {
+	private function capitalizeTitle(string $str): string {
 		$exceptions = [
 			'a',
 			'an',
@@ -366,7 +345,7 @@ class CitationBuilder {
 		];
 
 		$words = explode(' ', $str);
-		$newwords = [];
+		$newWords = [];
 		$followsColon = false;
 		foreach ($words as $word) {
 			// Capitalize words unless they are in the exception list...  but even
@@ -374,25 +353,24 @@ class CitationBuilder {
 			if (!in_array($word, $exceptions) || $followsColon) {
 				$word = ucfirst($word);
 			}
-			array_push($newwords, $word);
+			$newWords[] = $word;
 
-			$followsColon = substr($word, -1) == ':';
+			$followsColon = str_ends_with($word, ':');
 		}
 
-		return ucfirst(join(' ', $newwords));
+		return ucfirst(join(' ', $newWords));
 	}
 
 	/**
-	 * Convert a string to sentence case
-	 * 
-	 * @access private
+	 * Convert a string to sentence case.
+	 *
 	 * @param string $text
 	 * @return string
 	 */
-	private function convertToSentenceCase($text) {
+	private function convertToSentenceCase(string $text): string {
 
 		$abbreviations = [];
-	
+
 		//Regex pattern to match common exceptions e.g. "R&B" and "USA"
 		$pattern = '/\b[A-Z&]+\b/';
 		//Generate placeholders for abbreviations that match the pattern
@@ -405,7 +383,7 @@ class CitationBuilder {
 
 		$text = strtolower($text);
 		$text = ucfirst($text);
-		//Replace placeholders with their original abbreviations - unchanged by strtolower		
+		//Replace placeholders with their original abbreviations - unchanged by strtolower
 		foreach ($abbreviations as $placeholder => $abbr) {
 			$text = str_replace($placeholder, $abbr, $text);
 		}
@@ -413,33 +391,31 @@ class CitationBuilder {
 	}
 
 	/**
-	 * Get the full title for an APA citation.
+	 * Get the full title for a citation.
 	 *
-	 * @access  private
 	 * @return  string
 	 */
-	private function getAPATitle() {
+	private function getTitle(): string
+	{
 		// Create Title
 		$title = $this->stripPunctuation($this->details['title']);
 		if (isset($this->details['subtitle']) && strlen($this->details['subtitle']) > 0) {
 			$title .= ': ' . $this->stripPunctuation($this->details['subtitle']);
 		}
 
-		// Add period to titles not ending in punctuation
-		/*if (!((substr($title, -1) == '?') || (substr($title, -1) == '!'))) {
+		if (!((str_ends_with($title, '?')) || (str_ends_with($title, '!')))) {
 			$title .= '.';
-		}*/
+		}
 		return $title;
 	}
 
 	/**
-	 * Get the full citation for a Harvard Title
-	 * 
-	 * @access private
+	 * Get the full citation for a UCL Harvard Title.
+	 *
 	 * @return string
-	 * 
+	 *
 	 */
-	private function getHarvardTitle() {
+	private function getHarvardTitle(): string {
 		$title = $this->convertToSentenceCase($this->stripPunctuation($this->details['title']));
 
 		if (isset($this->details['subtitle']) && strlen($this->details['subtitle']) > 0){
@@ -448,7 +424,7 @@ class CitationBuilder {
 			$title .= ': ' . $subtitle;
 		}
 
-		if (!((substr($title, -1) == '?') || (substr($title, -1) == '!'))) {
+		if (!((str_ends_with($title, '?')) || (str_ends_with($title, '!')))) {
 			$title .= '.';
 		}
 		return $title;
@@ -458,10 +434,9 @@ class CitationBuilder {
 	/**
 	 * Get an array of authors for an APA citation.
 	 *
-	 * @access  private
-	 * @return  array
+	 * @return bool|array|string
 	 */
-	private function getAPAAuthors() {
+	private function getAPAAuthors(): bool|array|string {
 		$authorStr = '';
 		if (isset($this->details['authors']) && is_array($this->details['authors'])) {
 			$i = 0;
@@ -483,10 +458,9 @@ class CitationBuilder {
 	/**
 	 * Get an array of authors for an APA citation.
 	 *
-	 * @access  private
-	 * @return  array
+	 * @return bool|array|string
 	 */
-	private function getChicagoAuthors() {
+	private function getChicagoAuthors(): bool|array|string {
 		$authorStr = '';
 		if (isset($this->details['authors']) && is_array($this->details['authors'])) {
 			$i = 0;
@@ -517,10 +491,9 @@ class CitationBuilder {
 	/**
 	 * Get an array of authors for an APA citation.
 	 *
-	 * @access  private
-	 * @return  array
+	 * @return bool|array|string
 	 */
-	private function getAMAAuthors() {
+	private function getAMAAuthors(): bool|array|string {
 		$authorStr = '';
 		if (isset($this->details['authors']) && is_array($this->details['authors'])) {
 			$i = 0;
@@ -540,13 +513,11 @@ class CitationBuilder {
 	}
 
 	/**
-	 * Get a string of authors for a Harvard citation
-	 * 
-	 * @access private
-	 * @return string
-	 * 
+	 * Get a string of authors for a UCL Harvard citation.
+	 *
+	 * @return bool|string
 	 */
-	private function getHarvardAuthors() {
+	private function getHarvardAuthors(): bool|string {
 		$authorStr = ' ';
 		if (isset($this->details['authors']) && is_array($this->details['authors'])) {
 			$i = 0;
@@ -569,81 +540,76 @@ class CitationBuilder {
 				}
 				$i++;
 			}
-		}	
+		}
 		return (empty($authorStr) ? false: $authorStr);
 	}
 
 
 	/**
-	 * Get edition statement for inclusion in a citation.  Shared by APA and
-	 * MLA functionality.
+	 * Get edition statement for inclusion in a citation.
 	 *
-	 * @access  private
-	 * @return  string
+	 * @return bool|string
 	 */
-	private function getEdition() {
+	private function getEdition(): bool|string {
 		// Find the first edition statement that isn't "1st ed."
 		if (isset($this->details['edition'])) {
 			if (is_array($this->details['edition'])) {
 				foreach ($this->details['edition'] as $edition) {
 					if ($edition !== '1st ed.') {
-						return $edition;
+						return $this->stripPunctuation($edition);
 					}
 				}
 			} else {
 				if ($this->details['edition'] !== '1st ed.') {
-					return $this->details['edition'];
+					return $this->stripPunctuation($this->details['edition']);
 				}
 			}
 		}
-		// No edition statement found:
+		// No edition statement found.
 		return false;
 	}
 
 	/**
-	 * Get edition statement for inclusion in a citation. Used for Harvard functionality.
-	 * 
-	 * @access private
-	 * @return string
+	 * Get edition statement for inclusion in a UCL Harvard citation.
+	 *
+	 * @return bool|string
 	 */
-	private function getHarvardEdition() {
+	private function getHarvardEdition(): bool|string {
 		if (isset($this->details['edition'])) {
 			if (is_array($this->details['edition'])) {
 				foreach ($this->details['edition'] as $edition) {
 					if ($edition !== '1st ed.'){
 						$edition =preg_replace('/\bedition\b/i', 'edn', $edition);
-						return $edition;
+						return $this->stripPunctuation($edition);
 					}
 				}
 			} else {
 				if ($this->details['edition'] !== '1st ed.') {
 					$edition = preg_replace('/\bedition\b/i', 'edn', $this->details['edition']);
-					return $edition;
+					return $this->stripPunctuation($edition);
 				}
 			}
 		}
-		// No edition statement found:
+		// No edition statement found.
 		return false;
 	}
 
 	/**
-	 * Get the full title for an MLA citation.
+	 * Get the citation's full, title-case (i.e., capitalizing the major words) title.
 	 *
-	 * @access  private
-	 * @return  string
+	 * @return string
 	 */
-	private function getMLATitle() {
-		// MLA titles are just like APA titles, only capitalized differently:
-		return $this->capitalizeTitle($this->getAPATitle());
+	private function getCapitalizedTitle(): string {
+		// MLA titles are just like APA titles, only capitalized differently.
+		return $this->capitalizeTitle($this->getTitle());
 	}
 
 	/**
 	 * Get an array of authors for an APA citation.
 	 *
-	 * @access  private
-	 * @return  array
+	 * @return bool|string
 	 */
-	private function getMLAAuthors() {
+	private function getMLAAuthors(): bool|string {
 		$authorStr = '';
 		if (isset($this->details['authors']) && is_array($this->details['authors'])) {
 			$i = 0;
@@ -670,12 +636,10 @@ class CitationBuilder {
 
 	/**
 	 * Get publisher information (place: name) for inclusion in a citation.
-	 * Shared by APA and MLA functionality.
 	 *
-	 * @access  private
-	 * @return  string
+	 * @return bool|string
 	 */
-	private function getPublisher() {
+	private function getPublisherWithPlace(): bool|string {
 		$parts = [];
 		if (isset($this->details['placeOfPublication']) && !empty($this->details['placeOfPublication'])) {
 			$parts[] = $this->stripPunctuation($this->details['placeOfPublication']);
@@ -689,30 +653,19 @@ class CitationBuilder {
 		return $this->stripPunctuation(implode(': ', $parts));
 	}
 
-	private function getAPAPublisher() {
+	private function getPublisher(): bool|string {
 		if (isset($this->details['pubName']) && !empty($this->details['pubName'])) {
-			return $this->details['pubName'];
+			return $this->stripPunctuation($this->details['pubName']);
 		}
-
-		return false;
-	}
-
-	private function getMLAPublisher() {
-		if (isset($this->details['pubName']) && !empty($this->details['pubName'])) {
-			return $this->details['pubName'];
-		}
-
 		return false;
 	}
 
 	/**
 	 * Get the year of publication for inclusion in a citation.
-	 * Shared by APA and MLA functionality.
 	 *
-	 * @access  private
-	 * @return  string
+	 * @return bool|string
 	 */
-	private function getYear() {
+	private function getYear(): bool|string {
 		if (isset($this->details['pubDate'])) {
 			return preg_replace('/[^0-9]/', '', $this->details['pubDate']);
 		}
@@ -720,22 +673,18 @@ class CitationBuilder {
 	}
 
 	/**
-	 * Get the uear of publication for inclusion in a Harvard citation
-	 * 
-	 * @access private
+	 * Get the year of publication for inclusion in a UCL Harvard citation.
+	 *
 	 * @return string
 	 */
-
-	 private function getHarvardYear() {
+	private function getHarvardYear(): string {
 		if (isset($this->details['pubDate'])) {
 			$year = preg_replace('/[^0-9]/', '', $this->details['pubDate']);
 			if (strlen($year) === 4) {
 				return $year;
 			}
 		}
-		//Return "n.d." for missing or invalid dates
+		// Return "n.d." for missing or invalid dates.
 		return 'n.d.';
-	 }
+	}
 }
-
-?>


### PR DESCRIPTION
- Fixed missing or extra punctuation in titles, editions, and publisher fields.
- Cleaned up author formatting by removing full names in parentheses before abbreviating initials.
- Updated Chicago/Turabian citations to follow the 18th edition, removing place-of-publication details.
- Restored proper punctuation at the end of titles, adding a period only when needed.
- Refactored internal code structure and documentation for better maintainability.

Test Plan:
1. Navigate to a physical record and look at the Citations section. Depending on the record, it may contain improper grammatical formatting.
2. Apply the patch, reload the page, and repeat step 1.