### PR TITLE
DIS-848: Reposition & Style Expand Admin Sidebar Button

### DIFF
--- a/code/web/interface/themes/responsive/Admin/adminMenu.tpl
+++ b/code/web/interface/themes/responsive/Admin/adminMenu.tpl
@@ -1,9 +1,9 @@
 {strip}
 	{if !empty($loggedIn) && !empty($adminActions)}
 		<div id="account-menu-label" class="sidebar-label row">
-			<div class="col-xs-12">
-				{translate text='Administration Options' isAdminFacing=true}
-				<div id="sidebar-collapse"><button class="btn btn-default btn-sm" aria-label="{translate text="Collapse Sidebar" inAttribute=true isAdminFacing=true}"  title="{translate text="Collapse Sidebar" inAttribute=true isAdminFacing=true}" onclick="$('#side-bar').hide();$('#main-content-with-sidebar').addClass('col-sm-12').addClass('col-md-12').addClass('col-lg-12').removeClass('col-sm-8').removeClass('col-md-9').removeClass('col-lg-10').removeClass('col-lg-9');$('#sidebar-expand').show();"><i class="fas fa-angle-double-left"></i></button></div>
+			<div class="col-xs-12 sidebar-toggle-wrapper">
+				<span class="sidebar-title">{translate text='Administration Options' isAdminFacing=true}</span>
+				<div id="sidebar-collapse"><button class="btn btn-default btn-sm" aria-label="{translate text="Toggle Sidebar" inAttribute=true isAdminFacing=true}" title="{translate text="Toggle Sidebar" inAttribute=true isAdminFacing=true}" onclick="$('#side-bar').toggleClass('collapsed');"><i class="fas fa-angle-double-left"></i></button></div>
 			</div>
 			<div class="col-xs-12">
 				<a class='searchSettings searchSettingsColor' onClick="return AspenDiscovery.Admin.showSearch();" id='showSearchButton'><i class="fas fa-search" role="presentation"></i> {translate text="Search" isAdminFacing=true}</a>

--- a/code/web/interface/themes/responsive/css/layout.less
+++ b/code/web/interface/themes/responsive/css/layout.less
@@ -946,10 +946,56 @@ a.placard-link{
   z-index: 100;
 }
 
-#sidebar-expand{
-  display: block;
-  position: absolute;
-  top: 20px;
-  left: -15px;
-  z-index: 100;
+#side-bar.collapsed {
+  position: absolute !important;
+  width: 48px !important;
+  overflow: visible !important;
+  z-index: 3000 !important;
+  margin-left: 20px;
+}
+
+/* Hide everything except the toggle button. */
+#side-bar.collapsed #account-menu-label > :not(.sidebar-toggle-wrapper),
+#side-bar.collapsed #home-account-links,
+#side-bar.collapsed .sidebar-title  {
+  display: none !important;
+}
+
+/* Style the toggle button's background. */
+#side-bar.collapsed #sidebar-collapse {
+  margin: auto;
+  display: flex !important;
+  align-items: center;
+  justify-content: center;
+  top: 0 !important;
+  right: 0 !important;
+  width: 38px !important;
+  height: 36px !important;
+  background-color: @brand-primary !important;
+  border-radius: 10% !important;
+}
+
+#sidebar-collapse button i {
+  transition: transform 0.2s ease-in-out;
+}
+#side-bar.collapsed #sidebar-collapse button i {
+  transform: rotate(180deg);
+}
+
+/* Remove sidebar-label background when collapsed. */
+#side-bar.collapsed .sidebar-label {
+  background: none !important;
+  padding: 0 !important;
+}
+
+#side-bar.collapsed ~ #main-content-with-sidebar {
+  margin-left: 0 !important;
+  width: 100% !important;
+}
+
+/* Breadcrumb indent for collapsed sidebar. */
+@media (min-width: @screen-sm-min) {
+  #side-bar.collapsed + #main-content-with-sidebar .breadcrumbs {
+    margin-left: 60px !important;
+  }
 }

--- a/code/web/interface/themes/responsive/css/main.css
+++ b/code/web/interface/themes/responsive/css/main.css
@@ -8755,12 +8755,52 @@ a.placard-link {
   right: 5px;
   z-index: 100;
 }
