### PR TITLE
DIS-872 Ensure consistent expiration date display for reserved holds

### DIFF
--- a/code/web/interface/themes/responsive/MyAccount/hooplaHold.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/hooplaHold.tpl
@@ -79,7 +79,7 @@
                     </div>
                     {if $section == 'available'}
                         <div class="row">
-                            <div class="result-label col-tn-4">{translate text='Expiration Date' isPublicFacing=true}</div>
+                            <div class="result-label col-tn-4">{translate text='Expires' isPublicFacing=true}</div>
                             <div class="col-tn-8 result-value">
                                 {$record->expirationDate|date_format:"%b %d, %Y at %l:%M %p"}
                             </div>

--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -157,6 +157,9 @@
 - Fixed a Java compilation issue caused by ambiguity between `org.marc4j.marc.Record` and the new `java.lang.Record` class in Java 14+. (DIS-808) (*LS*)
 
 // yanjun
+### Hoopla Updates
+- Ensure consistent expiration display of reserved Holds Ready for Pickup for Hoopla Flex.  (DIS-872) (*YL*)
+
 ### Boundless Updates
 - Delete inactive Axis360 titles from database correctly. (DIS-785) (*YL*)
 


### PR DESCRIPTION
For holds that are ready for pickup, Aspen will display their expiration date for the holds reservation. ILS and other eContent expiration dates are displaying as ‘Expires’ while Hoopla Flex’s holds are displaying as ‘Expiration Date’. We should keep the consistency. 