### PR TITLE
DIS-791: Enhance `UpdateReadingHistory` Cron with Configurable Thread Pool & Improved Logging

### DIFF
--- a/code/cron/src/com/turning_leaf_technologies/cron/CronProcessLogEntry.java
+++ b/code/cron/src/com/turning_leaf_technologies/cron/CronProcessLogEntry.java
@@ -40,6 +40,7 @@ public class CronProcessLogEntry implements BaseLogEntry {
 			logger.error("Error creating prepared statements to update log", e);
 		}
 	}
+
 	private Date getLastUpdate() {
 		//The last time the log entry was updated, so we can tell if a process is stuck
 		return new Date();
@@ -52,6 +53,7 @@ public class CronProcessLogEntry implements BaseLogEntry {
 		this.saveResults();
 		logger.error(note);
 	}
+
 	public synchronized void incErrors(String note, Exception e){
 		this.addNote("ERROR: " + note + " " + e.toString());
 		this.numErrors++;
@@ -59,13 +61,22 @@ public class CronProcessLogEntry implements BaseLogEntry {
 		this.saveResults();
 		logger.error(note, e);
 	}
-	public void incUpdated() {
+
+	public synchronized void incUpdated() {
 		numUpdates++;
 		if (numUpdates + numSkipped % 100 == 0) {
 			this.saveResults();
 		}
 	}
-	void addUpdates(int updates) {
+
+	public synchronized void incSkipped() {
+		this.numSkipped++;
+		if (numUpdates + numSkipped % 100 == 0) {
+			this.saveResults();
+		}
+	}
+
+	public synchronized void addUpdates(int updates) {
 		numUpdates += updates;
 	}
 
@@ -98,7 +109,7 @@ public class CronProcessLogEntry implements BaseLogEntry {
 	private String getNotesHtml() {
 		return notesText + "</ol>";
 	}
-	
+
 	public synchronized boolean saveResults() {
 		try{
 			if (logProcessId == null){
@@ -132,12 +143,5 @@ public class CronProcessLogEntry implements BaseLogEntry {
 	}
 	public void setFinished() {
 		this.endTime = new Date();
-	}
-
-	public void incSkipped() {
-		this.numSkipped++;
-		if (numUpdates + numSkipped % 100 == 0) {
-			this.saveResults();
-		}
 	}
 }

--- a/code/cron/src/com/turning_leaf_technologies/cron/reading_history/UpdateReadingHistory.java
+++ b/code/cron/src/com/turning_leaf_technologies/cron/reading_history/UpdateReadingHistory.java
@@ -12,16 +12,13 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Date;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 @SuppressWarnings("unused")
 public class UpdateReadingHistory implements IProcessHandler {
 
 	public void doCronProcess(String servername, Ini configIni, Section processSettings, Connection dbConn, CronLogEntry cronEntry, Logger logger) {
-		CronProcessLogEntry processLog = new CronProcessLogEntry(cronEntry, "Update Reading History", dbConn, logger);
+		CronProcessLogEntry processLog = new CronProcessLogEntry(cronEntry, "Starting nightly reading history updates....", dbConn, logger);
 		processLog.saveResults();
 
 		logger.info("Updating Reading History");
@@ -29,100 +26,181 @@ public class UpdateReadingHistory implements IProcessHandler {
 
 		String aspenUrl = configIni.get("Site", "url");
 		if (aspenUrl == null || aspenUrl.isEmpty()) {
-			processLog.incErrors("Unable to get URL for Aspen in General settings.  Please add a url key to Site section.");
+			org.ini4j.Profile.Section siteSection = configIni.get("Site");
+			String siteConfig = (siteSection != null) ? siteSection.toString() : "<Site section missing>";
+			processLog.incErrors("Unable to get URL for Aspen in the site's config file. Please add a URL key to the Site section. Site config: " + siteConfig + ".");
 			return;
 		}
 
-		// Connect to the MySQL database
+		// Get the thread settings from the configuration, if any.
+		int minThreads = 8;
+		int maxThreads = 16;
+		try {
+			String minThreadsStr = processSettings.get("minThreads");
+			if (minThreadsStr != null && !minThreadsStr.isEmpty()) {
+				minThreads = Integer.parseInt(minThreadsStr);
+			}
+
+			String maxThreadsStr = processSettings.get("maxThreads");
+			if (maxThreadsStr != null && !maxThreadsStr.isEmpty()) {
+				maxThreads = Integer.parseInt(maxThreadsStr);
+			}
+		} catch (Exception e) {
+			logger.error("Error parsing thread configuration, using defaults: ", e);
+		}
+
+		// Get the batch size from configuration.
+		int batchSize = 1000;
+		try {
+			String batchSizeStr = processSettings.get("batchSize");
+			if (batchSizeStr != null && !batchSizeStr.isEmpty()) {
+				batchSize = Integer.parseInt(batchSizeStr);
+			}
+		} catch (Exception e) {
+			logger.error("Error parsing batch size configuration, using default: ", e);
+		}
+
 		int numSkipped = 0;
 		int numAlreadyUpToDate = 0;
 		long startTime = new Date().getTime() / 1000;
 		try {
-			//Get the number of patrons to update
-			PreparedStatement getNumUsersStmt = dbConn.prepareStatement("SELECT count(*) as numUsers FROM user where trackReadingHistory=1", ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+			// Get the number of patrons to update.
+			PreparedStatement getNumUsersStmt = dbConn.prepareStatement("SELECT COUNT(*) AS numUsers FROM user WHERE trackReadingHistory=1", ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
 			ResultSet numUsersResults = getNumUsersStmt.executeQuery();
 			int numUsersToUpdate = 0;
 			if (numUsersResults.next()) {
 				numUsersToUpdate = numUsersResults.getInt("numUsers");
-				processLog.addNote("Preparing to process " + numUsersToUpdate + " users");
+				processLog.addNote("Preparing to process " + numUsersToUpdate + " users.");
 			}
 
-			// Get a list of all patrons that have reading history turned on.
-			PreparedStatement getUsersStmt = dbConn.prepareStatement("SELECT id, ils_barcode, ils_password, lastReadingHistoryUpdate FROM user where trackReadingHistory=1", ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+			numUsersResults.close();
+			getNumUsersStmt.close();
 
 			if (numUsersToUpdate > 0) {
-				BlockingQueue<Runnable> blockingQueue = new ArrayBlockingQueue<>(numUsersToUpdate);
+				BlockingQueue<Runnable> blockingQueue = new ArrayBlockingQueue<>(Math.min(batchSize * 2, numUsersToUpdate));
+				ThreadPoolExecutor executor = new ThreadPoolExecutor(minThreads, maxThreads, 5000, TimeUnit.MILLISECONDS, blockingQueue, new BlockWhenFullPolicy());
 
-				//Process all the threads, we will allow up to 8 concurrent threads to start
-				ThreadPoolExecutor executor = new ThreadPoolExecutor(1, 1, 5000, TimeUnit.MILLISECONDS, blockingQueue);
+				logger.info("Created thread pool: corePoolSize={}, maximumPoolSize={}.", minThreads, maxThreads);
+				processLog.addNote("Created thread pool: corePoolSize=" + minThreads + ", maximumPoolSize=" + maxThreads + ".");
+				processLog.saveResults();
 
-				//Set up the ThreadGroup
-				ResultSet userResults = getUsersStmt.executeQuery();
-				while (userResults.next()) {
+				// Process the users in batches to avoid memory issues.
+				int offset = 0;
+				boolean moreUsersToProcess = true;
 
-					// For each patron
-					String cat_username = userResults.getString("ils_barcode");
-					String cat_password = null;
-					try{
-						cat_password = EncryptionUtils.decryptString(userResults.getString("ils_password"), servername, processLog);
-					}catch (Exception e){
-						processLog.addNote("Could not decrypt password for " + cat_username + " " + e);
+				while (moreUsersToProcess) {
+					PreparedStatement getUsersStmt = dbConn.prepareStatement(
+							"SELECT id, ils_barcode, ils_password, lastReadingHistoryUpdate FROM user WHERE trackReadingHistory=1 ORDER BY id LIMIT ?, ?",
+							ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY
+					);
+					getUsersStmt.setInt(1, offset);
+					getUsersStmt.setInt(2, batchSize);
+					ResultSet userResults = getUsersStmt.executeQuery();
+
+					int usersInBatch = 0;
+					while (userResults.next()) {
+						usersInBatch++;
+						String ilsBarcode = userResults.getString("ils_barcode");
+						String ilsPassword = null;
+						try {
+							ilsPassword = EncryptionUtils.decryptString(userResults.getString("ils_password"), servername, processLog);
+						} catch (Exception e) {
+							processLog.addNote("Could not decrypt password for " + ilsBarcode + ": " + e);
+						}
+
+						if (ilsPassword == null || ilsPassword.isEmpty()) {
+							numSkipped++;
+							processLog.incSkipped();
+							continue;
+						}
+
+						if (startTime - userResults.getLong("lastReadingHistoryUpdate") < (23 * 60 * 60)){
+							// Update a user's reading history every 23 hours as a buffer and to make sure the user's reading history stays updated.
+							// If the user has viewed his or her reading history within 23 hours, then no update is needed.
+							numAlreadyUpToDate++;
+							processLog.incSkipped();
+							continue;
+						}
+
+						UpdateReadingHistoryTask newTask = new UpdateReadingHistoryTask(aspenUrl, ilsBarcode, ilsPassword, processLog, logger);
+						executor.execute(newTask);
 					}
 
-					if (cat_password == null || cat_password.isEmpty()) {
-						numSkipped++;
-						processLog.incSkipped();
-						continue;
-					}
+					userResults.close();
+					getUsersStmt.close();
 
-					if (startTime - userResults.getLong("lastReadingHistoryUpdate") < (23 * 60 * 60)){
-						//Only update records every 23 hours (since the update runs every day, we give it a bit of buffer to make sure that we do update daily unless
-						//the user has updated themselves.
-						numAlreadyUpToDate++;
-						processLog.incSkipped();
-						continue;
-					}
-
-					UpdateReadingHistoryTask newTask = new UpdateReadingHistoryTask(aspenUrl, cat_username, cat_password, processLog, logger);
-					executor.execute(newTask);
-
+					processLog.addNote("Submitted batch #" + (offset/batchSize) + " (offset=" + offset + "), queued " + usersInBatch + " tasks" + ".");
 					processLog.saveResults();
+
+					// If fewer users than the batch size, the process has completed.
+					moreUsersToProcess = (usersInBatch == batchSize);
+					offset += batchSize;
 				}
-				userResults.close();
 
 				long lastThreadsCompleted = 0;
 				int numTimesCompletedThreadsHasNotChanged = 0;
 				while ((executor.getCompletedTaskCount() + numSkipped + numAlreadyUpToDate) < numUsersToUpdate) {
-					if (lastThreadsCompleted != (executor.getCompletedTaskCount() + numSkipped)){
+					long completed = executor.getCompletedTaskCount();
+					if (lastThreadsCompleted != (completed + numSkipped)) {
 						numTimesCompletedThreadsHasNotChanged = 0;
-						lastThreadsCompleted = (executor.getCompletedTaskCount() + numSkipped);
-					}else{
+						lastThreadsCompleted = (completed + numSkipped);
+					} else {
 						numTimesCompletedThreadsHasNotChanged++;
 					}
-					//If we haven't changed the number of threads completed for 10 minutes, something is stuck.
-					if (numTimesCompletedThreadsHasNotChanged == 10){
-						processLog.incErrors("Number of threads completed has not changed for 10 minutes and looks stuck");
+					if (numTimesCompletedThreadsHasNotChanged == 10) {
+						processLog.incErrors("Number of threads completed has not changed for 10 minutes and looks stuck.");
 						break;
 					}
+					processLog.addNote("Waiting on task completion: completed=" + completed + "/" + numUsersToUpdate + ", skipped=" + numSkipped + ".");
 					processLog.saveResults();
-					logger.debug("Num Users To Update = " + numUsersToUpdate + " Completed Task Count = " + executor.getCompletedTaskCount() + " Num Skipped = " + numSkipped + " Num already up to date = " + numAlreadyUpToDate);
+					logger.debug("Num Users To Update = {}; Completed Task Count = {}; Num Skipped = {}; Num already up to date = {}.", numUsersToUpdate, completed, numSkipped, numAlreadyUpToDate);
 					try {
 						Thread.sleep(60000);
 					} catch (InterruptedException e) {
-						logger.error("Sleep was interrupted", e);
+						logger.error("Sleep was interrupted:", e);
 					}
 				}
-				logger.debug("Finished processing all threads");
+				logger.debug("Finished processing all threads.");
 
 				executor.shutdownNow();
 
-				processLog.addNote("Skipped " + numSkipped + " records because the password was null");
+				int largestPool = executor.getLargestPoolSize();
+				logger.info("Largest thread pool size reached: {}.", largestPool);
+				processLog.addNote("Largest thread pool size reached: " + largestPool + ".");
+				processLog.addNote("Skipped due to NULL password: " + numSkipped + ".");
+				processLog.addNote("Skipped due to login unsuccessful: " + UpdateReadingHistoryTask.getLoginUnsuccessfulCount() + ".");
+				processLog.addNote("Skipped due to user not found: " + UpdateReadingHistoryTask.getUserNotFoundCount() + ".");
+				processLog.saveResults();
 			}
 		} catch (SQLException e) {
-			processLog.incErrors("Unable get a list of users that need to have their reading list updated ", e);
+			processLog.incErrors("Unable get a list of users that need to have their reading history updated: ", e);
 		}
-		
+
 		processLog.setFinished();
 		processLog.saveResults();
+	}
+
+	/**
+	 * A RejectedExecutionHandler that blocks the submitting thread when the pool and queue are full,
+	 * rather than rejecting the task or running it on the calling thread.
+	 */
+	private static class BlockWhenFullPolicy implements RejectedExecutionHandler {
+		/**
+		 * Called when the ThreadPoolExecutor cannot accept a task via execute().
+		 * This implementation blocks until the queue has space, then enqueues the task.
+		 *
+		 * @param r The runnable task requested to be executed.
+		 * @param executor The executor attempting to execute this task.
+		 * @throws RejectedExecutionException Thrown exception if interrupted while waiting to enqueue.
+		 */
+		@Override
+		public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
+			try {
+				executor.getQueue().put(r);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				throw new RejectedExecutionException("Interrupted while enqueuing task:", e);
+			}
+		}
 	}
 }

--- a/code/cron/src/com/turning_leaf_technologies/cron/reading_history/UpdateReadingHistory.java
+++ b/code/cron/src/com/turning_leaf_technologies/cron/reading_history/UpdateReadingHistory.java
@@ -18,11 +18,9 @@ import java.util.concurrent.*;
 public class UpdateReadingHistory implements IProcessHandler {
 
 	public void doCronProcess(String servername, Ini configIni, Section processSettings, Connection dbConn, CronLogEntry cronEntry, Logger logger) {
-		CronProcessLogEntry processLog = new CronProcessLogEntry(cronEntry, "Starting nightly reading history updates....", dbConn, logger);
+		CronProcessLogEntry processLog = new CronProcessLogEntry(cronEntry, "Updating Reading History", dbConn, logger);
 		processLog.saveResults();
-
-		logger.info("Updating Reading History");
-		processLog.addNote("Updating Reading History");
+		processLog.addNote("Starting nightly reading history updates....");
 
 		String aspenUrl = configIni.get("Site", "url");
 		if (aspenUrl == null || aspenUrl.isEmpty()) {

--- a/code/cron/src/com/turning_leaf_technologies/cron/reading_history/UpdateReadingHistoryTask.java
+++ b/code/cron/src/com/turning_leaf_technologies/cron/reading_history/UpdateReadingHistoryTask.java
@@ -131,7 +131,7 @@ public class UpdateReadingHistoryTask implements Runnable {
 			hadError = true;
 		} catch (IOException e) {
 			String errorMessage = e.getMessage();
-            errorMessage = errorMessage.replaceAll(ilsPassword, "XXXX");
+			errorMessage = errorMessage.replaceAll(ilsPassword, "XXXX");
 			processLog.incErrors("Unable to retrieve information from patron API for " + ilsBarcode + "; base URL is " + aspenUrl + ": " + errorMessage);
 			hadError = true;
 		}

--- a/code/web/Drivers/Sierra.php
+++ b/code/web/Drivers/Sierra.php
@@ -2228,7 +2228,7 @@ class Sierra extends Millennium {
 						$user->_state = substr($stateZip, 0, strrpos($stateZip, ' '));
 						$user->_zip = substr($stateZip, strrpos($stateZip, ' '));
 					} else {
-						$user->_state = trim($stateZip); 
+						$user->_state = trim($stateZip);
 					}
 				} else {
 					$parts = preg_split('/\s+/', $line2);
@@ -2430,7 +2430,11 @@ class Sierra extends Millennium {
 		}
 	}
 
-	public function getTitleAndAuthorForInnReachCheckout($checkoutId) {
+	/**
+	 * @param string $checkoutId
+	 * @return array|false
+	 */
+	public function getTitleAndAuthorForInnReachCheckout(string $checkoutId): array|false {
 		/** @noinspection SqlResolve */
 		$checkoutInfoSql = "SELECT 
 			  bib_record_property.best_title as title,
@@ -2445,12 +2449,18 @@ class Sierra extends Millennium {
 			  AND checkout.item_record_id = bib_record_item_record_link.item_record_id
 			  AND bib_record_item_record_link.bib_record_id = bib_record_property.bib_record_id";
 		$innReachConnection = $this->connectToSierraDNA();
+		if (!$innReachConnection) {
+			return false;
+		}
 		$res = pg_query_params($innReachConnection, $checkoutInfoSql, [$checkoutId]);
-		$titleAndAuthor = pg_fetch_array($res, 0);
-		return $titleAndAuthor;
+		return pg_fetch_array($res, 0);
 	}
 
-	public function getTitleAndAuthorForInnReachHold(string $holdId): array {
+	/**
+	 * @param string $holdId
+	 * @return array|false
+	 */
+	public function getTitleAndAuthorForInnReachHold(string $holdId): array|false {
 		/** @noinspection SqlResolve */
 		$holdInfoSql = "SELECT 
 			  bib_record_property.best_title as title,
@@ -2466,9 +2476,11 @@ class Sierra extends Millennium {
 					AND sierra_view.hold.record_id = bib_record_item_record_link.item_record_id
 					AND bib_record_item_record_link.bib_record_id = bib_record_property.bib_record_id";
 		$innReachConnection = $this->connectToSierraDNA();
+		if (!$innReachConnection) {
+			return false;
+		}
 		$res = pg_query_params($innReachConnection, $holdInfoSql, [$holdId]);
-		$titleAndAuthor = pg_fetch_array($res, 0);
-		return $titleAndAuthor;
+		return pg_fetch_array($res, 0);
 	}
 
 	public function showHoldPosition(): bool {

--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -156,6 +156,11 @@
 - Corrected logic in `RecordGroupingProcessor.java` to truncate any generated grouped-work title to a maximum of 500 characters. (DIS-810) (*LS*)
 - Fixed a Java compilation issue caused by ambiguity between `org.marc4j.marc.Record` and the new `java.lang.Record` class in Java 14+. (DIS-808) (*LS*)
 
+### Reading History Updates
+- Dramatically increased the processing rate of nightly user reading history updates. (DIS-791) (*LS*)
+- Enhanced log entries to show full configuration context and update progress for nightly user reading history updates. (DIS-791) (*LS*)
+- Fixed an issue where a failed Sierra INN-Reach connection would output errors in the nightly user reading history updates logs. (DIS-791) (*LS*)
+
 // yanjun
 ### Boundless Updates
 - Delete inactive Axis360 titles from database correctly. (DIS-785) (*YL*)

--- a/sites/default/conf/config.cron.ini
+++ b/sites/default/conf/config.cron.ini
@@ -43,10 +43,11 @@ frequencyHours = -1
 librariesToCreateReportsFor =
 
 [UpdateReadingHistory]
-description = Updates reading History for the patron based on what is currently checked out.
-lastRun = 1314200720449
-frequencyHours = -1
-lastRunFormatted = Wed Aug 24 09:45:20 MDT 2011
+description = Updates Reading History for the patron based on what is currently checked out.
+frequencyHours = 0
+minThreads = 8
+maxThreads = 16
+batchSize = 1000
 
 [BackupAspen]
 description = Backs up the Aspen database

--- a/sites/template.linux/conf/config.cron.ini
+++ b/sites/template.linux/conf/config.cron.ini
@@ -21,8 +21,11 @@ DatabaseCleanup = com.turning_leaf_technologies.cron.DatabaseCleanup
 GenealogyCleanup = com.turning_leaf_technologies.cron.genealogy.GenealogyCleanup
 
 [UpdateReadingHistory]
-description = Updates reading History for the patron based on what is currently checked out.
+description = Updates Reading History for the patron based on what is currently checked out.
 frequencyHours = 0
+minThreads = 8
+maxThreads = 16
+batchSize = 1000
 
 [BookCoverCleanup]
 description = Cleans up any book covers that are out of date (more than 2 weeks old).


### PR DESCRIPTION
- Dramatically increased the processing rate of nightly user reading history updates.
- Enhanced log entries to show full configuration context and update progress for nightly user reading history updates.
- Fixed an issue where a failed Sierra INN-Reach connection would output errors in the nightly user reading history updates logs.

Test Plan:
1. Wait or manually run the nightly `UpdateReadingHistory` Java process.
2. Apply the patch and repeat step 1. If you compare the completion times between the two in the Cron Logs, you will notice that after the patch, there was a dramatic decrease in the amount of time it took to complete.