### PR TITLE
DIS-981: Fixed Incorrect Title Display for Evergreen Meta-Record Holds in Patron Hold Lists

### DIFF
--- a/code/web/release_notes/25.07.00.MD
+++ b/code/web/release_notes/25.07.00.MD
@@ -149,6 +149,9 @@
 - Fixed an issue where empty or missing filter names could cause problems during event indexing. (DIS-1024) (*LS*)
 - Updated event indexer's handling of unexpected data in checkbox fields to ensure events are properly indexed. (DIS-1024) (*LS*)
 
+### Evergreen Updates
+- Fixed an issue where meta-record (M-level) holds were displaying incorrect titles in patrons' hold lists; they now show the correct associated title information. (DIS-981) (*LS*)
+
 ### Koha Updates
 - Resolved an issue where users could select, but could not delete, more than one material requests at once. (DIS-940) (*LS*)
 - The "Delete Selected" button for material requests is now disabled until at least one item is selected. (DIS-940) (*LS*)


### PR DESCRIPTION
- Fixed an issue where meta-record (M-level) holds were displaying incorrect titles in patrons' hold lists; they now show the correct associated title information.

Tested on CW Mars' test server. This requires that the hold be placed in the Evergreen ILS.