### PR TITLE
DIS-1042: Added HTTP Timeouts to LibCal Indexer to Prevent Stalling

### DIFF
--- a/code/events_indexer/src/com/turning_leaf_technologies/events/SpringshareLibCalIndexer.java
+++ b/code/events_indexer/src/com/turning_leaf_technologies/events/SpringshareLibCalIndexer.java
@@ -4,6 +4,7 @@ import com.turning_leaf_technologies.strings.AspenStringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.NameValuePair;
 import org.apache.http.StatusLine;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -47,6 +48,11 @@ class SpringshareLibCalIndexer {
 	private final HashMap<String, SpringshareLibCalEvent> existingEvents = new HashMap<>();
 	private final HashSet<String> librariesToShowFor = new HashSet<>();
 	private static final CRC32 checksumCalculator = new CRC32();
+	private static final RequestConfig REQUEST_CONFIG = RequestConfig.custom()
+		.setConnectTimeout(10000)
+		.setConnectionRequestTimeout(10000)
+		.setSocketTimeout(60000)
+		.build();
 
 	private PreparedStatement addEventStmt;
 	private PreparedStatement updateEventStmt;
@@ -516,8 +522,10 @@ class SpringshareLibCalIndexer {
 	}
 
 	private JSONArray getLibCalEvents() {
-		try {
-			CloseableHttpClient httpclient = HttpClients.createDefault();
+		try (CloseableHttpClient httpclient = HttpClients.custom()
+			.setDefaultRequestConfig(REQUEST_CONFIG)
+			.build()) {
+
 			HttpRequestBase apiRequest;
 			String authTokenUrl = baseUrl + "/1.1/oauth/token";
 			ArrayList<NameValuePair> params = new ArrayList<>();
@@ -582,7 +590,10 @@ class SpringshareLibCalIndexer {
 	private JSONArray getRegistrations(Integer eventId) {
 		try {
 			JSONArray eventRegistrations;
-			try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
+			try (CloseableHttpClient httpclient = HttpClients.custom()
+				.setDefaultRequestConfig(REQUEST_CONFIG)
+				.build()) {
+
 				HttpRequestBase apiRequest;
 
 				eventRegistrations = new JSONArray();

--- a/code/web/release_notes/25.07.00.MD
+++ b/code/web/release_notes/25.07.00.MD
@@ -205,6 +205,9 @@
 ### Reading History Updates
 - Added visual highlighting to the active page number on the "My Reading History" page. (DIS-986) (*LS*)
 
+### Springshare LibCal Events Updates
+- Fixed an issue where calendar syncing during indexing with Springshare LibCal could randomly stall by adding proper timeouts. (DIS-1042) (*LS*)
+
 ### Two-Factor Authentication Updates
 - Removed the “Libraries” and “Patron Types” labels and “Select All” options because users cannot scope Local Administrators to Libraries and Patron Types. (DIS-968) (*LS*)
 - Removed the option of selecting the “admin_sso” Account Profile, as the authentication flow is handled entirely by the identity provider. (DIS-968) (*LS*)


### PR DESCRIPTION
- Fixed an issue where calendar syncing during indexing with Springshare LibCal could randomly stall by adding proper timeouts.

Test Plan: Difficult to test, but the best way would be to either let the events indexer run, or manually run it, to ensure that it still functions accordingly.