### PR TITLE
DIS-1022 Cloud Library fix redirect handling

### DIFF
--- a/code/web/release_notes/25.07.00.MD
+++ b/code/web/release_notes/25.07.00.MD
@@ -211,6 +211,10 @@
 ### OverDrive Updates
 - Remove starRating from OverDrive metadata since starRating is no longer returned in the metadata API resposnes. (DIS-1016) (*YL*)
 
+### CloudLibrary Updates
+- Improve patron authentication flow for redirecting patrons to Cloud Library, to support libraries that don't require PIN login, with automatic fallback handling. (DIS-1022) (*YL*)
+- Restore the redirect URL for MP3 audiobooks. (DIS-1022) (*YL*)
+
 // laura
 
 // james


### PR DESCRIPTION
If libraries do not require a PIN in their Cloud Library, patrons usually only need to use a barcode to sign in the Cloud Library website. When patrons check out Cloud Library records on Aspen, and click “Open In CloudLibrary”, Aspen will redirect patrons to Cloud Library, but see an error` {"error":"Invalid Token"}`

According to Cloud Library support, Aspen should not be passing a password field to {$userInterfaceUrl}/login if the library does not require a PIN in Cloud Library. 

To recreate:
1. Set Cloud Library to do not require a PIN in Cloud Library website 
2. Check out CL records on Aspen
3. Go to “Check out Titles” > Cloud Library > click “Open In CloudLibrary” 
4. See the error {"error":"Invalid Token"}

For {$webPatronUrl}/login endpoint:
1. If Aspen submits a correct barcode and password, or only a correct barcode for the library does not require PIN, or
2. If Aspen includes a password for a library that does not require a PIN, or
3. If Aspen submits an incorrect barcode and password

In all three cases, the endpoint responds with a 200 status code and the same response structure. The only difference is that the session ID is invalid in cases 2 and 3. There doesn’t appear to be any clear indicator in the response that the session ID is invalid or not until we try to make a follow-up call to `webPatronUrl/ebooks/{recordId}?auth_cookie={sessionId}`
_Contacted Cloud Library to see if they can make any changes on their side._ 

Before Cloud Library could fix it or not, the current flow is:
try `/login` with password -> get sessionid -> try to call redirectUrl with sessionid -> gets 200 code, redirect patrons to the url -> if we get 400 code -> try `/login` **without** password -> get sessionid again -> try to call redirectUrl with new sessionid ->  gets 200 code, redirect patrons to the url -> if we get 400 again, redirect patron to the record detail page. 

To test:
1. Set Cloud Library to do not require a PIN in Cloud Library website 
2. Check out CL ebook record and mp3 record on Aspen
3. Go to “Check out Titles” > Cloud Library > click “Open In CloudLibrary” 
4. See the error {"error":"Invalid Token"}
5. Apply PR 
6. Click "Open in CloudLibrary" again for both ebook record and mp3 audiobook record on Aspen
7. Can access to the record without issue. See no obvious delay in between "clicking 'Open in CloudLibrary' button" and "a new tab opening" (excluding the time it takes for the page to fully render). 
