### PR TITLE
DIS-936: Refresh access token

### DIFF
--- a/code/web/Drivers/KohaApiUserAgent.php
+++ b/code/web/Drivers/KohaApiUserAgent.php
@@ -268,11 +268,12 @@ class KohaApiUserAgent {
 	}
 
 	/**
-	 * Get authorization header
+	 * Get the current authorization header.
 	 *
-	 * Checks the authentication method used and returns a string with the corresponding header
+	 * Checks the authentication method that will be use to make the call to the API
+	 * and returns a string with the appropiate header.
 	 *
-	 * @return  string|bool           Authorization header if successful, otherwise returns false.
+	 * @return  string|bool	An authorization header, otherwise returns false.
 	 * @access  private
 	 */
 	private function getAuthorizationHeader($caller): string|bool {
@@ -280,31 +281,26 @@ class KohaApiUserAgent {
 			$basicToken = $this->getBasicAuthToken();
 			$header = 'Authorization: Basic ' . $basicToken;
 		} else {
-			if ($this->isExpiredToken()) {
-				$oAuthToken = $this->getOAuthToken();
-				if ($oAuthToken) {
-					$this->oAuthToken = $oAuthToken;
-					$header = 'Authorization: Bearer ' . $this->oAuthToken;
-				} else {
-					global $logger;
-					//Special message case for patronLogin
-					if (stripos($caller, "koha.patronLogin") !== false) {
-						$logger->log("Unable to authenticate with the ILS from koha.patronLogin", Logger::LOG_ERROR);
-					} else {
-						$logger->log("Unable to retrieve OAuth2 token from " . $caller, Logger::LOG_ERROR);
-					}
-					$result['messages'][] = translate([
-						'text' => 'Unable to authenticate with the ILS.  Please try again later or contact the library.',
-						'isPublicFacing' => true,
-					]);
-					$result['api']['messages'] = translate([
-						'text' => 'Unable to authenticate with the ILS.  Please try again later or contact the library.',
-						'isPublicFacing' => true,
-					]);
-					return $oAuthToken;
-				}
+			$oAuthToken = $this->getOAuthToken();
+			if ($oAuthToken) {
+				$header = 'Authorization: Bearer ' . $oAuthToken;
 			} else {
-				$header = 'Authorization: Bearer ' . $this->oAuthToken;
+				global $logger;
+				//Special message case for patronLogin
+				if (stripos($caller, "koha.patronLogin") !== false) {
+					$logger->log("Unable to authenticate with the ILS from koha.patronLogin", Logger::LOG_ERROR);
+				} else {
+					$logger->log("Unable to retrieve OAuth2 token from " . $caller, Logger::LOG_ERROR);
+				}
+				$result['messages'][] = translate([
+					'text' => 'Unable to authenticate with the ILS.  Please try again later or contact the library.',
+					'isPublicFacing' => true,
+				]);
+				$result['api']['messages'] = translate([
+					'text' => 'Unable to authenticate with the ILS.  Please try again later or contact the library.',
+					'isPublicFacing' => true,
+				]);
+				return $oAuthToken;
 			}
 		}
 		return $header;

--- a/code/web/Drivers/KohaApiUserAgent.php
+++ b/code/web/Drivers/KohaApiUserAgent.php
@@ -399,13 +399,6 @@ class KohaApiUserAgent {
 		}
 	}
 
-	private function isExpiredToken(): bool {
-		if ( time() > $this->expiresAt) {
-			return true;
-		}
-		return false;
-	}
-
 	/**
 	 * Get basic authorization token
 	 *

--- a/code/web/release_notes/25.07.00.MD
+++ b/code/web/release_notes/25.07.00.MD
@@ -35,6 +35,8 @@
 // nick
 
 // lucas
+### Koha Updates
+- Fixed an issue where the access token, to communicate with the Koha API, was renewed on every request. (DIS-936) (*LM*)
 
 
 ## This release includes code contributions from


### PR DESCRIPTION
Until now, every time Aspen makes a Koha API call, it is renewing the access token, which means that Aspen is accessing the API unnecessarily. 
This patch fixes the problem by storing the access token as a cached value and renewing it if it has not yet expired. 