### PR TITLE
DIS-853 New York Times API updates

### DIFF
--- a/code/web/cron/updateNYTLists.php
+++ b/code/web/cron/updateNYTLists.php
@@ -33,10 +33,12 @@ if (!$nytSettings->find(true)) {
 		if ($nytUpdateLog != null) {
 			$nytUpdateLog->addError("Did not get a good response from the API");
 		}
-	}
+	} else{
+		//Record the number of lists to be processed
+		$nytUpdateLog->numLists = count($availableLists);
+		$nytUpdateLog->update();
 
-	$listAPI = new ListAPI();
-	if (!empty($availableLists)) {
+		$listAPI = new ListAPI();
 		foreach ($availableLists as $list) {
 			$listName = $list->display_name;
 			try {
@@ -46,8 +48,7 @@ if (!$nytSettings->find(true)) {
 			}
 			$nytUpdateLog->lastUpdate = time();
 			$nytUpdateLog->update();
-			//Make sure we don't hit our quota.  Wait between updates
-			sleep(7);
+			//We now get all information in a single call, so there is no need to wait between calls
 		}
 	}
 

--- a/code/web/release_notes/25.05.01.MD
+++ b/code/web/release_notes/25.05.01.MD
@@ -3,8 +3,7 @@
 - Update the New York Times API integration to use V3 of the API. (DIS-853) (*MDN*)
   - Updating results now only requires one API call to the New York Times which will reduce or eliminate timeouts. 
   - The list publication date has been removed from the overview response for lists so that information will no longer be included for individual lists. 
-  - When updating individual lists from the admin screen, the lists will always be updated regardless of publication date. 
-  - 
+  - When updating individual lists from the admin screen, the lists will always be updated regardless of publication date.
 
 ### Series Updates
 - Properly handle series that are normalized to empty strings (i.e. a series of a single period). (DIS-828) (*MDN*)

--- a/code/web/release_notes/25.06.01.MD
+++ b/code/web/release_notes/25.06.01.MD
@@ -8,6 +8,10 @@
   - Stripe 
   - Snap Pay
 
+### New York Times Updates
+- Update the number of lists processed within the log entry while processing New York Times updates. (DIS-853) (*MDN*)
+- Remove delay between processing lists for the New York Times since all information is immediately available. (DIS-853) (*MDN*)
+
 ## This release includes code contributions from
 ### Grove
 - Mark Noble (*MDN*)


### PR DESCRIPTION
- Update the number of lists processed within the log entry while processing New York Times updates.
- Remove delay between processing lists for the New York Times since all information is immediately available.