### PR TITLE
DIS-806: Remove Materials Request updated successfully page

### DIFF
--- a/code/web/interface/themes/responsive/MaterialsRequest/manageRequests.tpl
+++ b/code/web/interface/themes/responsive/MaterialsRequest/manageRequests.tpl
@@ -4,6 +4,11 @@
 	{if !empty($error)}
 		<div class="alert alert-danger">{$error}</div>
 	{/if}
+	{if !empty($updateMessage)}
+		<div class="alert {if !empty($updateMessageIsError)}alert-danger{else}alert-success{/if}">
+			{$updateMessage}
+		</div>
+	{/if}
 	{if !empty($loggedIn)}
 		<div id="materialsRequestFilters" class="accordion">
 			<div class="panel panel-default">

--- a/code/web/interface/themes/responsive/MaterialsRequest/myMaterialRequests.tpl
+++ b/code/web/interface/themes/responsive/MaterialsRequest/myMaterialRequests.tpl
@@ -17,6 +17,11 @@
 	{else}
 		{assign var="canSuggestMaterials" value=$user->canSuggestMaterials()}
 		{if $canSuggestMaterials > 0}
+			{if !empty($updateMessage)}
+				<div class="alert {if !empty($updateMessageIsError)}alert-danger{else}alert-success{/if}">
+					{$updateMessage}
+				</div>
+			{/if}
 			{if $canSuggestMaterials == 1}
 				<div id="materialsRequestSummary" class="alert alert-info">
 					{translate text="You have used <strong>%1%</strong> of your %2% yearly material requests.  We also limit patrons to %3% active material requests at a time.  You currently have <strong>%4%</strong> active material requests." 1=$requestsThisYear 2=$maxRequestsPerYear 3=$maxActiveRequests 4=$openRequests isPublicFacing=true}

--- a/code/web/interface/themes/responsive/MaterialsRequest/update-result.tpl
+++ b/code/web/interface/themes/responsive/MaterialsRequest/update-result.tpl
@@ -10,6 +10,6 @@
 			{translate text="The request for %1% by %2% was updated successfully." 1=$materialsRequest->title 2=$materialsRequest->author isAdminFacing=true}
 			</div>
 		{/if}
-		<a role="button" class="btn btn-primary" href='/MaterialsRequest/ManageRequests'>{translate text="Return to Manage Requests" isAdminFacing=true}</a>.
+		<a role="button" class="btn btn-primary" href='/MaterialsRequest/ManageRequests'>{translate text="Return to Manage Requests" isAdminFacing=true}</a>
 	</div>
 </div>

--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -108,6 +108,7 @@
 - Update managing/editing requests as an admin so both status and assignee can be updated at the same time (DIS-802) (*KL*)
   - Add "Assigned To" as an editable field when updating a single materials request as an admin
   - On Manage Materials Requests page, remove separate buttons for changing status/assignee and replace with a single button labeled "Update Selected Requests"
+- Remove both created/updated successfully pages for materials requests and instead redirect to the appropriate /MyRequests or /ManageRequests page (DIS-806) (*KL*)
 
 // kyle
 ### Installer Updates

--- a/code/web/services/MaterialsRequest/ManageRequests.php
+++ b/code/web/services/MaterialsRequest/ManageRequests.php
@@ -252,6 +252,18 @@ class MaterialsRequest_ManageRequests extends Admin_Admin {
 				}
 				$interface->assign('assignees', $assignees);
 			}
+
+			$updateMessage = '';
+			$updateMessageIsError = false;
+			if (!empty($user->updateMessage)) {
+				$updateMessage = $user->updateMessage;
+				$updateMessageIsError = $user->updateMessageIsError;
+				$user->updateMessage = '';
+				$user->updateMessageIsError = 0;
+				$user->update();
+			}
+			$interface->assign('updateMessage', $updateMessage);
+			$interface->assign('updateMessageIsError', $updateMessageIsError);
 		} else {
 			$interface->assign('error', "You must be logged in to manage requests.");
 		}

--- a/code/web/services/MaterialsRequest/MyRequests.php
+++ b/code/web/services/MaterialsRequest/MyRequests.php
@@ -97,6 +97,19 @@ class MaterialsRequest_MyRequests extends MyAccount {
 		}
 		$interface->assign('allRequests', $allRequests);
 
+		$user = UserAccount::getActiveUserObj();
+		$updateMessage = '';
+		$updateMessageIsError = false;
+		if (!empty($user->updateMessage)) {
+			$updateMessage = $user->updateMessage;
+			$updateMessageIsError = $user->updateMessageIsError;
+			$user->updateMessage = '';
+			$user->updateMessageIsError = 0;
+			$user->update();
+		}
+		$interface->assign('updateMessage', $updateMessage);
+		$interface->assign('updateMessageIsError', $updateMessageIsError);
+
 		$this->display('myMaterialRequests.tpl', 'My Materials Requests');
 	}
 

