### PR TITLE
DIS-992: Fixed Incorrectly Displayed HTML Entities

### DIFF
--- a/code/web/interface/themes/responsive/Search/advanced.tpl
+++ b/code/web/interface/themes/responsive/Search/advanced.tpl
@@ -184,7 +184,7 @@
 															<select name="filter[]" class="form-control" aria-label="{translate text=$facetInfo.facetLabel inAttribute=true isPublicFacing=true}">
 																{foreach from=$facetInfo.values item="value" key="display"}
 																	{if strlen($display) > 0}
-																		<option value="{$value.filter|escape}"{if !empty($value.selected)} selected="selected"{/if}>{$value.display|escape|truncate:80}</option>
+																		<option value="{$value.filter|escape}"{if !empty($value.selected)} selected="selected"{/if}>{$value.display|truncate:80}</option>
 																	{/if}
 																{/foreach}
 															</select>

--- a/code/web/release_notes/25.07.00.MD
+++ b/code/web/release_notes/25.07.00.MD
@@ -19,6 +19,8 @@
 // imani
 
 // leo
+### Other Updates
+- Fixed incorrect display of HTML entities on the Advanced Search page for facet values and on the Grouped Work Display Settings page for a setting. (DIS-992) (*LS*)
 
 // yanjun
 ### Other Updates

--- a/code/web/sys/Grouping/GroupedWorkDisplaySetting.php
+++ b/code/web/sys/Grouping/GroupedWorkDisplaySetting.php
@@ -100,7 +100,7 @@ class GroupedWorkDisplaySetting extends DataObject {
 		'showLanguages' => 'Show Language',
 		'showArInfo' => 'Show Accelerated Reader Information',
 		'showLexileInfo' => 'Show Lexile Information',
-		'showFountasPinnell' => 'Show Fountas &amp; Pinnell Information  (This data must be present in MARC records)',
+		'showFountasPinnell' => 'Show Fountas & Pinnell Information  (This data must be present in MARC records.)',
 		'showAudience' => 'Audience',
 	];
 
@@ -116,7 +116,7 @@ class GroupedWorkDisplaySetting extends DataObject {
 		'showISBNs' => 'ISBNs / ISSNs',
 		'showArInfo' => 'Show Accelerated Reader Information',
 		'showLexileInfo' => 'Show Lexile Information',
-		'showFountasPinnell' => 'Show Fountas &amp; Pinnell Information  (This data must be present in MARC records)',
+		'showFountasPinnell' => 'Show Fountas & Pinnell Information  (This data must be present in MARC records.)',
 		'showAudience' => 'Audience',
 	];
 


### PR DESCRIPTION
- Fixed incorrect display of HTML entities on the Advanced Search page for facet values and on the Grouped Work Display Settings page for a setting.

Test Plan:
1. If you don’t have one already, add a translated value containing & to the Translation Map for a facet that is in use (e.g., “Mag & News” for shelf_location Translation Map).
2. Navigate to the Advanced Search page and see that in its respective dropdown of the Optional Filters, the text contains an HTML entity (e.g., “Mag &amp; News”).
3. Navigate to the Grouped Work Display Settings page in the admin interface and look under the Search Results section for the “Show Fountas &amp; Pinnell Information” checkbox.
4. Apply the patch and repeat steps 2-3. Notice that the special character displays in both places rather than the HTML entity.