### PR TITLE
DIS-1053: Add detection and translation mapping for the Nintendo Swit…

### DIFF
--- a/code/reindexer/src/org/aspen_discovery/format_classification/MarcRecordFormatClassifier.java
+++ b/code/reindexer/src/org/aspen_discovery/format_classification/MarcRecordFormatClassifier.java
@@ -1095,6 +1095,9 @@ public class MarcRecordFormatClassifier {
 				} else if (editionData.contains("gamecube")) {
 					if (groupedWork != null && groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Adding bib level format GameCube based on 250 edition", 2);}
 					result.add("GameCube");
+				} else if (editionData.contains("nintendo switch 2")) {
+					if (groupedWork != null && groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Adding bib level format NintendoSwitch2 based on 250 edition", 2);}
+					result.add("NintendoSwitch2");
 				} else if (editionData.contains("nintendo switch")) {
 					if (groupedWork != null && groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Adding bib level format NintendoSwitch based on 250 edition", 2);}
 					result.add("NintendoSwitch");
@@ -1224,6 +1227,8 @@ public class MarcRecordFormatClassifier {
 			return "Wii";
 		} else if (value.contains("nintendo 3ds")) {
 			return "3DS";
+		} else if (value.contains("nintendo switch 2")) {
+			return "NintendoSwitch2";
 		} else if (value.contains("nintendo switch")) {
 			return "NintendoSwitch";
 		} else if (value.contains("nintendo ds")) {
@@ -1490,7 +1495,7 @@ public class MarcRecordFormatClassifier {
 				|| printFormats.contains("PlayStation4") || printFormats.contains("PlayStation5") || printFormats.contains("PlayStationVita")
 				|| printFormats.contains("Wii") || printFormats.contains("WiiU")
 				|| printFormats.contains("3DS") || printFormats.contains("WindowsGame")
-				|| printFormats.contains("NintendoSwitch") || printFormats.contains("NintendoDS")){
+				|| printFormats.contains("NintendoSwitch2") || printFormats.contains("NintendoSwitch") || printFormats.contains("NintendoDS")){
 			printFormats.remove("Software");
 			printFormats.remove("Electronic");
 			printFormats.remove("CDROM");

--- a/code/web/sys/Grouping/Record.php
+++ b/code/web/sys/Grouping/Record.php
@@ -291,15 +291,22 @@ class Grouping_Record {
 				return 'Map';
 
 			case 'Nintendo 3DS':
+			case 'Nintendo DS':
+			case 'Nintendo Switch':
+			case 'Nintendo Switch 2':
 			case 'Nintendo Wii':
 			case 'Nintendo Wii U':
 			case 'PlayStation':
+			case 'PlayStation 2':
 			case 'PlayStation 3':
 			case 'PlayStation 4':
+			case 'PlayStation 5':
+			case 'PlayStation Vita':
 			case 'Windows Game':
 			case 'Xbox 360':
 			case 'Xbox 360 Kinect':
 			case 'Xbox One':
+			case 'Xbox Series X':
 				return 'Game';
 
 			case 'Web Content':

--- a/sites/default/translation_maps/format_map.csv
+++ b/sites/default/translation_maps/format_map.csv
@@ -64,6 +64,7 @@ NOOK_Periodical, Nook Periodicals, eBook,3
 Newspaper, Newspaper, Books,3
 NintendoDS, Nintendo DS, Other,3
 NintendoSwitch, Nintendo Switch, Other,3
+NintendoSwitch2, Nintendo Switch 2, Other,3
 NumericData, Numeric Data, Other,1
 Open_EPUB_eBook, EPUB eBook, eBook,9
 Open_PDF_eBook, PDF eBook, eBook,3


### PR DESCRIPTION
- Added detection of "nintendo switch 2" in both edition and format fields and added default translation mapping for the Nintendo Switch 2 format.

Test Plan:
1. Locate a MARC record with the “nintendo switch 2” format and notice that the format is not displayed for the record.
2. Apply the patch, add the format mapping, where the Value is “NintendoSwitch2” and the Format (i.e., display name) is your choice, and reindex the record. Notice that the format now displays.