### PR TITLE
DIS-876: Reading History “Sort by Author” Should Push Entries with Missing Authors to the Bottom

### DIFF
--- a/code/web/CatalogConnection.php
+++ b/code/web/CatalogConnection.php
@@ -1536,6 +1536,14 @@ class CatalogConnection {
 		return $summary;
 	}
 
+	public function getExpirationInformation(User $user) : ExpirationInformation {
+		return $this->driver->getExpirationInformation($user);
+	}
+
+	public function getDebarmentStatus(User $user) {
+		return $this->driver->getDebarmentStatus($user);
+	}
+
 	/**
 	 * @return bool
 	 */

--- a/code/web/CatalogConnection.php
+++ b/code/web/CatalogConnection.php
@@ -706,7 +706,8 @@ class CatalogConnection {
 		} elseif ($sortOption == "title") {
 			$readingHistoryDB->orderBy('title ASC, MAX(checkOutDate) DESC');
 		} elseif ($sortOption == "author") {
-			$readingHistoryDB->orderBy('author ASC, title ASC, MAX(checkOutDate) DESC');
+			// Push entries with no author to the bottom when sorting by author.
+			$readingHistoryDB->orderBy("CASE WHEN author IS NULL OR author = '' THEN 1 ELSE 0 END ASC, author ASC, title ASC, MAX(checkOutDate) DESC");
 		} elseif ($sortOption == "format") {
 			$readingHistoryDB->orderBy('format ASC, title ASC, MAX(checkOutDate) DESC');
 		}
@@ -1533,14 +1534,6 @@ class CatalogConnection {
 			$summary->update();
 		}
 		return $summary;
-	}
-
-	public function getExpirationInformation(User $user) : ExpirationInformation {
-		return $this->driver->getExpirationInformation($user);
-	}
-
-	public function getDebarmentStatus(User $user) {
-		return $this->driver->getDebarmentStatus($user);
 	}
 
 	/**

--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -156,6 +156,9 @@
 - Corrected logic in `RecordGroupingProcessor.java` to truncate any generated grouped-work title to a maximum of 500 characters. (DIS-810) (*LS*)
 - Fixed a Java compilation issue caused by ambiguity between `org.marc4j.marc.Record` and the new `java.lang.Record` class in Java 14+. (DIS-808) (*LS*)
 
+### Reading History Updates
+- Fixed an issue where reading history entries missing an author were being pushed to the top of the sort when sorting Reading History by author. (DIS-876) (*LS*)
+
 // yanjun
 ### Boundless Updates
 - Delete inactive Axis360 titles from database correctly. (DIS-785) (*YL*)


### PR DESCRIPTION
- Fixed an issue where reading history entries missing an author were being pushed to the top of the sort when sorting Reading History by author.

Test Plan:
1. Navigate to your account’s Reading History page and select “Sort by Author.” If any entries are missing authors, notice that they are incorrectly pushed to the top.
2. Apply the patch and repeat step 1. Notice that entries with authors are properly sorted alphabetically.