### PR TITLE
DIS-922: Fix Password Requirements for All Password Inputs

### DIFF
--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -4515,6 +4515,7 @@ class Koha extends AbstractIlsDriver {
 						'description' => $passwordNotes,
 						'minLength' => $pinValidationRules['minLength'],
 						'maxLength' => $pinValidationRules['maxLength'],
+						'onlyDigitsAllowed' => $pinValidationRules['onlyDigitsAllowed'],
 						'showConfirm' => false,
 						'required' => true,
 						'showDescription' => true,
@@ -4527,6 +4528,7 @@ class Koha extends AbstractIlsDriver {
 						'description' => 'Reenter your PIN',
 						'minLength' => $pinValidationRules['minLength'],
 						'maxLength' => $pinValidationRules['maxLength'],
+						'onlyDigitsAllowed' => $pinValidationRules['onlyDigitsAllowed'],
 						'showConfirm' => false,
 						'required' => true,
 						'showDescription' => false,
@@ -4692,6 +4694,47 @@ class Koha extends AbstractIlsDriver {
 	function selfRegister(): array {
 		global $library;
 		$result = ['success' => false,];
+
+		if (isset($_REQUEST['borrower_password'])) {
+			$password = $_REQUEST['borrower_password'];
+			$pinValidationRules = $this->getPasswordPinValidationRules();
+
+			if (strlen($password) < $pinValidationRules['minLength']) {
+				$result['success'] = false;
+				$result['message'] = translate([
+					'text' => "Password must be at least {$pinValidationRules['minLength']} characters long.",
+					'isPublicFacing' => true
+				]);
+				return $result;
+			}
+
+			if (strlen($password) > $pinValidationRules['maxLength']) {
+				$result['success'] = false;
+				$result['message'] = translate([
+					'text' => "Password must be longer than {$pinValidationRules['maxLength']} characters.",
+					'isPublicFacing' => true
+				]);
+				return $result;
+			}
+
+			if ($pinValidationRules['onlyDigitsAllowed'] && !ctype_digit($password)) {
+				$result['success'] = false;
+				$result['message'] = translate([
+					'text' => "Password must only contain numbers.",
+					'isPublicFacing' => true
+				]);
+				return $result;
+			}
+
+			if (isset($_REQUEST['borrower_password2']) && $_REQUEST['borrower_password'] !== $_REQUEST['borrower_password2']) {
+				$result['success'] = false;
+				$result['message'] = translate([
+					'text' => "Passwords do not match.",
+					'isPublicFacing' => true
+				]);
+				return $result;
+			}
+		}
 
 		if ($this->getKohaVersion() < 20.05) {
 			$catalogUrl = $this->accountProfile->vendorOpacUrl;

--- a/code/web/interface/themes/responsive/DataObjectUtil/password.tpl
+++ b/code/web/interface/themes/responsive/DataObjectUtil/password.tpl
@@ -1,6 +1,29 @@
-<input type='password' name='{$propName}' id='{$propName}' {if !empty($propValue) && $property.type != 'storedPassword'}value='{$propValue|escape}'{/if} {if !empty($property.maxLength)}maxlength='{$property.maxLength}'{/if} {if !empty($property.maxLength)}maxlength='{$property.maxLength}'{/if} {if !empty($property.size)}size='{$property.size}'{/if} class='form-control {if !empty($property.required)}required{/if}' {if !empty($property.readOnly)}readonly{/if} {if $property.type == 'storedPassword' && !empty($propValue)}placeholder="{translate text='Use previously saved value' inAttribute=true isAdminFacing=true}"{/if} {if !empty($property.autocomplete)}autocomplete="{$property.autocomplete}"{/if}/>
-{if !empty($property.note)}<span id="{$propName}HelpBlock" class="help-block" style="margin-top:0"><small><i class="fas fa-info-circle"></i> {$property.note}</small></span>{/if}
+<input type='password' name='{$propName}' id='{$propName}'
+    {if !empty($propValue) && $property.type != 'storedPassword'} value='{$propValue|escape}'{/if}
+    {if !empty($property.minLength)} minlength='{$property.minLength}'{/if}
+    {if !empty($property.maxLength)} maxlength='{$property.maxLength}'{/if}
+    {if !empty($property.size)} size='{$property.size}'{/if}
+    class='form-control{if !empty($property.required)} required{/if}{if !empty($property.onlyDigitsAllowed)} digits{/if}'
+    {if !empty($property.readOnly)} readonly{/if}
+    {if $property.type == 'storedPassword' && !empty($propValue)} placeholder="{translate text='Use previously saved value' inAttribute=true isAdminFacing=true}"{/if}
+    {if !empty($property.autocomplete)} autocomplete="{$property.autocomplete}"{/if}
+/>
+
+{if !empty($property.note)}
+    <span id="{$propName}HelpBlock" class="help-block" style="margin-top:0">
+        <small><i class="fas fa-info-circle"></i> {$property.note}</small>
+    </span>
+{/if}
+
 {if !isset($property.showConfirm) || $property.showConfirm == true}
-{translate text="Confirm %1%" 1=$property.label translateParameters=true isAdminFacing=true}
-<input type='password' name='{$propName}Repeat' id='{$propName}Repeat' {if !empty($propValue) && $property.type != 'storedPassword'}value='{$propValue|escape}'{/if} {if !empty($property.maxLength)}maxlength='{$property.maxLength}'{/if} {if !empty($property.size)}size='{$property.size}'{/if} class='form-control repeat' {if !empty($property.readOnly)}readonly{/if}  {if !empty($property.autocomplete)}autocomplete="{$property.autocomplete}"{/if}/>
+    <div>{translate text="Confirm %1%" 1=$property.label translateParameters=true isAdminFacing=true}</div>
+    <input type='password' name='{$propName}Repeat' id='{$propName}Repeat'
+        {if !empty($propValue) && $property.type != 'storedPassword'} value='{$propValue|escape}'{/if}
+        {if !empty($property.minLength)} minlength='{$property.minLength}'{/if}
+        {if !empty($property.maxLength)} maxlength='{$property.maxLength}'{/if}
+        {if !empty($property.size)} size='{$property.size}'{/if}
+        class='form-control repeat {if !empty($property.onlyDigitsAllowed)} digits{/if}'
+        {if !empty($property.readOnly)} readonly{/if}
+        {if !empty($property.autocomplete)} autocomplete="{$property.autocomplete}"{/if}
+    />
 {/if}

--- a/code/web/interface/themes/responsive/MyAccount/selfReg.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/selfReg.tpl
@@ -91,14 +91,17 @@
 
 </script>
 {/if}
-{literal}
-	<script type="text/javascript">
+
+<script type="text/javascript">
+	$(function () {
 		// Clear form data when navigating back so user info is not retained.
-		window.addEventListener('pageshow', function() {
-			var forms = document.querySelectorAll('form[id^="objectEditor"]');
-			for (var i = 0; i < forms.length; i++) {
-				forms[i].reset();
-			}
+		window.addEventListener('pageshow', function () {
+			document.querySelectorAll('form[id^="objectEditor"]').forEach(form => form.reset());
 		});
-	</script>
-{/literal}
+		const $borrowPass2 = $("#borrower_password2");
+		if ($borrowPass2.length) {
+			$borrowPass2.attr('data-rule-equalTo', "#borrower_password");
+			$borrowPass2.attr('data-msg-equalTo', '{translate text="Passwords must match." isPublicFacing=true inAttribute=true}');
+		}
+	});
+</script>

--- a/code/web/release_notes/25.07.00.MD
+++ b/code/web/release_notes/25.07.00.MD
@@ -18,6 +18,13 @@
 // imani
 
 // leo
+### Koha Updates
+- Added backend validation to make sure password rules are enforced even if frontend validation is bypassed. (DIS-922) (*LS*)
+
+### Account Updates
+- Ensured that the “Confirm Password” field must match the original password field's input. (DIS-922) (*LS*)
+- Improved how password fields behave by enforcing minimum and maximum lengths, and digits-only input when required. (DIS-922) (*LS*)
+- For the confirm-password field, adjusted layout to prevent visual issues when password errors appear, ensuring labels stay in place. (DIS-922) (*LS*)
 
 // yanjun
 

--- a/code/web/services/MyAccount/SelfReg.php
+++ b/code/web/services/MyAccount/SelfReg.php
@@ -96,7 +96,7 @@ class SelfReg extends Action {
 								$interface->assign('selfRegResult', $result);
 							} else {
 								$ageMessage = translate([
-									'text' => 'Age should be at least' . $library->minSelfRegAge . ' years. Please enter a valid Date of Birth.',
+									'text' => 'You must be at least ' . $library->minSelfRegAge . ' years old. Please enter a valid date of birth.',
 									'isPublicFacing' => true
 								]);
 								$interface->assign('ageMessage', $ageMessage);


### PR DESCRIPTION
### Koha Updates
- Added backend validation to make sure password rules are enforced even if frontend validation is bypassed.

### Account Updates
- Ensured that the “Confirm Password” field must match the original password field's input.
- Improved how password fields behave by enforcing minimum and maximum lengths, and digits-only input when required. 
- For the confirm-password field, adjusted layout to prevent visual issues when password errors appear, ensuring labels stay in place.

Test Plan: Present in the description of the Jira issue.