### PR TITLE
DIS-1048: Removed PHP Warnings in Administrators Form

### DIFF
--- a/code/web/interface/themes/responsive/DataObjectUtil/objectEditForm.tpl
+++ b/code/web/interface/themes/responsive/DataObjectUtil/objectEditForm.tpl
@@ -41,7 +41,9 @@
 		{/if}
 
 		{foreach from=$structure item=property}
-			{include file="DataObjectUtil/property.tpl"}
+			{if is_array($property) && isset($property.property) && isset($property.type)}
+				{include file="DataObjectUtil/property.tpl"}
+			{/if}
 		{/foreach}
 
 		{if (!isset($canSave) || ($canSave == true))}

--- a/code/web/release_notes/25.07.00.MD
+++ b/code/web/release_notes/25.07.00.MD
@@ -230,6 +230,7 @@
 - Moved the "Library Hours" under the "ILS/Account Integration" section of the Locations settings to align with user expectations. (DIS-987) (*LS*)
 - Fixed incorrect display of HTML entities on the Advanced Search page for facet values and on the Grouped Work Display Settings page for a setting. (DIS-992) (*LS*)
 - Implemented a check to confirm file existence in the file system before rendering the uploaded file. (DIS-1004) (*LS*)
+- Resolved an issue where PHP warnings could display when editing the Administrators form. (DIS-1048) (*LS*)
 
 // yanjun
 ### Other Updates


### PR DESCRIPTION
- Resolved an issue where PHP warnings could display when editing the Administrators form.

Test Plan:
1. Navigate to the Administrators page in the admin interface.
2. Find and select the Aspen Admin’s setting. Notice the PHP warnings spanning the page.
   - Your IP must have debug mode enabled in the IP Addresses settings to see the warnings.
3. Apply the patch and reload the page. Notice that the PHP warnings have disappeared.