### PR TITLE
DIS-986: Highlight Active Page in "My Reading History" Pagination Controls

### DIFF
--- a/code/web/release_notes/25.07.00.MD
+++ b/code/web/release_notes/25.07.00.MD
@@ -19,6 +19,8 @@
 // imani
 
 // leo
+### Reading History Updates
+- Added visual highlighting to the active page number on the "My Reading History" page. (DIS-986) (*LS*)
 
 // yanjun
 

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -4328,8 +4328,11 @@ class MyAccount_AJAX extends JSON_Action {
 		return $result;
 	}
 
-	function renderReadingHistoryPaginationLink($page, $options) {
-		return "<a class='page-link btn btn-default btn-sm' onclick='AspenDiscovery.Account.loadReadingHistory(\"{$options['patronId']}\", \"{$options['sort']}\", \"{$page}\", undefined, \"{$options['filter']}\");AspenDiscovery.goToAnchor(\"topOfList\")'>";
+	/** @noinspection PhpUnused */
+	function renderReadingHistoryPaginationLink(int $page, array $options): string {
+		$currentPage = isset($_REQUEST['page']) && is_numeric($_REQUEST['page']) ? $_REQUEST['page'] : 1;
+		$activeClass = ($currentPage == $page) ? ' active' : '';
+		return "<a class='page-link btn btn-default btn-sm{$activeClass}' onclick='AspenDiscovery.Account.loadReadingHistory(\"{$options['patronId']}\", \"{$options['sort']}\", \"{$page}\", undefined, \"{$options['filter']}\");AspenDiscovery.goToAnchor(\"topOfList\")'>";
 	}
 
 	private function isValidTimeStamp($timestamp) {


### PR DESCRIPTION
- Added visual highlighting to the active page number on the "My Reading History" page.

Test Plan:
1. Log in or masquerade as a patron account with a reading history.
2. Navigate to the My Reading History page and click the page-number bottoms at the bottom. Notice that they are not highlighted when selected.
3. Apply the patch, reload the page, and repeat step 2. Notice that the page-number buttons are highlighted.