### PR TITLE
DIS-802: Materials Request: Assign and change status at the same time for materials request

### DIFF
--- a/code/web/interface/themes/responsive/MaterialsRequest/manageRequests.tpl
+++ b/code/web/interface/themes/responsive/MaterialsRequest/manageRequests.tpl
@@ -228,13 +228,13 @@
 											{/foreach}
 
 										</select>
-										<span class="btn btn-sm btn-primary input-group-addon" onclick="return AspenDiscovery.MaterialsRequest.assignSelectedRequests();">{translate text="Assign Selected Requests" isAdminFacing=true}</span>
 									{else}
 										<span class="text-warning">{translate text="No Valid Assignees Found" isAdminFacing=true}</span>
 									{/if}
 								</div>
 							</div>
 						</div>
+
 						<div class="row form-group">
 							<div class="col-sm-4">
 								<label for="newStatus" class="control-label">{translate text="Change status of selected to" isAdminFacing=true}</label>
@@ -247,10 +247,10 @@
 											<option value="{$status}">{translate text="$statusLabel"  isAdminFacing=true inAttribute=true}</option>
 										{/foreach}
 									</select>
-									<span class="btn btn-sm btn-primary input-group-addon" onclick="return AspenDiscovery.MaterialsRequest.updateSelectedRequests();">{translate text="Update Selected Requests" isAdminFacing=true}</span>
 								</div>
 							</div>
 						</div>
+
 						<div class="row">
 							<div class="col-xs-12">
 								{if !empty($page)}
@@ -258,6 +258,7 @@
 								{/if}
 								<input class="btn btn-default" type="submit" name="exportSelected" value="{translate text="Export Selected To CSV" inAttribute=true isAdminFacing=true}" onclick="return AspenDiscovery.MaterialsRequest.exportSelectedRequests();">
 								<input class="btn btn-default" type="submit" name="exportAll" value="{translate text="Export All To CSV" inAttribute=true isAdminFacing=true}">
+								<span class="btn btn-default" onclick="return AspenDiscovery.MaterialsRequest.updateSelectedRequests();">{translate text="Update Selected Requests" isAdminFacing=true}</span>
 							</div>
 						</div>
 					</div>

--- a/code/web/interface/themes/responsive/MaterialsRequest/request-form-fields.tpl
+++ b/code/web/interface/themes/responsive/MaterialsRequest/request-form-fields.tpl
@@ -184,6 +184,25 @@
 						</div>
 					</div>
 
