### PR TITLE
DIS-871 Add Null Checks for Hoopla scope

### DIFF
--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -160,6 +160,9 @@
 ### Boundless Updates
 - Delete inactive Axis360 titles from database correctly. (DIS-785) (*YL*)
 
+### Hoopla Updates
+- Fix issue where libraries with Hoopla Flex turned off will see warnings in My Account if debugging on, by adding null checks to the Hoopla scope. (DIS-871) (*YL*)
+
 // laura
 
 // james

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -868,7 +868,7 @@ class User extends DataObject {
 					return array_key_exists('Hoopla', $enabledModules) && $userHomeLibrary->hooplaLibraryID > 0;
 				} elseif ($source == 'hoopla_flex') {
 					$libraryHooplaScope = $userHomeLibrary->getHooplaScope();
-					$isFlexAvilable = $libraryHooplaScope->includeFlex;
+					$isFlexAvilable = $libraryHooplaScope ? $libraryHooplaScope->includeFlex : false;
 					return array_key_exists('Hoopla', $enabledModules) && $userHomeLibrary->hooplaLibraryID > 0 && $isFlexAvilable;
 				} elseif ($source == 'cloud_library') {
 					return array_key_exists('Cloud Library', $enabledModules) && ($userHomeLibrary->cloudLibraryScope > 0);


### PR DESCRIPTION
Below error happened when patrons' home library has Hoopla Flex turned off, in My Account page and sometimes above Place Hold buttons with debugging on:

`Warning: Attempt to read property "includeFlex" on null in /usr/local/aspen-discovery/code/web/sys/Account/User.php on line 866`

Adding a null check for Hoopla Scope can fix this issue