### PR TITLE
DIS-1026: Fixed Browse Category Creation for Admins Across Libraries and Improved Form Clarity

### DIFF
--- a/code/web/interface/themes/responsive/Browse/newBrowseCategoryForm.tpl
+++ b/code/web/interface/themes/responsive/Browse/newBrowseCategoryForm.tpl
@@ -16,23 +16,46 @@
 			{/if}
 			<input type="hidden" name="method" value="createBrowseCategory">
 			<div class="form-group">
-				<label for="categoryName" class="control-label">{translate text="New Category Name" isAdminFacing=true}</label>
+				<label for="categoryName" class="control-label">
+					{translate text="Category Name" isAdminFacing=true}
+					<a style="margin-right: .5em; margin-left: .25em" id="categoryNameTooltip" class="text-info" role="tooltip" tabindex="0" data-toggle="tooltip" data-placement="right" data-title="{translate text="Enter a descriptive name for the browse category that will be displayed to users." isAdminFacing=true inAttribute=true}">
+						<i class="fas fa-question-circle"></i>
+					</a>
+					<span class="label label-danger" style="margin-right: .5em;">{translate text="Required" isAdminFacing=true}</span>
+				</label>
 				<input type="text" id="categoryName" name="categoryName" value="" class="form-control required">
 			</div>
 			{if !empty($property)} {* If data for Select tag is present, use the object editor template to build the <select> *}
 			<div class="form-group">
-				<label for="make-as-a-sub-category-ofSelect" class="control-label">{translate text="Add as a Sub-Category to (optional)" isAdminFacing=true} </label>
+				<label for="make-as-a-sub-category-ofSelect" class="control-label">
+					{translate text="Parent Category (Optional)" isAdminFacing=true}
+					<a style="margin-right: .5em; margin-left: .25em" id="parentCategoryTooltip" class="text-info" role="tooltip" tabindex="0" data-toggle="tooltip" data-placement="right" data-title="{translate text="Select an existing category to make this new category a sub-category. Sub-categories appear under their parent category." isAdminFacing=true inAttribute=true}">
+						<i class="fas fa-question-circle"></i>
+					</a>
+				</label>
 				{include file="DataObjectUtil/enum.tpl"} {* create select list *}
 			</div>
 			{/if}
 			<div class="form-group">
-				<label for="addToHomePage" class="control-label"><input type="checkbox" id="addToHomePage" name="addToHomePage" {if $user->browseAddToHome}checked="checked"{/if}>{translate text="Add to Home Page after creation (main categories only)" isAdminFacing=true}</label>
+				<div class="checkbox" style="margin-bottom: 0">
+					<label for="addToHomePage" class="control-label">
+						<input type="checkbox" id="addToHomePage" name="addToHomePage" {if $user->browseAddToHome}checked="checked"{/if}>
+						{if !empty($displayLibraryName)}
+							{translate text="Display on %1% Home Page" 1=$displayLibraryName isAdminFacing=true}
+						{else}
+							{translate text="Display on Home Page" isAdminFacing=true}
+						{/if}
+					</label>
+				</div>
+				<span class="help-block" style="margin-top:0"><small><i class="fas fa-info-circle"></i> {translate text="Only applies to main categories, not sub-categories." isAdminFacing=true}</small></span>
 			</div>
 		</div>
 	</form>
 </div>
 {/strip}
 <script type="text/javascript">
+	$('[data-toggle="tooltip"]').tooltip();
+
 	{literal}
 	$("#createBrowseCategory").validate({
 		submitHandler: function(){

--- a/code/web/release_notes/25.07.00.MD
+++ b/code/web/release_notes/25.07.00.MD
@@ -142,6 +142,10 @@
 - Improved how password fields behave by enforcing minimum and maximum lengths, and digits-only input when required. (DIS-922) (*LS*)
 - For the confirm-password field, adjusted layout to prevent visual issues when password errors appear, ensuring labels stay in place. (DIS-922) (*LS*)
 
+### Browse Category Updates
+- Adjusted behavior to ensure administrators with the "Administer Library Browse Categories" permission can only add browse categories to their home library's catalog, regardless of which catalog they are currently viewing. (DIS-1026) (*LS*)
+- The "Add as New Browse Category" modal now displays the library catalog where the category will appear, and includes usability improvements such as clearer field names, hover descriptions, and indicators for required fields. (DIS-1026) (*LS*)
+
 ### eCommerce Updates
 - Fixed an issue where an AJAX error would display during PayPal Payflow payments when token authentication would fail. (DIS-945) (*LS*)
 


### PR DESCRIPTION
- Adjusted behavior to ensure administrators with the "Administer Library Browse Categories" permission can only add browse categories to their home library's catalog, regardless of which catalog they are currently viewing.
- The "Add as New Browse Category" modal now displays the library catalog where the category will appear, and includes usability improvements such as clearer field names, hover descriptions, and indicators for required fields.

Tested on CW Mars' test server.

Test Plan:
1. Log into an account that has the "Administer Library Browse Categories" permission; it should not have either of the other browse-category permissions.
2. Navigate to a catalog that is not the account’s home library.
3. On the search results page, click "Search Tools," click "Add to Browse," and click "Create New."
4. Submit the form and notice that the new browse category displays on the current catalog’s home page, despite the fact that the current catalog is not the account’s home library.
5. Apply the patch and repeat steps 3-4. Notice that the browse category is added to the account’s home library catalog for display, along with the label of that setting showing onto which library catalog the browse category will display.