--- a/code/web/services/MaterialsRequest/Submit.php
+++ b/code/web/services/MaterialsRequest/Submit.php
@@ -226,6 +226,13 @@ class MaterialsRequest_Submit extends Action {
 				}
 			}
 		}
+
+		$sidebar = '';
+		if (UserAccount::isLoggedIn()) {
+			$sidebar = 'Search/home-sidebar.tpl';
+		}
+
+		$this->display('submission-result.tpl', 'Submission Result', $sidebar);
 	}
 
 	function getBreadcrumbs(): array {

--- a/code/web/services/MaterialsRequest/Submit.php
+++ b/code/web/services/MaterialsRequest/Submit.php
@@ -190,19 +190,28 @@ class MaterialsRequest_Submit extends Action {
 										'isPublicFacing' => true,
 									]));
 								} else {
+									header('Location: /MaterialsRequest/MyRequests');
 									$materialsRequest->status = $defaultStatus->id;
 									$materialsRequest->dateCreated = time();
 									$materialsRequest->createdBy = UserAccount::getActiveUserId();
 									$materialsRequest->dateUpdated = time();
 
 									if ($materialsRequest->insert()) {
-										header('Location: /MaterialsRequest/Results?success=true&id=' . $materialsRequest->id);
-									} else {
-										$interface->assign('success', false);
-										$interface->assign('error', translate([
-											'text' => 'There was an error submitting your materials request.',
+										$user->updateMessage = translate([
+											'text' => 'Your request for %1% by %2% was submitted successfully.',
 											'isPublicFacing' => true,
-										]));
+											1 => $materialsRequest->title,
+											2 => $materialsRequest->author
+										]);
+										$user->updateMessageIsError = false;
+										$user->update();
+									} else {
+										$user->updateMessage = translate([
+											'text' => 'There was an error submitting your materials request.',
+											'isPublicFacing' => true
+										]);
+										$user->updateMessageIsError = true;
+										$user->update();
 									}
 								}
 							}
@@ -217,13 +226,6 @@ class MaterialsRequest_Submit extends Action {
 				}
 			}
 		}
-
-		$sidebar = '';
-		if (UserAccount::isLoggedIn()) {
-			$sidebar = 'Search/home-sidebar.tpl';
-		}
-
-		$this->display('submission-result.tpl', 'Submission Result', $sidebar);
 	}
 
 	function getBreadcrumbs(): array {

--- a/code/web/services/MaterialsRequest/Update.php
+++ b/code/web/services/MaterialsRequest/Update.php
@@ -25,115 +25,138 @@ class MaterialsRequest_Update extends Admin_Admin {
 			}
 		}
 
-		//Make sure that the user is valid
-		$processForm = true;
+		//Make sure that the user is logged in
 		$user = UserAccount::getLoggedInUser();
