### PR TITLE
DIS-1056: Ensured Correct Status for Mixed Records When Library Use Only Is Top-Ranked

### DIFF
--- a/code/web/interface/themes/responsive/GroupedWork/statusIndicator.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/statusIndicator.tpl
@@ -25,7 +25,7 @@
 			{/if}
 		{/if}
 	{elseif $statusInformation->isAvailableLocally()}
-		{if $statusInformation->isAllLibraryUseOnly()}
+		{if $statusInformation->isAllLibraryUseOnly() || $statusInformation->getGroupedStatus() == 'Library Use Only'}
 			<div class="related-manifestation-shelf-status status-library-use-only label label-success label-wrap">{translate text='Library Use Only' isPublicFacing=true}</div>
 		{else}
 			<div class="related-manifestation-shelf-status status-on-shelf label label-success label-wrap">{translate text='On Shelf' isPublicFacing=true}</div>

--- a/code/web/release_notes/25.07.00.MD
+++ b/code/web/release_notes/25.07.00.MD
@@ -283,6 +283,7 @@
 - Fixed incorrect display of HTML entities on the Advanced Search page for facet values and on the Grouped Work Display Settings page for a setting. (DIS-992) (*LS*)
 - Implemented a check to confirm file existence in the file system before rendering the uploaded file. (DIS-1004) (*LS*)
 - Resolved an issue where PHP warnings could display when editing the Administrators form. (DIS-1048) (*LS*)
+- Corrected status display for records with mixed item availability when "Library Use Only" is the best option. (DIS-1056) (*LS*)
 
 // yanjun
 ### CloudLibrary Updates


### PR DESCRIPTION
- Corrected status display for records with mixed item availability when "Library Use Only" is the best option.

Test Plan:
1. Navigate to a record with copies that are all checked out except one or more copies mapped to the "Library Use Only" status. Notice that the grouped work's status is incorrectly "On Shelf" or whatever the equivalent is based upon your Indexing Profile's status mapping.
2. Apply the patch and reload the page. Notice that the grouped work's status is now "Library Use Only".