### PR TITLE
DIS-825: Prevent login of expired cards

### DIFF
--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -1297,6 +1297,10 @@ class Koha extends AbstractIlsDriver {
 			$user->phone = $userFromDb['phone'];
 			$user->_dateOfBirth = $userFromDb['dateofbirth'];
 
+			$date = date("Y-m-d");
+
+			$user->_expired = $userFromDb['dateexpiry'] < $date;
+
 
 			$user->_web_note = $userFromDb['opacnote'];
 

--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -243,7 +243,7 @@
 ### Koha Updates
 - Ensure that users with frozen accounts in Koha are unable to place holds in Aspen. (DIS-599) (*LM*) 
 - Ensure that users with expired accounts in Koha are unable to place holds, place ILL requests or renew items in Aspen. (DIS-551) (*LM*)
-
+- Prevent users to login if their cards are expired and the option "Prevent Login for Expired Cards" is enabled. (DIS-825) (*LM*)
 ## This release includes code contributions from
 ### ByWater Solutions
 - Leo Stoyanov (LS)


### PR DESCRIPTION
**Test plan** 

Before the patch:

- Users with expired cards can login ignoring the Aspen preference "Prevent Login for Expired Cards" 

After the patch:

- Users with expired cards are not able to login if the preference "Prevent Login for Expired Cards" is enabled