### PR TITLE
DIS-895: QA fix - Update series_indexer class name

### DIFF
--- a/code/web/release_notes/25.07.00.MD
+++ b/code/web/release_notes/25.07.00.MD
@@ -77,6 +77,7 @@
 - Update Twitter icon and public-facing name to X. (DIS-271) (*MAF*)
 - Aspen will now load Font Awesome icons from separate `fontawesome.min.css`, `brands.min.css`, and `solid.min.css` files instead of `all.min.css` so Font Awesome 6 Brands can be used while retaining Font Awesome 5 Free (solid) use everywhere else. (DIS-271) (*MAF*)
 - Fix PHP deprecation errors caused by optional parameters being declared before required parameters in msgFeePaid and getBrowseCategoriesForLiDA functions. (DIS-1010) (*MAF*)
+- Update series indexer method class name in the default_intellij_project. (DIS-895) (*MAF*)
 
 ### Theme Updates
 - Use body text color from Theme settings for Explore More arrows instead of a default hex value. (DIS-962) (*MAF*)

--- a/default_intellij_project/.idea/workspace.xml
+++ b/default_intellij_project/.idea/workspace.xml
@@ -276,7 +276,7 @@
     </configuration>
     <configuration name="Series Indexer" type="Application" factoryName="Application">
       <option name="INCLUDE_PROVIDED_SCOPE" value="true" />
-      <option name="MAIN_CLASS_NAME" value="com.turning_leaf_technologies.reindexer.SeriesIndexerMain" />
+      <option name="MAIN_CLASS_NAME" value="com.turning_leaf_technologies.series.SeriesMain" />
       <module name="series_indexer" />
       <option name="PROGRAM_PARAMETERS" value="model.localhost fullReindex" />
       <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/../code/series_indexer" />


### PR DESCRIPTION
The series indexer showed up when using default_intellij_project out the box, but I was getting an error for the class and had to make these changes to get it to run for real.