### PR TITLE
DIS-911: Prevent Unauthorized Translation Term Insertion & Add Search Security

### DIFF
--- a/code/web/index.php
+++ b/code/web/index.php
@@ -1384,6 +1384,17 @@ function initializeSession() {
 
 //Look for spammy searches and kill them
 function isSpammySearchTerm($lookfor): bool {
+	// URL‑decode recursively to defeat double/triple encodings.
+	$decoded = $lookfor;
+	for ($i = 0; $i < 3; $i++) {
+		$tmp = urldecode($decoded);
+		if ($tmp === $decoded) {
+			break;
+		}
+		$decoded = $tmp;
+	}
+	$lookfor = $decoded;
+
 	if (strpos($lookfor, 'DBMS_PIPE.RECEIVE_MESSAGE') !== false) {
 		return true;
 	} elseif (strpos($lookfor, 'PG_SLEEP') !== false) {
@@ -1419,6 +1430,15 @@ function isSpammySearchTerm($lookfor): bool {
 	} elseif (strpos($lookfor, 'response.write') !== false) {
 		return true;
 	}
+
+	// Minimal directory‑traversal guards
+	if (str_contains($lookfor, '../') || str_contains($lookfor, '..\\')) {
+		return true;
+	}
+	if (str_contains($lookfor, '/etc/passwd') || str_contains($lookfor, 'boot.ini')) {
+		return true;
+	}
+
 	$termWithoutTags = strip_tags($lookfor);
 	if ($termWithoutTags != $lookfor) {
 		return true;

--- a/code/web/interface/plugins/function.translate.php
+++ b/code/web/interface/plugins/function.translate.php
@@ -15,7 +15,7 @@ function smarty_function_translate($params, Smarty_Internal_Template &$smarty) :
 		$translator = new Translator('lang', $code);
 	}
 	if (is_array($params)) {
-		$defaultText = $params['defaultText'] ?? null;
+		$defaultText = $params['defaultText'] ?? '';
 		$inAttribute = $params['inAttribute'] ?? false;
 		$isPublicFacing = $params['isPublicFacing'] ?? false;
 		$isAdminFacing = $params['isAdminFacing'] ?? false;
@@ -31,6 +31,6 @@ function smarty_function_translate($params, Smarty_Internal_Template &$smarty) :
 		}
 		return $translator->translate($params['text'], $defaultText, $replacementValues, $inAttribute, $isPublicFacing, $isAdminFacing, $isMetadata, $isAdminEnteredData, $translateParameters, $escape);
 	} else {
-		return $translator->translate($params, null, [], false);
+		return $translator->translate($params);
 	}
 }

--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -193,6 +193,8 @@
 - Fixed a Java compilation issue caused by ambiguity between `org.marc4j.marc.Record` and the new `java.lang.Record` class in Java 14+. (DIS-808) (*LS*)
 - Fixed a bug in administrative forms, specifically the Special Fields for Format of Material Request Formats configuration, where multi-select fields displayed as a list of checkboxes failed to correctly display current selections or subsequent changes. (DIS-864) (*LS*)
 - Allow users to upload GIFs. (DIS-870) (*LS*)
+- Translation database insertions and updates now only occur when actively in translation mode, improving performance and data integrity. (DIS-911) (*LS*)
+- Added protection against malicious search attempts, including directory traversal and invalid search parameters. (DIS-911) (*LS*)
 
 ### Interface Updates
 - Added front-end validation for fields with character limits to prevent users from inputting beyond the defined character limit. (DIS-803) (*LS*)

--- a/code/web/services/Search/Results.php
+++ b/code/web/services/Search/Results.php
@@ -807,7 +807,7 @@ class Search_Results extends ResultsAction {
 	 * and validating searchIndex values against whitelist.
 	 */
 	private function validateAndProcessSearchParameters(): void {
-		// Handle field prefixes in the lookfor parameter (e.g., ISBN:97812345...).
+		// Handle field prefixes in the 'lookfor' parameter (e.g., ISBN:97812345...).
 		if (isset($_REQUEST['lookfor']) && !isset($_REQUEST['searchIndex'])) {
 			$lookforRaw = $_REQUEST['lookfor'];
 			if (preg_match('/^(\w+)\s*:(.+)$/', $lookforRaw, $matches)) {
@@ -831,7 +831,7 @@ class Search_Results extends ResultsAction {
 			}
 		}
 
-		// Validate searchIndex parameter to prevent invalid or malicious index values.
+		// Validate 'searchIndex' parameter to prevent invalid or malicious index values.
 		if (isset($_REQUEST['searchIndex'])) {
 			if (!isset($tmpSearchObj)) {
 				require_once ROOT_DIR . '/sys/SearchObject/SearchObjectFactory.php';

--- a/code/web/sys/Interface.php
+++ b/code/web/sys/Interface.php
@@ -1155,13 +1155,13 @@ function translate($params) {
 		$translator = new Translator('lang', $code);
 	}
 	if (is_array($params)) {
-		$defaultText = isset($params['defaultText']) ? $params['defaultText'] : null;
-		$inAttribute = isset($params['inAttribute']) ? $params['inAttribute'] : false;
-		$isPublicFacing = isset($params['isPublicFacing']) ? $params['isPublicFacing'] : false;
-		$isAdminFacing = isset($params['isAdminFacing']) ? $params['isAdminFacing'] : false;
-		$isMetadata = isset($params['isMetadata']) ? $params['isMetadata'] : false;
-		$isAdminEnteredData = isset($params['isAdminEnteredData']) ? $params['isAdminEnteredData'] : false;
-		$translateParameters = isset($params['translateParameters']) ? $params['translateParameters'] : false;
+		$defaultText = $params['defaultText'] ?? '';
+		$inAttribute = $params['inAttribute'] ?? false;
+		$isPublicFacing = $params['isPublicFacing'] ?? false;
+		$isAdminFacing = $params['isAdminFacing'] ?? false;
+		$isMetadata = $params['isMetadata'] ?? false;
+		$isAdminEnteredData = $params['isAdminEnteredData'] ?? false;
+		$translateParameters = $params['translateParameters'] ?? false;
 		$replacementValues = [];
 		foreach ($params as $index => $param) {
 			if (is_numeric($index)) {
@@ -1170,6 +1170,6 @@ function translate($params) {
 		}
 		return $translator->translate($params['text'], $defaultText, $replacementValues, $inAttribute, $isPublicFacing, $isAdminFacing, $isMetadata, $isAdminEnteredData, $translateParameters);
 	} else {
-		return $translator->translate($params, null, [], false);
+		return $translator->translate($params);
 	}
 }

--- a/code/web/sys/Translation/Translator.php
+++ b/code/web/sys/Translation/Translator.php
@@ -59,21 +59,23 @@ class Translator {
 	private $communityContentCurlWrapper = null;
 
 	/**
-	 * Translate the phrase
+	 * Translate the phrase.
 	 *
-	 * @param string $phrase - The phrase to translate
-	 * @param string $defaultText - The default text for a phrase that is just a key for a longer phrase
-	 * @param string[] $replacementValues - Values to replace within the string
-	 * @param bool $inAttribute - Whether we are in an attribute. If we are, we can't show the span
-	 * @param bool $isPublicFacing - Whether the public will see this
-	 * @param bool $isAdminFacing - Whether this is in the admin interface
-	 * @param bool $isMetadata - Whether this is a translation of metadata in a MARC record, OverDrive, Axis360, etc
-	 * @param bool $isAdminEnteredData - Whether this is data an administrator entered (System message, etc)
-	 * @param bool $translateParameters - Whether parameters should be translated
-	 * @param bool $escape - Whether the translation should be escaped before rendering
-	 * @return  string                      - The translated phrase
+	 * @param string $phrase The phrase to translate.
+	 * @param string $defaultText The default text for a phrase that is just a key for a longer phrase.
+	 * @param string[] $replacementValues Values to replace within the string.
+	 * @param bool $inAttribute Whether we are in an attribute. If we are, we can't show the span.
+	 * @param bool $isPublicFacing Whether the public will see this.
+	 * @param bool $isAdminFacing Whether this is in the admin interface.
+	 * @param bool $isMetadata Whether this is a translation of metadata in a MARC record, OverDrive, Axis360, etc.
+	 * @param bool $isAdminEnteredData Whether this is data an administrator entered (System message, etc).
+	 * @param bool $translateParameters Whether parameters should be translated.
+	 * @param bool $escape Whether the translation should be escaped before rendering.
+	 * @return string The translated phrase.
 	 */
-	function translate($phrase, $defaultText = '', $replacementValues = [], $inAttribute = false, $isPublicFacing = false, $isAdminFacing = false, $isMetadata = false, $isAdminEnteredData = false, $translateParameters = false, $escape = false) : string {
+	function translate(string $phrase, string $defaultText = '', array $replacementValues = [], bool $inAttribute = false, bool $isPublicFacing = false,
+					   bool $isAdminFacing = false, bool $isMetadata = false, bool $isAdminEnteredData = false, bool $translateParameters = false, bool $escape = false): string
+	{
 		if ($phrase === '' || is_numeric($phrase)) {
 			return $phrase;
 		}
@@ -92,87 +94,93 @@ class Translator {
 					$translationTerm = new TranslationTerm();
 					$translationTerm->term = $phrase;
 					$defaultTextChanged = false;
-					if (!$translationTerm->find(true)) {
-						$translationTerm->defaultText = $defaultText;
-						//Insert the translation term
+					// Only write term records to DB in translation mode; otherwise, just load existing term.
+					if ($translationMode) {
+						if (!$translationTerm->find(true)) {
+							$translationTerm->defaultText = $defaultText;
+							//Insert the translation term
 
-						$translationTerm->samplePageUrl = mb_strimwidth($_SERVER['REQUEST_URI'], 0, 255);
-						$translationTerm->isPublicFacing = $isPublicFacing;
-						$translationTerm->isAdminFacing = $isAdminFacing;
-						$translationTerm->isMetadata = $isMetadata;
-						$translationTerm->isAdminEnteredData = $isAdminEnteredData;
-						$translationTerm->lastUpdate = time();
-						try {
-							if ($translationTerm->insert() !== false) {
-								$termTooLong = false;
-								//Send this to the Community Content Server as well
+							$translationTerm->samplePageUrl = mb_strimwidth($_SERVER['REQUEST_URI'], 0, 255);
+							$translationTerm->isPublicFacing = $isPublicFacing;
+							$translationTerm->isAdminFacing = $isAdminFacing;
+							$translationTerm->isMetadata = $isMetadata;
+							$translationTerm->isAdminEnteredData = $isAdminEnteredData;
+							$translationTerm->lastUpdate = time();
+							try {
+								if ($translationTerm->insert() !== false) {
+									$termTooLong = false;
+									//Send this to the Community Content Server as well
 
-								require_once ROOT_DIR . '/sys/SystemVariables.php';
-								$systemVariables = SystemVariables::getSystemVariables();
-								if ($systemVariables && !empty($systemVariables->communityContentUrl)) {
-									if ($this->communityContentCurlWrapper == null) {
-										require_once ROOT_DIR . '/sys/CurlWrapper.php';
-										$this->communityContentCurlWrapper = new CurlWrapper();
+									require_once ROOT_DIR . '/sys/SystemVariables.php';
+									$systemVariables = SystemVariables::getSystemVariables();
+									if ($systemVariables && !empty($systemVariables->communityContentUrl)) {
+										if ($this->communityContentCurlWrapper == null) {
+											require_once ROOT_DIR . '/sys/CurlWrapper.php';
+											$this->communityContentCurlWrapper = new CurlWrapper();
+										}
+										$body = [
+											'term' => $phrase,
+											'isPublicFacing' => $isPublicFacing,
+											'isAdminFacing' => $isAdminFacing,
+											'isMetadata' => $isMetadata,
+											'isAdminEnteredData' => $isAdminEnteredData,
+										];
+										$this->communityContentCurlWrapper->curlPostPage($systemVariables->communityContentUrl . '/API/CommunityAPI?method=addTranslationTerm', $body);
 									}
-									$body = [
-										'term' => $phrase,
-										'isPublicFacing' => $isPublicFacing,
-										'isAdminFacing' => $isAdminFacing,
-										'isMetadata' => $isMetadata,
-										'isAdminEnteredData' => $isAdminEnteredData,
-									];
-									$this->communityContentCurlWrapper->curlPostPage($systemVariables->communityContentUrl . '/API/CommunityAPI?method=addTranslationTerm', $body);
+								} else {
+									$termTooLong = true;
 								}
-							} else {
+							} catch (Exception $e) {
 								$termTooLong = true;
 							}
-						} catch (Exception $e) {
-							$termTooLong = true;
-						}
-						if ($termTooLong) {
-							if (UserAccount::isLoggedIn() && UserAccount::userHasPermission('Translate Aspen')) {
-								//Just show the phrase for now, maybe show the error in debug mode?
-								if (IPAddress::showDebuggingInformation()) {
-									return "TERM TOO LONG for translation \"$phrase\"";
+							if ($termTooLong) {
+								if (UserAccount::isLoggedIn() && UserAccount::userHasPermission('Translate Aspen')) {
+									//Just show the phrase for now, maybe show the error in debug mode?
+									if (IPAddress::showDebuggingInformation()) {
+										return "TERM TOO LONG for translation \"$phrase\"";
+									} else {
+										return $phrase;
+									}
 								} else {
 									return $phrase;
 								}
-							} else {
-								return $phrase;
 							}
-						}
-					} else {
-						$termChanged = false;
-						if ($defaultText == null) {
-							$defaultText = '';
-						}
-						if ($defaultText != $translationTerm->defaultText) {
-							if (empty($translationTerm->defaultText) && !empty($defaultText)) {
-								$translationTerm->defaultText = $defaultText;
-								$defaultTextChanged = true;
+						} else {
+							$termChanged = false;
+							if ($defaultText == null) {
+								$defaultText = '';
+							}
+							if ($defaultText != $translationTerm->defaultText) {
+								if (empty($translationTerm->defaultText) && !empty($defaultText)) {
+									$translationTerm->defaultText = $defaultText;
+									$defaultTextChanged = true;
+									$termChanged = true;
+								}
+							}
+							if ($isPublicFacing && !$translationTerm->isPublicFacing) {
+								$translationTerm->isPublicFacing = $isPublicFacing;
 								$termChanged = true;
 							}
+							if ($isAdminFacing && !$translationTerm->isAdminFacing) {
+								$translationTerm->isAdminFacing = $isAdminFacing;
+								$termChanged = true;
+							}
+							if ($isMetadata && !$translationTerm->isMetadata) {
+								$translationTerm->isMetadata = $isMetadata;
+								$termChanged = true;
+							}
+							if ($isAdminEnteredData && !$translationTerm->isAdminEnteredData) {
+								$translationTerm->isAdminEnteredData = $isAdminEnteredData;
+								$termChanged = true;
+							}
+							if ($termChanged) {
+								$translationTerm->lastUpdate = time();
+								$translationTerm->update();
+							}
 						}
-						if ($isPublicFacing && !$translationTerm->isPublicFacing) {
-							$translationTerm->isPublicFacing = $isPublicFacing;
-							$termChanged = true;
-						}
-						if ($isAdminFacing && !$translationTerm->isAdminFacing) {
-							$translationTerm->isAdminFacing = $isAdminFacing;
-							$termChanged = true;
-						}
-						if ($isMetadata && !$translationTerm->isMetadata) {
-							$translationTerm->isMetadata = $isMetadata;
-							$termChanged = true;
-						}
-						if ($isAdminEnteredData && !$translationTerm->isAdminEnteredData) {
-							$translationTerm->isAdminEnteredData = $isAdminEnteredData;
-							$termChanged = true;
-						}
-						if ($termChanged) {
-							$translationTerm->lastUpdate = time();
-							$translationTerm->update();
-						}
+					}
+					else {
+						$translationTerm->find(true);
 					}
 
 					if ($activeLanguage->code == 'pig') {
@@ -205,14 +213,18 @@ class Translator {
 							}
 
 							$translation->translation = $defaultTranslation;
-							$ret = $translation->update();
-							if (!$ret) {
-								global $logger;
-								$logger->log("Could not update translation", Logger::LOG_ERROR);
+							if ($translationMode) {
+								$ret = $translation->update();
+								if (!$ret) {
+									global $logger;
+									$logger->log("Could not update translation", Logger::LOG_ERROR);
+								}
 							}
 						} elseif ($defaultTextChanged) {
 							$translation->needsReview = 1;
-							$translation->update();
+							if ($translationMode) {
+								$translation->update();
+							}
 						}
 
 						if ($escape) {

--- a/code/web/sys/Translation/Translator.php
+++ b/code/web/sys/Translation/Translator.php
@@ -73,9 +73,13 @@ class Translator {
 	 * @param bool $escape Whether the translation should be escaped before rendering.
 	 * @return string The translated phrase.
 	 */
-	function translate(string $phrase, string $defaultText = '', array $replacementValues = [], bool $inAttribute = false, bool $isPublicFacing = false,
-					   bool $isAdminFacing = false, bool $isMetadata = false, bool $isAdminEnteredData = false, bool $translateParameters = false, bool $escape = false): string
-	{
+	function translate(
+		string $phrase, string $defaultText = '', array $replacementValues = [],
+		bool $inAttribute = false, bool $isPublicFacing = false, bool $isAdminFacing = false,
+		bool $isMetadata = false, bool $isAdminEnteredData = false,
+		bool $translateParameters = false, bool $escape = false
+	): string {
+
 		if ($phrase === '' || is_numeric($phrase)) {
 			return $phrase;
 		}


### PR DESCRIPTION
- Translation database insertions and updates now only occur when actively in translation mode, improving performance and data integrity.
- Added protection against malicious search attempts, including directory traversal and invalid search parameters.

Translations Test Plan:
1. Start translation mode and locate a translatable phrase in Aspen that is publicly visible for testing purposes. Exit translation mode.
2. Delete the translated phrase from the `translation_terms` and `translations` tables.
3. Log out of your administrator account and refresh the page containing your chosen phrase. Query those two tables to see that the term has been automatically reinserted.
4. Apply the patch and repeat steps 1-3. Notice that the translated term is not reinserted into either of those tables.
5. If you are logged into an administrator account that has the “Translate Aspen” permission, enter translation mode again and query the two tables to see that the phrase has been automatically reinserted into both tables.
   - Going further, you could translate the phrase, exit translation mode, and log out. You will still see the translated phrase you modified, even as a user without that permission, ensuring that functionality remains as before.

Searches Test Plan:
1. Perform a couple of searches with syntax that could be used to exploit Aspen’s security. Notice that the searches are completed, even if no results are returned.
   - Examples:
    `/Search/Results?lookfor=../../../etc/passwd`
    `/Search/Results?lookfor=..\\..\\windows\\system32`
    `/Search/Results?lookfor=%2e%2e%2f%2e%2e%2f%2e%2e%2fetc%2fpasswd`
2. Apply the patch and repeat step 1. Notice that a “Page not found” will display instead, thus blocking these searches. For additional tests, see below.
   - Valid:
   `/Search/Results?lookfor=title:harry potter`
   `/Search/Results?lookfor=author:stephen king`
   `/Search/Results?lookfor=subject:science fiction`
   `/Search/Results?lookfor=keyword:test search`
   - Invalid prefixes, should fallback to Keyword:
   `/Search/Results?lookfor=invalidfield:some search term`
   `/Search/Results?lookfor=notafield:test`
   `/Search/Results?lookfor=xyz:book title`
   - Invalid `searchIndexes`:
   `/Search/Results?lookfor=test&searchIndex=InvalidIndex`
   `/Search/Results?lookfor=test&searchIndex=<script>alert('xss')</script> (may be blocked by Cloudflare)`

