### PR TITLE
DIS-1004: Added Check for File Existence for MARC Records

### DIFF
--- a/code/web/RecordDrivers/MarcRecordDriver.php
+++ b/code/web/RecordDrivers/MarcRecordDriver.php
@@ -2615,7 +2615,7 @@ class MarcRecordDriver extends GroupedWorkSubDriver {
 		return true;
 	}
 
-	private function loadUploadedFileInfo() {
+	private function loadUploadedFileInfo(): void {
 		global $timer;
 		$this->_uploadedPDFs = [];
 		$this->_uploadedSupplementalFiles = [];
@@ -2629,10 +2629,13 @@ class MarcRecordDriver extends GroupedWorkSubDriver {
 				$fileUpload = new FileUpload();
 				$fileUpload->id = $recordFile->fileId;
 				if ($fileUpload->find(true)) {
-					if ($fileUpload->type == 'RecordPDF') {
-						$this->_uploadedPDFs[] = $fileUpload;
-					} elseif ($fileUpload->type == 'RecordSupplementalFile') {
-						$this->_uploadedSupplementalFiles[] = $fileUpload;
+					if (file_exists($fileUpload->fullPath)) {
+						if ($fileUpload->type == 'RecordPDF') {
+							$this->_uploadedPDFs[] = $fileUpload;
+						} elseif ($fileUpload->type == 'RecordSupplementalFile') {
+
+							$this->_uploadedSupplementalFiles[] = $fileUpload;
+						}
 					}
 				}
 			}

--- a/code/web/release_notes/25.07.00.MD
+++ b/code/web/release_notes/25.07.00.MD
@@ -106,6 +106,7 @@
 - Fixed an issue where bulk-deleting Two-Factor Authentication Settings did not work. (DIS-969) (*LS*)
 - Moved the "Library Hours" under the "ILS/Account Integration" section of the Locations settings to align with user expectations. (DIS-987) (*LS*)
 - Fixed incorrect display of HTML entities on the Advanced Search page for facet values and on the Grouped Work Display Settings page for a setting. (DIS-992) (*LS*)
+- Implemented a check to confirm file existence in the file system before rendering the uploaded file. (DIS-1004) (*LS*)
 
 // yanjun
 ### Other Updates


### PR DESCRIPTION
- Implemented a check to confirm file existence in the file system before rendering the uploaded file.

Test Plan: 
1. Upload a supplemental file and manually delete it from the file system. 
2. View that record in the catalog and attempt to delete it through the interface. Notice the error that it could not be deleted.
3. Apply the patch, reload the page, and notice that any display about the file is gone.