### PR TITLE
DIS-715: display uncontrolled series (490, first indicator 0)

### DIFF
--- a/code/reindexer/src/org/aspen_discovery/reindexer/AbstractGroupedWorkSolr.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/AbstractGroupedWorkSolr.java
@@ -81,7 +81,6 @@ public abstract class AbstractGroupedWorkSolr {
 	protected HashSet<String> placesOfPublication = new HashSet<>();
 	protected float rating = -1f;
 	protected HashMap<String, String> series = new HashMap<>();
-	protected HashMap<String, String> series2 = new HashMap<>();
 	protected HashMap<String, String> seriesWithVolume = new HashMap<>();
 	protected String subTitle;
 	protected HashSet<String> targetAudienceFull = new HashSet<>();
@@ -202,8 +201,6 @@ public abstract class AbstractGroupedWorkSolr {
 		clonedWork.placesOfPublication = (HashSet<String>)placesOfPublication.clone();
 		// noinspection unchecked
 		clonedWork.series = (HashMap<String, String>) series.clone();
-		// noinspection unchecked
-		clonedWork.series2 = (HashMap<String, String>) series2.clone();
 		// noinspection unchecked
 		clonedWork.seriesWithVolume = (HashMap<String, String>) seriesWithVolume.clone();
 		// noinspection unchecked
@@ -742,7 +739,6 @@ public abstract class AbstractGroupedWorkSolr {
 
 	void clearSeries(){
 		this.seriesWithVolume.clear();
-		this.series2.putAll(this.series);
 		this.series.clear();
 	}
 
@@ -805,18 +801,6 @@ public abstract class AbstractGroupedWorkSolr {
 					this.seriesWithVolume.put(normalizedSeriesInfoWithVolume, seriesInfoWithVolume);
 				}
 			}
-		}
-	}
-
-	void addSeries2(Set<String> fieldList) {
-		for (String curField : fieldList) {
-			this.addSeries2(curField);
-		}
-	}
-
-	private void addSeries2(String series2) {
-		if (series != null) {
-			addSeriesInfoToField(series2, this.series2);
 		}
 	}
 

--- a/code/reindexer/src/org/aspen_discovery/reindexer/GroupedWorkSolr.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/GroupedWorkSolr.java
@@ -86,7 +86,6 @@ public class GroupedWorkSolr extends AbstractGroupedWorkSolr implements Cloneabl
 			doc.addField("edition", editions);
 			doc.addField("dateSpan", dateSpans);
 			doc.addField("series", series.values());
-			doc.addField("series2", series2.values());
 			doc.addField("series_with_volume", seriesWithVolume.values());
 			doc.addField("topic", topics);
 			doc.addField("topic_facet", topicFacets);

--- a/code/reindexer/src/org/aspen_discovery/reindexer/GroupedWorkSolr2.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/GroupedWorkSolr2.java
@@ -96,8 +96,6 @@ public class GroupedWorkSolr2 extends AbstractGroupedWorkSolr implements Cloneab
 			doc.addField("dateSpan", dateSpans);
 			//series.values().removeAll(GroupedWorkIndexer.hideSeries);
 			doc.addField("series", series.values());
-			//series2.values().removeAll(GroupedWorkIndexer.hideSeries);
-			doc.addField("series2", series2.values());
 			//seriesWithVolume.values().removeAll(GroupedWorkIndexer.hideSeries);
 			doc.addField("series_with_volume", seriesWithVolume.values());
 

--- a/code/reindexer/src/org/aspen_discovery/reindexer/MarcRecordProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/MarcRecordProcessor.java
@@ -413,30 +413,31 @@ abstract class MarcRecordProcessor {
 			groupedWork.addSeriesWithVolume(series, volume);
 			foundSeriesIn800or830 = true;
 		}
