### PR TITLE
DIS-977 Add optional donations settings in Comprise Settings

### DIFF
--- a/code/web/release_notes/25.07.00.MD
+++ b/code/web/release_notes/25.07.00.MD
@@ -113,6 +113,7 @@
 
 ### Comprise Updates
 - Add optional donations settings in Comprise Settings to use separate Customer Name and Customer ID for donation transactions, allowing libraries to separate donation reports from fine reports in Comprise. (DIS-977) (*YL*)
+- Remove force nightly reindex for libraries in Comprise Settings. (DIS-977) (*YL*)
 
 // laura
 

--- a/code/web/release_notes/25.07.00.MD
+++ b/code/web/release_notes/25.07.00.MD
@@ -111,6 +111,9 @@
 ### Other Updates
 - Update ils_password as well while resetting PIN. (DIS-935) (*YL*)
 
+### Comprise Updates
+- Add optional donations settings in Comprise Settings to use separate Customer Name and Customer ID for donation transactions, allowing libraries to separate donation reports from fine reports in Comprise. (DIS-977) (*YL*)
+
 // laura
 
 // james

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -5927,8 +5927,13 @@ class MyAccount_AJAX extends JSON_Action {
 			$compriseSettings->id = $paymentLibrary->compriseSettingId;
 			if ($compriseSettings->find(true)) {
 				$paymentRequestUrl = 'https://smartpayapi2.comprisesmartterminal.com/smartpayapi/websmartpay.dll?GetCreditForm';
-				$paymentRequestUrl .= "&LocationID=" . $compriseSettings->customerName;
-				$paymentRequestUrl .= "&CustomerID=" . $compriseSettings->customerId;
+				if ($transactionType == 'donation' && !empty($compriseSettings->customerNameForDonation) && !empty($compriseSettings->customerIdForDonation)) {
+					$paymentRequestUrl .= "&LocationID=" . $compriseSettings->customerNameForDonation;
+					$paymentRequestUrl .= "&CustomerID=" . $compriseSettings->customerIdForDonation;
+				} else {
+					$paymentRequestUrl .= "&LocationID=" . $compriseSettings->customerName;
+					$paymentRequestUrl .= "&CustomerID=" . $compriseSettings->customerId;
+				}
 				if ($transactionType == 'donation') {
 					$paymentRequestUrl .= "&PatronID=Guest";
 				} else {

--- a/code/web/sys/DBMaintenance/version_updates/25.07.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.07.00.php
@@ -50,6 +50,14 @@ function getUpdates25_07_00(): array {
 		// Myranda - Grove
 
 		//Yanjun Li - ByWater
+		'add_comprise_donation_settings' => [
+			'title' => 'Add Comprise Donation Settings',
+			'description' => 'Add customer name and id for donation in Comprise Settings',
+			'sql' => [
+				"ALTER TABLE comprise_settings ADD COLUMN customerNameForDonation VARCHAR(50) DEFAULT NULL",
+				"ALTER TABLE comprise_settings ADD COLUMN customerIdForDonation INT(11) DEFAULT NULL",
+			]
+		], //add_comprise_donation_settings
 
 		// Leo Stoyanov - BWS
 

--- a/code/web/sys/ECommerce/CompriseSetting.php
+++ b/code/web/sys/ECommerce/CompriseSetting.php
@@ -80,7 +80,6 @@ class CompriseSetting extends DataObject {
 				'description' => 'Define libraries that use these settings',
 				'values' => $libraryList,
 				'hideInLists' => true,
-				'forcesReindex' => true,
 			],
 		];
 

--- a/code/web/sys/ECommerce/CompriseSetting.php
+++ b/code/web/sys/ECommerce/CompriseSetting.php
@@ -9,6 +9,9 @@ class CompriseSetting extends DataObject {
 	public $username;
 	public $password;
 
+	public $customerNameForDonation;
+	public $customerIdForDonation;
+
 	private $_libraries;
 
 	static function getObjectStructure($context = ''): array {
@@ -46,7 +49,29 @@ class CompriseSetting extends DataObject {
 				'description' => 'The Password assigned by Comprise',
 				'hideInLists' => true,
 			],
-
+			'donationSettings' => [
+				'property' => 'donationSettings',
+				'type' => 'section',
+				'label' => 'Donation Settings (Optional)',
+				'description' => 'Configure Customer Name and Id for donation transactions. These fields are optional.',
+				'hideInLists' => true,
+				'properties' => [
+					'customerNameForDonation' => [
+						'property' => 'customerNameForDonation',
+						'type' => 'text',
+						'label' => 'Customer Name for Donation (Optional)',
+						'description' => 'The Customer Name for the donation form (Optional)',
+						'note' => 'This is optional. Only use it if you want to separate the donation transactions from the fine transactions in Comprise.',
+					],
+					'customerIdForDonation' => [
+						'property' => 'customerIdForDonation',
+						'type' => 'integer',
+						'label' => 'Customer Id for Donation (Optional)',
+						'description' => 'The Customer Id for the donation form (Optional)',
+						'note' => 'This is optional. Only use it if you want to separate the donation transactions from the fine transactions in Comprise.',
+					],
+				]
+			],
 			'libraries' => [
 				'property' => 'libraries',
 				'type' => 'multiSelect',


### PR DESCRIPTION
Libraries using Comprise payments reported that donations being made through Aspen are being lumped together with fine payments on Comprise reports. 
To fix this, we can add a separate optional section for Donation, with a different Customer Name and Customer ID. If libraries do not fill out the donation section, the donation will use the general customer name and customer ID.

To Test:
1. Set the payment method to Comprise in Library > Fines/e-commerce > Show E-Commerce Link
2. Set a patron account with $2 fines 
3. Apply this PR, leave Comprise Settings > Donation settings (Optional) as blank 
4. Add a logger for `$paymentRequestUrl` in `code/web/services/MyAccount/AJAX.php` > `createCompriseOrder()`
5. Go to My Account > Fines > Click to pay fines online, in `messages.log` see the $paymentRequestUrl is using the General customer name and customer ID 
6. Try to submit donations, in `messages.log` see the $paymentRequestUrl is using the General customer name and customer ID
7. Go to Comprise Settings > Donation settings (Optional), enter values for Customer Name/ID for Donation (Optional)
8. Try to submit fines again, see $paymentRequestUrl use the General customer name and customer ID 
9. Try to submit donations again, see $paymentRequestUrl use the customer name for Donation and customer ID for Donation
10. Go to Comprise Settings  and remove the values for Customer Name/ID for Donation (Optional)
11. Try to submit fines and donations, see the $paymentRequestUrl use the general customer name and customer ID 
