### PR TITLE
DIS-1025 Allow default sort to be specified for searches

### DIFF
--- a/code/web/interface/themes/responsive/CourseReserves/deletedReservesEntry.tpl
+++ b/code/web/interface/themes/responsive/CourseReserves/deletedReservesEntry.tpl
@@ -29,8 +29,7 @@
 			{if !empty($listEditAllowed)}
 				<div class="btn-group-vertical" role="group">
 					<a href="/MyAccount/Edit?listEntryId={$listEntryId|escape:"url"}{if !is_null($listSelected)}&amp;listId={$listSelected|escape:"url"}{/if}" class="btn btn-default">{translate text='Edit' isPublicFacing=true}</a>
-					{* Use a different delete URL if we're removing from a specific list or the overall favorites: *}
-					<a href="/MyAccount/MyList/{$listSelected|escape:"url"}?delete={$listEntryId|escape:"url"}" onclick="return confirm('{translate text="Are you sure you want to delete this?" isPublicFacing=true}');" class="btn btn-default">{translate text='Delete' isPublicFacing=true}</a>
+					<a href="#" onclick="AspenDiscovery.confirm('Delete Title?', 'Are you sure you want to delete this?', 'Yes', 'No', true, 'AspenDiscovery.Lists.deleteEntryFromList({$listSelected}, {$listEntryId})', 'btn-danger');" class="btn btn-danger">{translate text='Delete' isPublicFacing=true}</a>
 				</div>
 
 			{/if}

--- a/code/web/interface/themes/responsive/MyAccount/deletedListEntry.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/deletedListEntry.tpl
@@ -42,8 +42,7 @@
 			{if !empty($listEditAllowed)}
 				<div class="btn-group-vertical" role="group">
 					<a href="/MyAccount/Edit?listEntryId={$listEntryId|escape:"url"}{if !is_null($listSelected)}&amp;listId={$listSelected|escape:"url"}{/if}" class="btn btn-default">{translate text='Edit' isPublicFacing=true}</a>
-					{* Use a different delete URL if we're removing from a specific list or the overall favorites: *}
-					<a href="/MyAccount/MyList/{$listSelected|escape:"url"}?delete={$listEntryId|escape:"url"}" onclick="return confirm('{translate text="Are you sure you want to delete this?" isPublicFacing=true}');" class="btn btn-default">{translate text='Delete' isPublicFacing=true}</a>
+					<a href="#" onclick="AspenDiscovery.confirm('Delete Title?', 'Are you sure you want to delete this?', 'Yes', 'No', true, 'AspenDiscovery.Lists.deleteEntryFromList({$listSelected}, {$listEntryId})', 'btn-danger');" class="btn btn-danger">{translate text='Delete' isPublicFacing=true}</a>
 				</div>
 
 			{/if}

--- a/code/web/interface/themes/responsive/MyAccount/myPreferences.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/myPreferences.tpl
@@ -13,7 +13,7 @@
 				{include file='ilsMessages.tpl' messages=$ilsMessages}
 			{/if}
 
-			<h1>{translate text='My Preferences' isPublicFacing=true}</h1>
+			<h1>{translate text='Preferences' isPublicFacing=true}</h1>
 			{if !empty($profileUpdateErrors)}
 				{foreach from=$profileUpdateErrors item=errorMsg}
 					<div class="alert alert-danger">{$errorMsg}</div>
@@ -31,233 +31,565 @@
 				<form action="" method="post" role="form">
 					<input type="hidden" name="updateScope" value="userPreference">
 					<input type="hidden" name="patronId" value={$profile->id|escape}>
-					{if !empty($showUsernameField)}
-						<div class="form-group propertyRow">
-							<label for="username">{translate text="Username" isPublicFacing=true}</label>
-							<input type="text" name="username" id="username" value="{$editableUsername|escape}" size="25" minlength="6" maxlength="25" class="form-control">
-							<a id="usernameHelpButton" href="#" role="button" aria-controls="usernameHelp" aria-expanded="false"><i class="fa fa-question-circle" role="presentation"></i> {translate text="What is this?" isPublicFacing=true}</a>
-							<div id="usernameHelp" style="display:none">
-								<p>{translate text="A username is an optional feature. If you set one, your username will be your alias on hold slips and can also be used to log into your account in place of your card number.  A username can be set, reset or removed from the “My Preferences” section of your online account. Usernames must be between 6 and 25 characters (letters and number only, no special characters)." isPublicFacing=true}</p>
+
+					<div id="preferences-accordion" class="panel-group">
+						<div class="panel" id="accountPreferencesPanel">
+							<a data-toggle="collapse" href="#accountPreferencesPanelBody">
+								<div class="panel-heading">
+									<div class="panel-title">
+										<h2>{translate text="Account" isPublicFacing=true}</h2>
+									</div>
+								</div>
+							</a>
+							<div id="accountPreferencesPanelBody" class="panel-collapse collapse">
+								<div class="panel-body">
+									{if !empty($showAutoRenewSwitch)}
+										<div class="form-group propertyRow">
+											<label for="allowAutoRenewal" class="control-label">{translate text='Allow Auto Renewal' isPublicFacing=true}</label>&nbsp;
+											{if $edit == true}
+												<input type="checkbox" class="form-control" name="allowAutoRenewal" id="allowAutoRenewal" {if $autoRenewalEnabled==1}checked='checked'{/if} data-switch="">
+											{else}
+												{if $profile->autoRenewalEnabled==0}{translate text="No" isPublicFacing=true}{else}{translate text="Yes" isPublicFacing=true}{/if}
+											{/if}
+										</div>
+									{/if}
+									{if $enableCostSavingsForLibrary}
+										<div class="form-group propertyRow">
+											<label for="enableCostSavings" class="control-label">{translate text='Display Library Savings' isPublicFacing=true}</label>&nbsp;
+											{if $edit == true}
+												<input type="checkbox" class="form-control" name="enableCostSavings" id="enableCostSavings" {if $profile->enableCostSavings==1}checked='checked'{/if} data-switch="">
+											{else}
+												&nbsp;{if $profile->enableCostSavings==0} {translate text='No' isPublicFacing=true}{else} {translate text='Yes' isPublicFacing=true}{/if}
+											{/if}
+										</div>
+									{/if}
+									{if !empty($allowHomeLibraryUpdates)  && !empty($isAssociatedWithILS)}
+										{* Allow editing home library *}
+										<div class="form-group  propertyRow">
+											<label for="homeLocation" class="control-label">{translate text='Home Library' isPublicFacing=true}</label>
+											{if $edit == true && $canUpdateContactInfo == true}
+												<select name="homeLocation" id="homeLocation" class="form-control">
+													{if count($homeLibraryLocations) > 0}
+														{foreach from=$homeLibraryLocations item=location}
+															{if is_object($location)}
+																<option value="{$location->code}" {if $location->locationId == $profile->homeLocationId}selected="selected"{/if}>{$location->displayName|escape}</option>
+															{else}
+																<option value="">{$location|escape}</option>
+															{/if}
+														{/foreach}
+													{else}
+														<option>placeholder</option>
+													{/if}
+												</select>
+											{else}
+												&nbsp;{$profile->getHomeLocationName()|escape}
+											{/if}
+										</div>
+									{else}
+										<div class="form-group propertyRow">
+											<strong>{translate text='Home Library' isPublicFacing=true}</strong> {$profile->getHomeLocationName()|escape}
+										</div>
+									{/if}
+
+									{if !empty($showUsernameField)}
+										<div class="form-group propertyRow">
+											<label for="username">{translate text="Username" isPublicFacing=true}</label>
+											<input type="text" name="username" id="username" value="{$editableUsername|escape}" size="25" minlength="6" maxlength="25" class="form-control">
+											<a id="usernameHelpButton" href="#" role="button" aria-controls="usernameHelp" aria-expanded="false"><i class="fa fa-question-circle" role="presentation"></i> {translate text="What is this?" isPublicFacing=true}</a>
+											<div id="usernameHelp" style="display:none">
+												<p>{translate text="A username is an optional feature. If you set one, your username will be your alias on hold slips and can also be used to log into your account in place of your card number.  A username can be set, reset or removed from the “My Preferences” section of your online account. Usernames must be between 6 and 25 characters (letters and number only, no special characters)." isPublicFacing=true}</p>
+											</div>
+										</div>
+									{/if}
+								</div>
 							</div>
 						</div>
-					{/if}
 
-					{if count($validLanguages) > 1}
-						<div class="form-group propertyRow">
-							<label for="profileLanguage" class="control-label">{translate text='Language to display catalog in' isPublicFacing=true}</label>
-							<select id="profileLanguage" name="profileLanguage" class="form-control">
-								{foreach from=$validLanguages key=languageCode item=language}
-									<option value="{$languageCode}"{if $profile->interfaceLanguage==$languageCode} selected="selected"{/if}>
-										{$language->displayName|escape}
-									</option>
-								{/foreach}
-							</select>
-						</div>
-					{/if}
-
-					{if count($allActiveThemes) > 1}
-						<div class="form-group propertyRow">
-							<label for="preferredTheme" class="control-label">{translate text='Display Mode' isPublicFacing=true}</label>
-							<select id="preferredTheme" name="preferredTheme" class="form-control">
-								{foreach from=$allActiveThemes key=themeId item=themeName}
-									<option value="{$themeId}"{if $profile->preferredTheme==$themeId} selected="selected"{/if}>
-										{$themeName}
-									</option>
-								{/foreach}
-							</select>
-						</div>
-					{/if}
-
-					<div class="form-group propertyRow" id="searchPreferenceLanguageGroup" {if $profile->interfaceLanguage=='en'}style="display:none"{/if}>
-						<label for="searchPreferenceLanguage" class="control-label">{translate text="Do you want prefer materials in %1%?" 1=$userLang->displayName|escape isPublicFacing=true}</label>
-						<select name="searchPreferenceLanguage" id="searchPreferenceLanguage" class="form-control">
-							<option value="0" {if $profile->searchPreferenceLanguage == 0}selected{/if}>{translate text="No, show interfiled with other languages" isPublicFacing=true}</option>
-							<option value="1" {if $profile->searchPreferenceLanguage == 1}selected{/if}>{translate text="Yes, show above other languages" isPublicFacing=true}</option>
-							<option value="2" {if $profile->searchPreferenceLanguage == 2}selected{/if}>{translate text="Yes, only show my preferred language" isPublicFacing=true}</option>
-						</select>
-					</div>
-
-					{if !empty($showRatings) && $showComments}
-						<div class="form-group propertyRow">
-							<label for="noPromptForUserReviews" class="control-label">{translate text='Do not prompt me for reviews after rating titles' isPublicFacing=true}</label>&nbsp;
-							{if $edit == true}
-								<input type="checkbox" class="form-control" name="noPromptForUserReviews" id="noPromptForUserReviews" {if $profile->noPromptForUserReviews==1}checked='checked'{/if} data-switch="">
-							{else}
-								{if $profile->noPromptForUserReviews==0} {translate text='No' isPublicFacing=true}{else} {translate text='Yes' isPublicFacing=true}{/if}
-							{/if}
-							<p class="help-block alert alert-info">
-								<span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span> {translate text="When you rate an item by clicking on the stars, you will be asked to review that item also. Selecting this option lets us know you don't want to give reviews after you have rated an item by clicking its stars." isPublicFacing=true}
-							</p>
-						</div>
-					{/if}
-
-					{if !empty($showEdsPreferences)}
-						<div class="form-group propertyRow">
-							<label for="hideResearchStarters" class="control-label">{translate text='Hide Research Starters' isPublicFacing=true}</label>&nbsp;
-							{if $edit == true}
-								<input type="checkbox" class="form-control" name="hideResearchStarters" id="hideResearchStarters" {if $profile->hideResearchStarters==1}checked='checked'{/if} data-switch="">
-							{else}
-								&nbsp;{if $profile->hideResearchStarters==0} {translate text='No' isPublicFacing=true}{else} {translate text='Yes' isPublicFacing=true}{/if}
-							{/if}
-						</div>
-					{/if}
-
-					{if !empty($allowHomeLibraryUpdates)  && !empty($isAssociatedWithILS)}
-						{* Allow editing home library *}
-						<div class="form-group  propertyRow">
-							<label for="homeLocation" class="control-label">{translate text='Home Library' isPublicFacing=true}</label>
-							{if $edit == true && $canUpdateContactInfo == true}
-								<select name="homeLocation" id="homeLocation" class="form-control">
-									{if count($homeLibraryLocations) > 0}
-										{foreach from=$homeLibraryLocations item=location}
-											{if is_object($location)}
-												<option value="{$location->code}" {if $location->locationId == $profile->homeLocationId}selected="selected"{/if}>{$location->displayName|escape}</option>
-											{else}
-												<option value="">{$location|escape}</option>
-											{/if}
-										{/foreach}
-									{else}
-										<option>placeholder</option>
-									{/if}
-								</select>
-							{else}
-								&nbsp;{$profile->getHomeLocationName()|escape}
-							{/if}
-						</div>
-					{else}
-						<div class="form-group propertyRow">
-							<strong>{translate text='Home Library' isPublicFacing=true}</strong> {$profile->getHomeLocationName()|escape}
-						</div>
-					{/if}
-
-					{if !empty($allowRememberPickupLocation) && count($pickupLocations) > 1 && !empty($isAssociatedWithILS)}
-						{* Allow editing the pickup location *}
-						<div class="form-group propertyRow">
-							<label for="pickupLocation" class="control-label">{translate text='Preferred Pickup Branch' isPublicFacing=true}</label>
-							{if $edit == true && !empty($allowPickupLocationUpdates)}
-								<select name="pickupLocation" id="pickupLocation" class="form-control" onchange="AspenDiscovery.Account.generateSublocationSelect();">
-									{if count($pickupLocations) > 0}
-										{foreach from=$pickupLocations item=location}
-											{if is_object($location)}
-												<option value="{$location->locationId}" {if $location->locationId == $profile->pickupLocationId}selected="selected"{/if}>{$location->displayName|escape}</option>
-											{else}
-												<option value="0">{$location}</option>
-											{/if}
-										{/foreach}
-									{else}
-										<option>placeholder</option>
-									{/if}
-								</select>
-							{else}
-								&nbsp;{$profile->getPickupLocationName()|escape}
-							{/if}
-						</div>
-						<div id="pickupSublocationOptions" class="form-group propertyRow">
-							{assign var=activePickupLocationId value=$profile->pickupLocationId}
-							{if $edit == true && !empty($allowPickupLocationUpdates)}
-								{if $activePickupLocationId > 0 && !empty($pickupSublocations.$activePickupLocationId) && count($pickupSublocations.$activePickupLocationId) > 1}
-									{if $profile->pickupLocationId}
-										<div id="sublocationSelectPlaceHolder">
-											<label class="control-label" for="pickupSublocation">{translate text='Preferred Pickup Area' isPublicFacing=true}</label>
-											<div class="controls">
-												<select name="pickupSublocation" id="pickupSublocation" class="form-control">
-													<option value="0default">{translate text='Please Select an Area' isPublicFacing=true}</option>
-													{foreach from=$pickupSublocations.$activePickupLocationId item=sublocation}
-														<option value="{$sublocation->id}" {if $sublocation->id == $profile->pickupSublocationId}selected="selected"{/if}>{$sublocation->name}</option>
+						{if !empty($showEdsPreferences) || !empty($validEdsSorts) || !empty($validEbscohostSorts) || !empty($validSummonSorts)}
+							<div class="panel" id="articlesAndDatabasesPreferencesPanel">
+								<a data-toggle="collapse" href="#articlesAndDatabasesPreferencesPanelBody">
+									<div class="panel-heading">
+										<div class="panel-title">
+											<h2>{translate text="Articles and Databases" isPublicFacing=true}</h2>
+										</div>
+									</div>
+								</a>
+								<div id="articlesAndDatabasesPreferencesPanelBody" class="panel-collapse collapse">
+									<div class="panel-body">
+										{if !empty($validEdsSorts)}
+											<div class="form-group propertyRow">
+												<label for="defaultEdsSort" class="control-label">{translate text='Default Sort For New Searches' isPublicFacing=true}</label>&nbsp;
+												<select name="defaultEdsSort" id="defaultEdsSort" class="form-control">
+													<option value="" {if empty($defaultEbscoEDSSort)}selected{/if}>{translate text="System Default" isPublicFacing=true inAttribuge=true}</option>
+													{foreach from=$validEdsSorts key="sortValue" item="sortName"}
+														<option value="{$sortValue}" {if $defaultEbscoEDSSort == $sortValue}selected{/if}>{translate text=$sortName isPublicFacing=true inAttribuge=true}</option>
 													{/foreach}
 												</select>
 											</div>
+										{/if}
+										{if !empty($validEbscohostSorts)}
+											<div class="form-group propertyRow">
+												<label for="defaultEbscohostSort" class="control-label">{translate text='Default Sort For New Searches' isPublicFacing=true}</label>&nbsp;
+												<select name="defaultEbscohostSort" id="defaultEbscohostSort" class="form-control">
+													<option value="" {if empty($defaultEbscoHostSort)}selected{/if}>{translate text="System Default" isPublicFacing=true inAttribuge=true}</option>
+													{foreach from=$validEbscohostSorts key="sortValue" item="sortName"}
+														<option value="{$sortValue}" {if $defaultEbscoHostSort == $sortValue}selected{/if}>{translate text=$sortName isPublicFacing=true inAttribuge=true}</option>
+													{/foreach}
+												</select>
+											</div>
+										{/if}
+										{if !empty($validSummonSorts)}
+											<div class="form-group propertyRow">
+												<label for="defaultSummonSort" class="control-label">{translate text='Default Sort For New Searches' isPublicFacing=true}</label>&nbsp;
+												<select name="defaultSummonSort" id="defaultSummonSort" class="form-control">
+													<option value="" {if empty($defaultSummonSort)}selected{/if}>{translate text="System Default" isPublicFacing=true inAttribuge=true}</option>
+													{foreach from=$validSummonSorts key="sortValue" item="sortName"}
+														<option value="{$sortValue}" {if $defaultSummonSort == $sortValue}selected{/if}>{translate text=$sortName isPublicFacing=true inAttribuge=true}</option>
+													{/foreach}
+												</select>
+											</div>
+										{/if}
+										{if !empty($showEdsPreferences)}
+											<div class="form-group propertyRow">
+												<label for="hideResearchStarters" class="control-label">{translate text='Hide Research Starters' isPublicFacing=true}</label>&nbsp;
+												{if $edit == true}
+													<input type="checkbox" class="form-control" name="hideResearchStarters" id="hideResearchStarters" {if $profile->hideResearchStarters==1}checked='checked'{/if} data-switch="">
+												{else}
+													&nbsp;{if $profile->hideResearchStarters==0} {translate text='No' isPublicFacing=true}{else} {translate text='Yes' isPublicFacing=true}{/if}
+												{/if}
+											</div>
+										{/if}
+									</div>
+								</div>
+							</div>
+						{/if}
+
+						<div class="panel" id="catalogSearchPreferencesPanel">
+							<a data-toggle="collapse" href="#catalogSearchPreferencesPanelBody">
+								<div class="panel-heading">
+									<div class="panel-title">
+										<h2>{translate text="Catalog Search" isPublicFacing=true}</h2>
+									</div>
+								</div>
+							</a>
+							<div id="catalogSearchPreferencesPanelBody" class="panel-collapse collapse">
+								<div class="panel-body">
+									<div class="form-group propertyRow">
+										<label for="defaultCatalogSort" class="control-label">{translate text='Default Sort For New Searches' isPublicFacing=true}</label>&nbsp;
+										<select name="defaultCatalogSort" id="defaultCatalogSort" class="form-control">
+											<option value="" {if empty($defaultCatalogSort)}selected{/if}>{translate text="System Default" isPublicFacing=true inAttribuge=true}</option>
+											{foreach from=$validCatalogSorts key="sortValue" item="sortName"}
+												<option value="{$sortValue}" {if $defaultCatalogSort == $sortValue}selected{/if}>{translate text=$sortName isPublicFacing=true inAttribuge=true}</option>
+											{/foreach}
+										</select>
+									</div>
+									{if !empty($isAssociatedWithILS)}
+										<div class="form-group propertyRow">
+											<label for="disableCirculationActions" class="control-label">{translate text='Show Checkouts and Holds in Results' isPublicFacing=true}</label>&nbsp;
+											{if $edit == true}
+												<input type="checkbox" class="form-control" name="disableCirculationActions" id="disableCirculationActions" {if $profile->disableCirculationActions==0}checked='checked'{/if} data-switch="">
+											{else}
+												&nbsp;{if $profile->disableCirculationActions==1} {translate text='No' isPublicFacing=true}{else} {translate text='Yes' isPublicFacing=true}{/if}
+											{/if}
 										</div>
-									{else}
-										<div id="sublocationSelectPlaceHolder"></div>
 									{/if}
-								{else}
-									<div id="sublocationSelectPlaceHolder"></div>
-								{/if}
-							{else}
-								{$profile->getPickupSublocationName()|escape}
-							{/if}
+								</div>
+							</div>
 						</div>
-					{/if}
 
-					{if !empty($showAlternateLibraryOptions)  && !empty($isAssociatedWithILS)}
-						{if count($locationList) > 2} {* First option is none *}
-							<div class="form-group propertyRow">
-								<label for="myLocation1" class="control-label">{translate text='Alternate Pickup Location 1' isPublicFacing=true}</label>
-								{if $edit == true}
-									{html_options name="myLocation1" id="myLocation1" class="form-control" options=$locationList selected=$profile->myLocation1Id}
-								{else}
-									&nbsp;{$profile->_myLocation1|escape}
-								{/if}
+						{if array_key_exists('Community Engagement', $enabledModules)}
+							<div class="panel" id="communityEngagementPreferencesPanel">
+								<a data-toggle="collapse" href="#communityEngagementPreferencesPanelBody">
+									<div class="panel-heading">
+										<div class="panel-title">
+											<h2>{translate text="Community Engagement" isPublicFacing=true}</h2>
+										</div>
+									</div>
+								</a>
+								<div id="communityEngagementPreferencesPanelBody" class="panel-collapse collapse">
+									<div class="panel-body">
+										<div class="form-group propertyRow">
+											<label for="campaignNotificationsByEmail" class="control-label">{translate text="Get Campaign Notifications By Email" isPublicFacing=true}</label>&nbsp;
+											<input type="checkbox" class="form-control" name="campaignNotificationsByEmail" id="campaignNotificationsByEmail" {if $profile->campaignNotificationsByEmail==1}checked='checked'{/if} data-switch="">
+										</div>
+										{if $campaignLeaderboardDisplay == 'displayUser'}
+											<div class="form-group propertyRow">
+												<label for="optInToAllCampaignLeaderboards" class="control-label">{translate text="Opt in to All Leaderboards" isPublicFacing=true}</label>&nbsp;
+												<input type="checkbox" class="form-control" name="optInToAllCampaignLeaderboards" id="optInToAllCampaignLeaderboards" {if $profile->optInToAllCampaignLeaderboards==1}checked='checked'{/if} data-switch="">
+											</div>
+										{/if}
+									</div>
+								</div>
 							</div>
 						{/if}
-						{if count($locationList) > 3  && !empty($isAssociatedWithILS)} {* First option is none *}
-							<div class="form-group propertyRow">
-								<label for="myLocation2" class="control-label">{translate text='Alternate Pickup Location 2' isPublicFacing=true}</label>
-								&nbsp;{if $edit == true}{html_options name="myLocation2" id="myLocation2" class="form-control" options=$locationList selected=$profile->myLocation2Id}{else}{$profile->_myLocation2|escape}{/if}
+
+						{if !empty($validCourseReservesSorts)}
+							<div class="panel" id="courseReservesPreferencesPanel">
+								<a data-toggle="collapse" href="#courseReservesPreferencesPanelBody">
+									<div class="panel-heading">
+										<div class="panel-title">
+											<h2>{translate text="CourseReserves" isPublicFacing=true}</h2>
+										</div>
+									</div>
+								</a>
+								<div id="courseReservesPreferencesPanelBody" class="panel-collapse collapse">
+									<div class="panel-body">
+										{if !empty($validCourseReservesSorts)}
+											<div class="form-group propertyRow">
+												<label for="defaultCourseReservesSort" class="control-label">{translate text='Default Sort For New Searches' isPublicFacing=true}</label>&nbsp;
+												<select name="defaultCourseReservesSort" id="defaultCourseReservesSort" class="form-control">
+													<option value="" {if empty($defaultCourseReservesSort)}selected{/if}>{translate text="System Default" isPublicFacing=true inAttribuge=true}</option>
+													{foreach from=$validCourseReservesSorts key="sortValue" item="sortName"}
+														<option value="{$sortValue}" {if $defaultCourseReservesSort == $sortValue}selected{/if}>{translate text=$sortName isPublicFacing=true inAttribuge=true}</option>
+													{/foreach}
+												</select>
+											</div>
+										{/if}
+									</div>
+								</div>
 							</div>
 						{/if}
-					{/if}
 
-					{if !empty($allowRememberPickupLocation)  && !empty($isAssociatedWithILS)}
-						<div class="form-group propertyRow">
-							<label for="rememberHoldPickupLocation" class="control-label">{translate text='Bypass pickup location prompt when placing holds' isPublicFacing=true}</label>&nbsp;
-							{if $edit == true}
-								<input type="checkbox" class="form-control" name="rememberHoldPickupLocation" id="rememberHoldPickupLocation" {if $profile->rememberHoldPickupLocation==1}checked='checked'{/if} data-switch="">
-							{else}
-								{if $profile->rememberHoldPickupLocation==0}{translate text="No" isPublicFacing=true}{else}{translate text="Yes" isPublicFacing=true}{/if}
-							{/if}
-						</div>
-					{/if}
+						{if count($allActiveThemes) > 1 || count($validLanguages) > 1}
+							<div class="panel" id="displayPreferencesPanel">
+								<a data-toggle="collapse" href="#displayPreferencesPanelBody">
+									<div class="panel-heading">
+										<div class="panel-title">
+											<h2>{translate text="Display" isPublicFacing=true}</h2>
+										</div>
+									</div>
+								</a>
+								<div id="displayPreferencesPanelBody" class="panel-collapse collapse">
+									<div class="panel-body">
+										{if count($allActiveThemes) > 1}
+											<div class="form-group propertyRow">
+												<label for="preferredTheme" class="control-label">{translate text='Display Mode' isPublicFacing=true}</label>
+												<select id="preferredTheme" name="preferredTheme" class="form-control">
+													{foreach from=$allActiveThemes key=themeId item=themeName}
+														<option value="{$themeId}"{if $profile->preferredTheme==$themeId} selected="selected"{/if}>
+															{$themeName}
+														</option>
+													{/foreach}
+												</select>
+											</div>
+										{/if}
+										{if count($validLanguages) > 1}
+											<div class="form-group propertyRow">
+												<label for="profileLanguage" class="control-label">{translate text='Language to display catalog in' isPublicFacing=true}</label>
+												<select id="profileLanguage" name="profileLanguage" class="form-control">
+													{foreach from=$validLanguages key=languageCode item=language}
+														<option value="{$languageCode}"{if $profile->interfaceLanguage==$languageCode} selected="selected"{/if}>
+															{$language->displayName|escape}
+														</option>
+													{/foreach}
+												</select>
+											</div>
+										{/if}
 
-					{if !empty($showAutoRenewSwitch)}
-						<div class="form-group propertyRow">
-							<label for="allowAutoRenewal" class="control-label">{translate text='Allow Auto Renewal' isPublicFacing=true}</label>&nbsp;
-							{if $edit == true}
-								<input type="checkbox" class="form-control" name="allowAutoRenewal" id="allowAutoRenewal" {if $autoRenewalEnabled==1}checked='checked'{/if} data-switch="">
-							{else}
-								{if $profile->autoRenewalEnabled==0}{translate text="No" isPublicFacing=true}{else}{translate text="Yes" isPublicFacing=true}{/if}
-							{/if}
-						</div>
-					{/if}
-
-					{if !empty($isAssociatedWithILS)}
-						<div class="form-group propertyRow">
-							<label for="disableCirculationActions" class="control-label">{translate text='Show Checkouts and Holds in Results' isPublicFacing=true}</label>&nbsp;
-							{if $edit == true}
-								<input type="checkbox" class="form-control" name="disableCirculationActions" id="disableCirculationActions" {if $profile->disableCirculationActions==0}checked='checked'{/if} data-switch="">
-							{else}
-								&nbsp;{if $profile->disableCirculationActions==1} {translate text='No' isPublicFacing=true}{else} {translate text='Yes' isPublicFacing=true}{/if}
-							{/if}
-						</div>
-					{/if}
-
-					{if $enableCostSavingsForLibrary}
-						<div class="form-group propertyRow">
-							<label for="enableCostSavings" class="control-label">{translate text='Display Library Savings' isPublicFacing=true}</label>&nbsp;
-							{if $edit == true}
-								<input type="checkbox" class="form-control" name="enableCostSavings" id="enableCostSavings" {if $profile->enableCostSavings==1}checked='checked'{/if} data-switch="">
-							{else}
-								&nbsp;{if $profile->enableCostSavings==0} {translate text='No' isPublicFacing=true}{else} {translate text='Yes' isPublicFacing=true}{/if}
-							{/if}
-						</div>
-					{/if}
-					{if array_key_exists('Community Engagement', $enabledModules)}
-						<div class="form-group propertyRow">
-							<label for="campaignNotificationsByEmail" class="control-label">{translate text="Get Campaign Notifications By Email" isPublicFacing=true}</label>&nbsp;
-							<input type="checkbox" class="form-control" name="campaignNotificationsByEmail" id="campaignNotificationsByEmail" {if $profile->campaignNotificationsByEmail==1}checked='checked'{/if} data-switch="">
-						</div>
-						{if $campaignLeaderboardDisplay == 'displayUser'}
-							<div class="form-group propertyRow">
-								<label for="optInToAllCampaignLeaderboards" class="control-label">{translate text="Opt in to All Leaderboards" isPublicFacing=true}</label>&nbsp;
-								<input type="checkbox" class="form-control" name="optInToAllCampaignLeaderboards" id="optInToAllCampaignLeaderboards" {if $profile->optInToAllCampaignLeaderboards==1}checked='checked'{/if} data-switch="">
+										<div class="form-group propertyRow" id="searchPreferenceLanguageGroup" {if $profile->interfaceLanguage=='en'}style="display:none"{/if}>
+											<label for="searchPreferenceLanguage" class="control-label">{translate text="Do you want prefer materials in %1%?" 1=$userLang->displayName|escape isPublicFacing=true}</label>
+											<select name="searchPreferenceLanguage" id="searchPreferenceLanguage" class="form-control">
+												<option value="0" {if $profile->searchPreferenceLanguage == 0}selected{/if}>{translate text="No, show interfiled with other languages" isPublicFacing=true}</option>
+												<option value="1" {if $profile->searchPreferenceLanguage == 1}selected{/if}>{translate text="Yes, show above other languages" isPublicFacing=true}</option>
+												<option value="2" {if $profile->searchPreferenceLanguage == 2}selected{/if}>{translate text="Yes, only show my preferred language" isPublicFacing=true}</option>
+											</select>
+										</div>
+									</div>
+								</div>
 							</div>
 						{/if}
-					{/if}
+
+						{if !empty($validEventsSorts)}
+							<div class="panel" id="eventsPreferencesPanel">
+								<a data-toggle="collapse" href="#eventsPreferencesPanelBody">
+									<div class="panel-heading">
+										<div class="panel-title">
+											<h2>{translate text="Events" isPublicFacing=true}</h2>
+										</div>
+									</div>
+								</a>
+								<div id="eventsPreferencesPanelBody" class="panel-collapse collapse">
+									<div class="panel-body">
+										{if !empty($validEventsSorts)}
+											<div class="form-group propertyRow">
+												<label for="defaultEventsSort" class="control-label">{translate text='Default Sort For New Searches' isPublicFacing=true}</label>&nbsp;
+												<select name="defaultEventsSort" id="defaultEventsSort" class="form-control">
+													<option value="" {if empty($defaultEventsSort)}selected{/if}>{translate text="System Default" isPublicFacing=true inAttribuge=true}</option>
+													{foreach from=$validEventsSorts key="sortValue" item="sortName"}
+														<option value="{$sortValue}" {if $defaultEventsSort == $sortValue}selected{/if}>{translate text=$sortName isPublicFacing=true inAttribuge=true}</option>
+													{/foreach}
+												</select>
+											</div>
+										{/if}
+									</div>
+								</div>
+							</div>
+						{/if}
+
+						{if !empty($validGenealogySorts)}
+							<div class="panel" id="genealogyPreferencesPanel">
+								<a data-toggle="collapse" href="#genealogyPreferencesPanelBody">
+									<div class="panel-heading">
+										<div class="panel-title">
+											<h2>{translate text="Genealogy" isPublicFacing=true}</h2>
+										</div>
+									</div>
+								</a>
+								<div id="genealogyPreferencesPanelBody" class="panel-collapse collapse">
+									<div class="panel-body">
+										{if !empty($validGenealogySorts)}
+											<div class="form-group propertyRow">
+												<label for="defaultGenealogySort" class="control-label">{translate text='Default Sort For New Searches' isPublicFacing=true}</label>&nbsp;
+												<select name="defaultGenealogySort" id="defaultGenealogySort" class="form-control">
+													<option value="" {if empty($defaultGenealogySort)}selected{/if}>{translate text="System Default" isPublicFacing=true inAttribuge=true}</option>
+													{foreach from=$validGenealogySorts key="sortValue" item="sortName"}
+														<option value="{$sortValue}" {if $defaultGenealogySort == $sortValue}selected{/if}>{translate text=$sortName isPublicFacing=true inAttribuge=true}</option>
+													{/foreach}
+												</select>
+											</div>
+										{/if}
+									</div>
+								</div>
+							</div>
+						{/if}
+
+						{if !empty($validOpenArchivesSorts)}
+							<div class="panel" id="openArchivesPreferencesPanel">
+								<a data-toggle="collapse" href="#openArchivesPreferencesPanelBody">
+									<div class="panel-heading">
+										<div class="panel-title">
+											<h2>{translate text="History & Archives" isPublicFacing=true}</h2>
+										</div>
+									</div>
+								</a>
+								<div id="openArchivesPreferencesPanelBody" class="panel-collapse collapse">
+									<div class="panel-body">
+										{if !empty($validOpenArchivesSorts)}
+											<div class="form-group propertyRow">
+												<label for="defaultOpenArchivesSort" class="control-label">{translate text='Default Sort For New Searches' isPublicFacing=true}</label>&nbsp;
+												<select name="defaultOpenArchivesSort" id="defaultOpenArchivesSort" class="form-control">
+													<option value="" {if empty($defaultOpenArchivesSort)}selected{/if}>{translate text="System Default" isPublicFacing=true inAttribuge=true}</option>
+													{foreach from=$validOpenArchivesSorts key="sortValue" item="sortName"}
+														<option value="{$sortValue}" {if $defaultOpenArchivesSort == $sortValue}selected{/if}>{translate text=$sortName isPublicFacing=true inAttribuge=true}</option>
+													{/foreach}
+												</select>
+											</div>
+										{/if}
+									</div>
+								</div>
+							</div>
+						{/if}
+
+						{if !empty($isAssociatedWithILS) && ((!empty($allowRememberPickupLocation) && count($pickupLocations) > 1) || !empty($showAlternateLibraryOptions) || !empty($allowRememberPickupLocation))}
+							<div class="panel" id="holdPreferencesPanel">
+								<a data-toggle="collapse" href="#holdPreferencesPanelBody">
+									<div class="panel-heading">
+										<div class="panel-title">
+											<h2>{translate text="Holds" isPublicFacing=true}</h2>
+										</div>
+									</div>
+								</a>
+								<div id="holdPreferencesPanelBody" class="panel-collapse collapse">
+									<div class="panel-body">
+										{if !empty($allowRememberPickupLocation) && count($pickupLocations) > 1 && !empty($isAssociatedWithILS)}
+											{* Allow editing the pickup location *}
+											<div class="form-group propertyRow">
+												<label for="pickupLocation" class="control-label">{translate text='Preferred Pickup Branch' isPublicFacing=true}</label>
+												{if $edit == true && !empty($allowPickupLocationUpdates)}
+													<select name="pickupLocation" id="pickupLocation" class="form-control" onchange="AspenDiscovery.Account.generateSublocationSelect();">
+														{if count($pickupLocations) > 0}
+															{foreach from=$pickupLocations item=location}
+																{if is_object($location)}
+																	<option value="{$location->locationId}" {if $location->locationId == $profile->pickupLocationId}selected="selected"{/if}>{$location->displayName|escape}</option>
+																{else}
+																	<option value="0">{$location}</option>
+																{/if}
+															{/foreach}
+														{else}
+															<option>placeholder</option>
+														{/if}
+													</select>
+												{else}
+													&nbsp;{$profile->getPickupLocationName()|escape}
+												{/if}
+											</div>
+											<div id="pickupSublocationOptions" class="form-group propertyRow">
+												{assign var=activePickupLocationId value=$profile->pickupLocationId}
+												{if $edit == true && !empty($allowPickupLocationUpdates)}
+													{if $activePickupLocationId > 0 && !empty($pickupSublocations.$activePickupLocationId) && count($pickupSublocations.$activePickupLocationId) > 1}
+														{if $profile->pickupLocationId}
+															<div id="sublocationSelectPlaceHolder">
+																<label class="control-label" for="pickupSublocation">{translate text='Preferred Pickup Area' isPublicFacing=true}</label>
+																<div class="controls">
+																	<select name="pickupSublocation" id="pickupSublocation" class="form-control">
+																		<option value="0default">{translate text='Please Select an Area' isPublicFacing=true}</option>
+																		{foreach from=$pickupSublocations.$activePickupLocationId item=sublocation}
+																			<option value="{$sublocation->id}" {if $sublocation->id == $profile->pickupSublocationId}selected="selected"{/if}>{$sublocation->name}</option>
+																		{/foreach}
+																	</select>
+																</div>
+															</div>
+														{else}
+															<div id="sublocationSelectPlaceHolder"></div>
+														{/if}
+													{else}
+														<div id="sublocationSelectPlaceHolder"></div>
+													{/if}
+												{else}
+													{$profile->getPickupSublocationName()|escape}
+												{/if}
+											</div>
+										{/if}
+
+										{if !empty($showAlternateLibraryOptions)  && !empty($isAssociatedWithILS)}
+											{if count($locationList) > 2} {* First option is none *}
+												<div class="form-group propertyRow">
+													<label for="myLocation1" class="control-label">{translate text='Alternate Pickup Location 1' isPublicFacing=true}</label>
+													{if $edit == true}
+														{html_options name="myLocation1" id="myLocation1" class="form-control" options=$locationList selected=$profile->myLocation1Id}
+													{else}
+														&nbsp;{$profile->_myLocation1|escape}
+													{/if}
+												</div>
+											{/if}
+											{if count($locationList) > 3  && !empty($isAssociatedWithILS)} {* First option is none *}
+												<div class="form-group propertyRow">
+													<label for="myLocation2" class="control-label">{translate text='Alternate Pickup Location 2' isPublicFacing=true}</label>
+													&nbsp;{if $edit == true}{html_options name="myLocation2" id="myLocation2" class="form-control" options=$locationList selected=$profile->myLocation2Id}{else}{$profile->_myLocation2|escape}{/if}
+												</div>
+											{/if}
+										{/if}
+
+										{if !empty($allowRememberPickupLocation)  && !empty($isAssociatedWithILS)}
+											<div class="form-group propertyRow">
+												<label for="rememberHoldPickupLocation" class="control-label">{translate text='Bypass pickup location prompt when placing holds' isPublicFacing=true}</label>&nbsp;
+												{if $edit == true}
+													<input type="checkbox" class="form-control" name="rememberHoldPickupLocation" id="rememberHoldPickupLocation" {if $profile->rememberHoldPickupLocation==1}checked='checked'{/if} data-switch="">
+												{else}
+													{if $profile->rememberHoldPickupLocation==0}{translate text="No" isPublicFacing=true}{else}{translate text="Yes" isPublicFacing=true}{/if}
+												{/if}
+											</div>
+										{/if}
+									</div>
+								</div>
+							</div>
+						{/if}
+
+						{if !empty($validListsSorts)}
+							<div class="panel" id="listsPreferencesPanel">
+								<a data-toggle="collapse" href="#listsPreferencesPanelBody">
+									<div class="panel-heading">
+										<div class="panel-title">
+											<h2>{translate text="Lists" isPublicFacing=true}</h2>
+										</div>
+									</div>
+								</a>
+								<div id="listsPreferencesPanelBody" class="panel-collapse collapse">
+									<div class="panel-body">
+										{if !empty($validListsSorts)}
+											<div class="form-group propertyRow">
+												<label for="defaultListsSort" class="control-label">{translate text='Default Sort For New Searches' isPublicFacing=true}</label>&nbsp;
+												<select name="defaultListsSort" id="defaultListsSort" class="form-control">
+													<option value="" {if empty($defaultListsSort)}selected{/if}>{translate text="System Default" isPublicFacing=true inAttribuge=true}</option>
+													{foreach from=$validListsSorts key="sortValue" item="sortName"}
+														<option value="{$sortValue}" {if $defaultListsSort == $sortValue}selected{/if}>{translate text=$sortName isPublicFacing=true inAttribuge=true}</option>
+													{/foreach}
+												</select>
+											</div>
+										{/if}
+									</div>
+								</div>
+							</div>
+						{/if}
+
+						{if !empty($showRatings) && $showComments}
+							<div class="panel" id="ratingsPreferencesPanel">
+								<a data-toggle="collapse" href="#ratingsPreferencesPanelBody">
+									<div class="panel-heading">
+										<div class="panel-title">
+											<h2>{translate text="Ratings" isPublicFacing=true}</h2>
+										</div>
+									</div>
+								</a>
+								<div id="ratingsPreferencesPanelBody" class="panel-collapse collapse">
+									<div class="panel-body">
+										{if !empty($showRatings) && $showComments}
+											<div class="form-group propertyRow">
+												<label for="noPromptForUserReviews" class="control-label">{translate text='Do not prompt me for reviews after rating titles' isPublicFacing=true}</label>&nbsp;
+												{if $edit == true}
+													<input type="checkbox" class="form-control" name="noPromptForUserReviews" id="noPromptForUserReviews" {if $profile->noPromptForUserReviews==1}checked='checked'{/if} data-switch="">
+												{else}
+													{if $profile->noPromptForUserReviews==0} {translate text='No' isPublicFacing=true}{else} {translate text='Yes' isPublicFacing=true}{/if}
+												{/if}
+												<p class="help-block alert alert-info">
+													<span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span> {translate text="When you rate an item by clicking on the stars, you will be asked to review that item also. Selecting this option lets us know you don't want to give reviews after you have rated an item by clicking its stars." isPublicFacing=true}
+												</p>
+											</div>
+										{/if}
+									</div>
+								</div>
+							</div>
+						{/if}
+
+						{if !empty($validSeriesSorts)}
+							<div class="panel" id="seriesPreferencesPanel">
+								<a data-toggle="collapse" href="#seriesPreferencesPanelBody">
+									<div class="panel-heading">
+										<div class="panel-title">
+											<h2>{translate text="Series" isPublicFacing=true}</h2>
+										</div>
+									</div>
+								</a>
+								<div id="seriesPreferencesPanelBody" class="panel-collapse collapse">
+									<div class="panel-body">
+										{if !empty($validSeriesSorts)}
+											<div class="form-group propertyRow">
+												<label for="defaultSeriesSort" class="control-label">{translate text='Default Sort For New Searches' isPublicFacing=true}</label>&nbsp;
+												<select name="defaultSeriesSort" id="defaultSeriesSort" class="form-control">
+													<option value="" {if empty($defaultSeriesSort)}selected{/if}>{translate text="System Default" isPublicFacing=true inAttribuge=true}</option>
+													{foreach from=$validSeriesSorts key="sortValue" item="sortName"}
+														<option value="{$sortValue}" {if $defaultSeriesSort == $sortValue}selected{/if}>{translate text=$sortName isPublicFacing=true inAttribuge=true}</option>
+													{/foreach}
+												</select>
+											</div>
+										{/if}
+									</div>
+								</div>
+							</div>
+						{/if}
+
+						{if !empty($validWebsitesSorts)}
+							<div class="panel" id="websitesPreferencesPanel">
+								<a data-toggle="collapse" href="#websitesPreferencesPanelBody">
+									<div class="panel-heading">
+										<div class="panel-title">
+											<h2>{translate text="Website Searches" isPublicFacing=true}</h2>
+										</div>
+									</div>
+								</a>
+								<div id="websitesPreferencesPanelBody" class="panel-collapse collapse">
+									<div class="panel-body">
+										{if !empty($validWebsitesSorts)}
+											<div class="form-group propertyRow">
+												<label for="defaultWebsitesSort" class="control-label">{translate text='Default Sort For New Searches' isPublicFacing=true}</label>&nbsp;
+												<select name="defaultWebsitesSort" id="defaultWebsitesSort" class="form-control">
+													<option value="" {if empty($defaultWebsitesSort)}selected{/if}>{translate text="System Default" isPublicFacing=true inAttribuge=true}</option>
+													{foreach from=$validWebsitesSorts key="sortValue" item="sortName"}
+														<option value="{$sortValue}" {if $defaultWebsitesSort == $sortValue}selected{/if}>{translate text=$sortName isPublicFacing=true inAttribuge=true}</option>
+													{/foreach}
+												</select>
+											</div>
+										{/if}
+									</div>
+								</div>
+							</div>
+						{/if}
+
+					</div>
 
 					{if empty($offline) && $edit == true}
 						<div class="form-group propertyRow">
-							<button type="submit" name="updateMyPreferences" class="btn btn-sm btn-primary">{translate text="Update My Preferences" isPublicFacing=true}</button>
+							<button type="submit" name="updateMyPreferences" class="btn btn-sm btn-primary">{translate text="Update Preferences" isPublicFacing=true}</button>
 						</div>
 					{/if}
 				</form>

--- a/code/web/interface/themes/responsive/RecordDrivers/CourseReserve/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/CourseReserve/listEntry.tpl
@@ -91,8 +91,7 @@
 				<div class="btn-group-vertical" role="group">
 					{if !empty($userSort) && $resultIndex != '1'}<span class="btn btn-xs btn-default" onclick="return AspenDiscovery.Lists.changeWeight('{$listEntryId}', 'up');" title="{translate text="Move Up" isPublicFacing=true}">&#x25B2;</span>{/if}
 					<a href="/MyAccount/Edit?listEntryId={$listEntryId|escape:"url"}{if !is_null($listSelected)}&amp;listId={$listSelected|escape:"url"}{/if}" class="btn btn-default">{translate text='Edit' isPublicFacing=true}</a>
-					{* Use a different delete URL if we're removing from a specific list or the overall favorites: *}
-					<a href="/MyAccount/MyList/{$listSelected|escape:"url"}?delete={$listEntryId|escape:"url"}" onclick="return confirm('Are you sure you want to delete this?');" class="btn btn-danger">{translate text='Delete' isPublicFacing=true}</a>
+					<a href="#" onclick="AspenDiscovery.confirm('Delete Title?', 'Are you sure you want to delete this?', 'Yes', 'No', true, 'AspenDiscovery.Lists.deleteEntryFromList({$listSelected}, {$listEntryId})', 'btn-danger');" class="btn btn-danger">{translate text='Delete' isPublicFacing=true}</a>
 					{if !empty($userSort) && ($resultIndex != $listEntryCount)}<span class="btn btn-xs btn-default" onclick="return AspenDiscovery.Lists.changeWeight('{$listEntryId}', 'down');" title="{translate text="Move Down" isPublicFacing=true}">&#x25BC;</span>{/if}
 				</div>
 			</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/EBSCO/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/EBSCO/listEntry.tpl
@@ -108,8 +108,7 @@
 				<div class="btn-group-vertical" role="group">
 					{if !empty($userSort) && ($resultIndex != '1')}<span class="btn btn-xs btn-default" onclick="return AspenDiscovery.Lists.changeWeight('{$listEntryId}', 'up');" title="{translate text="Move Up" isPublicFacing=true}">&#x25B2;</span>{/if}
 					<a href="#" onclick="return AspenDiscovery.Account.getEditListForm({$listEntryId},{$listSelected})" class="btn btn-default">{translate text="Edit" isPublicFacing=true}</a>
-					{* Use a different delete URL if we're removing from a specific list or the overall favorites: *}
-					<a href="/MyAccount/MyList/{$listSelected|escape:"url"}?delete={$listEntryId|escape:"url"}" onclick="return confirm('{translate text="Are you sure you want to delete this?" isPublicFacing=true inAttribute=true}');" class="btn btn-danger">{translate text='Delete' isPublicFacing=true}</a>
+					<a href="#" onclick="AspenDiscovery.confirm('Delete Title?', 'Are you sure you want to delete this?', 'Yes', 'No', true, 'AspenDiscovery.Lists.deleteEntryFromList({$listSelected}, {$listEntryId})', 'btn-danger');" class="btn btn-danger">{translate text='Delete' isPublicFacing=true}</a>
 					{if !empty($userSort) && ($resultIndex != $listEntryCount)}<span class="btn btn-xs btn-default" onclick="return AspenDiscovery.Lists.changeWeight('{$listEntryId}', 'down');" title="{translate text="Move Down" isPublicFacing=true}">&#x25BC;</span>{/if}
 				</div>
 			</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/EBSCOhost/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/EBSCOhost/listEntry.tpl
@@ -103,8 +103,7 @@
 				<div class="btn-group-vertical" role="group">
 					{if !empty($userSort) && ($resultIndex != '1')}<span class="btn btn-xs btn-default" onclick="return AspenDiscovery.Lists.changeWeight('{$listEntryId}', 'up');" title="{translate text="Move Up" isPublicFacing=true}">&#x25B2;</span>{/if}
 					<a href="#" onclick="return AspenDiscovery.Account.getEditListForm({$listEntryId},{$listSelected})" class="btn btn-default">{translate text="Edit" isPublicFacing=true}</a>
-					{* Use a different delete URL if we're removing from a specific list or the overall favorites: *}
-					<a href="/MyAccount/MyList/{$listSelected|escape:"url"}?delete={$listEntryId|escape:"url"}" onclick="return confirm('{translate text="Are you sure you want to delete this?" isPublicFacing=true inAttribute=true}');" class="btn btn-danger">{translate text='Delete' isPublicFacing=true}</a>
+					<a href="#" onclick="AspenDiscovery.confirm('Delete Title?', 'Are you sure you want to delete this?', 'Yes', 'No', true, 'AspenDiscovery.Lists.deleteEntryFromList({$listSelected}, {$listEntryId})', 'btn-danger');" class="btn btn-danger">{translate text='Delete' isPublicFacing=true}</a>
 					{if !empty($userSort) && ($resultIndex != $listEntryCount)}<span class="btn btn-xs btn-default" onclick="return AspenDiscovery.Lists.changeWeight('{$listEntryId}', 'down');" title="{translate text="Move Down" isPublicFacing=true}">&#x25BC;</span>{/if}
 				</div>
 			</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/Events/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Events/listEntry.tpl
@@ -87,8 +87,7 @@
 				<div class="btn-group-vertical" role="group">
 					{if !empty($userSort) && ($resultIndex != '1')}<span class="btn btn-xs btn-default" onclick="return AspenDiscovery.Lists.changeWeight('{$listEntryId}', 'up');" title="{translate text="Move Up" isPublicFacing=true}">&#x25B2;</span>{/if}
 					<a href="#" onclick="return AspenDiscovery.Account.getEditListForm({$listEntryId},{$listSelected})" class="btn btn-default">{translate text="Edit" isPublicFacing=true}</a>
-					{* Use a different delete URL if we're removing from a specific list or the overall favorites: *}
-					<a href="/MyAccount/MyList/{$listSelected|escape:"url"}?delete={$listEntryId|escape:"url"}" onclick="return confirm('{translate text="Are you sure you want to delete this?" isPublicFacing=true inAttribute=true}');" class="btn btn-danger">{translate text='Delete' isPublicFacing=true}</a>
+					<a href="#" onclick="AspenDiscovery.confirm('Delete Title?', 'Are you sure you want to delete this?', 'Yes', 'No', true, 'AspenDiscovery.Lists.deleteEntryFromList({$listSelected}, {$listEntryId})', 'btn-danger');" class="btn btn-danger">{translate text='Delete' isPublicFacing=true}</a>
 					{if !empty($userSort) && ($resultIndex != $listEntryCount)}<span class="btn btn-xs btn-default" onclick="return AspenDiscovery.Lists.changeWeight('{$listEntryId}', 'down');" title="{translate text="Move Down" isPublicFacing=true}">&#x25BC;</span>{/if}
 				</div>
 			</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/listEntry.tpl
@@ -126,8 +126,7 @@
 				<div class="btn-group-vertical" role="group">
 					{if !empty($userSort) && ($resultIndex != '1')}<span class="btn btn-xs btn-default" onclick="return AspenDiscovery.Lists.changeWeight('{$listEntryId}', 'up');" title="{translate text="Move Up" isPublicFacing=true}">&#x25B2;</span>{/if}
 					<a href="#" onclick="return AspenDiscovery.Account.getEditListForm({$listEntryId},{$listSelected})" class="btn btn-default">{translate text="Edit" isPublicFacing=true}</a>
-					{* Use a different delete URL if we're removing from a specific list or the overall favorites: *}
-					<a href="/MyAccount/MyList/{$listSelected|escape:"url"}?delete={$listEntryId|escape:"url"}" onclick="return confirm('{translate text="Are you sure you want to delete this?" isPublicFacing=true inAttribute=true}');" class="btn btn-danger">{translate text='Delete' isPublicFacing=true}</a>
+					<a href="#" onclick="AspenDiscovery.confirm('Delete Title?', 'Are you sure you want to delete this?', 'Yes', 'No', true, 'AspenDiscovery.Lists.deleteEntryFromList({$listSelected}, {$listEntryId})', 'btn-danger');" class="btn btn-danger">{translate text='Delete' isPublicFacing=true}</a>
 					{if !empty($userSort) && ($resultIndex != $listEntryCount)}<span class="btn btn-xs btn-default" onclick="return AspenDiscovery.Lists.changeWeight('{$listEntryId}', 'down');" title="{translate text="Move Down" isPublicFacing=true}">&#x25BC;</span>{/if}
 				</div>
 			</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/List/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/List/listEntry.tpl
@@ -91,8 +91,7 @@
 				<div class="btn-group-vertical" role="group">
 					{if !empty($userSort) && $resultIndex != '1'}<span class="btn btn-xs btn-default" onclick="return AspenDiscovery.Lists.changeWeight('{$listEntryId}', 'up');" title="{translate text="Move Up" isPublicFacing=true}">&#x25B2;</span>{/if}
 					<a href="#" onclick="return AspenDiscovery.Account.getEditListForm({$listEntryId},{$listSelected})" class="btn btn-default">{translate text='Edit' isPublicFacing=true}</a>
-					{* Use a different delete URL if we're removing from a specific list or the overall favorites: *}
-					<a href="/MyAccount/MyList/{$listSelected|escape:"url"}?delete={$listEntryId|escape:"url"}" onclick="return confirm('Are you sure you want to delete this?');" class="btn btn-danger">{translate text='Delete' isPublicFacing=true}</a>
+					<a href="#" onclick="AspenDiscovery.confirm('Delete Title?', 'Are you sure you want to delete this?', 'Yes', 'No', true, 'AspenDiscovery.Lists.deleteEntryFromList({$listSelected}, {$listEntryId})', 'btn-danger');" class="btn btn-danger">{translate text='Delete' isPublicFacing=true}</a>
 					{if !empty($userSort) && ($resultIndex != $listEntryCount)}<span class="btn btn-xs btn-default" onclick="return AspenDiscovery.Lists.changeWeight('{$listEntryId}', 'down');" title="{translate text="Move Down" isPublicFacing=true}">&#x25BC;</span>{/if}
 				</div>
 			</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/OpenArchives/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/OpenArchives/listEntry.tpl
@@ -104,8 +104,7 @@
 				<div class="btn-group-vertical" role="group">
 					{if !empty($userSort) && $resultIndex != '1'}<span class="btn btn-xs btn-default" onclick="return AspenDiscovery.Lists.changeWeight('{$listEntryId}', 'up');" title="{translate text="Move Up" isPublicFacing=true}">&#x25B2;</span>{/if}
 					<a href="/MyAccount/Edit?listEntryId={$listEntryId|escape:"url"}{if !is_null($listSelected)}&amp;listId={$listSelected|escape:"url"}{/if}" class="btn btn-default">{translate text='Edit' isPublicFacing=true}</a>
-					{* Use a different delete URL if we're removing from a specific list or the overall favorites: *}
-					<a href="/MyAccount/MyList/{$listSelected|escape:"url"}?delete={$listEntryId|escape:"url"}" onclick="return confirm('Are you sure you want to delete this?');" class="btn btn-danger">{translate text='Delete' isPublicFacing=true}</a>
+					<a href="#" onclick="AspenDiscovery.confirm('Delete Title?', 'Are you sure you want to delete this?', 'Yes', 'No', true, 'AspenDiscovery.Lists.deleteEntryFromList({$listSelected}, {$listEntryId})', 'btn-danger');" class="btn btn-danger">{translate text='Delete' isPublicFacing=true}</a>
 					{if !empty($userSort) && ($resultIndex != $listEntryCount)}<span class="btn btn-xs btn-default" onclick="return AspenDiscovery.Lists.changeWeight('{$listEntryId}', 'down');" title="{translate text="Move Down" isPublicFacing=true}">&#x25BC;</span>{/if}
 				</div>
 

--- a/code/web/interface/themes/responsive/RecordDrivers/Person/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Person/listEntry.tpl
@@ -80,8 +80,7 @@
 				<div class="btn-group-vertical" role="group">
 					{if !empty($userSort) && $resultIndex != '1'}<span class="btn btn-xs btn-default" onclick="return AspenDiscovery.Lists.changeWeight('{$listEntryId}', 'up');" title="{translate text="Move Up" isPublicFacing=true}">&#x25B2;</span>{/if}
 					<a href="/MyAccount/Edit?listEntryId={$listEntryId|escape:"url"}{if !is_null($listSelected)}&amp;listId={$listSelected|escape:"url"}{/if}" class="btn btn-default">{translate text='Edit' isPublicFacing=true}</a>
-					{* Use a different delete URL if we're removing from a specific list or the overall favorites: *}
-					<a href="/MyAccount/MyList/{$listSelected|escape:"url"}?delete={$listEntryId|escape:"url"}" onclick="return confirm('Are you sure you want to delete this?');" class="btn btn-danger">{translate text='Delete' isPublicFacing=true}</a>
+					<a href="#" onclick="AspenDiscovery.confirm('Delete Title?', 'Are you sure you want to delete this?', 'Yes', 'No', true, 'AspenDiscovery.Lists.deleteEntryFromList({$listSelected}, {$listEntryId})', 'btn-danger');" class="btn btn-danger">{translate text='Delete' isPublicFacing=true}</a>
 					{if !empty($userSort) && ($resultIndex != $listEntryCount)}<span class="btn btn-xs btn-default" onclick="return AspenDiscovery.Lists.changeWeight('{$listEntryId}', 'down');" title="{translate text="Move Down" isPublicFacing=true}">&#x25BC;</span>{/if}
 				</div>
 

--- a/code/web/interface/themes/responsive/RecordDrivers/Series/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Series/listEntry.tpl
@@ -99,8 +99,7 @@
 				<div class="btn-group-vertical" role="group">
 					{if !empty($userSort) && $resultIndex != '1'}<span class="btn btn-xs btn-default" onclick="return AspenDiscovery.Lists.changeWeight('{$listEntryId}', 'up');" title="{translate text="Move Up" isPublicFacing=true}">&#x25B2;</span>{/if}
 					<a href="#" onclick="return AspenDiscovery.Account.getEditListForm({$listEntryId},{$listSelected})" class="btn btn-default">{translate text='Edit' isPublicFacing=true}</a>
-					{* Use a different delete URL if we're removing from a specific list or the overall favorites: *}
-					<a href="/MyAccount/MyList/{$listSelected|escape:"url"}?delete={$listEntryId|escape:"url"}" onclick="return confirm('Are you sure you want to delete this?');" class="btn btn-danger">{translate text='Delete' isPublicFacing=true}</a>
+					<a href="#" onclick="AspenDiscovery.confirm('Delete Title?', 'Are you sure you want to delete this?', 'Yes', 'No', true, 'AspenDiscovery.Lists.deleteEntryFromList({$listSelected}, {$listEntryId})', 'btn-danger');" class="btn btn-danger">{translate text='Delete' isPublicFacing=true}</a>
 					{if !empty($userSort) && ($resultIndex != $listEntryCount)}<span class="btn btn-xs btn-default" onclick="return AspenDiscovery.Lists.changeWeight('{$listEntryId}', 'down');" title="{translate text="Move Down" isPublicFacing=true}">&#x25BC;</span>{/if}
 				</div>
 			</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/Summon/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Summon/listEntry.tpl
@@ -103,8 +103,7 @@
 					<div class="btn-group-vertical" role="group">
 						{if !empty($userSort) && ($resultIndex != '1')}<span class="btn btn-xs btn-default" onclick="return AspenDiscovery.Lists.changeWeight('{$listEntryId}', 'up');" title="{translate text="Move Up" isPublicFacing=true}">&#x25B2;</span>{/if}
 						<a href="#" onclick="return AspenDiscovery.Account.getEditListForm({$listEntryId},{$listSelected})" class="btn btn-default">{translate text="Edit" isPublicFacing=true}</a>
-						{* Use a different delete URL if we're removing from a specific list or the overall favorites: *}
-						<a href="/MyAccount/MyList/{$listSelected|escape:"url"}?delete={$listEntryId|escape:"url"}" onclick="return confirm('{translate text="Are you sure you want to delete this?" isPublicFacing=true inAttribute=true}');" class="btn btn-danger">{translate text='Delete' isPublicFacing=true}</a>
+						<a href="#" onclick="AspenDiscovery.confirm('Delete Title?', 'Are you sure you want to delete this?', 'Yes', 'No', true, 'AspenDiscovery.Lists.deleteEntryFromList({$listSelected}, {$listEntryId})', 'btn-danger');" class="btn btn-danger">{translate text='Delete' isPublicFacing=true}</a>
 						{if !empty($userSort) && ($resultIndex != $listEntryCount)}<span class="btn btn-xs btn-default" onclick="return AspenDiscovery.Lists.changeWeight('{$listEntryId}', 'down');" title="{translate text="Move Down" isPublicFacing=true}">&#x25BC;</span>{/if}
 					</div>
 				</div>

--- a/code/web/interface/themes/responsive/Series/placeholderListEntry.tpl
+++ b/code/web/interface/themes/responsive/Series/placeholderListEntry.tpl
@@ -73,8 +73,7 @@
 				{if !empty($listEditAllowed)}
 					<div class="btn-group-vertical" role="group">
 						<a href="/MyAccount/Edit?seriesMemberId={$seriesMemberId|escape:"url"}{if !is_null($listSelected)}&amp;listId={$listSelected|escape:"url"}{/if}" class="btn btn-default">{translate text='Edit' isPublicFacing=true}</a>
-						{* Use a different delete URL if we're removing from a specific list or the overall favorites: *}
-						<a href="/MyAccount/MyList/{$listSelected|escape:"url"}?delete={$seriesMemberId|escape:"url"}" onclick="return confirm('{translate text="Are you sure you want to delete this?" isPublicFacing=true}');" class="btn btn-default">{translate text='Delete' isPublicFacing=true}</a>
+						<a href="#" onclick="AspenDiscovery.confirm('Delete Title?', 'Are you sure you want to delete this?', 'Yes', 'No', true, 'AspenDiscovery.Lists.deleteEntryFromList({$listSelected}, {$listEntryId})', 'btn-danger');" class="btn btn-danger">{translate text='Delete' isPublicFacing=true}</a>
 					</div>
 
 				{/if}

--- a/code/web/interface/themes/responsive/css/account.less
+++ b/code/web/interface/themes/responsive/css/account.less
@@ -160,3 +160,31 @@
     overflow: hidden;
   }
 }
+
+// Preferences formatting //
+#preferences-accordion {
+  .panel-group .panel + .panel{
+    margin-top: 0;
+  }
+  .panel-heading{
+    padding: 5px 15px;
+  }
+  .panel-title{
+    font-size: 13px;
+    //text-shadow: 1px 1px #fff;
+    h2{
+      font-size: 13px;
+      margin: unset;
+      font-weight: unset;
+      display: unset;
+    }
+  }
+  .panel-body{
+    font-size:12px;
+    color: @gray-dark;
+    background-color: #fcfcfc;
+    border-color: #c5c5c5;
+    border-width: 0 1px 1px 1px;
+    border-style: solid;
+  }
+}

--- a/code/web/interface/themes/responsive/css/main.css
+++ b/code/web/interface/themes/responsive/css/main.css
@@ -9860,6 +9860,29 @@ a.browse-thumbnail.active {
   height: 275px;
   overflow: hidden;
 }
+#preferences-accordion .panel-group .panel + .panel {
+  margin-top: 0;
+}
+#preferences-accordion .panel-heading {
+  padding: 5px 15px;
+}
+#preferences-accordion .panel-title {
+  font-size: 13px;
+}
+#preferences-accordion .panel-title h2 {
+  font-size: 13px;
+  margin: unset;
+  font-weight: unset;
+  display: unset;
+}
+#preferences-accordion .panel-body {
+  font-size: 12px;
+  color: #333333;
+  background-color: #fcfcfc;
+  border-color: #c5c5c5;
+  border-width: 0 1px 1px 1px;
+  border-style: solid;
+}
 /**
  * Additional Styling related to the help system
  */

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -14165,6 +14165,10 @@ AspenDiscovery.Lists = (function(){
 			return false;
 		},
 
+		deleteEntryFromList: function (listId, listEntryId){
+			window.location.href = Globals.path + '/MyAccount/MyList/' + listId + '?delete=' + listEntryId;
+		},
+
 		doDeleteList: function () {
 			this.submitListForm('deleteList');
 		},

--- a/code/web/interface/themes/responsive/js/aspen/lists.js
+++ b/code/web/interface/themes/responsive/js/aspen/lists.js
@@ -38,6 +38,10 @@ AspenDiscovery.Lists = (function(){
 			return false;
 		},
 
+		deleteEntryFromList: function (listId, listEntryId){
+			window.location.href = Globals.path + '/MyAccount/MyList/' + listId + '?delete=' + listEntryId;
+		},
+
 		doDeleteList: function () {
 			this.submitListForm('deleteList');
 		},

--- a/code/web/interface/themes/responsive/theme.css.tpl
+++ b/code/web/interface/themes/responsive/theme.css.tpl
@@ -215,10 +215,10 @@ div.striped > div:nth-child(odd), div.striped > div:nth-child(odd){ldelim}
 .facetTitle, .exploreMoreTitle,.panel-title,.panel-default > .panel-heading, .sidebar-links .panel-heading, #account-link-accordion .panel .panel-title, #account-settings-accordion .panel .panel-title, .panel-title > a,.panel-default > .panel-heading{ldelim}
     color: {$closedPanelForegroundColor};
 {rdelim}
-.facetTitle.expanded, .exploreMoreTitle.expanded,.active .panel-heading,#more-details-accordion .active .panel-heading,.active .panel-default > .panel-heading, .sidebar-links .active .panel-heading, #account-link-accordion .panel.active .panel-title, #account-settings-accordion .panel.active .panel-title,.active .panel-title,.active .panel-title > a,.active.panel-default > .panel-heading, .adminSection .adminPanel .adminSectionLabel{ldelim}
+.facetTitle.expanded, .exploreMoreTitle.expanded,.active .panel-heading,#more-details-accordion .active .panel-heading,#preferences-accordion .active .panel-heading,.active .panel-default > .panel-heading, .sidebar-links .active .panel-heading, #account-link-accordion .panel.active .panel-title, #account-settings-accordion .panel.active .panel-title,.active .panel-title,.active .panel-title > a,.active.panel-default > .panel-heading, .adminSection .adminPanel .adminSectionLabel{ldelim}
     background-color: {$openPanelBackgroundColor};
 {rdelim}
-.facetTitle.expanded, .exploreMoreTitle.expanded,.active .panel-heading,#more-details-accordion .active .panel-heading,#more-details-accordion .active .panel-title,#account-link-accordion .panel.active .panel-title,.active .panel-title,.active .panel-title > a,.active.panel-default > .panel-heading,.adminSection .adminPanel .adminSectionLabel, .facetLock.pull-right a{ldelim}
+.facetTitle.expanded, .exploreMoreTitle.expanded,.active .panel-heading,#more-details-accordion .active .panel-heading,#more-details-accordion .active .panel-title,#preferences-accordion .active .panel-heading,#preferences-accordion .active .panel-title,#account-link-accordion .panel.active .panel-title,.active .panel-title,.active .panel-title > a,.active.panel-default > .panel-heading,.adminSection .adminPanel .adminSectionLabel, .facetLock.pull-right a{ldelim}
     color: {$openPanelForegroundColor};
 {rdelim}
 .panel-body,.sidebar-links .panel-body,#more-details-accordion .panel-body,.facetDetails,.sidebar-links .panel-body a:not(.btn), .sidebar-links .panel-body a:visited:not(.btn), .sidebar-links .panel-body a:hover:not(.btn),.adminSection .adminPanel{ldelim}
@@ -920,7 +920,7 @@ color: {$bodyTextColor};
 		filter: invert(1);
 	{rdelim}
 
-	#more-details-accordion .panel-body, .itemSummary{ldelim}
+	#more-details-accordion .panel-body, #preferences-accordion .panel-body, .itemSummary{ldelim}
         font-size: 85%;
     {rdelim}
 {/if}

--- a/code/web/release_notes/25.07.00.MD
+++ b/code/web/release_notes/25.07.00.MD
@@ -153,6 +153,14 @@
 - Settings under the Materials Request section of Library Systems now dynamically show or hide configuration fields based on the selected Materials Request System. This is to reduce confusion and to streamline the admin interface by only displaying relevant options. (DIS-902) (*LS*)
 - Renamed labels and removed unnecessary notes for certain email-related settings under the Materials Request section of Library Systems to improve user clarity. (DIS-902) (*LS*)
 
+### Preferences Updates
+- Update MyPreferences to break settings up into meaningful sections. (DIS-1025) (*MDN*)
+  - Sections include: Account, Articles and Databases, Catalog Search, Community Engagement, Display, Holds, Ratings. 
+- Add preference to control the default sort for each active search type within preferences. (DIS-1025) (*MDN*)
+  - Sections include: Articles and Databases, Catalog Search, Course Reserves, Events, Genealogy, Open Archives, Lists, Series, Website Searches
+  - All searches can continue to use the default sort.
+  - When no sort is specified for a search, the default set by the user will be used.
+
 ### Reading History Updates
 - Added visual highlighting to the active page number on the "My Reading History" page. (DIS-986) (*LS*)
 
@@ -297,6 +305,7 @@
 - Myranda Fuentes (Grove)
 - Jordan Fields (Grove)
 - Mark Noble (Grove)
+- Kirstien Kroeger (KK)
 
 ## Special Documentation thanks to
 - Myranda Fuentes (Grove)

--- a/code/web/services/CourseReserves/Results.php
+++ b/code/web/services/CourseReserves/Results.php
@@ -16,6 +16,16 @@ class CourseReserves_Results extends ResultsAction {
 		require_once ROOT_DIR . '/sys/SolrConnector/Solr.php';
 		$timer->logTime('Include search engine');
 
+		//Set default sort by setting the request variable so the init grabs it
+		if (!array_key_exists('sort', $_REQUEST) && UserAccount::isLoggedIn()) {
+			$userId = UserAccount::getActiveUserId();
+			require_once ROOT_DIR . '/sys/User/PageDefaults.php';
+			$pageDefaults = PageDefaults::getPageDefaultsForUser($userId, 'CourseReserves', 'Results', null);
+			if ($pageDefaults != null) {
+				$_REQUEST['sort'] = $pageDefaults->pageSort;
+			}
+		}
+
 		// Initialise from the current search globals
 		/** @var SearchObject_ListsSearcher $searchObject */
 		$searchObject = SearchObjectFactory::initSearchObject('CourseReserves');

--- a/code/web/services/EBSCO/Results.php
+++ b/code/web/services/EBSCO/Results.php
@@ -14,6 +14,16 @@ class EBSCO_Results extends ResultsAction {
 
 		$aspenUsage->ebscoEdsSearches++;
 
+		//Set default sort by setting the request variable so the init grabs it
+		if (!array_key_exists('sort', $_REQUEST) && UserAccount::isLoggedIn()) {
+			$userId = UserAccount::getActiveUserId();
+			require_once ROOT_DIR . '/sys/User/PageDefaults.php';
+			$pageDefaults = PageDefaults::getPageDefaultsForUser($userId, 'EBSCO', 'Results', null);
+			if ($pageDefaults != null) {
+				$_REQUEST['sort'] = $pageDefaults->pageSort;
+			}
+		}
+
 		//Include Search Engine
 		/** @var SearchObject_EbscoEdsSearcher $searchObject */
 		$searchObject = SearchObjectFactory::initSearchObject("EbscoEds");

--- a/code/web/services/EBSCOhost/Results.php
+++ b/code/web/services/EBSCOhost/Results.php
@@ -14,6 +14,16 @@ class EBSCOhost_Results extends ResultsAction {
 
 		$aspenUsage->ebscohostSearches++;
 
+		//Set default sort by setting the request variable so the init grabs it
+		if (!array_key_exists('sort', $_REQUEST) && UserAccount::isLoggedIn()) {
+			$userId = UserAccount::getActiveUserId();
+			require_once ROOT_DIR . '/sys/User/PageDefaults.php';
+			$pageDefaults = PageDefaults::getPageDefaultsForUser($userId, 'EBSCOhost', 'Results', null);
+			if ($pageDefaults != null) {
+				$_REQUEST['sort'] = $pageDefaults->pageSort;
+			}
+		}
+
 		//Include Search Engine
 		/** @var SearchObject_EbscohostSearcher $searchObject */
 		$searchObject = SearchObjectFactory::initSearchObject("Ebscohost");

--- a/code/web/services/Events/Results.php
+++ b/code/web/services/Events/Results.php
@@ -70,6 +70,16 @@ class Events_Results extends ResultsAction {
 			}
 		}
 
+		//Set default sort by setting the request variable so the init grabs it
+		if (!array_key_exists('sort', $_REQUEST) && UserAccount::isLoggedIn()) {
+			$userId = UserAccount::getActiveUserId();
+			require_once ROOT_DIR . '/sys/User/PageDefaults.php';
+			$pageDefaults = PageDefaults::getPageDefaultsForUser($userId, 'Events', 'Results', null);
+			if ($pageDefaults != null) {
+				$_REQUEST['sort'] = $pageDefaults->pageSort;
+			}
+		}
+
 		// Initialise from the current search globals
 		/** @var SearchObject_EventsSearcher $searchObject */
 		$searchObject = SearchObjectFactory::initSearchObject('Events');

--- a/code/web/services/Genealogy/Results.php
+++ b/code/web/services/Genealogy/Results.php
@@ -76,6 +76,16 @@ class Genealogy_Results extends ResultsAction {
 		// Hide Covers when the user has set that setting on the Search Results Page
 		$this->setShowCovers();
 
+		//Set default sort by setting the request variable so the init grabs it
+		if (!array_key_exists('sort', $_REQUEST) && UserAccount::isLoggedIn()) {
+			$userId = UserAccount::getActiveUserId();
+			require_once ROOT_DIR . '/sys/User/PageDefaults.php';
+			$pageDefaults = PageDefaults::getPageDefaultsForUser($userId, 'Genealogy', 'Results', null);
+			if ($pageDefaults != null) {
+				$_REQUEST['sort'] = $pageDefaults->pageSort;
+			}
+		}
+
 		// Include Search Engine Class
 		require_once ROOT_DIR . '/sys/SolrConnector/GenealogySolrConnector.php';
 		$timer->logTime('Include search engine');

--- a/code/web/services/Lists/Results.php
+++ b/code/web/services/Lists/Results.php
@@ -16,6 +16,16 @@ class Lists_Results extends ResultsAction {
 		require_once ROOT_DIR . '/sys/SolrConnector/Solr.php';
 		$timer->logTime('Include search engine');
 
+		//Set default sort by setting the request variable so the init grabs it
+		if (!array_key_exists('sort', $_REQUEST) && UserAccount::isLoggedIn()) {
+			$userId = UserAccount::getActiveUserId();
+			require_once ROOT_DIR . '/sys/User/PageDefaults.php';
+			$pageDefaults = PageDefaults::getPageDefaultsForUser($userId, 'Lists', 'Results', null);
+			if ($pageDefaults != null) {
+				$_REQUEST['sort'] = $pageDefaults->pageSort;
+			}
+		}
+
 		// Initialise from the current search globals
 		/** @var SearchObject_ListsSearcher $searchObject */
 		$searchObject = SearchObjectFactory::initSearchObject('Lists');

--- a/code/web/services/MyAccount/MyPreferences.php
+++ b/code/web/services/MyAccount/MyPreferences.php
@@ -2,6 +2,7 @@
 
 require_once ROOT_DIR . '/services/MyAccount/MyAccount.php';
 require_once ROOT_DIR . '/sys/CommunityEngagement/Campaign.php';
+require_once ROOT_DIR . '/sys/User/PageDefaults.php';
 
 class MyAccount_MyPreferences extends MyAccount {
 	function launch() : void {
@@ -97,6 +98,95 @@ class MyAccount_MyPreferences extends MyAccount {
 			}
 			$interface->assign('usersCampaigns', $usersCampaigns);
 
+			require_once(ROOT_DIR . '/Drivers/marmot_inc/SearchSources.php');
+			$searchSources = new SearchSources();
+			$validSearchSources = $searchSources->getSearchSources();
+			$catalogSearchObject = SearchSources::getSearcherForSource('catalog');
+			$validCatalogSorts = $catalogSearchObject->getSortOptions();
+			$interface->assign('validCatalogSorts', $validCatalogSorts);
+			$catalogPageDefaults = PageDefaults::getPageDefaultsForUser($user->id, 'Search', 'Results', null);
+			$interface->assign('defaultCatalogSort', $catalogPageDefaults == null ? '' : $catalogPageDefaults->pageSort);
+
+			if (array_key_exists('ebsco_eds', $validSearchSources)){
+				$edsSearchObject = SearchSources::getSearcherForSource('ebsco_eds');
+				$validEdsSorts = $edsSearchObject->getSortOptions();
+				$interface->assign('validEdsSorts', $validEdsSorts);
+				$ebscoEDSPageDefaults = PageDefaults::getPageDefaultsForUser($user->id, 'EBSCO', 'Results', null);
+				$interface->assign('defaultEbscoEDSSort', $ebscoEDSPageDefaults == null ? '' : $ebscoEDSPageDefaults->pageSort);
+			}
+
+			if (array_key_exists('ebscohost', $validSearchSources)){
+				$ebscohostSearchObject = SearchSources::getSearcherForSource('ebscohost');
+				$validEbscohostSorts = $ebscohostSearchObject->getSortOptions();
+				$interface->assign('validEbscohostSorts', $validEbscohostSorts);
+				$ebscoHostPageDefaults = PageDefaults::getPageDefaultsForUser($user->id, 'EBSCOhost', 'Results', null);
+				$interface->assign('defaultEbscoHostSort', $ebscoHostPageDefaults == null ? '' : $ebscoHostPageDefaults->pageSort);
+			}
+
+			if (array_key_exists('summon', $validSearchSources)){
+				$summonSearchObject = SearchSources::getSearcherForSource('summon');
+				$validSummonSorts = $summonSearchObject->getSortOptions();
+				$interface->assign('validSummonSorts', $validSummonSorts);
+				$summonPageDefaults = PageDefaults::getPageDefaultsForUser($user->id, 'Summon', 'Results', null);
+				$interface->assign('defaultSummonSort', $summonPageDefaults == null ? '' : $summonPageDefaults->pageSort);
+			}
+
+			if (array_key_exists('course_reserves', $validSearchSources)){
+				$courseReservesSearchObject = SearchSources::getSearcherForSource('course_reserves');
+				$validCourseReservesSorts = $courseReservesSearchObject->getSortOptions();
+				$interface->assign('validCourseReservesSorts', $validCourseReservesSorts);
+				$courseReservesPageDefaults = PageDefaults::getPageDefaultsForUser($user->id, 'CourseReserves', 'Results', null);
+				$interface->assign('defaultCourseReservesSort', $courseReservesPageDefaults == null ? '' : $courseReservesPageDefaults->pageSort);
+			}
+
+			if (array_key_exists('events', $validSearchSources)){
+				$eventsSearchObject = SearchSources::getSearcherForSource('events');
+				$validEventsSorts = $eventsSearchObject->getSortOptions();
+				$interface->assign('validEventsSorts', $validEventsSorts);
+				$eventsPageDefaults = PageDefaults::getPageDefaultsForUser($user->id, 'Events', 'Results', null);
+				$interface->assign('defaultEventsSort', $eventsPageDefaults == null ? '' : $eventsPageDefaults->pageSort);
+			}
+
+			if (array_key_exists('genealogy', $validSearchSources)){
+				$genealogySearchObject = SearchSources::getSearcherForSource('genealogy');
+				$validGenealogySorts = $genealogySearchObject->getSortOptions();
+				$interface->assign('validGenealogySorts', $validGenealogySorts);
+				$genealogyPageDefaults = PageDefaults::getPageDefaultsForUser($user->id, 'Genealogy', 'Results', null);
+				$interface->assign('defaultGenealogySort', $genealogyPageDefaults == null ? '' : $genealogyPageDefaults->pageSort);
+			}
+
+			if (array_key_exists('lists', $validSearchSources)){
+				$listsSearchObject = SearchSources::getSearcherForSource('lists');
+				$validListsSorts = $listsSearchObject->getSortOptions();
+				$interface->assign('validListsSorts', $validListsSorts);
+				$listsPageDefaults = PageDefaults::getPageDefaultsForUser($user->id, 'Lists', 'Results', null);
+				$interface->assign('defaultListsSort', $listsPageDefaults == null ? '' : $listsPageDefaults->pageSort);
+			}
+
+			if (array_key_exists('series', $validSearchSources)){
+				$seriesSearchObject = SearchSources::getSearcherForSource('series');
+				$validSeriesSorts = $seriesSearchObject->getSortOptions();
+				$interface->assign('validSeriesSorts', $validSeriesSorts);
+				$seriesPageDefaults = PageDefaults::getPageDefaultsForUser($user->id, 'Series', 'Results', null);
+				$interface->assign('defaultSeriesSort', $seriesPageDefaults == null ? '' : $seriesPageDefaults->pageSort);
+			}
+
+			if (array_key_exists('open_archives', $validSearchSources)){
+				$openArchivesSearchObject = SearchSources::getSearcherForSource('open_archives');
+				$validOpenArchivesSorts = $openArchivesSearchObject->getSortOptions();
+				$interface->assign('validOpenArchivesSorts', $validOpenArchivesSorts);
+				$openArchivesPageDefaults = PageDefaults::getPageDefaultsForUser($user->id, 'OpenArchives', 'Results', null);
+				$interface->assign('defaultOpenArchivesSort', $openArchivesPageDefaults == null ? '' : $openArchivesPageDefaults->pageSort);
+			}
+
+			if (array_key_exists('websites', $validSearchSources)){
+				$websitesSearchObject = SearchSources::getSearcherForSource('websites');
+				$validWebsitesSorts = $websitesSearchObject->getSortOptions();
+				$interface->assign('validWebsitesSorts', $validWebsitesSorts);
+				$websitesPageDefaults = PageDefaults::getPageDefaultsForUser($user->id, 'Websites', 'Results', null);
+				$interface->assign('defaultWebsitesSort', $websitesPageDefaults == null ? '' : $websitesPageDefaults->pageSort);
+			}
+
 			// Save/Update Actions
 			global $offlineMode;
 			if (isset($_POST['updateScope']) && !$offlineMode) {
@@ -123,6 +213,82 @@ class MyAccount_MyPreferences extends MyAccount {
 								$user->updateMessage .=$result2['messages'];
 							}
 							$user->updateMessageIsError = $user->updateMessageIsError && !$result2['success'];
+						}
+					}
+
+					if (!empty($_REQUEST['defaultCatalogSort']) && array_key_exists($_REQUEST['defaultCatalogSort'], $validCatalogSorts)) {
+						PageDefaults::updatePageDefaultsForUser($user->id, 'Search', 'Results', null, null, $_REQUEST['defaultCatalogSort']);
+					}else{
+						PageDefaults::updatePageDefaultsForUser($user->id, 'Search', 'Results', null, null, '');
+					}
+					if (!empty($validEdsSorts)) {
+						if (!empty($_REQUEST['defaultEdsSort']) && array_key_exists($_REQUEST['defaultEdsSort'], $validEdsSorts)) {
+							PageDefaults::updatePageDefaultsForUser($user->id, 'EBSCO', 'Results', null, null, $_REQUEST['defaultEdsSort']);
+						} else {
+							PageDefaults::updatePageDefaultsForUser($user->id, 'EBSCO', 'Results', null, null, '');
+						}
+					}
+					if (!empty($validEbscoHostSorts)) {
+						if (!empty($_REQUEST['defaultEbscohostSort']) && array_key_exists($_REQUEST['defaultEbscohostSort'], $validEbscoHostSorts)) {
+							PageDefaults::updatePageDefaultsForUser($user->id, 'EBSCOhost', 'Results', null, null, $_REQUEST['defaultEbscohostSort']);
+						} else {
+							PageDefaults::updatePageDefaultsForUser($user->id, 'EBSCOhost', 'Results', null, null, '');
+						}
+					}
+					if (!empty($validSummonSorts)) {
+						if (!empty($_REQUEST['defaultSummonSort']) && array_key_exists($_REQUEST['defaultSummonSort'], $validSummonSorts)) {
+							PageDefaults::updatePageDefaultsForUser($user->id, 'Summon', 'Results', null, null, $_REQUEST['defaultSummonSort']);
+						} else {
+							PageDefaults::updatePageDefaultsForUser($user->id, 'Summon', 'Results', null, null, '');
+						}
+					}
+					if (!empty($validCourseReservesSorts)) {
+						if (!empty($_REQUEST['defaultCourseReservesSort']) && array_key_exists($_REQUEST['defaultCourseReservesSort'], $validCourseReservesSorts)) {
+							PageDefaults::updatePageDefaultsForUser($user->id, 'CourseReserves', 'Results', null, null, $_REQUEST['defaultCourseReservesSort']);
+						} else {
+							PageDefaults::updatePageDefaultsForUser($user->id, 'CourseReserves', 'Results', null, null, '');
+						}
+					}
+					if (!empty($validEventsSorts)) {
+						if (!empty($_REQUEST['defaultEventsSort']) && array_key_exists($_REQUEST['defaultEventsSort'], $validEventsSorts)) {
+							PageDefaults::updatePageDefaultsForUser($user->id, 'Events', 'Results', null, null, $_REQUEST['defaultEventsSort']);
+						} else {
+							PageDefaults::updatePageDefaultsForUser($user->id, 'Events', 'Results', null, null, '');
+						}
+					}
+					if (!empty($validGenealogySorts)) {
+						if (!empty($_REQUEST['defaultGenealogySort']) && array_key_exists($_REQUEST['defaultGenealogySort'], $validGenealogySorts)) {
+							PageDefaults::updatePageDefaultsForUser($user->id, 'Genealogy', 'Results', null, null, $_REQUEST['defaultGenealogySort']);
+						} else {
+							PageDefaults::updatePageDefaultsForUser($user->id, 'Genealogy', 'Results', null, null, '');
+						}
+					}
+					if (!empty($validOpenArchivesSorts)) {
+						if (!empty($_REQUEST['defaultOpenArchivesSort']) && array_key_exists($_REQUEST['defaultOpenArchivesSort'], $validOpenArchivesSorts)) {
+							PageDefaults::updatePageDefaultsForUser($user->id, 'OpenArchives', 'Results', null, null, $_REQUEST['defaultOpenArchivesSort']);
+						} else {
+							PageDefaults::updatePageDefaultsForUser($user->id, 'OpenArchives', 'Results', null, null, '');
+						}
+					}
+					if (!empty($validListsSorts)) {
+						if (!empty($_REQUEST['defaultListsSort']) && array_key_exists($_REQUEST['defaultListsSort'], $validListsSorts)) {
+							PageDefaults::updatePageDefaultsForUser($user->id, 'Lists', 'Results', null, null, $_REQUEST['defaultListsSort']);
+						} else {
+							PageDefaults::updatePageDefaultsForUser($user->id, 'Lists', 'Results', null, null, '');
+						}
+					}
+					if (!empty($validSeriesSorts)) {
+						if (!empty($_REQUEST['defaultSeriesSort']) && array_key_exists($_REQUEST['defaultSeriesSort'], $validSeriesSorts)) {
+							PageDefaults::updatePageDefaultsForUser($user->id, 'Series', 'Results', null, null, $_REQUEST['defaultSeriesSort']);
+						} else {
+							PageDefaults::updatePageDefaultsForUser($user->id, 'Series', 'Results', null, null, '');
+						}
+					}
+					if (!empty($validWebsitesSorts)) {
+						if (!empty($_REQUEST['defaultWebsitesSort']) && array_key_exists($_REQUEST['defaultWebsitesSort'], $validWebsitesSorts)) {
+							PageDefaults::updatePageDefaultsForUser($user->id, 'Websites', 'Results', null, null, $_REQUEST['defaultWebsitesSort']);
+						} else {
+							PageDefaults::updatePageDefaultsForUser($user->id, 'Websites', 'Results', null, null, '');
 						}
 					}
 				} else {
@@ -184,7 +350,7 @@ class MyAccount_MyPreferences extends MyAccount {
 			}
 		}
 
-		$this->display('myPreferences.tpl', 'My Preferences');
+		$this->display('myPreferences.tpl', 'Preferences');
 	}
 
 	function getBreadcrumbs(): array {

--- a/code/web/services/OpenArchives/Results.php
+++ b/code/web/services/OpenArchives/Results.php
@@ -16,6 +16,16 @@ class OpenArchives_Results extends ResultsAction {
 		require_once ROOT_DIR . '/sys/SolrConnector/Solr.php';
 		$timer->logTime('Include search engine');
 
+		//Set default sort by setting the request variable so the init grabs it
+		if (!array_key_exists('sort', $_REQUEST) && UserAccount::isLoggedIn()) {
+			$userId = UserAccount::getActiveUserId();
+			require_once ROOT_DIR . '/sys/User/PageDefaults.php';
+			$pageDefaults = PageDefaults::getPageDefaultsForUser($userId, 'OpenArchives', 'Results', null);
+			if ($pageDefaults != null) {
+				$_REQUEST['sort'] = $pageDefaults->pageSort;
+			}
+		}
+
 		// Initialise from the current search globals
 		/** @var SearchObject_OpenArchivesSearcher $searchObject */
 		$searchObject = SearchObjectFactory::initSearchObject('OpenArchives');

--- a/code/web/services/Search/Results.php
+++ b/code/web/services/Search/Results.php
@@ -212,6 +212,16 @@ class Search_Results extends ResultsAction {
 			}
 		}
 
+		//Set default sort by setting the request variable so the init grabs it
+		if (!array_key_exists('sort', $_REQUEST) && UserAccount::isLoggedIn()) {
+			$userId = UserAccount::getActiveUserId();
+			require_once ROOT_DIR . '/sys/User/PageDefaults.php';
+			$pageDefaults = PageDefaults::getPageDefaultsForUser($userId, 'Search', 'Results', null);
+			if ($pageDefaults != null) {
+				$_REQUEST['sort'] = $pageDefaults->pageSort;
+			}
+		}
+
 		// Cannot use the current search globals since we may change the search term above
 		// Display of query is not right when reusing the global search object
 		/** @var SearchObject_AbstractGroupedWorkSearcher $searchObject */

--- a/code/web/services/Series/Results.php
+++ b/code/web/services/Series/Results.php
@@ -16,6 +16,16 @@ class Series_Results extends ResultsAction {
 		require_once ROOT_DIR . '/sys/SolrConnector/Solr.php';
 		$timer->logTime('Include search engine');
 
+		//Set default sort by setting the request variable so the init grabs it
+		if (!array_key_exists('sort', $_REQUEST) && UserAccount::isLoggedIn()) {
+			$userId = UserAccount::getActiveUserId();
+			require_once ROOT_DIR . '/sys/User/PageDefaults.php';
+			$pageDefaults = PageDefaults::getPageDefaultsForUser($userId, 'Series', 'Results', null);
+			if ($pageDefaults != null) {
+				$_REQUEST['sort'] = $pageDefaults->pageSort;
+			}
+		}
+
 		// Initialise from the current search globals
 		/** @var SearchObject_SeriesSearcher $searchObject */
 		$searchObject = SearchObjectFactory::initSearchObject('Series');

--- a/code/web/services/Summon/Results.php
+++ b/code/web/services/Summon/Results.php
@@ -13,6 +13,16 @@ class Summon_Results extends ResultsAction {
 
 		$aspenUsage->summonSearches++;
 
+		//Set default sort by setting the request variable so the init grabs it
+		if (!array_key_exists('sort', $_REQUEST) && UserAccount::isLoggedIn()) {
+			$userId = UserAccount::getActiveUserId();
+			require_once ROOT_DIR . '/sys/User/PageDefaults.php';
+			$pageDefaults = PageDefaults::getPageDefaultsForUser($userId, 'Summon', 'Results', null);
+			if ($pageDefaults != null) {
+				$_REQUEST['sort'] = $pageDefaults->pageSort;
+			}
+		}
+
 		//Include Search Engine
 		/** @var SearchObject_SummonSearcher $searchObject */
 		$searchObject = SearchObjectFactory::initSearchObject("Summon");

--- a/code/web/services/Websites/Results.php
+++ b/code/web/services/Websites/Results.php
@@ -16,6 +16,16 @@ class Websites_Results extends ResultsAction {
 		require_once ROOT_DIR . '/sys/SolrConnector/Solr.php';
 		$timer->logTime('Include search engine');
 
+		//Set default sort by setting the request variable so the init grabs it
+		if (!array_key_exists('sort', $_REQUEST) && UserAccount::isLoggedIn()) {
+			$userId = UserAccount::getActiveUserId();
+			require_once ROOT_DIR . '/sys/User/PageDefaults.php';
+			$pageDefaults = PageDefaults::getPageDefaultsForUser($userId, 'Websites', 'Results', null);
+			if ($pageDefaults != null) {
+				$_REQUEST['sort'] = $pageDefaults->pageSort;
+			}
+		}
+
 		// Initialise from the current search globals
 		/** @var SearchObject_WebsitesSearcher $searchObject */
 		$searchObject = SearchObjectFactory::initSearchObject('Websites');

--- a/code/web/sys/DBMaintenance/version_updates/25.07.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.07.00.php
@@ -61,6 +61,13 @@ function getUpdates25_07_00(): array {
 				)'
 			]
 		], //remember_page_defaults_for_user
+		'increase_allowable_sort_length' => [
+			'title' => 'Increase Allowable Sort Length for User page defaults',
+			'description' => 'Increase Allowable Sort Length for User page defaults',
+			'sql' => [
+				'ALTER TABLE user_page_defaults CHANGE COLUMN pageSort pageSort VARCHAR(50)'
+			]
+		], //increase_allowable_sort_length
 
 		//katherine - Grove
 		'add_series_member_priority_score' => [

--- a/code/web/sys/SearchObject/AbstractGroupedWorkSearcher.php
+++ b/code/web/sys/SearchObject/AbstractGroupedWorkSearcher.php
@@ -428,7 +428,7 @@ abstract class SearchObject_AbstractGroupedWorkSearcher extends SearchObject_Sol
 	 * @access  public
 	 * @return  array    Sort value => description array.
 	 */
-	protected function getSortOptions() {
+	public function getSortOptions() {
 		// Author/Search screen
 		if ($this->searchType == 'author' && $this->searchSubType == 'search') {
 			// It's important to remember here we are talking about on-screen

--- a/code/web/sys/SearchObject/BaseSearcher.php
+++ b/code/web/sys/SearchObject/BaseSearcher.php
@@ -1426,7 +1426,7 @@ abstract class SearchObject_BaseSearcher {
 	 * @access  protected
 	 * @return  mixed    various internal variables
 	 */
-	protected function getSortOptions() {
+	public function getSortOptions() {
 		return $this->sortOptions;
 	}
 

--- a/code/web/sys/SearchObject/GenealogySearcher.php
+++ b/code/web/sys/SearchObject/GenealogySearcher.php
@@ -219,7 +219,7 @@ class SearchObject_GenealogySearcher extends SearchObject_SolrSearcher {
 	 * @access  public
 	 * @return  array    Sort value => description array.
 	 */
-	protected function getSortOptions() {
+	public function getSortOptions() {
 		// Everywhere else -- use normal default behavior
 		return parent::getSortOptions();
 	}


### PR DESCRIPTION
- Update MyPreferences to break settings up into meaningful sections. (DIS-1025) (*MDN*)
  - Sections include: Account, Articles and Databases, Catalog Search, Community Engagement, Display, Holds, Ratings. 
- Add preference to control the default sort for each active search type within preferences. (DIS-1025) (*MDN*)
  - Sections include: Articles and Databases, Catalog Search, Course Reserves, Events, Genealogy, Open Archives, Lists, Series, Website Searches
  - All searches can continue to use the default sort.
  - When no sort is specified for a search, the default set by the user will be used.