-		if (!foundSeriesIn800or830){
-			seriesFields = MarcUtil.getDataFields(record, 490);
-			for (DataField seriesField : seriesFields){
-				String series = AspenStringUtils.trimTrailingPunctuation(MarcUtil.getSpecifiedSubfieldsAsString(seriesField, "a","")).toString();
+
+		seriesFields = MarcUtil.getDataFields(record, 490);
+		for (DataField seriesField : seriesFields){
+			// Include only uncontrolled series from 490, since controlled will also be in 800/830
+			if (seriesField.getIndicator1() == '0') {
+				String series = AspenStringUtils.trimTrailingPunctuation(MarcUtil.getSpecifiedSubfieldsAsString(seriesField, "a", "")).toString();
 				//Remove anything in parentheses since it's normally just the format
 				//series = series.replaceAll("\\s+\\(.*?\\)", "");
 				//Remove the word series at the end since this gets cataloged inconsistently
 				series = series.replaceAll("(?i)\\s+series$", "");
 
 				String volume = "";
-				if (seriesField.getSubfield('v') != null){
+				if (seriesField.getSubfield('v') != null) {
 					//Separate out the volume so we can link specially
 					volume = seriesField.getSubfield('v').getData();
 				}
 				groupedWork.addSeriesWithVolume(series, volume);
+				groupedWork.addSeries(series);
 			}
 		}
 
 		if (foundSeriesIn800or830) {
 			groupedWork.addSeries(MarcUtil.getFieldList(record, "830ap:800pqt"));
-			groupedWork.addSeries2(MarcUtil.getFieldList(record, "490a"));
-		}else{
-			groupedWork.addSeries(MarcUtil.getFieldList(record, "490a"));
 		}
+		
 		groupedWork.addDateSpan(MarcUtil.getFieldList(record, "362a"));
 		groupedWork.addContents(MarcUtil.getFieldList(record, "505a:505t"));
 		//Check to see if we have any child records and if so add them as well

--- a/code/reindexer/src/org/aspen_discovery/reindexer/MarcRecordProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/MarcRecordProcessor.java
@@ -437,7 +437,7 @@ abstract class MarcRecordProcessor {
 		if (foundSeriesIn800or830) {
 			groupedWork.addSeries(MarcUtil.getFieldList(record, "830ap:800pqt"));
 		}
-		
+
 		groupedWork.addDateSpan(MarcUtil.getFieldList(record, "362a"));
 		groupedWork.addContents(MarcUtil.getFieldList(record, "505a:505t"));
 		//Check to see if we have any child records and if so add them as well

--- a/code/web/release_notes/25.07.00.MD
+++ b/code/web/release_notes/25.07.00.MD
@@ -3,7 +3,8 @@
 
 
 // katherine
-
+### Series Updates
+- During indexing, include uncontrolled (not traced) series (490a with a first indicator of 0).  Remove series2 field from reindexer and Solr since it is no longer in use. (DIS-715) (*KP*)
 
 // kirstien
 

--- a/data_dir_setup/solr7/grouped_works_v2/conf/schema.xml
+++ b/data_dir_setup/solr7/grouped_works_v2/conf/schema.xml
@@ -236,7 +236,6 @@
 
 		<!-- SERIES Fields -->
 		<field name="series" type="searchable_text" indexed="true" stored="true" multiValued="true"/>
-		<field name="series2" type="searchable_text" indexed="true" stored="true" multiValued="true"/>
 		<field name="series_facet" type="unchanged_string" indexed="true" stored="true" multiValued="true" docValues="true"/>
 		<field name="series_proper" type="textProper" indexed="true" stored="false" multiValued="true"/>
 		<field name="series_with_volume" type="textProper" indexed="false" stored="true" multiValued="true"/>

--- a/sites/default/conf/groupedWorksSearchSpecs.yaml
+++ b/sites/default/conf/groupedWorksSearchSpecs.yaml
@@ -23,13 +23,13 @@
 #    #     dynamic query generated using the QueryFields; see JournalTitle below
 #    #     for an example.
 #    FilterQuery: (optional Lucene filter query)
-# 
+#
 # ...etc.
 #
 #-----------------------------------------------------------------------------------
 #
-# Within the QueryFields area, fields are OR'd together, unless they're in an 
-# anonymous array, in which case the first element is a two-value array that tells 
+# Within the QueryFields area, fields are OR'd together, unless they're in an
+# anonymous array, in which case the first element is a two-value array that tells
 # us what the type (AND or OR) and weight of the whole group should be.
 #
 # So, given:
@@ -40,30 +40,30 @@
 #       - [onephrase, 500]
 #       - [and, 200]
 #     - B:
-#       - [and, 100]   
-#       - [or, 50]  
-#     # Start an anonymous array to group; first element indicates AND grouping 
+#       - [and, 100]
+#       - [or, 50]
+#     # Start an anonymous array to group; first element indicates AND grouping
 #     #     and a weight of 50
 #     -
-#       - [AND, 50]                 
+#       - [AND, 50]
 #       - C:
 #         - [onephrase, 200]
 #       - D:
 #         - [onephrase, 300]
-#       # Note the "not" attached to the field name as a minus, and the use of ~ 
+#       # Note the "not" attached to the field name as a minus, and the use of ~
 #       #     to mean null ("no special weight")
 #       - -E:
 #         - [or, ~]
 #     - D:
 #       - [or, 100]
-# 
-#  ...and the search string 
+#
+#  ...and the search string
 #
 #      test "one two"
 #
 #  ...we'd get
-#   
-#   (A:"test one two"^500 OR 
+#
+#   (A:"test one two"^500 OR
 #    A:(test AND "one two")^ 200 OR
 #    B:(test AND "one two")^100 OR
 #    B:(test OR "one two")^50
@@ -79,7 +79,7 @@
 #
 # Munge types are based on the original Solr.php code, and consist of:
 #
-# onephrase: eliminate all quotes and do it as a single phrase. 
+# onephrase: eliminate all quotes and do it as a single phrase.
 #   testing "one two"
 #    ...becomes ("testing one two")
 #
@@ -217,8 +217,6 @@ Title:
       - [exact, 600]
       - [onephrase, 200]
       - [and, 50]
-    - series2:
-      - [and, 30]
 
 TitleProper:
   QueryFields:
@@ -244,18 +242,12 @@ Series:
       - [text_left, 1000]
       - [onephrase, 500]
       - [and, 100]
-    - series2:
-      - [onephrase, 50]
-      - [and, 50]
 
 SeriesProper:
   QueryFields:
     - series_proper:
       - [localized_callnumber, 2400]
       - [onephrase, 500]
-    - series2:
-      - [onephrase, 750]
-      - [exact, 250]
     - series:
       - [onephrase, 1000]
       - [exact, 400]
@@ -334,8 +326,6 @@ Keyword:
         - [exact_quoted, 1500]
         - [onephrase, 600]
         - [and, 50]
-      - series2:
-        - [and, 30]
 # Check everything else
     - table_of_contents:
       - [and, 50]
@@ -395,7 +385,7 @@ KeywordProper:
       - [or, ~]
     - upc:
       - [and, 100]
-      - [or, ~]      
+      - [or, ~]
     - oclc:
       - [and, 100]
       - [or, ~]

--- a/sites/default/conf/groupedWorksSearchSpecs2.yaml
+++ b/sites/default/conf/groupedWorksSearchSpecs2.yaml
@@ -223,8 +223,6 @@ Title:
       - [onephrase, 50]
     - series:
       - [and, 10]
-    - series2:
-      - [and, 10]
 
 TitleProper:
   QueryFields:
@@ -250,18 +248,12 @@ Series:
       - [text_left, 1000]
       - [onephrase, 500]
       - [and, 100]
-    - series2:
-      - [onephrase, 50]
-      - [and, 50]
 
 SeriesProper:
   QueryFields:
     - series_proper:
       - [localized_callnumber, 2400]
       - [onephrase, 500]
-    - series2:
-      - [onephrase, 750]
-      - [exact, 250]
     - series:
       - [onephrase, 1000]
       - [exact, 400]


### PR DESCRIPTION
- Update MARC indexing so that 490 fields with a first indicator of 0 are always added as series.  First indicator of 1 is ignored, since it should have duplicate content in 800 or 830. 800 and 830 series are still included as before.
- Remove series2 field from reindexer and Solr schema, since it's no longer necessary.
- Update release notes.