### PR TITLE
DIS-866: Update Display Name When Updating Koha Contact Info

### DIFF
--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -121,6 +121,8 @@
 ### Koha Updates
 - Resolved an issue that could prevent users with expired passwords from successfully resetting their password when prompted on the login screen. (DIS-744) (*LS*)
 - Patrons’ reading histories now update correctly each night, ensuring their recent check-outs and returns are always recorded, even if they haven’t signed in daily. (DIS-768) (*LS*)
+- The navigation bar now immediately reflects the patron's updated display name after saving Contact Information. (DIS-866) (*LS*)
+- Fixed PHP warnings in the Koha driver when fetching empty extended attributes on the Contact Information page. (DIS-866) (*LS*)
 
 ### Searching Updates
 - Added an 'X' button inside the search box to easily clear entered text; the button appears automatically when text is present. (DIS-778, DIS-852) (*LS*)


### PR DESCRIPTION
- The navigation bar now immediately reflects the patron's updated display name after saving Contact Information.
- Fixed PHP warnings in the Koha driver when fetching empty extended attributes on the Contact Information page.

Test Plan:
1. Navigate to your Contact Information page, fill out the form, and submit it. Notice that your display name at the top right above the navigation bar has not changed.
2. Apply the patch and repeat step 1. Notice that your display name has updated.