### PR TITLE
DIS-1011: Fixed Sierra Checkout Limit & Added Checkouts Pagination

### DIFF
--- a/code/web/Drivers/Sierra.php
+++ b/code/web/Drivers/Sierra.php
@@ -697,7 +697,7 @@ class Sierra extends Millennium {
 				$sortKey = "{$curCheckout->source}_{$curCheckout->sourceId}_$index";
 				$checkedOutTitles[$sortKey] = $curCheckout;
 			}
-			$numProcessed += $checkouts->total;
+			$numProcessed += count($checkouts->entries);
 		}
 
 		return $checkedOutTitles;

--- a/code/web/interface/themes/responsive/MyAccount/checkoutsList.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/checkoutsList.tpl
@@ -1,4 +1,5 @@
 {strip}
+<a id="topOfList"></a>
 {if !empty($transList)}
 	<form id="renewForm_{$source}" action="/MyAccount/CheckedOut">
 		<div id="pager" class="row">
@@ -35,17 +36,17 @@
 		<div class="striped">
 			{foreach from=$transList item=checkedOutTitle name=checkedOutTitleLoop key=checkedOutKey}
 				{if $checkedOutTitle->type == 'ils'}
-					{include file="MyAccount/ilsCheckedOutTitle.tpl" record=$checkedOutTitle resultIndex=$smarty.foreach.checkedOutTitleLoop.iteration}
+					{include file="MyAccount/ilsCheckedOutTitle.tpl" record=$checkedOutTitle resultIndex=$smarty.foreach.checkedOutTitleLoop.iteration+$startIndex}
 				{elseif $checkedOutTitle->type == 'overdrive'}
-					{include file="MyAccount/overdriveCheckedOutTitle.tpl" record=$checkedOutTitle resultIndex=$smarty.foreach.checkedOutTitleLoop.iteration}
+					{include file="MyAccount/overdriveCheckedOutTitle.tpl" record=$checkedOutTitle resultIndex=$smarty.foreach.checkedOutTitleLoop.iteration+$startIndex}
 				{elseif $checkedOutTitle->type == 'hoopla'}
-					{include file="MyAccount/hooplaCheckedOutTitle.tpl" record=$checkedOutTitle resultIndex=$smarty.foreach.checkedOutTitleLoop.iteration}
+					{include file="MyAccount/hooplaCheckedOutTitle.tpl" record=$checkedOutTitle resultIndex=$smarty.foreach.checkedOutTitleLoop.iteration+$startIndex}
 				{elseif $checkedOutTitle->type == 'cloud_library'}
-					{include file="MyAccount/cloudLibraryCheckedOutTitle.tpl" record=$checkedOutTitle resultIndex=$smarty.foreach.checkedOutTitleLoop.iteration}
+					{include file="MyAccount/cloudLibraryCheckedOutTitle.tpl" record=$checkedOutTitle resultIndex=$smarty.foreach.checkedOutTitleLoop.iteration+$startIndex}
 				{elseif $checkedOutTitle->type == 'axis360'}
-					{include file="MyAccount/axis360CheckedOutTitle.tpl" record=$checkedOutTitle resultIndex=$smarty.foreach.checkedOutTitleLoop.iteration}
+					{include file="MyAccount/axis360CheckedOutTitle.tpl" record=$checkedOutTitle resultIndex=$smarty.foreach.checkedOutTitleLoop.iteration+$startIndex}
 				{elseif $checkedOutTitle->type == 'palace_project'}
-					{include file="MyAccount/palaceProjectCheckedOutTitle.tpl" record=$checkedOutTitle resultIndex=$smarty.foreach.checkedOutTitleLoop.iteration}
+					{include file="MyAccount/palaceProjectCheckedOutTitle.tpl" record=$checkedOutTitle resultIndex=$smarty.foreach.checkedOutTitleLoop.iteration+$startIndex}
 				{else}
 					<div class="row">
 						{translate text="Unknown record source %1%" 1=$checkedOutTitle->type isPublicFacing=true}
@@ -69,6 +70,9 @@
 			{/if}
 		</div>
 	</form>
+	{if !empty($pageLinks.all)}
+		<div class="text-center">{$pageLinks.all}</div>
+	{/if}
 {else}
 	{translate text='You do not have any items checked out' isPublicFacing=true}.
 {/if}

