### PR TITLE
DIS-1010: Fix PHP deprecation errors 

### DIFF
--- a/code/web/Drivers/Nashville.php
+++ b/code/web/Drivers/Nashville.php
@@ -281,7 +281,7 @@ class Nashville extends CarlX {
 	protected function feePaidViaSIP($SIP2FeeType = '01', $pmtType = '02', $pmtAmount, $curType = 'USD', $feeId = '', $transId = '', $patronId = ''): array {
 		$mySip = $this->initSIPConnection();
 		if (!is_null($mySip)) {
-			$in = $mySip->msgFeePaid($SIP2FeeType, $pmtType, $pmtAmount, $curType, $feeId, $transId, $patronId);
+			$in = $mySip->msgFeePaid($pmtAmount, $SIP2FeeType, $pmtType, $curType, $feeId, $transId, $patronId);
 			$msg_result = $mySip->get_message($in);
 			ExternalRequestLogEntry::logRequest('carlx.feePaid', 'SIP2', $mySip->hostname . ':' . $mySip->port, [], $in, 0, $msg_result, []);
 			if (preg_match("/^38/", $msg_result)) {

--- a/code/web/release_notes/25.07.00.MD
+++ b/code/web/release_notes/25.07.00.MD
@@ -25,6 +25,7 @@
 ### Other Updates
 - Update Twitter icon and public-facing name to X. (DIS-271) (*MAF*)
 - Aspen will now load Font Awesome icons from separate `fontawesome.min.css`, `brands.min.css`, and `solid.min.css` files instead of `all.min.css` so Font Awesome 6 Brands can be used while retaining Font Awesome 5 Free (solid) use everywhere else. (DIS-271) (*MAF*)
+- Fix PHP deprecation errors caused by optional parameters being declared before required parameters in msgFeePaid and getBrowseCategoriesForLiDA functions. (DIS-1010) (*MAF*)
 
 // kirstien
 

--- a/code/web/services/API/SearchAPI.php
+++ b/code/web/services/API/SearchAPI.php
@@ -1804,9 +1804,9 @@ class SearchAPI extends AbstractAPI {
 
 		/** @var BrowseCategoryGroupEntry[] $browseCategories */
 		if ($activeLocation == null) {
-			$browseCategories = $library->getBrowseCategoryGroup()->getBrowseCategoriesForLiDA(null, $appUser, false);
+			$browseCategories = $library->getBrowseCategoryGroup()->getBrowseCategoriesForLiDA($appUser, null, false);
 		} else {
-			$browseCategories = $activeLocation->getBrowseCategoryGroup()->getBrowseCategoriesForLiDA(null, $appUser, false);
+			$browseCategories = $activeLocation->getBrowseCategoryGroup()->getBrowseCategoriesForLiDA($appUser, null, false);
 		}
 		$formattedCategories = [];
 		require_once ROOT_DIR . '/sys/Browse/BrowseCategory.php';
@@ -1983,14 +1983,14 @@ class SearchAPI extends AbstractAPI {
 		if ($activeLocation == null) {
 			//We don't have an active location, look at the library
 			if ($isLiDARequest) {
-				$browseCategories = $library->getBrowseCategoryGroup()->getBrowseCategoriesForLiDA($maxCategories, $appUser);
+				$browseCategories = $library->getBrowseCategoryGroup()->getBrowseCategoriesForLiDA($appUser, $maxCategories);
 			} else {
 				$browseCategories = $library->getBrowseCategoryGroup()->getBrowseCategories();
 			}
 		} else {
 			//We have a location get data for that
 			if ($isLiDARequest) {
-				$browseCategories = $activeLocation->getBrowseCategoryGroup()->getBrowseCategoriesForLiDA($maxCategories, $appUser);
+				$browseCategories = $activeLocation->getBrowseCategoryGroup()->getBrowseCategoriesForLiDA($appUser, $maxCategories);
 			} else {
 				$browseCategories = $activeLocation->getBrowseCategoryGroup()->getBrowseCategories();
 			}

--- a/code/web/sys/Browse/BrowseCategoryGroup.php
+++ b/code/web/sys/Browse/BrowseCategoryGroup.php
@@ -184,7 +184,7 @@ class BrowseCategoryGroup extends DB_LibraryLocationLinkedObject {
 		return $this->_browseCategories;
 	}
 
-	public function getBrowseCategoriesForLiDA($max = null, $user, $checkDismiss = true): array {
+	public function getBrowseCategoriesForLiDA($user, $max = null, $checkDismiss = true): array {
 		if (!isset($this->_browseCategories) && $this->id) {
 			if ($max) {
 				$count = 0;

--- a/code/web/sys/SIP2.php
+++ b/code/web/sys/SIP2.php
@@ -266,7 +266,7 @@ class sip2 {
 	}
 
 	/* Fee paid function should go here */
-	function msgFeePaid($feeType = '01', $pmtType = '02', $pmtAmount, $curType = 'USD', $feeId = '', $transId = '', $patronId = '') {
+	function msgFeePaid($pmtAmount, $feeType = '01', $pmtType = '02', $curType = 'USD', $feeId = '', $transId = '', $patronId = '') {
 		/* Fee payment function (37) - untested */ /* Fee Types: */ /* 01 other/unknown */ /* 02 administrative */ /* 03 damage */ /* 04 overdue */ /* 05 processing */ /* 06 rental*/ /* 07 replacement */ /* 08 computer access charge */ /* 09 hold fee */
 
 		/* Value Payment Type */ /* 00   cash */ /* 01   VISA */


### PR DESCRIPTION
This aims to fix the following errors:
- `Deprecated: Optional parameter $max declared before required parameter $user is implicitly treated as a required parameter in C:\web\aspen-discovery\code\web\sys\Browse\BrowseCategoryGroup.php on line 187`
- `Deprecated: Optional parameter $feeType declared before required parameter $pmtAmount is implicitly treated as a required parameter in C:\web\aspen-discovery\code\web\sys\SIP2.php on line 269`
- `Deprecated: Optional parameter $pmtType declared before required parameter $pmtAmount is implicitly treated as a required parameter in C:\web\aspen-discovery\code\web\sys\SIP2.php on line 269`