### PR TITLE
DIS-962: Use theme color for Explore More arrows

### DIFF
--- a/code/web/interface/themes/responsive/theme.css.tpl
+++ b/code/web/interface/themes/responsive/theme.css.tpl
@@ -193,6 +193,10 @@ div.striped > div:nth-child(odd), div.striped > div:nth-child(odd){ldelim}
     background: {$primaryBackgroundColor}07;
 {rdelim}
 
+.exploreMoreBar .jcarousel-control-prev, .exploreMoreBar .jcarousel-control-next{ldelim}
+	color: {$bodyTextColor}
+{rdelim}
+
 {if !empty($primaryForegroundColor)}
 #home-page-search-label,#home-page-advanced-search-link,#keepFiltersSwitchLabel,.menu-bar, #horizontal-menu-bar-container {ldelim}
     color: {$primaryForegroundColor}

--- a/code/web/release_notes/25.07.00.MD
+++ b/code/web/release_notes/25.07.00.MD
@@ -26,6 +26,9 @@
 - Update Twitter icon and public-facing name to X. (DIS-271) (*MAF*)
 - Aspen will now load Font Awesome icons from separate `fontawesome.min.css`, `brands.min.css`, and `solid.min.css` files instead of `all.min.css` so Font Awesome 6 Brands can be used while retaining Font Awesome 5 Free (solid) use everywhere else. (DIS-271) (*MAF*)
 
+### Theme Updates
+- Use body text color from Theme settings for Explore More arrows instead of a default hex value. (DIS-962) (*MAF*)
+
 // kirstien
 
 


### PR DESCRIPTION
I ended up picking `$bodyTextColor` instead of `$primaryForegroundColor` because it worked better with sample custom themes already in use for me locally ¯\_(ツ)_/¯