### PR TITLE
DIS-969: Fixed Bulk-Deletion of Two Factor Auth Settings

### DIFF
--- a/code/web/release_notes/25.07.00.MD
+++ b/code/web/release_notes/25.07.00.MD
@@ -19,6 +19,8 @@
 // imani
 
 // leo
+### Other Updates
+- Fixed an issue where bulk-deleting Two-Factor Authentication Settings did not work. (DIS-969) (*LS*)
 
 // yanjun
 

--- a/code/web/services/Admin/TwoFactorAuth.php
+++ b/code/web/services/Admin/TwoFactorAuth.php
@@ -4,7 +4,7 @@ require_once ROOT_DIR . '/Action.php';
 require_once ROOT_DIR . '/services/Admin/ObjectEditor.php';
 require_once ROOT_DIR . '/sys/TwoFactorAuthSetting.php';
 
-class TwoFactorAuth extends ObjectEditor {
+class Admin_TwoFactorAuth extends ObjectEditor {
 	function launch() : void {
 		global $interface;
 		global $library;


### PR DESCRIPTION
- Fixed an issue where bulk-deleting Two-Factor Authentication Settings did not work.

Test Plan:
1. Navigate to the Two-Factor Authentication Settings page of the admin interface.
2. Create a fake setting, select it using the table's checkbox, and click either of the delete buttons. Notice that neither button does anything.
3. Apply the patch and repeat step 2. Notice that the selected setting is deleted after a warning prompt.