### PR TITLE
DIS-848: Corrected Collapsed Sidebar Button to Use Theme Primary BG Color

### DIFF
--- a/code/web/interface/themes/responsive/css/layout.less
+++ b/code/web/interface/themes/responsive/css/layout.less
@@ -971,7 +971,6 @@ a.placard-link{
   right: 0 !important;
   width: 38px !important;
   height: 36px !important;
-  background-color: @brand-primary !important;
   border-radius: 10% !important;
 }
 

--- a/code/web/interface/themes/responsive/css/main.css
+++ b/code/web/interface/themes/responsive/css/main.css
@@ -8803,7 +8803,6 @@ a.placard-link {
   right: 0 !important;
   width: 38px !important;
   height: 36px !important;
-  background-color: #3174AF !important;
   border-radius: 10% !important;
 }
 #sidebar-collapse button i {

--- a/code/web/interface/themes/responsive/theme.css.tpl
+++ b/code/web/interface/themes/responsive/theme.css.tpl
@@ -845,6 +845,10 @@ label{ldelim}
 	color: {$primaryForegroundColor};
 {rdelim}
 
+#side-bar.collapsed #sidebar-collapse{ldelim}
+    background-color: {$primaryBackgroundColor} !important;
+{rdelim}
+
 pre{ldelim}
 	background-color: {$primaryBackgroundColor}70;
 	border-color: {$primaryBackgroundColor};

--- a/code/web/interface/themes/responsive/theme.css.tpl
+++ b/code/web/interface/themes/responsive/theme.css.tpl
@@ -846,7 +846,7 @@ label{ldelim}
 {rdelim}
 
 #side-bar.collapsed #sidebar-collapse{ldelim}
-    background-color: {$primaryBackgroundColor} !important;
+    background-color: {$primaryBackgroundColor};
 {rdelim}
 
 pre{ldelim}


### PR DESCRIPTION
**Note**: After applying this patch, you must re-save your theme to regenerate the theme's CSS (or perform a DB maintenance, which regenerates CSS for all themes) and for the correct background color to display.