+				{elseif $formField->fieldType == 'assignedTo'}
+					{assign var="materialRequestTableColumnName" value=$formField->fieldType}
+					<div class="request_detail_field row">
+						<label for="{$materialRequestTableColumnName}" class="control-label col-sm-3">{translate text=$formField->fieldLabel isPublicFacing=true isAdminEnteredData=true} </label>
+						<div class=" request_detail_field_value col-sm-9">
+							{if !empty($assignees)}
+								<select name="{$materialRequestTableColumnName}" id="{$materialRequestTableColumnName}" class="form-control">
+									<option value="unselected">{translate text="Select One" inAttribute=true isAdminFacing=true}</option>
+									<option value="unassign">{translate text="Un-assign (remove assignee)" inAttribute=true isAdminFacing=true}</option>
+										{foreach from=$assignees item=displayName key=assigneeId}
+											<option value="{$assigneeId}"{if $assigneeId == $materialsRequest->assignedTo} selected="selected"{/if}>{$displayName|escape}</option>
+										{/foreach}
+								</select>
+							{else}
+								<span class="text-warning">{translate text="No Valid Assignees Found" isAdminFacing=true}</span>
+							{/if}
+						</div>
+					</div>
+
 				{elseif $formField->fieldType == 'status'}
 					{assign var="materialRequestTableColumnName" value=$formField->fieldType}
 					<div class="request_detail_field row">

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -14414,21 +14414,9 @@ AspenDiscovery.MaterialsRequest = (function(){
 
 		updateSelectedRequests: function(){
 			var newStatus = $("#newStatus").val();
-			if (newStatus === "unselected"){
-				alert("Please select a status to update the requests to.");
-				return false;
-			}
-			var selectedRequests = this.getSelectedRequests(false);
-			if (selectedRequests.length !== 0){
-				$("#updateRequests").submit();
-			}
-			return false;
-		},
-
-		assignSelectedRequests: function(){
 			var newAssignee = $("#newAssignee").val();
-			if (newAssignee === "unselected"){
-				alert("Please select a user to assign the requests to.");
+			if (newAssignee === "unselected" && newStatus === "unselected"){
+				alert("Please select a new assignee and/or status to update.");
 				return false;
 			}
 			var selectedRequests = this.getSelectedRequests(false);

--- a/code/web/interface/themes/responsive/js/aspen/materials-request.js
+++ b/code/web/interface/themes/responsive/js/aspen/materials-request.js
@@ -42,21 +42,9 @@ AspenDiscovery.MaterialsRequest = (function(){
 
 		updateSelectedRequests: function(){
 			var newStatus = $("#newStatus").val();
-			if (newStatus === "unselected"){
-				alert("Please select a status to update the requests to.");
-				return false;
-			}
-			var selectedRequests = this.getSelectedRequests(false);
-			if (selectedRequests.length !== 0){
-				$("#updateRequests").submit();
-			}
-			return false;
-		},
-
-		assignSelectedRequests: function(){
 			var newAssignee = $("#newAssignee").val();
-			if (newAssignee === "unselected"){
-				alert("Please select a user to assign the requests to.");
+			if (newAssignee === "unselected" && newStatus === "unselected"){
+				alert("Please select a new assignee and/or status to update.");
 				return false;
 			}
 			var selectedRequests = this.getSelectedRequests(false);

--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -100,6 +100,11 @@
 ### Masquerade Mode Updates
 - Fix issue where if a user has "Masquerade as unrestricted patron types" and a permission that allows them to masquerade as restricted patron types in their home library or location, they were not able to masquerade as these restricted patrons. (DIS-820) (*KL*)
 
+### Materials Requests Updates
+- Update managing/editing requests as an admin so both status and assignee can be updated at the same time (DIS-802) (*KL*)
+  - Add "Assigned To" as an editable field when updating a single materials request as an admin
+  - On Manage Materials Requests page, remove separate buttons for changing status/assignee and replace with a single button labeled "Update Selected Requests"
+
 // kyle
 ### Installer Updates
 - Fix script to update session.gc_probability. Update the script to dynamically determine the current PHP version, ensuring compatibility with the PHP version installed on the system. (*KMH*)

--- a/code/web/services/MaterialsRequest/AJAX.php
+++ b/code/web/services/MaterialsRequest/AJAX.php
@@ -229,6 +229,47 @@ class MaterialsRequest_AJAX extends Action {
 									}
 									$interface->assign('availableStatuses', $availableStatuses);
 
+									// Get Assignees
+									$homeLibrary = Library::getPatronHomeLibrary();
+									if (is_null($homeLibrary)) {
+										//User does not have a home library, this is likely an admin account.  Use the active library
+										global $library;
+										$homeLibrary = $library;
+									}
+									$locations = new Location();
+									$locations->libraryId = $homeLibrary->libraryId;
+									$locations->find();
+									$locationsForLibrary = [];
+									while ($locations->fetch()) {
+										$locationsForLibrary[] = $locations->locationId;
+									}
+									//Get a list of other users that are materials request users for this library
+									$permission = new Permission();
+									$permission->name = 'Manage Library Materials Requests';
+									if ($permission->find(true)) {
+										//Get roles for the user
+										$rolePermissions = new RolePermissions();
+										$rolePermissions->permissionId = $permission->id;
+										$rolePermissions->find();
+										$assignees = [];
+										while ($rolePermissions->fetch()) {
+											// Get Available Assignees
+											$materialsRequestManagers = new User();
+											if (count($locationsForLibrary) > 0) {
+												if ($materialsRequestManagers->query("SELECT * from user WHERE id IN (SELECT userId FROM user_roles WHERE roleId = $rolePermissions->roleId) AND homeLocationId IN (" . implode(', ', $locationsForLibrary) . ")")) {
+													while ($materialsRequestManagers->fetch()) {
+														if (empty($materialsRequestManagers->displayName)) {
+															$assignees[$materialsRequestManagers->id] = $materialsRequestManagers->firstname . ' ' . $materialsRequestManagers->lastname;
+														} else {
+															$assignees[$materialsRequestManagers->id] = $materialsRequestManagers->getDisplayName();
+														}
+													}
+												}
+											}
+										}
+										$interface->assign('assignees', $assignees);
+									}
+
 									// Get Barcode Column
 									$interface->assign('barCodeColumn', 'ils_barcode');
 

--- a/code/web/services/MaterialsRequest/Update.php
+++ b/code/web/services/MaterialsRequest/Update.php
@@ -82,6 +82,13 @@ class MaterialsRequest_Update extends Admin_Admin {
 						$statusChanged = true;
 					}
 				}
+				$assigneeChanged = false;
+				if (!empty($_REQUEST['assignedTo'])) {
+					if ($materialsRequest->assignedTo != $_REQUEST['assignedTo']) {
+						$materialsRequest->assignedTo = $_REQUEST['assignedTo'];
+						$assigneeChanged = true;
+					}
+				}
 
 				$materialsRequest->libraryId = $requestUser->getHomeLibrary()->libraryId;
 
@@ -114,6 +121,10 @@ class MaterialsRequest_Update extends Admin_Admin {
 					if ($statusChanged) {
 						//Send an email as needed
 						$materialsRequest->sendStatusChangeEmail();
+					}
+					if ($assigneeChanged) {
+						//Send an email as needed
+						$materialsRequest->sendStaffNewMaterialsRequestAssignedEmail();
 					}
 				} else {
 					$interface->assign('success', false);


### PR DESCRIPTION
- Add "Assigned To" as an editable field when updating a single materials request as an admin 

- On Manage Materials Requests page, remove separate buttons for changing status/assignee and replace with a single button labeled "Update Selected Requests" If one is left as the default "Select One" value, it will not be updated for the selected materials requests

- Updated release notes

Tested on my local instance of Aspen