### PR TITLE
DIS-188: Series bug fixes

### DIFF
--- a/code/reindexer/src/org/aspen_discovery/reindexer/GroupedWorkIndexer.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/GroupedWorkIndexer.java
@@ -1533,6 +1533,8 @@ public class GroupedWorkIndexer {
 								if (numSeriesMembersRS.getInt("numMembers") == 0) {
 									deleteSeriesStmt.setInt(1, seriesId); // Deletes if it only had 1 member (this work)
 									deleteSeriesStmt.executeUpdate();
+									// Also remove from Solr
+									updateServer.deleteByQuery("recordtype:series AND id:" + seriesId);
 								}
 							}
 							numSeriesMembersRS.close();
@@ -1558,8 +1560,17 @@ public class GroupedWorkIndexer {
 					int result = deleteSeriesMemberStmt.executeUpdate();
 					// Also delete the series if it no longer has any members
 					if (result != 0) {
-						deleteSeriesStmt.setLong(1, seriesId); // Deletes if it only had 1 member (this work)
-						deleteSeriesStmt.executeUpdate();
+						getNumberOfSeriesMembersStmt.setLong(1, seriesId);
+						ResultSet numSeriesMembersRS = getNumberOfSeriesMembersStmt.executeQuery();
+						if (numSeriesMembersRS.next()) {
+							if (numSeriesMembersRS.getInt("numMembers") == 0) {
+								deleteSeriesStmt.setLong(1, seriesId); // Deletes if it only had 1 member (this work)
+								deleteSeriesStmt.executeUpdate();
+								// Also remove from Solr
+								updateServer.deleteByQuery("recordtype:series AND id:" + seriesId);
+							}
+						}
+						numSeriesMembersRS.close();
 					}
 				}
 				seriesMemberRS.close();

