### PR TITLE
DIS-493: Added Option to Prioritize Titles from Available Koha Records for Grouped Works Display Titles (25.06.00)

### DIFF
--- a/code/java_shared_libraries/src/com/turning_leaf_technologies/indexing/IndexingProfile.java
+++ b/code/java_shared_libraries/src/com/turning_leaf_technologies/indexing/IndexingProfile.java
@@ -114,6 +114,9 @@ public class IndexingProfile extends BaseIndexingSettings {
 
 	private SierraExportFieldMapping sierraExportFieldMappings = null;
 
+	// Whether to ignore on-order records when selecting titles for display in grouped works
+	private boolean ignoreOnOrderRecordsForTitleSelection = false;
+
 	public IndexingProfile(String serverName, BaseIndexingLogEntry logEntry){
 		//This is only intended to be used for unit testing
 		super(serverName, logEntry);
@@ -264,6 +267,8 @@ public class IndexingProfile extends BaseIndexingSettings {
 
 		index856Links = indexingProfileRS.getInt("index856Links");
 		treatUnknownAudienceAs = indexingProfileRS.getString("treatUnknownAudienceAs");
+
+		ignoreOnOrderRecordsForTitleSelection = indexingProfileRS.getBoolean("ignoreOnOrderRecordsForTitleSelection");
 
 		//Custom Facet 1
 		this.customFacet1SourceField = indexingProfileRS.getString("customFacet1SourceField");
@@ -1155,5 +1160,23 @@ public class IndexingProfile extends BaseIndexingSettings {
 
 	public void setOrderRecordStatusToTreatAsUnderConsideration(String orderRecordStatusToTreatAsUnderConsideration) {
 		this.orderRecordStatusToTreatAsUnderConsideration = orderRecordStatusToTreatAsUnderConsideration;
+	}
+
+	/**
+	 * Return the flag indicating whether on-order records should be ignored for title selection.
+	 *
+	 * @return {@code true} if on-order records should be ignored for title selection, {@code false} otherwise.
+	 */
+	public boolean getIgnoreOnOrderRecordsForTitleSelection() {
+		return ignoreOnOrderRecordsForTitleSelection;
+	}
+
+	/**
+	 * Sets the flag indicating whether on-order records should be ignored for title selection.
+	 *
+	 * @param ignoreOnOrderRecordsForTitleSelection {@code true} to ignore on-order records for title selection, {@code false} otherwise.
+	 */
+	public void setIgnoreOnOrderRecordsForTitleSelection(boolean ignoreOnOrderRecordsForTitleSelection) {
+		this.ignoreOnOrderRecordsForTitleSelection = ignoreOnOrderRecordsForTitleSelection;
 	}
 }

--- a/code/java_shared_libraries/src/com/turning_leaf_technologies/indexing/IndexingProfile.java
+++ b/code/java_shared_libraries/src/com/turning_leaf_technologies/indexing/IndexingProfile.java
@@ -114,8 +114,8 @@ public class IndexingProfile extends BaseIndexingSettings {
 
 	private SierraExportFieldMapping sierraExportFieldMappings = null;
 
-	// Whether to ignore on-order records when selecting titles for display in grouped works
-	private boolean ignoreOnOrderRecordsForTitleSelection = false;
+	// Whether to ignore on-order records when selecting titles for display in grouped works.
+	private boolean prioritizeAvailableRecordsForTitleSelection = false;
 
 	public IndexingProfile(String serverName, BaseIndexingLogEntry logEntry){
 		//This is only intended to be used for unit testing
@@ -268,7 +268,7 @@ public class IndexingProfile extends BaseIndexingSettings {
 		index856Links = indexingProfileRS.getInt("index856Links");
 		treatUnknownAudienceAs = indexingProfileRS.getString("treatUnknownAudienceAs");
 
-		ignoreOnOrderRecordsForTitleSelection = indexingProfileRS.getBoolean("ignoreOnOrderRecordsForTitleSelection");
+		prioritizeAvailableRecordsForTitleSelection = indexingProfileRS.getBoolean("prioritizeAvailableRecordsForTitleSelection");
 
 		//Custom Facet 1
 		this.customFacet1SourceField = indexingProfileRS.getString("customFacet1SourceField");
@@ -1163,12 +1163,12 @@ public class IndexingProfile extends BaseIndexingSettings {
 	}
 
 	/**
-	 * Return the flag indicating whether on-order records should be ignored for title selection.
+	 * Return the flag indicating whether available records should be prioritized for title selection.
 	 *
-	 * @return {@code true} if on-order records should be ignored for title selection, {@code false} otherwise.
+	 * @return {@code true} if available records should be ignored for title selection, {@code false} otherwise.
 	 */
-	public boolean getIgnoreOnOrderRecordsForTitleSelection() {
-		return ignoreOnOrderRecordsForTitleSelection;
+	public boolean getPrioritizeAvailableRecordsForTitleSelection() {
+		return prioritizeAvailableRecordsForTitleSelection;
 	}
 
 	/**
@@ -1176,7 +1176,7 @@ public class IndexingProfile extends BaseIndexingSettings {
 	 *
 	 * @param ignoreOnOrderRecordsForTitleSelection {@code true} to ignore on-order records for title selection, {@code false} otherwise.
 	 */
-	public void setIgnoreOnOrderRecordsForTitleSelection(boolean ignoreOnOrderRecordsForTitleSelection) {
-		this.ignoreOnOrderRecordsForTitleSelection = ignoreOnOrderRecordsForTitleSelection;
+	public void setPrioritizeAvailableRecordsForTitleSelection(boolean prioritizeAvailableRecordsForTitleSelection) {
+		this.prioritizeAvailableRecordsForTitleSelection = prioritizeAvailableRecordsForTitleSelection;
 	}
 }

--- a/code/reindexer/src/org/aspen_discovery/reindexer/AbstractGroupedWorkSolr.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/AbstractGroupedWorkSolr.java
@@ -1356,6 +1356,18 @@ public abstract class AbstractGroupedWorkSolr {
 		}
 	}
 
+	/**
+	 * Get the RecordInfo for a specific source and identifier.
+	 *
+	 * @param source The source of the record (e.g. "koha").
+	 * @param recordIdentifier The identifier of the record.
+	 * @return The {@code RecordInfo} object if found, null otherwise.
+	 */
+	RecordInfo getRecordInfo(String source, String recordIdentifier) {
+		String recordIdentifierWithType = source + ":" + recordIdentifier;
+		return relatedRecords.get(recordIdentifierWithType);
+	}
+
 	void addLCSubject(String lcSubject) {
 		this.lcSubjects.add(AspenStringUtils.normalizeSubject(lcSubject));
 	}

--- a/code/reindexer/src/org/aspen_discovery/reindexer/AbstractGroupedWorkSolr.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/AbstractGroupedWorkSolr.java
@@ -437,7 +437,7 @@ public abstract class AbstractGroupedWorkSolr {
 				updateTitle = true;
 			} else {
 				// Skip unavailable records for title selection if we have any other title.
-				if (recordInfo == null || !recordInfo.isOnOrder()) {
+				if (recordInfo == null || !recordInfo.hasNotForLoanStatus()) {
 					// Only overwrite if we get a better format.
 					if (formatCategory.equals("Books")) {
 						// We have a book, update if we didn't have a book before.

--- a/code/reindexer/src/org/aspen_discovery/reindexer/AbstractGroupedWorkSolr.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/AbstractGroupedWorkSolr.java
@@ -424,42 +424,45 @@ public abstract class AbstractGroupedWorkSolr {
 	private final static Pattern punctuationPattern = Pattern.compile("[.\\\\/()\\[\\]:;]");
 
 	void setTitle(String shortTitle, String subTitle, String displayTitle, String sortableTitle, String recordFormat, String formatCategory) {
-		this.setTitle(shortTitle, subTitle, displayTitle, sortableTitle, formatCategory, false);
+		this.setTitle(shortTitle, subTitle, displayTitle, sortableTitle, recordFormat, formatCategory, false, null);
 	}
 
-	void setTitle(String shortTitle, String subTitle, String displayTitle, String sortableTitle, String formatCategory, boolean isDisplayInfo) {
+	void setTitle(String shortTitle, String subTitle, String displayTitle, String sortableTitle, String recordFormat, String formatCategory, boolean isDisplayInfo, RecordInfo recordInfo) {
 		if (shortTitle != null) {
 			shortTitle = AspenStringUtils.trimTrailingPunctuation(shortTitle);
 
-			//Figure out if we want to use this title or if the one we have is better.
+			// Figure out if we want to use this title or if the one we have is better.
 			boolean updateTitle = false;
 			if (this.title == null) {
 				updateTitle = true;
 			} else {
-				//Only overwrite if we get a better format
-				if (formatCategory.equals("Books")) {
-					//We have a book, update if we didn't have a book before
-					if (!formatCategory.equals(titleFormat)) {
-						updateTitle = true;
-						//Or update if we had a book before and this title is longer
-					} else if (shortTitle.length() > this.title.length()) {
-						updateTitle = true;
-					}
-				} else if (formatCategory.equals("eBook")) {
-					//Update if the format we had before is not a book
-					if (!titleFormat.equals("Books")) {
-						//And the new format was not an eBook or the new title is longer than what we had before
+				// Skip unavailable records for title selection if we have any other title.
+				if (recordInfo == null || !recordInfo.isOnOrder()) {
+					// Only overwrite if we get a better format.
+					if (formatCategory.equals("Books")) {
+						// We have a book, update if we didn't have a book before.
 						if (!formatCategory.equals(titleFormat)) {
 							updateTitle = true;
-							//or update if we had a book before and this title is longer
+							// Or update if we had a book before and this title is longer.
 						} else if (shortTitle.length() > this.title.length()) {
 							updateTitle = true;
 						}
-					}
-				} else if (!titleFormat.equals("Books") && !titleFormat.equals("eBook")) {
-					//If we don't have a Book or an eBook then we can update the title if we get a longer title
-					if (shortTitle.length() > this.title.length()) {
-						updateTitle = true;
+					} else if (formatCategory.equals("eBook")) {
+						// Update if the format we had before is not a book.
+						if (!titleFormat.equals("Books")) {
+							// And the new format was not an eBook or the new title is longer than what we had before.
+							if (!formatCategory.equals(titleFormat)) {
+								updateTitle = true;
+								// Or, update if we had a book before and this title is longer.
+							} else if (shortTitle.length() > this.title.length()) {
+								updateTitle = true;
+							}
+						}
+					} else if (!titleFormat.equals("Books") && !titleFormat.equals("eBook")) {
+						// If we don't have a Book or an eBook, then we can update the title if we get a longer title.
+						if (shortTitle.length() > this.title.length()) {
+							updateTitle = true;
+						}
 					}
 				}
 			}
@@ -506,9 +509,6 @@ public abstract class AbstractGroupedWorkSolr {
 					this.displayTitle = shortTitle.concat(": ").concat(subTitle);
 				}
 			}
-
-			//replace apostrophes in contractions
-			shortTitle = shortTitle.replaceAll("(\\w)'(\\w)", "$1$2");
 
 			//Create an alternate title for searching by replacing ampersands with the word and.
 			String tmpTitle = shortTitle.replace("&", " and ").replace("  ", " ");

--- a/code/reindexer/src/org/aspen_discovery/reindexer/GroupedWorkIndexer.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/GroupedWorkIndexer.java
@@ -380,9 +380,9 @@ public class GroupedWorkIndexer {
 		Http2SolrClient http2Client = new Http2SolrClient.Builder().build();
 		try {
 			updateServer = new ConcurrentUpdateHttp2SolrClient.Builder(solrUrl, http2Client)
-					.withThreadCount(1)
-					.withQueueSize(25)
-					.build();
+				.withThreadCount(1)
+				.withQueueSize(25)
+				.build();
 		}catch (OutOfMemoryError e) {
 			logger.error("Unable to create solr client, out of memory", e);
 			System.exit(-7);
@@ -1576,7 +1576,7 @@ public class GroupedWorkIndexer {
 			if (displayInfoRS.next()) {
 				String title = displayInfoRS.getString("title");
 				if (!title.isEmpty()){
-					groupedWork.setTitle(title, "", title, AspenStringUtils.makeValueSortable(title), "", true);
+					groupedWork.setTitle(title, "", title, AspenStringUtils.makeValueSortable(title), "", "", true, null);
 					groupedWork.clearSubTitle();
 				}
 				String author = displayInfoRS.getString("author");
@@ -1727,11 +1727,11 @@ public class GroupedWorkIndexer {
 	LinkedHashSet<String> translateSystemCollection(String mapName, Set<String> values, String identifier) {
 		LinkedHashSet<String> translatedCollection = new LinkedHashSet<>();
 		for (String value : values){
-				String translatedValue = translateSystemValue(mapName, value, identifier);
-				if (translatedValue != null) {
-						translatedCollection.add(translatedValue);
-					}
+			String translatedValue = translateSystemValue(mapName, value, identifier);
+			if (translatedValue != null) {
+				translatedCollection.add(translatedValue);
 			}
+		}
 		return  translatedCollection;
 	}
 
@@ -2713,8 +2713,8 @@ public class GroupedWorkIndexer {
 					}
 					addItemForWorkRS.close();
 					SavedItemInfo savedItemInfo = new SavedItemInfo(itemId, recordId, variationId, itemInfo.getItemIdentifier(), shelfLocationId, callNumberId, sortableCallNumberId, itemInfo.getNumCopies(),
-							itemInfo.isOrderItem(), statusId, itemInfo.getDateAdded(), locationCodeId, subLocationId, itemInfo.getLastCheckinDate(), groupedStatusId, itemInfo.isAvailable(),
-							itemInfo.isHoldable(), itemInfo.isInLibraryUseOnly(), itemInfo.getLocationOwnedScopes(), itemInfo.getLibraryOwnedScopes(), itemInfo.getRecordsIncludedScopes());
+						itemInfo.isOrderItem(), statusId, itemInfo.getDateAdded(), locationCodeId, subLocationId, itemInfo.getLastCheckinDate(), groupedStatusId, itemInfo.isAvailable(),
+						itemInfo.isHoldable(), itemInfo.isInLibraryUseOnly(), itemInfo.getLocationOwnedScopes(), itemInfo.getLibraryOwnedScopes(), itemInfo.getRecordsIncludedScopes());
 
 					existingItems.put(itemInfo.getItemIdentifier().toLowerCase(), savedItemInfo);
 				}catch (SQLException e){
@@ -2722,8 +2722,8 @@ public class GroupedWorkIndexer {
 					errorsSavingItem = true;
 				}
 			}else if (savedItem.hasChanged(recordId, variationId, itemInfo.getItemIdentifier(), shelfLocationId, callNumberId, sortableCallNumberId, itemInfo.getNumCopies(),
-					itemInfo.isOrderItem(), statusId, itemInfo.getDateAdded(), locationCodeId, subLocationId, itemInfo.getLastCheckinDate(), groupedStatusId, itemInfo.isAvailable(),
-					itemInfo.isHoldable(), itemInfo.isInLibraryUseOnly(), itemInfo.getLocationOwnedScopes(), itemInfo.getLibraryOwnedScopes(), itemInfo.getRecordsIncludedScopes())){
+				itemInfo.isOrderItem(), statusId, itemInfo.getDateAdded(), locationCodeId, subLocationId, itemInfo.getLastCheckinDate(), groupedStatusId, itemInfo.isAvailable(),
+				itemInfo.isHoldable(), itemInfo.isInLibraryUseOnly(), itemInfo.getLocationOwnedScopes(), itemInfo.getLibraryOwnedScopes(), itemInfo.getRecordsIncludedScopes())){
 				try {
 					updateItemForRecordStmt.setLong(1, variationId);
 					updateItemForRecordStmt.setLong(2, shelfLocationId);

--- a/code/reindexer/src/org/aspen_discovery/reindexer/KohaRecordProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/KohaRecordProcessor.java
@@ -559,9 +559,9 @@ class KohaRecordProcessor extends IlsRecordProcessor {
 		// Add the record to the grouped work first to ensure it exists in the relatedRecords map.
 		RecordInfo recordInfo = groupedWork.addRelatedRecord(profileType, identifier);
 
-		// Check if this is an unavailable (e.g., "On Order") record and if the setting is enabled to set the flag accordingly.
-		boolean isOnOrder = settings.getIgnoreOnOrderRecordsForTitleSelection() && isRecordExcludedFromTitleSelection(record);
-		recordInfo.setOnOrder(isOnOrder);
+		// Check if the setting is enabled to set the flag accordingly and if this is a not-for-loan (e.g., "On Order") record.
+		boolean isNotForLoan = settings.getPrioritizeAvailableRecordsForTitleSelection() && isRecordExcludedFromTitleSelection(record);
+		recordInfo.setNotForLoan(isNotForLoan);
 
 		super.updateGroupedWorkSolrDataBasedOnMarc(groupedWork, record, identifier);
 	}

--- a/code/reindexer/src/org/aspen_discovery/reindexer/KohaRecordProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/KohaRecordProcessor.java
@@ -583,8 +583,9 @@ class KohaRecordProcessor extends IlsRecordProcessor {
 
 		boolean allItemsExcluded = true;
 		for (DataField itemField : itemRecords) {
-			String itemStatus = getItemStatus(itemField, "");
-			if (itemStatus.equals("On Shelf") || itemStatus.equals("Checked Out")) {
+			ItemStatus itemStatus = getItemStatus(itemField, "");
+			String status = itemStatus.getStatus();
+			if ("On Shelf".equals(status) || "Checked Out".equals(status)) {
 				// Found an available item, so the record should not be excluded.
 				allItemsExcluded = false;
 				break;

--- a/code/reindexer/src/org/aspen_discovery/reindexer/MarcRecordProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/MarcRecordProcessor.java
@@ -1556,12 +1556,6 @@ abstract class MarcRecordProcessor {
 			if (!hasParentRecord) {
 				RecordInfo recordInfo = groupedWork.getRecordInfo(profileType, identifier);
 
-				// Log if recordInfo is null.
-				if (recordInfo == null) {
-					logger.warn("RecordInfo was null for {}:{} when loading titles.", profileType, identifier);
-				}
-
-				//noinspection SpellCheckingInspection
 				groupedWork.setTitle(
 					titleField.getSubfieldsAsString("a"),
 					subTitle,

--- a/code/reindexer/src/org/aspen_discovery/reindexer/MarcRecordProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/MarcRecordProcessor.java
@@ -357,7 +357,7 @@ abstract class MarcRecordProcessor {
 	}
 
 	void updateGroupedWorkSolrDataBasedOnStandardMarcData(AbstractGroupedWorkSolr groupedWork, org.marc4j.marc.Record record, ArrayList<ItemInfo> printItems, String identifier, String format, String formatCategory, boolean hasParentRecord) {
-		loadTitles(groupedWork, record, format, formatCategory, hasParentRecord);
+		loadTitles(groupedWork, record, format, formatCategory, hasParentRecord, identifier);
 		loadAuthors(groupedWork, record, identifier, formatCategory);
 		loadSubjects(groupedWork, record);
 
@@ -1544,7 +1544,7 @@ abstract class MarcRecordProcessor {
 		groupedWork.setAuthorDisplay(displayAuthor, formatCategory);
 	}
 
-	private void loadTitles(AbstractGroupedWorkSolr groupedWork, org.marc4j.marc.Record record, String format, String formatCategory, boolean hasParentRecord) {
+	private void loadTitles(AbstractGroupedWorkSolr groupedWork, org.marc4j.marc.Record record, String format, String formatCategory, boolean hasParentRecord, String identifier) {
 		//title (full title done by index process by concatenating short and subtitle
 
 		//title short
@@ -1554,8 +1554,24 @@ abstract class MarcRecordProcessor {
 			//noinspection SpellCheckingInspection
 			String subTitle = titleField.getSubfieldsAsString("bfgnp", " ");
 			if (!hasParentRecord) {
+				RecordInfo recordInfo = groupedWork.getRecordInfo(profileType, identifier);
+
+				// Log if recordInfo is null.
+				if (recordInfo == null) {
+					logger.warn("RecordInfo was null for {}:{} when loading titles.", profileType, identifier);
+				}
+
 				//noinspection SpellCheckingInspection
-				groupedWork.setTitle(titleField.getSubfieldsAsString("a"), subTitle, titleField.getSubfieldsAsString("abfgnp", " "), this.getSortableTitle(record), format, formatCategory);
+				groupedWork.setTitle(
+					titleField.getSubfieldsAsString("a"),
+					subTitle,
+					titleField.getSubfieldsAsString("abfgnp", " "),
+					this.getSortableTitle(record),
+					format,
+					formatCategory,
+					false,
+					recordInfo
+				);
 			}
 			//title full
 			authorInTitleField = titleField.getSubfieldsAsString("c");

--- a/code/reindexer/src/org/aspen_discovery/reindexer/RecordInfo.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/RecordInfo.java
@@ -27,7 +27,7 @@ public class RecordInfo {
 
 	private boolean hasParentRecord;
 	private boolean hasChildRecord;
-	private boolean onOrder;
+	private boolean notForLoan;
 
 	private final ArrayList<ItemInfo> relatedItems = new ArrayList<>();
 
@@ -426,21 +426,22 @@ public class RecordInfo {
 	}
 
 	/**
-	 * Checks if the record is currently on order.
+	 * Checks if the record has a not-for-loan status; that is, it is not on-shelf or checked-out, where
+	 * if it is checked-out, that means it is loanable.
 	 *
 	 * @return {@code true} if the item is on order, {@code false} otherwise.
 	 */
-	public boolean isOnOrder() {
-		return onOrder;
+	public boolean hasNotForLoanStatus() {
+		return notForLoan;
 	}
 
 	/**
 	 * Sets the on-order status of the record.
 	 *
-	 * @param onOrder {@code true} to indicate the item is on order, {@code false} otherwise.
+	 * @param notForLoan {@code true} to indicate the item is on order, {@code false} otherwise.
 	 */
-	public void setOnOrder(boolean onOrder) {
-		this.onOrder = onOrder;
+	public void setNotForLoan(boolean notForLoan) {
+		this.notForLoan = notForLoan;
 	}
 
 

--- a/code/reindexer/src/org/aspen_discovery/reindexer/RecordInfo.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/RecordInfo.java
@@ -27,6 +27,7 @@ public class RecordInfo {
 
 	private boolean hasParentRecord;
 	private boolean hasChildRecord;
+	private boolean onOrder;
 
 	private final ArrayList<ItemInfo> relatedItems = new ArrayList<>();
 
@@ -423,5 +424,24 @@ public class RecordInfo {
 	public void setHasChildRecord(boolean hasChildRecord) {
 		this.hasChildRecord = hasChildRecord;
 	}
+
+	/**
+	 * Checks if the record is currently on order.
+	 *
+	 * @return {@code true} if the item is on order, {@code false} otherwise.
+	 */
+	public boolean isOnOrder() {
+		return onOrder;
+	}
+
+	/**
+	 * Sets the on-order status of the record.
+	 *
+	 * @param onOrder {@code true} to indicate the item is on order, {@code false} otherwise.
+	 */
+	public void setOnOrder(boolean onOrder) {
+		this.onOrder = onOrder;
+	}
+
 
 }

--- a/code/web/interface/themes/responsive/DataObjectUtil/property.tpl
+++ b/code/web/interface/themes/responsive/DataObjectUtil/property.tpl
@@ -539,6 +539,9 @@
 				{include file="DataObjectUtil/fieldLockingInfo.tpl"}
 				{if !empty($property.description)}<a style="margin-right: .5em; margin-left: .25em" id="{$propName}Tooltip" class="text-info" role="tooltip" tabindex="0" data-toggle="tooltip" data-placement="right" data-title="{translate text=$property.description isAdminFacing=true inAttribute=true}"><i class="fas fa-question-circle"></i></a>{/if}
 			</div>
+			{if !empty($property.forcesReindex)}<span id="{$propName}HelpBlock" class="help-block" style="margin-top:0"><small class="text-warning"><i class="fas fa-exclamation-triangle"></i> {translate text="Updating this setting causes a nightly reindex" isAdminFacing=true}</small></span>{/if}
+			{if !empty($property.affectsLiDA)}<span id="{$propName}HelpBlock" class="help-block" style="margin-top:0"><small class="text-info"><i class="fas fa-info-circle"></i> {translate text="Aspen LiDA also uses this setting" isAdminFacing=true}</small></span>{/if}
+			{if !empty($property.note)}<span id="{$propName}HelpBlock" class="help-block" style="margin-top:0"><small><i class="fas fa-info-circle"></i> {$property.note}</small></span>{/if}
 		{elseif $property.type == 'checkboxFromNestedSection'}
 			{* {$propValue.$propName|@var_dump} *}
 			<div class="checkbox" {if !empty($property.forcesReindex) || !empty($property.affectsLiDA) || !empty($property.note)}style="margin-bottom: 0"{/if}>
@@ -549,9 +552,9 @@
 				{include file="DataObjectUtil/fieldLockingInfo.tpl"}
 				{if !empty($property.description)}<a style="margin-right: .5em; margin-left: .25em" id="{$propName}Tooltip" class="text-info" role="tooltip" tabindex="0" data-toggle="tooltip" data-placement="right" data-title="{translate text=$property.description isAdminFacing=true inAttribute=true}"><i class="fas fa-question-circle"></i></a>{/if}
 			</div>
-		{if !empty($property.forcesReindex)}<span id="{$propName}HelpBlock" class="help-block" style="margin-top:0"><small class="text-warning"><i class="fas fa-exclamation-triangle"></i> {translate text="Updating this setting causes a nightly reindex" isAdminFacing=true}</small></span>{/if}
-		{if !empty($property.affectsLiDA)}<span id="{$propName}HelpBlock" class="help-block" style="margin-top:0"><small class="text-info"><i class="fas fa-info-circle"></i> {translate text="Aspen LiDA also uses this setting" isAdminFacing=true}</small></span>{/if}
-		{if !empty($property.note)}<span id="{$propName}HelpBlock" class="help-block" style="margin-top:0"><small><i class="fas fa-info-circle"></i> {$property.note}</small></span>{/if}
+			{if !empty($property.forcesReindex)}<span id="{$propName}HelpBlock" class="help-block" style="margin-top:0"><small class="text-warning"><i class="fas fa-exclamation-triangle"></i> {translate text="Updating this setting causes a nightly reindex" isAdminFacing=true}</small></span>{/if}
+			{if !empty($property.affectsLiDA)}<span id="{$propName}HelpBlock" class="help-block" style="margin-top:0"><small class="text-info"><i class="fas fa-info-circle"></i> {translate text="Aspen LiDA also uses this setting" isAdminFacing=true}</small></span>{/if}
+			{if !empty($property.note)}<span id="{$propName}HelpBlock" class="help-block" style="margin-top:0"><small><i class="fas fa-info-circle"></i> {$property.note}</small></span>{/if}
 		{elseif $property.type == 'webBuilderColor'}
 			<section style="display: flex; flex-flow: row wrap; margin-top: 2rem;">
 				{foreach from=$property.colorOptions item=colorOption}

--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -127,6 +127,14 @@
 ### Koha Updates
 - Resolved an issue that could prevent users with expired passwords from successfully resetting their password when prompted on the login screen. (DIS-744) (*LS*)
 - Patrons’ reading histories now update correctly each night, ensuring their recent check-outs and returns are always recorded, even if they haven’t signed in daily. (DIS-768) (*LS*)
+- Added the Prioritize Available Records for Title Selection option to the Indexing Profile. (DIS-493) (*LS*)
+  - If the above option is enabled, titles from available records will be prioritized as the display title for their grouped work. (DIS-493) (*LS*)
+
+<div markdown="1" class="settings">
+
+#### New Settings
+- ILS Integration > Indexing Profiles > Format Information > Prioritize Available Records for Title Selection
+</div>
 
 ### Searching Updates
 - Added an 'X' button inside the search box to easily clear entered text; the button appears automatically when text is present. (DIS-778, DIS-852) (*LS*)

--- a/code/web/sys/DBMaintenance/version_updates/25.06.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.06.00.php
@@ -118,6 +118,13 @@ function getUpdates25_06_00(): array {
 				"ALTER TABLE web_builder_portal_cell ADD COLUMN IF NOT EXISTS staticLocationId int(11) NOT NULL DEFAULT -1",
 			]
 		], //add_static_location_id_to_portal_cell
+		'add_ignore_on_order_records_for_title_selection' => [
+			'title' => 'Add ignoreOnOrderRecordsForTitleSelection to indexing profiles',
+			'description' => 'Adds a setting to skip on-order records when selecting titles for display in grouped works (Koha-specific)',
+			'sql' => [
+				"ALTER TABLE indexing_profiles ADD COLUMN IF NOT EXISTS ignoreOnOrderRecordsForTitleSelection TINYINT(1) DEFAULT 0"
+			],
+		], // add_ignore_on_order_records_for_title_selection
 
 		// Laura Escamilla - ByWater Solutions
 

--- a/code/web/sys/Indexing/IndexingProfile.php
+++ b/code/web/sys/Indexing/IndexingProfile.php
@@ -221,6 +221,8 @@ class IndexingProfile extends DataObject {
 		$numMillisecondsToPauseAfterBibLookups;
 	public /** @noinspection PhpUnused */
 		$numExtractionThreads;
+	public /** @noinspection PhpUnused */
+		$ignoreOnOrderRecordsForTitleSelection;
 
 	private $_translationMaps;
 	private $_timeToReshelve;
@@ -249,7 +251,8 @@ class IndexingProfile extends DataObject {
 			'orderRecordsToSuppressByDate',
 			'numRetriesForBibLookups',
 			'numMillisecondsToPauseAfterBibLookups',
-			'numExtractionThreads'
+			'numExtractionThreads',
+			'ignoreOnOrderRecordsForTitleSelection',
 		];
 	}
 
@@ -640,6 +643,15 @@ class IndexingProfile extends DataObject {
 						'default' => true,
 						'description' => 'Check metadata within the record to see if a book is large print',
 						'note'        => 'Only applies when all items have formats of either Book or Large Print',
+						'forcesReindex' => true,
+					],
+					'ignoreOnOrderRecordsForTitleSelection' => [
+						'property' => 'ignoreOnOrderRecordsForTitleSelection',
+						'type' => 'checkbox',
+						'label' => 'Ignore On-Order Records for Title Selection',
+						'description' => 'When checked, titles from on-order records will not be selected as the primary display title in grouped works.',
+						'hideInLists' => true,
+						'default' => 0,
 						'forcesReindex' => true,
 					],
 					'formatMap' => [
@@ -1588,7 +1600,13 @@ class IndexingProfile extends DataObject {
 					unset($formatMapStructure['appliesToItemSublocation']);
 					unset($formatMapStructure['appliesToItemCollection']);
 					unset($formatMapStructure['appliesToItemType']);
+
+					// Hide the ignoreOnOrderRecordsForTitleSelection setting for non-Koha ILS.
+					if (isset($structure['formatSection']['properties']['ignoreOnOrderRecordsForTitleSelection'])) {
+						unset($structure['formatSection']['properties']['ignoreOnOrderRecordsForTitleSelection']);
+					}
 				}
+
 				if ($activeIls != 'sierra') {
 					unset($formatMapStructure['appliesToMatType']);
 					unset($formatMapStructure['displaySierraCheckoutGrid']);

--- a/code/web/sys/Indexing/IndexingProfile.php
+++ b/code/web/sys/Indexing/IndexingProfile.php
@@ -648,8 +648,8 @@ class IndexingProfile extends DataObject {
 					'ignoreOnOrderRecordsForTitleSelection' => [
 						'property' => 'ignoreOnOrderRecordsForTitleSelection',
 						'type' => 'checkbox',
-						'label' => 'Ignore On-Order Records for Title Selection',
-						'description' => 'When checked, titles from on-order records will not be selected as the primary display title in grouped works.',
+						'label' => 'Prioritize Available Records for Title Selection',
+						'description' => 'When checked, if there are available records in a grouped work, titles from those available records will be prioritized as the display title for the grouped work.',
 						'hideInLists' => true,
 						'default' => 0,
 						'forcesReindex' => true,

--- a/code/web/sys/Indexing/IndexingProfile.php
+++ b/code/web/sys/Indexing/IndexingProfile.php
@@ -650,7 +650,6 @@ class IndexingProfile extends DataObject {
 						'type' => 'checkbox',
 						'label' => 'Prioritize Available Records for Title Selection',
 						'description' => 'When checked, if there are available records in a grouped work, titles from those available records will be prioritized as the display title for the grouped work.',
-						'hideInLists' => true,
 						'default' => 0,
 						'forcesReindex' => true,
 					],

--- a/code/web/sys/Indexing/IndexingProfile.php
+++ b/code/web/sys/Indexing/IndexingProfile.php
@@ -222,7 +222,7 @@ class IndexingProfile extends DataObject {
 	public /** @noinspection PhpUnused */
 		$numExtractionThreads;
 	public /** @noinspection PhpUnused */
-		$ignoreOnOrderRecordsForTitleSelection;
+		$prioritizeAvailableRecordsForTitleSelection;
 
 	private $_translationMaps;
 	private $_timeToReshelve;
@@ -252,7 +252,7 @@ class IndexingProfile extends DataObject {
 			'numRetriesForBibLookups',
 			'numMillisecondsToPauseAfterBibLookups',
 			'numExtractionThreads',
-			'ignoreOnOrderRecordsForTitleSelection',
+			'prioritizeAvailableRecordsForTitleSelection',
 		];
 	}
 
@@ -645,8 +645,8 @@ class IndexingProfile extends DataObject {
 						'note'        => 'Only applies when all items have formats of either Book or Large Print',
 						'forcesReindex' => true,
 					],
-					'ignoreOnOrderRecordsForTitleSelection' => [
-						'property' => 'ignoreOnOrderRecordsForTitleSelection',
+					'prioritizeAvailableRecordsForTitleSelection' => [
+						'property' => 'prioritizeAvailableRecordsForTitleSelection',
 						'type' => 'checkbox',
 						'label' => 'Prioritize Available Records for Title Selection',
 						'description' => 'When checked, if there are available records in a grouped work, titles from those available records will be prioritized as the display title for the grouped work.',
@@ -1601,9 +1601,9 @@ class IndexingProfile extends DataObject {
 					unset($formatMapStructure['appliesToItemCollection']);
 					unset($formatMapStructure['appliesToItemType']);
 
-					// Hide the ignoreOnOrderRecordsForTitleSelection setting for non-Koha ILS.
-					if (isset($structure['formatSection']['properties']['ignoreOnOrderRecordsForTitleSelection'])) {
-						unset($structure['formatSection']['properties']['ignoreOnOrderRecordsForTitleSelection']);
+					// Hide the prioritizeAvailableRecordsForTitleSelection setting for non-Koha ILS.
+					if (isset($structure['formatSection']['properties']['prioritizeAvailableRecordsForTitleSelection'])) {
+						unset($structure['formatSection']['properties']['prioritizeAvailableRecordsForTitleSelection']);
 					}
 				}
 


### PR DESCRIPTION
- Added the Prioritize Available Records for Title Selection option to the Indexing Profile.
   - If the above option is enabled, titles from available records will be prioritized as the display title for their grouped work.

Test Plan:
1. This is only applicable to Aspen instances with a Koha ILS. Find a grouped work in the catalog that has at least one on-order record, and it will likely have a title in all capital letters. This is how Koha typically titles on-order records.
2. Apply the patch and force reindex the grouped work. After a couple of minutes, and if it has other records, one of their titles will have been chosen, according to the hierarchy listed above, for the grouped work to use as its display title.