--- a/code/web/interface/themes/responsive/js/aspen/account.js
+++ b/code/web/interface/themes/responsive/js/aspen/account.js
@@ -221,10 +221,9 @@ AspenDiscovery.Account = (function () {
 			return false;
 		},
 
-		loadCheckouts: function (source, sort, showCovers, selectedUser) {
-
+		loadCheckouts(source, sort, showCovers, selectedUser, page) {
 			AspenDiscovery.Account.currentCheckoutsSource = source;
-			var url = Globals.path + "/MyAccount/AJAX?method=getCheckouts&source=" + source;
+			let url = Globals.path + "/MyAccount/AJAX?method=getCheckouts&source=" + source;
 			if (selectedUser || selectedUser == "") {
 				url += "&selectedUserCheckouts=" + selectedUser;
 			}
@@ -235,16 +234,23 @@ AspenDiscovery.Account = (function () {
 			if (showCovers !== undefined) {
 				url += "&showCovers=" + showCovers;
 			}
-			var stateObj = {
+			if (page !== undefined) {
+				url += "&page=" + page;
+			}
+			const stateObj = {
 				page: 'Checkouts',
 				source: source,
 				sort: sort,
 				showCovers: showCovers,
-				selectedUserCheckouts: selectedUser
+				selectedUserCheckouts: selectedUser,
+				pageNumber: page
 			};
-			var newUrl = AspenDiscovery.buildUrl(document.location.origin + document.location.pathname, 'source', source);
+			let newUrl = AspenDiscovery.buildUrl(document.location.origin + document.location.pathname, 'source', source);
+			if (page !== undefined) {
+				newUrl = AspenDiscovery.buildUrl(newUrl, 'page', page);
+			}
 			if (document.location.href) {
-				var label = 'Checkouts';
+				let label = 'Checkouts';
 				if (source === 'ils') {
 					label = 'Physical Checkouts';
 				} else if (source === 'overdrive') {
@@ -275,6 +281,7 @@ AspenDiscovery.Account = (function () {
 						$("#costSavingsPlaceholder").html(data.costSavingsMessage);
 					}
 					AspenDiscovery.Account.loadMenuData();
+					AspenDiscovery.goToAnchor("topOfList");
 				} else {
 					$("#" + source + "CheckoutsPlaceholder").html(data.message);
 				}
@@ -407,6 +414,7 @@ AspenDiscovery.Account = (function () {
 						// noinspection JSUnresolvedReference
 						$("#costSavingsPlaceholder").html(data.costSavingsMessage);
 					}
+					AspenDiscovery.goToAnchor("topOfList");
 				} else {
 					$("#readingHistoryListPlaceholder").html(data.message);
 				}

--- a/code/web/release_notes/25.07.00.MD
+++ b/code/web/release_notes/25.07.00.MD
@@ -71,6 +71,11 @@
 
 ### Account Updates
 - Ensured that the “Confirm Password” field must match the original password field's input during self registration. (DIS-922) (*LS*)
+- Implemented page navigation controls on the Checked Out Titles page for checkout lists with more than 100 titles. (DIS-1011) (*LS*)
+- Added scroll-to-top functionality when navigating between checkout pages for better usability. (DIS-1011) (*LS*)
+
+### Sierra Updates
+- Corrected pagination logic to fetch all patron checkouts beyond the initial 100-title limit. (DIS-1011) (*LS*)
 
 ### Assabet Events Updates
 - Limit the "Number of Days to Index" to 30 days, as Assabet only provides events data up to 30 days via their API. (DIS-994) (*LS*)


### PR DESCRIPTION
### Account Updates
- Implemented page navigation controls on the Checked Out Titles page for checkout lists with more than 100 titles.
- Added scroll-to-top functionality when navigating between checkout pages for better usability.

### Sierra Updates
- Corrected pagination logic to fetch all patron checkouts beyond the initial 100-title limit.

Test Plan:
1. Masquerade as or log in to a patron account with more than 100 current checkouts.
2. Navigate to the Checked Out Titles page and notice that despite the counters on the left and top, only 100 of the total checked-out titles are displaying.
3. Apply the patch and hard reload the page. Notice that the remaining titles are now visible on a second, third, etc. page.