--- a/code/web/RecordDrivers/GroupedWorkDriver.php
+++ b/code/web/RecordDrivers/GroupedWorkDriver.php
@@ -2240,27 +2240,29 @@ class GroupedWorkDriver extends IndexRecordDriver {
 				$seriesMember->excluded = 0;
 				$seriesInfo = null;
 				$seriesMember->find();
-				if ($seriesMember->fetch()) {
-					$series = $seriesMember->getSeries();
-					if ($series != null) {
-						$seriesInfo = [
-							'seriesTitle' => $series->displayName,
-							'seriesId' => $series->id,
-							'volume' => $seriesMember->volume,
-							'fromNovelist' => false,
-							'fromSeriesIndex' => true
-						];
-					}
-				}
+				$first = true;
 				while ($seriesMember->fetch()) {
 					$series = $seriesMember->getSeries();
-					$seriesInfo['additionalSeries'][] = [
-						'seriesTitle' => $series->displayName,
-						'seriesId' => $series->id,
-						'volume' => $seriesMember->volume,
-						'fromNovelist' => false,
-						'fromSeriesIndex' => true
-					];
+					if ($series != null) {
+						if ($first) {
+							$seriesInfo = [
+								'seriesTitle' => $series->displayName,
+								'seriesId' => $series->id,
+								'volume' => $seriesMember->volume,
+								'fromNovelist' => false,
+								'fromSeriesIndex' => true
+							];
+							$first = false;
+						} else {
+							$seriesInfo['additionalSeries'][] = [
+								'seriesTitle' => $series->displayName,
+								'seriesId' => $series->id,
+								'volume' => $seriesMember->volume,
+								'fromNovelist' => false,
+								'fromSeriesIndex' => true
+							];
+						}
+					}
 				}
 				$this->seriesData = $seriesInfo;
 			}else{

--- a/code/web/RecordDrivers/SeriesRecordDriver.php
+++ b/code/web/RecordDrivers/SeriesRecordDriver.php
@@ -115,11 +115,13 @@ class SeriesRecordDriver extends IndexRecordDriver {
 	public function checkIfContainsNewTitles() {
 		global $solrScope;
 		$series = $this->getSeriesObject();
-		$records = $series->getSeriesRecords(0, 1, 'recordDrivers', 'id desc', false);
-		foreach ($records as $record) {
-			if ($record->fields && isset($record->fields["local_time_since_added_$solrScope"])) {
-				if (in_array('Week', $record->fields["local_time_since_added_$solrScope"])) {
-					return true;
+		if (!empty($series)) {
+			$records = $series->getSeriesRecords(0, 1, 'recordDrivers', 'id desc', false);
+			foreach ($records as $record) {
+				if ($record->fields && isset($record->fields["local_time_since_added_$solrScope"])) {
+					if (in_array('Week', $record->fields["local_time_since_added_$solrScope"])) {
+						return true;
+					}
 				}
 			}
 		}

--- a/code/web/interface/themes/responsive/GroupedWork/series-summary.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/series-summary.tpl
@@ -20,7 +20,7 @@
 					</div>
 				{/if}
 			{/if}
-		{else}
+		{elseif !empty($summSeries.seriesTitle)}
 			<a href="/Search/Results?searchIndex=Series&lookfor={$summSeries.seriesTitle}&sort=year+asc%2Ctitle+asc">{$summSeries.seriesTitle}</a>{if !empty($summSeries.volume)}<strong> {translate text="volume %1%" 1=$summSeries.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}
 		{/if}
 		{if !empty($indexedSeries) && empty($summSeries.fromSeriesIndex)}

--- a/code/web/interface/themes/responsive/GroupedWork/work-details.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/work-details.tpl
@@ -32,7 +32,7 @@
 									</div>
 								{/if}
 							{/if}
-						{else}
+						{elseif !empty($summSeries.seriesTitle)}
 							<a href="/Search/Results?searchIndex=Series&lookfor={$summSeries.seriesTitle}&sort=year+asc%2Ctitle+asc">{$summSeries.seriesTitle}</a>{if !empty($summSeries.volume)}<strong> {translate text="volume %1%" 1=$summSeries.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}
 						{/if}
 					</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/result.tpl
@@ -80,7 +80,7 @@
 												</div>
 											{/if}
 										{/if}
-									{else}
+									{elseif !empty($summSeries.seriesTitle)}
 										<a href="/Search/Results?searchIndex=Series&lookfor={$summSeries.seriesTitle}&sort=year+asc%2Ctitle+asc">{$summSeries.seriesTitle}</a>{if !empty($summSeries.volume)}<strong> {translate text="volume %1%" 1=$summSeries.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}<br>
 									{/if}
 								{/if}

--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -58,6 +58,9 @@
 ### API Updates
 - Add keyboard type options for barcode entry to Aspen LiDA self check settings and update SystemAPI:getSelfCheckSettings to return the new setting.(DIS-773) (*KP*)
 
+### Series Updates
+- Fix bugs related to series improperly being deleted and deleted series persisting in the Solr index. (DIS-188) (*KP*) 
+
 // kirstien
 
 ### Account Updates

--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -59,7 +59,7 @@
 - Add keyboard type options for barcode entry to Aspen LiDA self check settings and update SystemAPI:getSelfCheckSettings to return the new setting.(DIS-773) (*KP*)
 
 ### Series Updates
-- Fix bugs related to series improperly being deleted and deleted series persisting in the Solr index. (DIS-188) (*KP*) 
+- Fix bugs related to series improperly being deleted and deleted series persisting in the Solr index. This will trigger a full update of the series index.  (DIS-188) (*KP*) 
 
 // kirstien
 

--- a/code/web/sys/DBMaintenance/version_updates/25.06.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.06.00.php
@@ -56,6 +56,13 @@ function getUpdates25_06_00(): array {
 				"ALTER TABLE aspen_lida_self_check_settings ADD COLUMN barcodeEntryKeyboardType TINYINT(1) NOT NULL DEFAULT 1;",
 			]
 		], //add_lida_barcode_entry_keyboard_type_setting
+		'run_full_series_index_update' => [
+			'title' => 'Run Full Series Index Update',
+			'description' => 'Run full Series Index update to clean up deleted series records that are still in the index',
+			'sql' => [
+				"UPDATE series_indexing_settings SET runFullUpdate = 1;"
+			]
+		], //run_full_series_index
 
 		//kirstien - Grove
         'last_used_sort_for_user' => [


### PR DESCRIPTION
- Add check to make sure that series are only deleted when they don't have any members.  This wasn't getting checked if the update was due to a grouped record permanent ID getting deleted.
- Delete series from Solr at the same time that they are being deleted from the database.
- Better handling in templates for situations where series don't exist but are still in the index or database for some reason.