### PR TITLE
DIS-550: Updated ILS Hours Label and Hid It for non-Koha ILSs

### DIFF
--- a/code/web/release_notes/25.07.00.MD
+++ b/code/web/release_notes/25.07.00.MD
@@ -164,6 +164,7 @@
 - Added backend validation during self registration to make sure password rules are enforced even if frontend validation is bypassed. (DIS-922) (*LS*)
 - Pass down the more informative error message when `loginToKohaOpac()` is invoked and the patron account has a null `ils_password`. (DIS-967) (*LS*)
 - Corrected an issue where the `ils_password` was not being fetched from the user object, so the condition would always be true. (DIS-719) (*LS*)
+- Updated the label "Automatically update hours from the ILS" to "Automatically Update with Closures from the ILS" under the Location settings to more accurately reflect its purpose. This option is now hidden for Aspen instances using other ILSs. (DIS-550) (*LS*)
 
 ### Materials Request Updates
 - Resolved an issue where, if more than one entry in the Materials Request Formats list shared the same Format value, none of the entries could be deleted if any one of them was being used by an existing material request. (DIS-942) (*LS*) 

--- a/code/web/sys/LibraryLocation/Location.php
+++ b/code/web/sys/LibraryLocation/Location.php
@@ -736,8 +736,8 @@ class Location extends DataObject {
 					'allowUpdatingHoursFromILS' => [
 						'property' => 'allowUpdatingHoursFromILS',
 						'type' => 'checkbox',
-						'label' => 'Automatically update hours from the ILS',
-						'description' => 'Whether closures should be automatically updated (Koha Only).',
+						'label' => 'Automatically Update with Closures from the ILS',
+						'description' => 'Whether closures should be automatically updated from the ILS.',
 						'hideInLists' => true,
 						'default' => 1,
 						'permissions' => ['Location ILS Connection'],
@@ -3201,6 +3201,7 @@ class Location extends DataObject {
 	 * Dynamically adjust object structure when editing an existing Location.
 	 * - Remove curbsidePickupInstructionsSetting if the ILS is not Koha.
 	 * - Disable and change the note of curbsidePickupInstructionsSetting if allowCheckIn is enabled.
+	 * - Remove allowUpdatingHoursFromILS if the ILS is not Koha.
 	 *
 	 * @param array $structure
 	 * @return array
@@ -3210,9 +3211,10 @@ class Location extends DataObject {
 		if ($parentLibrary) {
 			$accountProfile = $parentLibrary->getAccountProfile();
 			$ils = $accountProfile ? $accountProfile->ils : '';
-			// Currently, only Koha curbside pickups are implemented in Aspen.
 			if ($ils !== 'koha') {
+				// Currently, only Koha curbside pickups are implemented in Aspen.
 				unset($structure['ilsSection']['properties']['curbsidePickupInstructionsSetting']);
+				unset($structure['hoursSection']['properties']['allowUpdatingHoursFromILS']);
 			} else {
 				// Check if "Mark Arrived" is enabled in the CurbsidePickupSetting.
 				require_once ROOT_DIR . '/sys/CurbsidePickups/CurbsidePickupSetting.php';


### PR DESCRIPTION
- Updated the label "Automatically update hours from the ILS" to "Automatically Update with Closures from the ILS" under the Location settings to more accurately reflect its purpose. This option is now hidden for Aspen instances using other ILSs.

Test Plan:
1. Navigate to your Location settings and select a location.
2. Navigate to the Library Hours section and open the accordion. Note the current label "Automatically update hours from the ILS".
3. Apply the patch. Notice the label has changed to "Automatically Update with Closures from the ILS," and the option will be hidden for Aspen instances using an ILS other than Koha.