### PR TITLE
DIS-719: Correction to Fetch the `ils_password` from the User Object

### DIFF
--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -3664,7 +3664,7 @@ class Koha extends AbstractIlsDriver {
 			'userid' => $user->ils_barcode,
 		];
 
-		if (empty($user->ils_barcode)) {
+		if (empty($user->ils_password)) {
 			if ($user->isLoggedInViaSSO) {
 				// This is a limitation of using Koha pages to perform logins rather than API requests.
 				// In the future, with an API request, user verification could be performed without a password when a user has logged in to Aspen via SSO.

--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -3664,7 +3664,7 @@ class Koha extends AbstractIlsDriver {
 			'userid' => $user->ils_barcode,
 		];
 
-		if (empty($ils_password)) {
+		if (empty($user->ils_barcode)) {
 			if ($user->isLoggedInViaSSO) {
 				// This is a limitation of using Koha pages to perform logins rather than API requests.
 				// In the future, with an API request, user verification could be performed without a password when a user has logged in to Aspen via SSO.

--- a/code/web/release_notes/25.07.00.MD
+++ b/code/web/release_notes/25.07.00.MD
@@ -136,6 +136,7 @@
 - Implemented a green success alert for successful deletions and a red error alert for failures, to clearly indicate the status of material request operations. (DIS-940) (*LS*)
 - Added backend validation during self registration to make sure password rules are enforced even if frontend validation is bypassed. (DIS-922) (*LS*)
 - Pass down the more informative error message when `loginToKohaOpac()` is invoked and the patron account has a null `ils_password`. (DIS-967) (*LS*)
+- Corrected an issue where the `ils_barcode` was not being fetched from the user object, so the condition would always be true. (DIS-719) (*LS*)
 
 ### Materials Request Updates
 - Resolved an issue where, if more than one entry in the Materials Request Formats list shared the same Format value, none of the entries could be deleted if any one of them was being used by an existing material request. (DIS-942) (*LS*) 

--- a/code/web/release_notes/25.07.00.MD
+++ b/code/web/release_notes/25.07.00.MD
@@ -136,7 +136,7 @@
 - Implemented a green success alert for successful deletions and a red error alert for failures, to clearly indicate the status of material request operations. (DIS-940) (*LS*)
 - Added backend validation during self registration to make sure password rules are enforced even if frontend validation is bypassed. (DIS-922) (*LS*)
 - Pass down the more informative error message when `loginToKohaOpac()` is invoked and the patron account has a null `ils_password`. (DIS-967) (*LS*)
-- Corrected an issue where the `ils_barcode` was not being fetched from the user object, so the condition would always be true. (DIS-719) (*LS*)
+- Corrected an issue where the `ils_password` was not being fetched from the user object, so the condition would always be true. (DIS-719) (*LS*)
 
 ### Materials Request Updates
 - Resolved an issue where, if more than one entry in the Materials Request Formats list shared the same Format value, none of the entries could be deleted if any one of them was being used by an existing material request. (DIS-942) (*LS*) 


### PR DESCRIPTION
- Corrected an issue where the `ils_password` was not being fetched from the user object, so the condition would always be true.