### PR TITLE
DIS-1027: Fixed Location Display Order in Search Results Availability

### DIFF
--- a/code/web/release_notes/25.08.00.MD
+++ b/code/web/release_notes/25.08.00.MD
@@ -121,6 +121,8 @@
 - The volume holds form now hides suppressed volumes that would previously appear as selectable options but lead to errors when placing a hold. (DIS-1152) (*LS*)
 - Validate patron's actual preferred pickup location instead of defaulting to home location when "Remember Pickup Location" preference is enabled. (DIS-1172) (*LS*)
 - Added messages on hold prompts to provide context about why manual pickup location selection is needed for some cases. (DIS-1172) (*LS*)
+- Refined pickup location display order so that search results availability now correctly prioritizes pickup locations in the logical sequence: preferred pickup location, alternate pickup location 1, alternate pickup location 2, home library, and so on. (DIS-1027) (*LS*)
+- Resolved an issue where the patron's home library would always be the top result when selecting at what location to place a hold. (DIS-1027) (*LS*)
 
 <div markdown="1" class="settings">
 


### PR DESCRIPTION
- Refined pickup location display order so that search results availability now correctly prioritizes pickup locations in the logical sequence: preferred pickup location, alternate pickup location 1, alternate pickup location 2, home library, and so on.
- Resolved an issue where the patron's home library would always be the top result when selecting at what location to place a hold.

Test Plan:
1. Log into a patron account and check your “My Preferences” page. Keep note of your home library and pickup location preferences; set any that might be missing.
2. Search the catalog and click “Place Hold” on an ILS record. Notice that it does not display the pickup location options in the following order: preferred pickup location, alternate location 1, alternate location 2, then home library, etc.
3. Apply the patch and repeat step 1. Notice that the pickup location options are now in the aforementioned order.