### PR TITLE
DIS-937: Correct herader links title and aria label

### DIFF
--- a/code/web/interface/themes/responsive/horizontal-menu-bar.tpl
+++ b/code/web/interface/themes/responsive/horizontal-menu-bar.tpl
@@ -29,7 +29,7 @@
 								{* Only render HTML contents in the header menu *}
 								{if empty($link->htmlContents)}
 									<div class="header-menu-option childMenuItem">
-										<a href="{$link->url}" {if $link->openInNewTab}target="_blank"{/if} aria-label="{translate text=$linkName isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})" title="{translate text=$linkName isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})">
+										<a href="{$link->url}" {if $link->openInNewTab}target="_blank"{/if} aria-label="{translate text=$linkName isPublicFacing=true inAttribute=true}{if $link->openInNewTab} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true}){/if}" title="{translate text=$linkName isPublicFacing=true inAttribute=true}{if $link->openInNewTab} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true}){/if}">
 											{if $link->published == 0}<em>{/if}
 											{translate text=$linkName isPublicFacing=true}
 											{if $link->published == 0}</em>{/if}
@@ -54,7 +54,7 @@
 					</script>
 				{/literal}
 				{else}
-					<a href="{$topCategory->url}" role="link" class="menu-icon menu-bar-option {if !$topCategory->alwaysShowIconInTopMenu}visible-inline-block-lg{/if}" aria-label="{translate text=$categoryName inAttribute=true isPublicFacing=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})" title="{translate text=$categoryName inAttribute=true isPublicFacing=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})" {if $topCategory->openInNewTab}target="_blank"{/if} tabindex="0">
+					<a href="{$topCategory->url}" role="link" class="menu-icon menu-bar-option {if !$topCategory->alwaysShowIconInTopMenu}visible-inline-block-lg{/if}" aria-label="{translate text=$categoryName inAttribute=true isPublicFacing=true}{if $topCategory->openInNewTab} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true}){/if}" title="{translate text=$categoryName inAttribute=true isPublicFacing=true}{if $topCategory->openInNewTab} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true}){/if}" {if $topCategory->openInNewTab}target="_blank"{/if} tabindex="0">
 						{if !empty($topCategory->iconName)}
 							<i class="fas fa-{$topCategory->iconName} fa-lg" role="presentation"></i>
 						{/if}

--- a/code/web/release_notes/25.07.00.MD
+++ b/code/web/release_notes/25.07.00.MD
@@ -1,4 +1,9 @@
 ## Aspen Discovery Updates
+
+// jboyer
+### Theme Updates
+- Header / menu links will accurately reflect whether they open in a new tab or not. (DIS-937) (*JB*)
+
 // mark
 
 
@@ -35,7 +40,6 @@
 
 // lucas
 
-
 ## This release includes code contributions from
 ### ByWater Solutions
 - Leo Stoyanov (LS)
@@ -44,6 +48,9 @@
 - Ian Walls (IW)
 - Laura Escamilla (LE)
 - Nick Clemens (NC)
+
+### Equinox Open Library Intiative
+- Jason Boyer (JB)
 
 ### Grove For Libraries
 - Mark Noble (MDN)


### PR DESCRIPTION
Change the display of header link titles and aria labels to accurately reflect whether the links will open in the current or new tabs.