-#sidebar-expand {
-  display: block;
-  position: absolute;
-  top: 20px;
-  left: -15px;
-  z-index: 100;
+#side-bar.collapsed {
+  position: absolute !important;
+  width: 48px !important;
+  overflow: visible !important;
+  z-index: 3000 !important;
+  margin-left: 20px;
+}
+/* Hide everything except the toggle button. */
+#side-bar.collapsed #account-menu-label > :not(.sidebar-toggle-wrapper),
+#side-bar.collapsed #home-account-links,
+#side-bar.collapsed .sidebar-title {
+  display: none !important;
+}
+/* Style the toggle button's background. */
+#side-bar.collapsed #sidebar-collapse {
+  margin: auto;
+  display: flex !important;
+  align-items: center;
+  justify-content: center;
+  top: 0 !important;
+  right: 0 !important;
+  width: 38px !important;
+  height: 36px !important;
+  background-color: #3174AF !important;
+  border-radius: 10% !important;
+}
+#sidebar-collapse button i {
+  transition: transform 0.2s ease-in-out;
+}
+#side-bar.collapsed #sidebar-collapse button i {
+  transform: rotate(180deg);
+}
+/* Remove sidebar-label background when collapsed. */
+#side-bar.collapsed .sidebar-label {
+  background: none !important;
+  padding: 0 !important;
+}
+#side-bar.collapsed ~ #main-content-with-sidebar {
+  margin-left: 0 !important;
+  width: 100% !important;
+}
+/* Breadcrumb indent for collapsed sidebar. */
+@media (min-width: 768px) {
+  #side-bar.collapsed + #main-content-with-sidebar .breadcrumbs {
+    margin-left: 60px !important;
+  }
 }
 .swiper {
   width: 100%;

--- a/code/web/interface/themes/responsive/layout.tpl
+++ b/code/web/interface/themes/responsive/layout.tpl
@@ -139,7 +139,6 @@
 							</div>
 						{/if}
 						<div role="main">
-							<div id="sidebar-expand" style="display: none"><button class="btn btn-default btn-sm" aria-label="{translate text="Expand Sidebar" inAttribute=true isAdminFacing=true}"  title="{translate text="Expand Sidebar" inAttribute=true isAdminFacing=true}" onclick="$('#side-bar').show();$('#main-content-with-sidebar').removeClass('col-sm-12').removeClass('col-md-12').removeClass('col-lg-12').addClass('col-sm-8').addClass('col-md-9'){if !empty($fullWidthTheme) && !empty($showContentAsFullWidth)}.addClass('col-lg-10'){else}.addClass('col-lg-9'){/if};$('#sidebar-expand').hide();"><i class="fas fa-angle-double-right"></i></button></div>
 							{if !empty($module)}
 								{include file="$module/$pageTemplate"}
 							{else}

--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -1,7 +1,7 @@
 ## Aspen Discovery Updates
 // mark
 ### Administration Updates
-- Allow the admin sidebar to be expanded and collapsed to be able to better view the contents of a page. (DIS-848) (*MDN*)
+- Allow the admin sidebar to be expanded and collapsed to be able to better view the contents of a page. (DIS-848) (*MDN*, *LS*)
 - If a value for an enum has been filtered from the list of allowable values, display the value from allValues if applicable. (DIS-811) (*MDN*)
 - Update clearOneToManySettings and saveOneToManySettings to optionally handle a list of allowable values to better handle cases where what an administrator can edit is restricted by permission. (DIS-812) (*MDN*)
 - Update Grouped Work Display Settings to use the new methods for clearOneToManySettings and saveOneToManySettings to ensure that an administrator does not change the linked libraries and locations if they do not have permission. (DIS-812) (*MDN*) 


### PR DESCRIPTION
- Allow the admin sidebar to be expanded and collapsed to be able to better view the contents of a page. (DIS-848) (*MDN*, *LS*)

Test Plan:
1. On the current 25.06.00, navigate to the admin interface and notice the position of button to collapse the admin sidebar.
2. Apply the patch and notice the new position and styling of the button to collapse the admin sidebar.