### PR TITLE
DIS-1047 Fix Event Date facet not applying collapseByDefault setting

### DIFF
--- a/code/web/release_notes/25.07.00.MD
+++ b/code/web/release_notes/25.07.00.MD
@@ -243,6 +243,9 @@
 - Fix the numberOfDays calculation for holds suspension. (DIS-1036) (*YL*)
 - Remove starRating from OverDrive metadata since starRating is no longer returned in the metadata API resposnes. (DIS-1016) (*YL*)
 
+### Events Updates
+- Fix Event Date facet not applying collapseByDefault setting from Events Facets configuration. (DIS-1047) (*YL*)
+
 // laura
 
 // james

--- a/code/web/sys/Recommend/SideFacets.php
+++ b/code/web/sys/Recommend/SideFacets.php
@@ -161,13 +161,17 @@ class SideFacets implements RecommendationInterface {
 			//Process other searchers to add more facet popup
 			foreach ($sideFacets as $facetKey => $facet) {
 				/** @var FacetSetting $facetSetting */
+				$facetSetting = $this->facetSettings[$facetKey];
 				if ($facetKey == 'start_date') {
 					$startDateFacet = $this->updateStartDateRatingsFacet($facet);
 					$sideFacets[$facetKey] = $startDateFacet;
+					$sideFacets[$facetKey]['hasApplied'] = isset($startDateFacet['start']) || isset($startDateFacet['end']);
 				}else {
-					$facetSetting = $this->facetSettings[$facetKey];
 					$sideFacets = $this->applyFacetSettings($facetKey, $sideFacets, $facetSetting, $lockedFacets);
 				}
+				$sideFacets[$facetKey]['collapseByDefault'] = $facetSetting->collapseByDefault;
+				$sideFacets[$facetKey]['locked'] = array_key_exists($facetKey, $lockedFacets);
+				$sideFacets[$facetKey]['canLock'] = $facetSetting->canLock;
 			}
 		} elseif ($this->searchObject instanceof SearchObject_ListsSearcher) {
 			foreach ($sideFacets as $facetKey => $facet) {


### PR DESCRIPTION
Currently, the Event Date is not honoring collapse by default even with “Collapse by Default” selected in Events Facets.

To replicate:
1. Set up Events
2. Go to Events Facets and make sure the Collapse by Default of Event Date is selected
3. Do a blank search or any searches in Events, see the Event Date facet is expanded. 

To Test:
1. Set up Events
2. Go to Events Facets and make sure the Collapse by Default of Event Date is selected
3. Do a blank search or any searches in Events, see the Event Date facet is expanded
4. Apply the PR
5. repeat step 3 and see the Event Date is collapsed. 
6. Select start date and end date in the Event Date facet and apply the filter, see the page reload with the filter applied, and Event Date facet expanded.