### PR TITLE
DIS-325 Keyboard focus for browse categories can be hard to see

### DIFF
--- a/code/web/interface/themes/responsive/css/main.css
+++ b/code/web/interface/themes/responsive/css/main.css
@@ -9338,6 +9338,18 @@ a.placard-link {
 .browse-category div:focus {
   outline: none;
 }
+
+.browse-category:focus {
+  outline: none;
+  border: 6px solid #3174af;
+  box-shadow: 0 0 2px 6px rgba(26, 115, 232, 0.4);
+}
+
+.browse-category.selected:focus {
+  border: 6px solid #3174af;
+  box-shadow: 0 0 2px 6px rgba(26, 115, 232, 0.4);
+}
+
 .browse-category div:hover {
   text-decoration: underline;
 }


### PR DESCRIPTION
Steps to Test
1. Initial Setup (Before Patch)
    * Open Aspen Discovery in a browser.
    * Click inside the search box.
    * Press the Tab key repeatedly to move focus to the browse categories.
    * Observe the focus indicator:
        * You should see thin outlines (usually black or based on OS accent color).
        * A slight color change may appear (blue border, faint background).
        * These indicators are subtle and hard to see.
2. After Applying the Patch
    * Reload the page and clear cache if necessary.
    * Repeat the steps:
        * Place cursor in the search box.
        * Use Tab to navigate to browse categories.
    * Observe the focus indicator:
        * You should see a thicker border.
        * A highlighted background and/or glow (box-shadow) around the focused category.
        * The focus should now be clearly visible on all categories, including the selected one.
