### PR TITLE
DIS-657: Prevent Uploaded File Overwrite Part I

### DIFF
--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -10245,6 +10245,19 @@ AspenDiscovery.Admin = (function () {
 				}
 			});
 		},
+		toggleLibrarySharingOptions: function () {
+			if ($('#owningLibrarySelect').val() !== '-1'){
+				$('#propertyRowsharing').show();
+				if ($('#sharingSelect').val() === '1'){
+					$('#propertyRowsharedWithLibrary').show();
+				} else {
+					$('#propertyRowsharedWithLibrary').hide();
+				}
+			} else {
+				$('#propertyRowsharing').hide();
+				$('#propertyRowsharedWithLibrary').hide();
+			}
+		},
 		linkingSettingOptionChange: function () {
 			var url = Globals.path + "/Admin/AJAX";
 			var pType = $("#pType").val();

--- a/code/web/interface/themes/responsive/js/aspen/admin.js
+++ b/code/web/interface/themes/responsive/js/aspen/admin.js
@@ -1824,6 +1824,19 @@ AspenDiscovery.Admin = (function () {
 				}
 			});
 		},
+		toggleLibrarySharingOptions: function () {
+			if ($('#owningLibrarySelect').val() !== '-1'){
+				$('#propertyRowsharing').show();
+				if ($('#sharingSelect').val() === '1'){
+					$('#propertyRowsharedWithLibrary').show();
+				} else {
+					$('#propertyRowsharedWithLibrary').hide();
+				}
+			} else {
+				$('#propertyRowsharing').hide();
+				$('#propertyRowsharedWithLibrary').hide();
+			}
+		},
 		linkingSettingOptionChange: function () {
 			var url = Globals.path + "/Admin/AJAX";
 			var pType = $("#pType").val();

--- a/code/web/release_notes/25.07.00.MD
+++ b/code/web/release_notes/25.07.00.MD
@@ -29,7 +29,26 @@
 
 
 // kodi
+### Web Builder Updates
+- Added an option for home library web content administration including sharing options and the owning library for images and PDFs (DIS-657) (*KL*)
+    - Users with reduced permissions will only be able to see and edit web content owned by their library or shared with their library.
+    - Users with reduced permissions will not be able to edit web content information for web content that is shared with them, but only editable by other libraries.
+    - Users with reduced permissions cannot add images or PDFs that are valid for All Libraries or share them with all libraries.
 
+<div markdown="1" class="settings">
+
+#### New Permissions
+- Administer Web Content for Home Library - Allows the user to manage images and PDFs for their home library only.
+
+#### New Settings
+- Images > Owning Library
+- Images > Share With
+- Images > Library to Share With
+- PDFs > Owning Library
+- PDFs > Share With
+- PDFs > Library to Share With
+
+</div>
 
 // kyle
 

--- a/code/web/services/WebBuilder/AJAX.php
+++ b/code/web/services/WebBuilder/AJAX.php
@@ -361,7 +361,7 @@ class WebBuilder_AJAX extends JSON_Action {
 			'message' => 'Unknown error uploading image',
 		];
 		if (UserAccount::isLoggedIn()) {
-			if (UserAccount::userHasPermission('Administer All Web Content')) {
+			if (UserAccount::userHasPermission(['Administer All Web Content', 'Administer Web Content for Home Library'])) {
 				if (!empty($_FILES)) {
 					require_once ROOT_DIR . '/sys/File/ImageUpload.php';
 					$structure = ImageUpload::getObjectStructure('');
@@ -417,7 +417,7 @@ class WebBuilder_AJAX extends JSON_Action {
 	/** @noinspection PhpUnused */
 	function uploadImageTinyMCE() {
 		if (UserAccount::isLoggedIn()) {
-			if (UserAccount::userHasPermission('Administer All Web Content')) {
+			if (UserAccount::userHasPermission(['Administer All Web Content', 'Administer Web Content for Home Library'])) {
 				if (!empty($_FILES)) {
 					require_once ROOT_DIR . '/sys/File/ImageUpload.php';
 					$structure = ImageUpload::getObjectStructure('');
@@ -476,7 +476,7 @@ class WebBuilder_AJAX extends JSON_Action {
 			'message' => 'Unknown error getting upload form',
 		];
 		if (UserAccount::isLoggedIn()) {
-			if (UserAccount::userHasPermission('Administer All Web Content')) {
+			if (UserAccount::userHasPermission(['Administer All Web Content', 'Administer Web Content for Home Library'])) {
 				$editorName = strip_tags($_REQUEST['editorName']);
 				$interface->assign('editorName', $editorName);
 				$result = [

--- a/code/web/services/WebBuilder/Images.php
+++ b/code/web/services/WebBuilder/Images.php
@@ -20,11 +20,19 @@ class WebBuilder_Images extends ObjectEditor {
 	}
 
 	function getAllObjects($page, $recordsPerPage): array {
+		$user = UserAccount::getLoggedInUser();
 		$object = new ImageUpload();
 		$object->type = 'web_builder_image';
 		$this->applyFilters($object);
 		$object->orderBy($this->getSort());
 		$object->limit(($page - 1) * $recordsPerPage, $recordsPerPage);
+		if (!UserAccount::userHasPermission('Administer All Web Content') && (UserAccount::userHasPermission('Administer Web Content for Home Library'))) {
+			$libraryList = Library::getLibraryList(true);
+			$object->whereAddIn("owningLibrary", array_keys($libraryList), false, "OR");
+			$object->whereAdd("owningLibrary = -1", "OR");
+			$object->whereAdd("sharing = 2 OR sharing = 3", "OR");
+			$object->whereAdd("sharing = 1 AND sharedWithLibrary = " . $user->getHomeLibrary()->libraryId, "OR");
+		}
 		$object->find();
 		$objectList = [];
 		while ($object->fetch()) {
@@ -84,10 +92,14 @@ class WebBuilder_Images extends ObjectEditor {
 	}
 
 	function canView(): bool {
-		return UserAccount::userHasPermission(['Administer All Web Content']);
+		return UserAccount::userHasPermission(['Administer All Web Content', 'Administer Web Content for Home Library']);
 	}
 
 	function getActiveAdminSection(): string {
 		return 'web_builder';
+	}
+
+	function getInitializationJs(): string {
+		return 'AspenDiscovery.Admin.toggleLibrarySharingOptions();';
 	}
 }

--- a/code/web/services/WebBuilder/PDFs.php
+++ b/code/web/services/WebBuilder/PDFs.php
@@ -20,11 +20,19 @@ class WebBuilder_PDFs extends ObjectEditor {
 	}
 
 	function getAllObjects($page, $recordsPerPage): array {
+		$user = UserAccount::getLoggedInUser();
 		$object = new FileUpload();
 		$object->type = 'web_builder_pdf';
 		$object->orderBy($this->getSort());
 		$this->applyFilters($object);
 		$object->limit(($page - 1) * $recordsPerPage, $recordsPerPage);
+		if (!UserAccount::userHasPermission('Administer All Web Content') && (UserAccount::userHasPermission('Administer Web Content for Home Library'))) {
+			$libraryList = Library::getLibraryList(true);
+			$object->whereAddIn("owningLibrary", array_keys($libraryList), false, "OR");
+			$object->whereAdd("owningLibrary = -1", "OR");
+			$object->whereAdd("sharing = 2 OR sharing = 3", "OR");
+			$object->whereAdd("sharing = 1 AND sharedWithLibrary = " . $user->getHomeLibrary()->libraryId, "OR");
+		}
 		$object->find();
 		$objectList = [];
 		while ($object->fetch()) {
@@ -98,10 +106,14 @@ class WebBuilder_PDFs extends ObjectEditor {
 	}
 
 	function canView(): bool {
-		return UserAccount::userHasPermission(['Administer All Web Content']);
+		return UserAccount::userHasPermission(['Administer All Web Content', 'Administer Web Content for Home Library']);
 	}
 
 	function getActiveAdminSection(): string {
 		return 'web_builder';
+	}
+
+	function getInitializationJs(): string {
+		return 'AspenDiscovery.Admin.toggleLibrarySharingOptions();';
 	}
 }

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -4276,8 +4276,8 @@ class User extends DataObject {
 				'Administer All Staff Members',
 				'Administer Library Staff Members',
 			]);
-			$sections['web_builder']->addAction(new AdminAction('Images', 'Add images to Aspen Discovery.', '/WebBuilder/Images'), ['Administer All Web Content']);
-			$sections['web_builder']->addAction(new AdminAction('PDFs', 'Add PDFs to Aspen Discovery.', '/WebBuilder/PDFs'), ['Administer All Web Content']);
+			$sections['web_builder']->addAction(new AdminAction('Images', 'Add images to Aspen Discovery.', '/WebBuilder/Images'), ['Administer All Web Content', 'Administer Web Content for Home Library']);
+			$sections['web_builder']->addAction(new AdminAction('PDFs', 'Add PDFs to Aspen Discovery.', '/WebBuilder/PDFs'), ['Administer All Web Content', 'Administer Web Content for Home Library']);
 			//$sections['web_builder']->addAction(new AdminAction('Videos', 'Add Videos to Aspen Discovery.', '/WebBuilder/Videos'), ['Administer All Web Content']);
 			$sections['web_builder']->addAction(new AdminAction('Audiences', 'Define Audiences to categorize content within Aspen Discovery.', '/WebBuilder/Audiences'), ['Administer All Web Categories']);
 			$sections['web_builder']->addAction(new AdminAction('Categories', 'Define Categories to categorize content within Aspen Discovery.', '/WebBuilder/Categories'), ['Administer All Web Categories']);

--- a/code/web/sys/DBMaintenance/version_updates/25.07.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.07.00.php
@@ -19,8 +19,26 @@ function getUpdates25_07_00(): array {
 		//kirstien - Grove
 
 		//kodi - Grove
-
-		//Mark - Grove
+		'image_pdf_owning_sharing' => [
+			'title' => 'Owning and Sharing for Images and PDFs',
+			'description' => 'Add owning and sharing columns to file_uploads and image_uploads.',
+			'sql' => [
+				"ALTER TABLE file_uploads ADD COLUMN owningLibrary INT(11) NOT NULL DEFAULT -1",
+				"ALTER TABLE file_uploads ADD COLUMN sharing INT(11) NOT NULL DEFAULT 2",
+				"ALTER TABLE file_uploads ADD COLUMN sharedWithLibrary INT(11) NOT NULL DEFAULT -1",
+				"ALTER TABLE image_uploads ADD COLUMN owningLibrary INT(11) NOT NULL DEFAULT -1",
+				"ALTER TABLE image_uploads ADD COLUMN sharing INT(11) NOT NULL DEFAULT 2",
+				"ALTER TABLE image_uploads ADD COLUMN sharedWithLibrary INT(11) NOT NULL DEFAULT -1",
+			],
+		], //image_pdf_owning_sharing
+		'web_content_permissions' => [
+			'title' => 'Web Content Permissions',
+			'description' => 'Add restricted (home library only) permissions for web content.',
+			'sql' => [
+				"INSERT INTO permissions (sectionName, name, requiredModule, weight, description) VALUES
+					('Web Builder', 'Administer Web Content for Home Library', 'Web Builder', 61, 'Allows the user to manage images and pdfs for their home library only.')",
+			],
+		], //custom_web_resource_pages_roles
 
 		// Myranda - Grove
 

--- a/code/web/sys/File/ImageUpload.php
+++ b/code/web/sys/File/ImageUpload.php
@@ -15,6 +15,9 @@ class ImageUpload extends DataObject {
 	public $generateSmallSize;
 	public $smallSizePath; //Stores the thumbnail with a maximum size of 200x200px
 	public $type;
+	public $owningLibrary;
+	public $sharing;
+	public $sharedWithLibrary;
 
 	static $xLargeSize = 1100;
 	static $largeSize = 600;
@@ -27,6 +30,28 @@ class ImageUpload extends DataObject {
 
 	static function getObjectStructure($context = ''): array {
 		global $serverName;
+		$allSharingOptions = [
+			0 => 'Not Shared',
+			1 => 'Selected Library',
+			2 => 'All Libraries',
+			3 => 'All Libraries - Read Only'
+		];
+		$allowableSharingOptions = $allSharingOptions;
+		$libraryListForSharing[-1] = '';
+		//need to get restricted list first
+		$libraryList = Library::getLibraryList(true);
+
+		$allLibraryList[-1] = 'All Libraries';
+		$allLibraryList = $allLibraryList + Library::getLibraryList(false);
+
+		if (!UserAccount::userHasPermission('Administer All Web Content') && (UserAccount::userHasPermission('Administer Web Content for Home Library'))) {
+			unset($allowableSharingOptions[2]);
+		}else{
+			$libraryList = $allLibraryList;
+		}
+
+		$libraryListForSharing = $libraryListForSharing + $libraryList;
+
 		return [
 			'id' => [
 				'property' => 'id',
@@ -48,6 +73,32 @@ class ImageUpload extends DataObject {
 				'label' => 'Type',
 				'description' => 'The type of image being uploaded',
 				'maxLength' => 50,
+			],
+			'owningLibrary' => [
+				'property' => 'owningLibrary',
+				'type' => 'enum',
+				'values' => $libraryList,
+				'allValues' => $allLibraryList,
+				'label' => 'Owning Library',
+				'description' => 'Which library owns this content.',
+				'onchange' => "return AspenDiscovery.Admin.toggleLibrarySharingOptions();",
+			],
+			'sharing' => [
+				'property' => 'sharing',
+				'type' => 'enum',
+				'values' => $allowableSharingOptions,
+				'allValues' => $allSharingOptions,
+				'label' => 'Share With',
+				'description' => 'Who the content should be shared with.',
+				'onchange' => "return AspenDiscovery.Admin.toggleLibrarySharingOptions();",
+			],
+			'sharedWithLibrary' => [
+				'property' => 'sharedWithLibrary',
+				'type' => 'enum',
+				'values' => $libraryListForSharing,
+				'allValues' => $allLibraryList,
+				'label' => 'Library to Share With',
+				'description' => 'Which library this content is shared with.',
 			],
 			'fullSizePath' => [
 				'property' => 'fullSizePath',
@@ -219,6 +270,57 @@ class ImageUpload extends DataObject {
 				}
 			}
 		}
+	}
+
+	public function updateStructureForEditingObject($structure) : array {
+		if ($this->isReadOnly()) {
+			$structure['title']['readOnly'] = true;
+			$structure['owningLibrary']['readOnly'] = true;
+			$structure['sharing']['readOnly'] = true;
+			$structure['sharedWithLibrary']['readOnly'] = true;
+			$structure['fullSizePath']['readOnly'] = true;
+			$structure['generateXLargeSize']['readOnly'] = true;
+			$structure['xLargeSizePath']['readOnly'] = true;
+			$structure['generateLargeSize']['readOnly'] = true;
+			$structure['largeSizePath']['readOnly'] = true;
+			$structure['generateMediumSize']['readOnly'] = true;
+			$structure['mediumSizePath']['readOnly'] = true;
+			$structure['generateSmallSize']['readOnly'] = true;
+			$structure['smallSizePath']['readOnly'] = true;
+		}
+		return $structure;
+	}
+
+	private ?bool $_isReadOnly = null;
+	/**
+	 * Determine whether the Image can be changed by the active user.
+	 * This is slightly different from canActiveUserEdit because we want the user to be able to view
+	 * but not change the image and access the image(s) they have access to
+	 *
+	 * @return bool
+	 */
+	public function isReadOnly() : bool {
+		if ($this->_isReadOnly === null) {
+			//Active user can edit if they have permission to edit everything or this is for their home location or sharing allows editing
+			if (UserAccount::userHasPermission('Administer All Web Content')) {
+				$this->_isReadOnly = false;
+			}elseif (UserAccount::userHasPermission( 'Administer Web Content for Home Library')){
+				$allowableLibraries = Library::getLibraryList(true);
+				if (array_key_exists($this->owningLibrary, $allowableLibraries)) {
+					$this->_isReadOnly = false;
+				}else{
+					//Ok if shared by everyone
+					if ($this->sharing == 2) {
+						$this->_isReadOnly = false;
+					}else{
+						$this->_isReadOnly = true;
+					}
+				}
+			}else{ //Manage images for Home Library Only
+				$this->_isReadOnly = true;
+			}
+		}
+		return $this->_isReadOnly;
 	}
 
 	public function okToExport(array $selectedFilters): bool {


### PR DESCRIPTION
- Add new restrictive permission for managing images and pdfs for user home library
- Add related logic for this permission to ImageUpload.php, FileUpload.php, Images.php, PDFs.php, WebBuilder/AJAX.php, and User.php 
- Add new function for toggling showing/hiding sharing options in admin.js
- Update Release Notes

Tested on my local instance of Aspen