### PR TITLE
DIS-1005: Add manage pickup preferences in LiDA

### DIFF
--- a/code/web/release_notes/25.07.00.MD
+++ b/code/web/release_notes/25.07.00.MD
@@ -82,7 +82,10 @@
 - Use body text color from Theme settings for Explore More arrows instead of a default hex value. (DIS-962) (*MAF*)
 
 // kirstien
-
+### API Updates
+- Update placeHold in User API to allow user to set rememberHoldPickupLocation and assign provided pickup locations to the user. (DIS-1005) (*KK*)
+- Add updateHoldPickupPreferences in User API to allow user to manage preferred hold pickup locations and sublocations, as well as the setting to bypass the hold prompt. (DIS-1005) (*KK*)
+- Update getLibraryInfo in System API to output allowRememberPickupLocation and allowPickupLocationUpdates configurations. (DIS-1005) (*KK*)
 
 // kodi
 ### Web Builder Updates

--- a/code/web/sys/LibraryLocation/Library.php
+++ b/code/web/sys/LibraryLocation/Library.php
@@ -5694,6 +5694,8 @@ class Library extends DataObject {
 			'selfRegistrationFormMessage' => $this->selfRegistrationFormMessage,
 			'selfRegistrationSuccessMessage' => $this->selfRegistrationSuccessMessage,
 			'promptForBirthDateInSelfReg' => $this->promptForBirthDateInSelfReg,
+			'allowRememberPickupLocation' => $this->allowRememberPickupLocation,
+			'allowPickupLocationUpdates' => $this->allowPickupLocationUpdates,
 		];
 		if (empty($this->baseUrl)) {
 			$apiInfo['baseUrl'] = $configArray['Site']['url'];


### PR DESCRIPTION
- Update placeHold in User API to allow user to set rememberHoldPickupLocation and assign provided pickup locations to the user.
- Add updateHoldPickupPreferences in User API to allow user to manage preferred hold pickup locations and sublocations, as well as the setting to bypass the hold prompt.
- Update getLibraryInfo in System API to output allowRememberPickupLocation and allowPickupLocationUpdates configurations.