### PR TITLE
DIS-1010: Fix PHP deprecation errors

### DIFF
--- a/code/web/services/API/SearchAPI.php
+++ b/code/web/services/API/SearchAPI.php
@@ -1804,9 +1804,9 @@ class SearchAPI extends AbstractAPI {
 
 		/** @var BrowseCategoryGroupEntry[] $browseCategories */
 		if ($activeLocation == null) {
-			$browseCategories = $library->getBrowseCategoryGroup()->getBrowseCategoriesForLiDA(null, $appUser, false);
+			$browseCategories = $library->getBrowseCategoryGroup()->getBrowseCategoriesForLiDA($appUser, null, false);
 		} else {
-			$browseCategories = $activeLocation->getBrowseCategoryGroup()->getBrowseCategoriesForLiDA(null, $appUser, false);
+			$browseCategories = $activeLocation->getBrowseCategoryGroup()->getBrowseCategoriesForLiDA($appUser, null, false);
 		}
 		$formattedCategories = [];
 		require_once ROOT_DIR . '/sys/Browse/BrowseCategory.php';
@@ -1983,14 +1983,14 @@ class SearchAPI extends AbstractAPI {
 		if ($activeLocation == null) {
 			//We don't have an active location, look at the library
 			if ($isLiDARequest) {
-				$browseCategories = $library->getBrowseCategoryGroup()->getBrowseCategoriesForLiDA($maxCategories, $appUser);
+				$browseCategories = $library->getBrowseCategoryGroup()->getBrowseCategoriesForLiDA($appUser, $maxCategories);
 			} else {
 				$browseCategories = $library->getBrowseCategoryGroup()->getBrowseCategories();
 			}
 		} else {
 			//We have a location get data for that
 			if ($isLiDARequest) {
-				$browseCategories = $activeLocation->getBrowseCategoryGroup()->getBrowseCategoriesForLiDA($maxCategories, $appUser);
+				$browseCategories = $activeLocation->getBrowseCategoryGroup()->getBrowseCategoriesForLiDA($appUser, $maxCategories);
 			} else {
 				$browseCategories = $activeLocation->getBrowseCategoryGroup()->getBrowseCategories();
 			}

--- a/code/web/sys/Browse/BrowseCategoryGroup.php
+++ b/code/web/sys/Browse/BrowseCategoryGroup.php
@@ -184,7 +184,7 @@ class BrowseCategoryGroup extends DB_LibraryLocationLinkedObject {
 		return $this->_browseCategories;
 	}
 
-	public function getBrowseCategoriesForLiDA($max = null, $user, $checkDismiss = true): array {
+	public function getBrowseCategoriesForLiDA($user, $max = null, $checkDismiss = true): array {
 		if (!isset($this->_browseCategories) && $this->id) {
 			if ($max) {
 				$count = 0;

--- a/code/web/sys/SIP2.php
+++ b/code/web/sys/SIP2.php
@@ -266,7 +266,7 @@ class sip2 {
 	}
 
 	/* Fee paid function should go here */
-	function msgFeePaid($feeType = '01', $pmtType = '02', $pmtAmount, $curType = 'USD', $feeId = '', $transId = '', $patronId = '') {
+	function msgFeePaid($pmtAmount, $feeType = '01', $pmtType = '02', $curType = 'USD', $feeId = '', $transId = '', $patronId = '') {
 		/* Fee payment function (37) - untested */ /* Fee Types: */ /* 01 other/unknown */ /* 02 administrative */ /* 03 damage */ /* 04 overdue */ /* 05 processing */ /* 06 rental*/ /* 07 replacement */ /* 08 computer access charge */ /* 09 hold fee */
 
 		/* Value Payment Type */ /* 00   cash */ /* 01   VISA */


### PR DESCRIPTION
Attempted fix for the following errors:
- `Deprecated: Optional parameter $max declared before required parameter $user is implicitly treated as a required parameter in C:\web\aspen-discovery\code\web\sys\Browse\BrowseCategoryGroup.php on line 187`
- `Deprecated: Optional parameter $feeType declared before required parameter $pmtAmount is implicitly treated as a required parameter in C:\web\aspen-discovery\code\web\sys\SIP2.php on line 269`
- `Deprecated: Optional parameter $pmtType declared before required parameter $pmtAmount is implicitly treated as a required parameter in C:\web\aspen-discovery\code\web\sys\SIP2.php on line 269`