-		if ($materialsRequest == null) {
-			$interface->assign('success', false);
-			$interface->assign('error', 'Sorry, we could not find a request with that id.');
-			$processForm = false;
-		} elseif (!UserAccount::isLoggedIn()) {
+		if (!UserAccount::isLoggedIn()) {
 			$interface->assign('error', 'Sorry, you must be logged in to update a materials request.');
-			$processForm = false;
-		} elseif (UserAccount::userHasPermission('Manage Library Materials Requests') && $requestUser && ($user->getHomeLibrary() == null || ($requestUser->getHomeLibrary()->libraryId == $user->getHomeLibrary()->libraryId))) {
-			//Ok to process because they are an admin for the user's home library
+		} else {
+			header('Location: /MaterialsRequest/ManageRequests');
 			$processForm = true;
-		} elseif ($user->id != $materialsRequest->createdBy) {
-			$interface->assign('error', 'Sorry, you do not have permission to update this materials request.');
-			$processForm = false;
-		}
-		if ($processForm) {
-			//Materials request can be submitted.
-			$materialsRequest->format = empty($_REQUEST['format']) ? '' : strip_tags($_REQUEST['format']);
-			if (empty($materialsRequest->format)) {
-				$interface->assign('success', false);
-				$interface->assign('error', 'No format was specified.');
-			} else {
-				$materialsRequest->phone = isset($_REQUEST['phone']) ? strip_tags($_REQUEST['phone']) : '';
-				$materialsRequest->email = isset($_REQUEST['email']) ? strip_tags($_REQUEST['email']) : '';
-				$materialsRequest->title = isset($_REQUEST['title']) ? strip_tags($_REQUEST['title']) : '';
-				$materialsRequest->season = isset($_REQUEST['season']) ? strip_tags($_REQUEST['season']) : '';
-				$materialsRequest->magazineTitle = isset($_REQUEST['magazineTitle']) ? strip_tags($_REQUEST['magazineTitle']) : '';
-				$materialsRequest->magazineDate = isset($_REQUEST['magazineDate']) ? strip_tags($_REQUEST['magazineDate']) : '';
-				$materialsRequest->magazineVolume = isset($_REQUEST['magazineVolume']) ? strip_tags($_REQUEST['magazineVolume']) : '';
-				$materialsRequest->magazineNumber = isset($_REQUEST['magazineNumber']) ? strip_tags($_REQUEST['magazineNumber']) : '';
-				$materialsRequest->magazinePageNumbers = isset($_REQUEST['magazinePageNumbers']) ? strip_tags($_REQUEST['magazinePageNumbers']) : '';
-				$materialsRequest->author = empty($_REQUEST['author']) ? '' : strip_tags($_REQUEST['author']);
-				$materialsRequest->ageLevel = isset($_REQUEST['ageLevel']) ? strip_tags($_REQUEST['ageLevel']) : '';
-				$materialsRequest->bookType = isset($_REQUEST['bookType']) ? strip_tags($_REQUEST['bookType']) : '';
-				$materialsRequest->isbn = isset($_REQUEST['isbn']) ? strip_tags($_REQUEST['isbn']) : '';
-				$materialsRequest->upc = isset($_REQUEST['upc']) ? strip_tags($_REQUEST['upc']) : '';
-				$materialsRequest->issn = isset($_REQUEST['issn']) ? strip_tags($_REQUEST['issn']) : '';
-				$materialsRequest->oclcNumber = isset($_REQUEST['oclcNumber']) ? strip_tags($_REQUEST['oclcNumber']) : '';
-				$materialsRequest->publisher = empty($_REQUEST['publisher']) ? '' : strip_tags($_REQUEST['publisher']);
-				$materialsRequest->publicationYear = empty($_REQUEST['publicationYear']) ? '' : strip_tags($_REQUEST['publicationYear']);
-				$materialsRequest->about = empty($_REQUEST['about']) ? '' : strip_tags($_REQUEST['about']);
-				$materialsRequest->comments = empty($_REQUEST['comments']) ? '' : strip_tags($_REQUEST['comments']);
-				$materialsRequest->staffComments = empty($_REQUEST['staffComments']) ? '' : strip_tags($_REQUEST['staffComments']);
-				$materialsRequest->placeHoldWhenAvailable = empty($_REQUEST['placeHoldWhenAvailable']) ? 0 : $_REQUEST['placeHoldWhenAvailable'];
-				$materialsRequest->holdPickupLocation = empty($_REQUEST['holdPickupLocation']) ? '' : $_REQUEST['holdPickupLocation'];
-				$materialsRequest->bookmobileStop = empty($_REQUEST['bookmobileStop']) ? '' : $_REQUEST['bookmobileStop'];
-				$materialsRequest->illItem = empty($_REQUEST['illItem']) ? 0 : $_REQUEST['illItem'];
-				$materialsRequest->emailSent = empty($_REQUEST['emailSent']) ? 0 : $_REQUEST['emailSent'];
-				$statusChanged = false;
-				if (!empty($_REQUEST['status'])) {
-					if ($materialsRequest->status != $_REQUEST['status']) {
-						$materialsRequest->status = $_REQUEST['status'];
-						$statusChanged = true;
-					}
-				}
-				$assigneeChanged = false;
-				if (!empty($_REQUEST['assignedTo'])) {
-					if ($materialsRequest->assignedTo != $_REQUEST['assignedTo']) {
-						$materialsRequest->assignedTo = $_REQUEST['assignedTo'];
-						$assigneeChanged = true;
-					}
-				}
-
-				$materialsRequest->libraryId = $requestUser->getHomeLibrary()->libraryId;
-
-				$formatObject = $materialsRequest->getFormatObjectByFormat();
-				if (!empty($formatObject->id)) {
-					$materialsRequest->formatId = $formatObject->id;
-				}
-
-				if (isset($_REQUEST['ebookFormat']) && $formatObject->hasSpecialFieldOption('Ebook format')) {
-					$materialsRequest->subFormat = strip_tags($_REQUEST['ebookFormat']);
-
-				} elseif (isset($_REQUEST['eaudioFormat']) && $formatObject->hasSpecialFieldOption('Eaudio format')) {
-					$materialsRequest->subFormat = strip_tags($_REQUEST['eaudioFormat']);
-
-				}
-				if (isset($_REQUEST['abridged'])) {
-					if ($_REQUEST['abridged'] == 'abridged') {
-						$materialsRequest->abridged = 1;
-					} elseif ($_REQUEST['abridged'] == 'unabridged') {
-						$materialsRequest->abridged = 0;
-					} else {
-						$materialsRequest->abridged = 2; //Not applicable
-					}
-				}
-				$materialsRequest->dateUpdated = time();
-
-				if ($materialsRequest->update()) {
-					$interface->assign('success', true);
-					$interface->assign('materialsRequest', $materialsRequest);
-					if ($statusChanged) {
-						//Send an email as needed
-						$materialsRequest->sendStatusChangeEmail();
-					}
-					if ($assigneeChanged) {
-						//Send an email as needed
-						$materialsRequest->sendStaffNewMaterialsRequestAssignedEmail();
-					}
+			//Make sure that the user is valid
+			if ($materialsRequest == null) {
+				$user->updateMessage = translate([
+					'text' => 'Sorry, we could not find a request with that id.',
+					'isPublicFacing' => true
+				]);
+				$user->updateMessageIsError = true;
+				$user->update();
+				$processForm = false;
+			} elseif (UserAccount::userHasPermission('Manage Library Materials Requests') && $requestUser && ($user->getHomeLibrary() == null || ($requestUser->getHomeLibrary()->libraryId == $user->getHomeLibrary()->libraryId))) {
+				//Ok to process because they are an admin for the user's home library
+				$processForm = true;
+			} elseif ($user->id != $materialsRequest->createdBy) {
+				$user->updateMessage = translate([
+					'text' => 'Sorry, you do not have permission to update this materials request.',
+					'isPublicFacing' => true
+				]);
+				$user->updateMessageIsError = true;
+				$user->update();
+				$processForm = false;
+			}
+			if ($processForm) {
+				//Materials request can be submitted.
+				$materialsRequest->format = empty($_REQUEST['format']) ? '' : strip_tags($_REQUEST['format']);
+				if (empty($materialsRequest->format)) {
+					$user->updateMessage = translate([
+						'text' => 'There was an error updating the materials request. No format was specified.',
+						'isPublicFacing' => true
+					]);
+					$user->updateMessageIsError = true;
+					$user->update();
 				} else {
-					$interface->assign('success', false);
-					$interface->assign('error', 'There was an error updating the materials request.');
+					$materialsRequest->phone = isset($_REQUEST['phone']) ? strip_tags($_REQUEST['phone']) : '';
+					$materialsRequest->email = isset($_REQUEST['email']) ? strip_tags($_REQUEST['email']) : '';
+					$materialsRequest->title = isset($_REQUEST['title']) ? strip_tags($_REQUEST['title']) : '';
+					$materialsRequest->season = isset($_REQUEST['season']) ? strip_tags($_REQUEST['season']) : '';
+					$materialsRequest->magazineTitle = isset($_REQUEST['magazineTitle']) ? strip_tags($_REQUEST['magazineTitle']) : '';
+					$materialsRequest->magazineDate = isset($_REQUEST['magazineDate']) ? strip_tags($_REQUEST['magazineDate']) : '';
+					$materialsRequest->magazineVolume = isset($_REQUEST['magazineVolume']) ? strip_tags($_REQUEST['magazineVolume']) : '';
+					$materialsRequest->magazineNumber = isset($_REQUEST['magazineNumber']) ? strip_tags($_REQUEST['magazineNumber']) : '';
+					$materialsRequest->magazinePageNumbers = isset($_REQUEST['magazinePageNumbers']) ? strip_tags($_REQUEST['magazinePageNumbers']) : '';
+					$materialsRequest->author = empty($_REQUEST['author']) ? '' : strip_tags($_REQUEST['author']);
+					$materialsRequest->ageLevel = isset($_REQUEST['ageLevel']) ? strip_tags($_REQUEST['ageLevel']) : '';
+					$materialsRequest->bookType = isset($_REQUEST['bookType']) ? strip_tags($_REQUEST['bookType']) : '';
+					$materialsRequest->isbn = isset($_REQUEST['isbn']) ? strip_tags($_REQUEST['isbn']) : '';
+					$materialsRequest->upc = isset($_REQUEST['upc']) ? strip_tags($_REQUEST['upc']) : '';
+					$materialsRequest->issn = isset($_REQUEST['issn']) ? strip_tags($_REQUEST['issn']) : '';
+					$materialsRequest->oclcNumber = isset($_REQUEST['oclcNumber']) ? strip_tags($_REQUEST['oclcNumber']) : '';
+					$materialsRequest->publisher = empty($_REQUEST['publisher']) ? '' : strip_tags($_REQUEST['publisher']);
+					$materialsRequest->publicationYear = empty($_REQUEST['publicationYear']) ? '' : strip_tags($_REQUEST['publicationYear']);
+					$materialsRequest->about = empty($_REQUEST['about']) ? '' : strip_tags($_REQUEST['about']);
+					$materialsRequest->comments = empty($_REQUEST['comments']) ? '' : strip_tags($_REQUEST['comments']);
+					$materialsRequest->staffComments = empty($_REQUEST['staffComments']) ? '' : strip_tags($_REQUEST['staffComments']);
+					$materialsRequest->placeHoldWhenAvailable = empty($_REQUEST['placeHoldWhenAvailable']) ? 0 : $_REQUEST['placeHoldWhenAvailable'];
+					$materialsRequest->holdPickupLocation = empty($_REQUEST['holdPickupLocation']) ? '' : $_REQUEST['holdPickupLocation'];
+					$materialsRequest->bookmobileStop = empty($_REQUEST['bookmobileStop']) ? '' : $_REQUEST['bookmobileStop'];
+					$materialsRequest->illItem = empty($_REQUEST['illItem']) ? 0 : $_REQUEST['illItem'];
+					$materialsRequest->emailSent = empty($_REQUEST['emailSent']) ? 0 : $_REQUEST['emailSent'];
+					$statusChanged = false;
+					if (!empty($_REQUEST['status'])) {
+						if ($materialsRequest->status != $_REQUEST['status']) {
+							$materialsRequest->status = $_REQUEST['status'];
+							$statusChanged = true;
+						}
+					}
+					$assigneeChanged = false;
+					if (!empty($_REQUEST['assignedTo'])) {
+						if ($materialsRequest->assignedTo != $_REQUEST['assignedTo']) {
+							$materialsRequest->assignedTo = $_REQUEST['assignedTo'];
+							$assigneeChanged = true;
+						}
+					}
+
+					$materialsRequest->libraryId = $requestUser->getHomeLibrary()->libraryId;
+
+					$formatObject = $materialsRequest->getFormatObjectByFormat();
+					if (!empty($formatObject->id)) {
+						$materialsRequest->formatId = $formatObject->id;
+					}
+
+					if (isset($_REQUEST['ebookFormat']) && $formatObject->hasSpecialFieldOption('Ebook format')) {
+						$materialsRequest->subFormat = strip_tags($_REQUEST['ebookFormat']);
+
+					} elseif (isset($_REQUEST['eaudioFormat']) && $formatObject->hasSpecialFieldOption('Eaudio format')) {
+						$materialsRequest->subFormat = strip_tags($_REQUEST['eaudioFormat']);
+
+					}
+					if (isset($_REQUEST['abridged'])) {
+						if ($_REQUEST['abridged'] == 'abridged') {
+							$materialsRequest->abridged = 1;
+						} elseif ($_REQUEST['abridged'] == 'unabridged') {
+							$materialsRequest->abridged = 0;
+						} else {
+							$materialsRequest->abridged = 2; //Not applicable
+						}
+					}
+					$materialsRequest->dateUpdated = time();
+
+					if ($materialsRequest->update()) {
+						$user->updateMessage = translate([
+							'text' => 'The request for %1% by %2% was updated successfully.',
+							'isPublicFacing' => true,
+							1 => $materialsRequest->title,
+							2 => $materialsRequest->author
+						]);
+						$user->updateMessageIsError = false;
+						$user->update();
+						if ($statusChanged) {
+							//Send an email as needed
+							$materialsRequest->sendStatusChangeEmail();
+						}
+						if ($assigneeChanged) {
+							//Send an email as needed
+							$materialsRequest->sendStaffNewMaterialsRequestAssignedEmail();
+						}
+					} else {
+						$user->updateMessage = translate([
+							'text' => 'There was an error updating the materials request.',
+							'isPublicFacing' => true
+						]);
+						$user->updateMessageIsError = true;
+						$user->update();
+					}
 				}
 			}
-		} else {
-			$interface->assign('success', false);
-			$interface->assign('error', 'Sorry, we could not find a request with that id.');
 		}
 
 		//Get a list of formats to show


### PR DESCRIPTION
Remove both created/updated successfully pages for materials requests and instead redirect to the appropriate /MyRequests or /ManageRequests page

For most errors on submitting new requests, the user will still be redirected to a new page

Update release notes

Tested on my local instance of Aspen