### PR TITLE
DIS-803: Narrow Scope of Selector, Fix Selector Targeting, & Fix Layout Clashes with jQuery's Validation Errors

### DIFF
--- a/code/web/interface/themes/responsive/DataObjectUtil/objectEditForm.tpl
+++ b/code/web/interface/themes/responsive/DataObjectUtil/objectEditForm.tpl
@@ -141,7 +141,6 @@
 				{include file="DataObjectUtil/validationRule.tpl"}
 			{/foreach}
 			objectEditorObject.data('serialize',objectEditorObject.serialize()); // On load save form current state
-			AspenDiscovery.FormFields.initializeCharacterCounters(objectEditorObject);
 			{if !empty($initializationJs)}
 				{$initializationJs}
 			{/if}

--- a/code/web/interface/themes/responsive/js/aspen/base.js
+++ b/code/web/interface/themes/responsive/js/aspen/base.js
@@ -58,6 +58,7 @@ var AspenDiscovery = (function(){
 		});
 		// Set initial visibility.
 		$lookfor.trigger("input");
+		AspenDiscovery.FormFields.initializeCharacterCounters();
 	});
 
 	return {


### PR DESCRIPTION
- Narrow the scope of selectors so only genuine text-based inputs (e.g., `text`, `search`, `tel`, `URL`, `email`) along with `textareas` get counters.
   - Thus, with this scoping, centralize the counter initialization in `base.js` so no individual templates must call it and so it applies to all pages.
- Fixed the counter selector so it will always find the right `<span class="char-counter">` (even if the validator’s error `<label>` gets injected in between).
- Overrode jQuery Validate’s `errorPlacement` for `maxlength` fields so error labels are injected after the field wrapper, preventing layout shifts.