### PR TITLE
DIS-896 Change Default Sort for Many Admin Pages to ID Desc

### DIFF
--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -168,6 +168,7 @@
 - Updated `formattedTitle.tpl` and `formattedHorizontalCarouselTitle.tpl` to pass required variables, fixing missing-data issues in horizontal and carousel spotlights. (DIS-842) (*LS*)
 - Corrected logic in `RecordGroupingProcessor.java` to truncate any generated grouped-work title to a maximum of 500 characters. (DIS-810) (*LS*)
 - Fixed a Java compilation issue caused by ambiguity between `org.marc4j.marc.Record` and the new `java.lang.Record` class in Java 14+. (DIS-808) (*LS*)
+- Modified the default sort for the following admin pages to newest-first (i.e., ID descending): Audiences, Basic Pages, Browse Categories, Browse Category Groups, Categories, Collection Spotlights, Custom Forms, Custom Web Resource Pages, Grape Pages, Images, JavaScript Snippets, Records To Not Group, PDFs, Placards, Portal Pages, Quick Polls, Staff Members, System Messages, Templates, Web Resources, Web Resource Settings, Website Pages, and Year In Review. (DIS-896) (*LS*)
 
 ### Interface Updates
 - Added front-end validation for fields with character limits to prevent users from inputting beyond the defined character limit. (DIS-803) (*LS*)

