### PR TITLE
Dis 720 sorting sierra holds by date placed

### DIFF
--- a/code/web/Drivers/Sierra.php
+++ b/code/web/Drivers/Sierra.php
@@ -244,7 +244,7 @@ class Sierra extends Millennium {
 		if ($this->accountProfile->apiVersion > 4) {
 			$sierraUrl .= "?fields=default,priorityQueueLength&limit=1000";
 		} else {
-			$sierraUrl .= "?fields=default,frozen,priority,priorityQueueLength,notWantedBeforeDate,notNeededAfterDate&limit=1000";
+			$sierraUrl .= "?fields=default,frozen,priority,priorityQueueLength,notWantedBeforeDate,notNeededAfterDate,placed&limit=1000";
 		}
 		$holds = $this->_callUrl('sierra.getHolds', $sierraUrl);
 
@@ -2476,6 +2476,10 @@ class Sierra extends Millennium {
 	}
 
 	public function showTimesRenewed(): bool {
+		return true;
+	}
+
+	public function showHoldPlacedDate(): bool {
 		return true;
 	}
 

--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -79,6 +79,9 @@
 ### Series Updates
 - Fix bugs related to series improperly being deleted and deleted series persisting in the Solr index. This will trigger a full update of the series index.  (DIS-188) (*KP*) 
 
+### Sierra Updates
+- Allow holds to be sorted by date placed. (DIS-720) (*KP*)
+
 // kirstien
 ### Account Updates
 - The last used sort method for checkouts, available holds, and unavailable holds will now be remembered and preferred


### PR DESCRIPTION
Include 'placed' field in Sierra get holds request so that holds can be sorted by when they were placed.