--- a/code/web/services/Admin/BrowseCategories.php
+++ b/code/web/services/Admin/BrowseCategories.php
@@ -38,7 +38,7 @@ class Admin_BrowseCategories extends ObjectEditor {
 	}
 
 	function getDefaultSort(): string {
-		return 'label asc';
+		return 'id desc';
 	}
 
 	function getObjectStructure($context = ''): array {

--- a/code/web/services/Admin/BrowseCategoryGroups.php
+++ b/code/web/services/Admin/BrowseCategoryGroups.php
@@ -60,7 +60,7 @@ class Admin_BrowseCategoryGroups extends ObjectEditor {
 	}
 
 	function getDefaultSort(): string {
-		return 'name asc';
+		return 'id desc';
 	}
 
 	function getObjectStructure($context = ''): array {

--- a/code/web/services/Admin/CollectionSpotlights.php
+++ b/code/web/services/Admin/CollectionSpotlights.php
@@ -40,7 +40,7 @@ class Admin_CollectionSpotlights extends ObjectEditor {
 	}
 
 	function getDefaultSort(): string {
-		return 'name asc';
+		return 'id desc';
 	}
 
 	function getObjectStructure($context = ''): array {

--- a/code/web/services/Admin/JavaScriptSnippets.php
+++ b/code/web/services/Admin/JavaScriptSnippets.php
@@ -68,7 +68,7 @@ class Admin_JavaScriptSnippets extends ObjectEditor {
 	}
 
 	function getDefaultSort(): string {
-		return 'name asc';
+		return 'id desc';
 	}
 
 	function getObjectStructure($context = ''): array {

--- a/code/web/services/Admin/NonGroupedRecords.php
+++ b/code/web/services/Admin/NonGroupedRecords.php
@@ -31,7 +31,7 @@ class Admin_NonGroupedRecords extends ObjectEditor {
 	}
 
 	function getDefaultSort(): string {
-		return 'source asc';
+		return 'id desc';
 	}
 
 	function getObjectStructure($context = ''): array {

--- a/code/web/services/Admin/Placards.php
+++ b/code/web/services/Admin/Placards.php
@@ -60,7 +60,7 @@ class Admin_Placards extends ObjectEditor {
 	}
 
 	function getDefaultSort(): string {
-		return 'title asc';
+		return 'id desc';
 	}
 
 	function getObjectStructure($context = ''): array {

--- a/code/web/services/Admin/SystemMessages.php
+++ b/code/web/services/Admin/SystemMessages.php
@@ -59,7 +59,7 @@ class Admin_SystemMessages extends ObjectEditor {
 	}
 
 	function getDefaultSort(): string {
-		return 'title asc';
+		return 'id desc';
 	}
 
 	function getObjectStructure($context = ''): array {

--- a/code/web/services/Admin/YearInReview.php
+++ b/code/web/services/Admin/YearInReview.php
@@ -61,7 +61,7 @@ class Admin_YearInReview extends ObjectEditor {
 	}
 
 	function getDefaultSort(): string {
-		return 'name asc';
+		return 'id desc';
 	}
 
 	function getObjectStructure($context = ''): array {

--- a/code/web/services/WebBuilder/Audiences.php
+++ b/code/web/services/WebBuilder/Audiences.php
@@ -33,7 +33,7 @@ class WebBuilder_Audiences extends ObjectEditor {
 	}
 
 	function getDefaultSort(): string {
-		return 'name asc';
+		return 'id desc';
 	}
 
 	function getObjectStructure($context = ''): array {

--- a/code/web/services/WebBuilder/BasicPages.php
+++ b/code/web/services/WebBuilder/BasicPages.php
@@ -39,7 +39,7 @@ class WebBuilder_BasicPages extends ObjectEditor {
 	}
 
 	function getDefaultSort(): string {
-		return 'title asc';
+		return 'id desc';
 	}
 
 	function getObjectStructure($context = ''): array {

--- a/code/web/services/WebBuilder/Categories.php
+++ b/code/web/services/WebBuilder/Categories.php
@@ -33,7 +33,7 @@ class WebBuilder_Categories extends ObjectEditor {
 	}
 
 	function getDefaultSort(): string {
-		return 'name asc';
+		return 'id desc';
 	}
 
 	function getObjectStructure($context = ''): array {

--- a/code/web/services/WebBuilder/CustomForms.php
+++ b/code/web/services/WebBuilder/CustomForms.php
@@ -39,7 +39,7 @@ class WebBuilder_CustomForms extends ObjectEditor {
 	}
 
 	function getDefaultSort(): string {
-		return 'title asc';
+		return 'id desc';
 	}
 
 	function getObjectStructure($context = ''): array {

--- a/code/web/services/WebBuilder/CustomWebResourcePages.php
+++ b/code/web/services/WebBuilder/CustomWebResourcePages.php
@@ -39,7 +39,7 @@ class WebBuilder_CustomWebResourcePages extends ObjectEditor {
 	}
 
 	function getDefaultSort(): string {
-		return 'title asc';
+		return 'id desc';
 	}
 
 	function getObjectStructure($context = ''): array {

--- a/code/web/services/WebBuilder/GrapesPages.php
+++ b/code/web/services/WebBuilder/GrapesPages.php
@@ -39,7 +39,7 @@ class WebBuilder_GrapesPages extends ObjectEditor {
 	}
 
 	function getDefaultSort(): string {
-		return 'title asc';
+		return 'id desc';
 	}
 
 	function getObjectStructure($context = ''): array {

--- a/code/web/services/WebBuilder/Images.php
+++ b/code/web/services/WebBuilder/Images.php
@@ -34,7 +34,7 @@ class WebBuilder_Images extends ObjectEditor {
 	}
 
 	function getDefaultSort(): string {
-		return 'title asc';
+		return 'id desc';
 	}
 
 	function updateFromUI($object, $structure, $fieldLocks) {

--- a/code/web/services/WebBuilder/PDFs.php
+++ b/code/web/services/WebBuilder/PDFs.php
@@ -34,7 +34,7 @@ class WebBuilder_PDFs extends ObjectEditor {
 	}
 
 	function getDefaultSort(): string {
-		return 'title asc';
+		return 'id desc';
 	}
 
 	function updateFromUI($object, $structure, $fieldLocks) {

--- a/code/web/services/WebBuilder/PortalPages.php
+++ b/code/web/services/WebBuilder/PortalPages.php
@@ -45,7 +45,7 @@ class WebBuilder_PortalPages extends ObjectEditor {
 	}
 
 	function getDefaultSort(): string {
-		return 'title asc';
+		return 'id desc';
 	}
 
 	function getObjectStructure($context = ''): array {

--- a/code/web/services/WebBuilder/QuickPolls.php
+++ b/code/web/services/WebBuilder/QuickPolls.php
@@ -39,7 +39,7 @@ class WebBuilder_QuickPolls extends ObjectEditor {
 	}
 
 	function getDefaultSort(): string {
-		return 'title asc';
+		return 'id desc';
 	}
 
 	function getObjectStructure($context = ''): array {

--- a/code/web/services/WebBuilder/StaffMembers.php
+++ b/code/web/services/WebBuilder/StaffMembers.php
@@ -37,7 +37,7 @@ class WebBuilder_StaffMembers extends ObjectEditor {
 	}
 
 	function getDefaultSort(): string {
-		return 'name asc';
+		return 'id desc';
 	}
 
 	function getObjectStructure($context = ''): array {

--- a/code/web/services/WebBuilder/Templates.php
+++ b/code/web/services/WebBuilder/Templates.php
@@ -20,7 +20,7 @@ class WebBuilder_Templates  extends ObjectEditor{
 	}
 
 	function getDefaultSort(): string {
-		return 'templateName';
+		return 'id desc';
 	}
 
 	function getObjectStructure($context = ''): array {

--- a/code/web/services/WebBuilder/WebResourceSettings.php
+++ b/code/web/services/WebBuilder/WebResourceSettings.php
@@ -36,7 +36,7 @@ class WebBuilder_WebResourceSettings extends ObjectEditor {
 	}
 
 	function getDefaultSort(): string {
-		return 'name asc';
+		return 'id desc';
 	}
 
 	function getObjectStructure($context = ''): array {

--- a/code/web/services/WebBuilder/WebResources.php
+++ b/code/web/services/WebBuilder/WebResources.php
@@ -39,7 +39,7 @@ class WebBuilder_WebResources extends ObjectEditor {
 	}
 
 	function getDefaultSort(): string {
-		return 'name asc';
+		return 'id desc';
 	}
 
 	function getObjectStructure($context = ''): array {

--- a/code/web/services/Websites/WebsitePages.php
+++ b/code/web/services/Websites/WebsitePages.php
@@ -84,6 +84,6 @@ class Websites_WebsitePages extends ObjectEditor {
 	}
 
 	function getDefaultSort(): string {
-		return 'url asc';
+		return 'id desc';
 	}
 }


### PR DESCRIPTION
- Modified the default sort for the following admin pages to newest-first (i.e., ID descending): Audiences, Basic Pages, Browse Categories, Browse Category Groups, Categories, Collection Spotlights, Custom Forms, Custom Web Resource Pages, Grape Pages, Images, JavaScript Snippets, Records To Not Group, PDFs, Placards, Portal Pages, Quick Polls, Staff Members, System Messages, Templates, Web Resources, Web Resource Settings, Website Pages, and Year In Review.