### PR TITLE
DIS-392 include stage of release within version information

### DIFF
--- a/code/web/Drivers/OverDriveDriver.php
+++ b/code/web/Drivers/OverDriveDriver.php
@@ -280,7 +280,7 @@ class OverDriveDriver extends AbstractEContentDriver {
 				$this->apiCurlWrapper->addCustomHeaders([
 					"Content-Type: application/x-www-form-urlencoded;charset=UTF-8",
 					"Authorization: Basic " . $encodedAuthValue,
-					"User-Agent: Aspen Discovery " . $interface->getVariable('gitBranch'),
+					"User-Agent: Aspen Discovery " . $interface->getVariable('aspenVersion'),
 				], true);
 
 				$patronBarcode = urlencode($patronBarcode);
@@ -340,7 +340,7 @@ class OverDriveDriver extends AbstractEContentDriver {
 			global $interface;
 			$this->apiCurlWrapper->addCustomHeaders([
 				"Authorization: $tokenData->token_type $tokenData->access_token",
-				"User-Agent: Aspen Discovery " . $interface->getVariable('gitBranch'),
+				"User-Agent: Aspen Discovery " . $interface->getVariable('aspenVersion'),
 			], true);
 
 			$content = $this->apiCurlWrapper->curlGetPage($url);
@@ -406,7 +406,7 @@ class OverDriveDriver extends AbstractEContentDriver {
 				global $interface;
 				$this->apiCurlWrapper->addCustomHeaders([
 					"Authorization: $authorizationData",
-					"User-Agent: Aspen Discovery " . $interface->getVariable('gitBranch'),
+					"User-Agent: Aspen Discovery " . $interface->getVariable('aspenVersion'),
 					"Host: $patronApiHost",
 				], true);
 			} else {
@@ -494,12 +494,12 @@ class OverDriveDriver extends AbstractEContentDriver {
 			$patronApiHost = $this->getPatronApiHost($settings);
 			$this->apiCurlWrapper->addCustomHeaders([
 				"Authorization: $authorizationData",
-				"User-Agent: Aspen Discovery " . $interface->getVariable('gitBranch'),
+				"User-Agent: Aspen Discovery " . $interface->getVariable('aspenVersion'),
 				"Host: $patronApiHost",
 			], true);
 		} else {
 			$this->apiCurlWrapper->addCustomHeaders([
-				"User-Agent: Aspen Discovery " . $interface->getVariable('gitBranch'),
+				"User-Agent: Aspen Discovery " . $interface->getVariable('aspenVersion'),
 				"Host: {$this->getOverDriveApiHost($settings)}",
 			], true);
 		}

--- a/code/web/Drivers/PalaceProjectDriver.php
+++ b/code/web/Drivers/PalaceProjectDriver.php
@@ -873,17 +873,17 @@ class PalaceProjectDriver extends AbstractEContentDriver {
 	private function getPalaceProjectHeaders(User $patron) {
 		global $interface;
 		if ($interface != null) {
-			$gitBranch = $interface->getVariable('gitBranch');
-			if (substr($gitBranch, -1) == "\n") {
-				$gitBranch = substr($gitBranch, 0, -1);
+			$aspenVersion = $interface->getVariable('aspenVersion');
+			if (substr($aspenVersion, -1) == "\n") {
+				$aspenVersion = substr($aspenVersion, 0, -1);
 			}
 		} else {
-			$gitBranch = 'Primary';
+			$aspenVersion = 'Primary';
 		}
 		return [
 			'Authorization: Basic ' . base64_encode("$patron->ils_barcode:$patron->ils_password"),
 			'Accept: application/opds+json',
-			'User-Agent: Aspen Discovery ' . $gitBranch,
+			'User-Agent: Aspen Discovery ' . $aspenVersion,
 		];
 	}
 

--- a/code/web/bootstrap.php
+++ b/code/web/bootstrap.php
@@ -435,29 +435,17 @@ function getValidServerNames(): array {
 	return $validServerNames;
 }
 
-function getGitBranch() {
+function getAspenVersion() {
 	global $interface;
 
-	$files = [];
-	foreach (glob(ROOT_DIR . '/release_notes/*.MD') as $filename) {
-		if (preg_match('/\d{2}\.\d{2}\.\d{2}\.MD/', $filename)) {
-			$tmp = str_replace('.MD', '', $filename);
-			/** @noinspection RegExpRedundantEscape */
-			$tmp = preg_replace('~.*release_notes[\\/]~', '', $tmp);
-			$files[] = $tmp;
-		}
-	}
-	asort($files);
-
-	$branchName = end($files);
-	$branchNameWithCommit = end($files);
+	$versionData = json_decode(file_get_contents(ROOT_DIR . '/version.json'));
+	$aspenVersion = trim($versionData->version . ' ' . $versionData->stage);
 
 	if (!empty($interface)) {
-		$interface->assign('gitBranch', $branchName);
-		$interface->assign('gitBranchWithCommit', $branchNameWithCommit);
+		$interface->assign('aspenVersion', $aspenVersion);
 	}
 
-	return $branchName;
+	return $aspenVersion;
 }
 
 //Look for spammy user agents and kill them

--- a/code/web/cron/runScheduledUpdate.php
+++ b/code/web/cron/runScheduledUpdate.php
@@ -33,7 +33,10 @@ if (count($updatesToRun) == 0) {
 			$scheduledUpdate->update();
 
 			$versionToUpdateTo = $scheduledUpdate->updateToVersion;
-			$currentVersion = getGitBranch();
+			$currentVersion = getAspenVersion();
+			if (str_contains($versionToUpdateTo, ' ')) {
+				$currentVersion  = substr($versionToUpdateTo, 0, strpos($versionToUpdateTo, ' '));
+			}
 
 			if (!preg_match('/\d{2}\.\d{2}\.\d{2}/', $versionToUpdateTo)) {
 				$scheduledUpdate->notes = "FAILED: Bad version to update to $versionToUpdateTo \n";

--- a/code/web/index.php
+++ b/code/web/index.php
@@ -46,7 +46,7 @@ if ($activeSessionObject != null) {
 }
 
 global $locationSingleton;
-getGitBranch();
+getAspenVersion();
 //Set a counter for CSS and JavaScript so we can have browsers clear their cache automatically
 $interface->assign('cssJsCacheCounter', 47);
 

--- a/code/web/interface/plugins/function.css.php
+++ b/code/web/interface/plugins/function.css.php
@@ -43,5 +43,5 @@ function smarty_function_css($params, &$smarty) {
 
 	// We found the file -- build the link tag:
 	$media = isset($params['media']) ? " media=\"{$params['media']}\"" : '';
-	return "<link rel=\"stylesheet\" type=\"text/css\"{$media} href=\"{$css}?v=" . urlencode($interface->getVariable('gitBranch')) . '.' . urlencode($interface->getVariable('cssJsCacheCounter')) ."\" />";
+	return "<link rel=\"stylesheet\" type=\"text/css\"{$media} href=\"{$css}?v=" . urlencode($interface->getVariable('aspenVersion')) . '.' . urlencode($interface->getVariable('cssJsCacheCounter')) ."\" />";
 }

--- a/code/web/interface/plugins/function.js.php
+++ b/code/web/interface/plugins/function.js.php
@@ -72,5 +72,5 @@ function smarty_function_js($params, &$smarty) {
 
 	// We found the file -- build the script tag:
 	global $interface;
-	return "<script type=\"text/javascript\" src=\"{$js}?v=" . urlencode($interface->getVariable('gitBranch')) . '.' . urlencode($interface->getVariable('cssJsCacheCounter')) . "\"></script>";
+	return "<script type=\"text/javascript\" src=\"{$js}?v=" . urlencode($interface->getVariable('aspenVersion')) . '.' . urlencode($interface->getVariable('cssJsCacheCounter')) . "\"></script>";
 }

--- a/code/web/interface/themes/responsive/Greenhouse/updateCenter.tpl
+++ b/code/web/interface/themes/responsive/Greenhouse/updateCenter.tpl
@@ -5,13 +5,6 @@
 		</div>
 	</div>
 
-	{*<p class="alert alert-info">
-		{translate text="Quick Update to current version" isAdminFacing=true}
-		<pre>
-			cd /usr/local/aspen-discovery; sudo git pull origin {$gitBranch}
-		</pre>
-	</p>*}
-
 	<form class="form well" id="updateCenterFilters" style="padding-bottom:1em">
 		<div class="row align-middle">
 			<div class="col-xs-12 col-md-3">

--- a/code/web/interface/themes/responsive/cssAndJsIncludes.tpl
+++ b/code/web/interface/themes/responsive/cssAndJsIncludes.tpl
@@ -15,12 +15,12 @@
 	{* Include correct all javascript *}
 	{if !empty($ie8)}
 		{* include to give responsive capability to ie8 browsers, but only on successful detection of those browsers. For that reason, don't include in aspen.min.js *}
-		<script src="/interface/themes/responsive/js/lib/respond.min.js?v={$gitBranch|urlencode}.{$cssJsCacheCounter}"></script>
+		<script src="/interface/themes/responsive/js/lib/respond.min.js?v={$aspenVersion|urlencode}.{$cssJsCacheCounter}"></script>
 	{/if}
 
 	{* This is all merged using the merge_javascript.php file called automatically with a File Watcher*}
 	{* Code is minified using uglify.js *}
-	<script src="/interface/themes/responsive/js/aspen.js?v={$gitBranch|urlencode}.{$cssJsCacheCounter}"></script>
+	<script src="/interface/themes/responsive/js/aspen.js?v={$aspenVersion|urlencode}.{$cssJsCacheCounter}"></script>
 
 	{/strip}
 	<script type="text/javascript">
@@ -90,9 +90,9 @@
 
 	{if !empty($includeAutoLogoutCode)}
 		{if !empty($debugJs)}
-			<script type="text/javascript" src="/interface/themes/responsive/js/aspen/autoLogout.js?v={$gitBranch|urlencode}.{$cssJsCacheCounter}"></script>
+			<script type="text/javascript" src="/interface/themes/responsive/js/aspen/autoLogout.js?v={$aspenVersion|urlencode}.{$cssJsCacheCounter}"></script>
 		{else}
-			<script type="text/javascript" src="/interface/themes/responsive/js/aspen/autoLogout.min.js?v={$gitBranch|urlencode}.{$cssJsCacheCounter}"></script>
+			<script type="text/javascript" src="/interface/themes/responsive/js/aspen/autoLogout.min.js?v={$aspenVersion|urlencode}.{$cssJsCacheCounter}"></script>
 		{/if}
 	{/if}
 	<script type="text/javascript">

--- a/code/web/interface/themes/responsive/footer_responsive.tpl
+++ b/code/web/interface/themes/responsive/footer_responsive.tpl
@@ -11,7 +11,7 @@
 				{if empty($productionServer)}
 					<small class='location_info'>{$physicalLocation}{if !empty($debug)} ({$activeIp}){/if} - {$deviceName}</small>
 				{/if}
-				<small class='version_info'>{if empty($productionServer)} / {/if}{translate text="v. %1%" 1=$gitBranch isPublicFacing=true}</small>
+				<small class='version_info'>{if empty($productionServer)} / {/if}{translate text="v. %1%" 1=$aspenVersion isPublicFacing=true}</small>
 				{if !empty($debug)}
 					<small class='session_info'> / {translate text="session %1%" 1=$session isAdminFacing=true}</small>
 					<small class='scope_info'> / {translate text="scope %1%" 1=$solrScope isAdminFacing=true}</small>

--- a/code/web/release_notes/25.07.00.MD
+++ b/code/web/release_notes/25.07.00.MD
@@ -78,6 +78,12 @@
 ### Other Updates
 - Correct quotes within Enable Talpa as a search mode tooltip in Library settings. (DIS-321) (*MDN*)
 - Add the ability to remove trailing punctuation from terms when imploding terms. (DIS-614) (*MDN*)
+- Include stage of release within version information in footer. (DIS-392) (*MDN*)
+  - alpha during development process
+  - beta with number during testing period
+  - blank for full release
+- Load version from version.json rather than by scanning release notes. (DIS-392) (*MDN*)
+- Add a Supplemental.MD file for to display release notes for supplemental changes for a system that are not part of an official release. (DIS-392) (*MDN*)
 
 // katherine
 ### Series Updates

--- a/code/web/services/API/GreenhouseAPI.php
+++ b/code/web/services/API/GreenhouseAPI.php
@@ -447,7 +447,10 @@ class GreenhouseAPI extends AbstractAPI {
 			$library = new Library();
 			$library->libraryId = $location->libraryId;
 			if ($library->find(true)) {
-				$version = $interface->getVariable('gitBranch');
+				$version = $interface->getVariable('aspenVersion');
+				if (str_contains($version, ' ')) {
+					$version  = substr($version, 0, strpos($version, ' '));
+				}
 				if ($version >= "22.09.00") {
 					require_once ROOT_DIR . '/sys/AspenLiDA/LocationSetting.php';
 					$appSettings = new LocationSetting();

--- a/code/web/services/API/SearchAPI.php
+++ b/code/web/services/API/SearchAPI.php
@@ -756,12 +756,12 @@ class SearchAPI extends AbstractAPI {
 		}
 
 		global $interface;
-		$gitBranch = $interface->getVariable('gitBranchWithCommit');
+		$aspenVersion = $interface->getVariable('aspenVersion');
 		if ($hasCriticalErrors || $hasWarnings) {
 			$result = [
 				'aspen_health_status' => $hasCriticalErrors ? self::STATUS_CRITICAL : self::STATUS_WARN,
 				// Critical warnings trump Warnings;
-				'version' => $gitBranch,
+				'version' => $aspenVersion,
 				'message' => "Errors have been found",
 				'checks' => $checks,
 				'serverStats' => $serverStats,
@@ -769,7 +769,7 @@ class SearchAPI extends AbstractAPI {
 		} else {
 			$result = [
 				'aspen_health_status' => self::STATUS_OK,
-				'version' => $gitBranch,
+				'version' => $aspenVersion,
 				'message' => "Everything is current",
 				'checks' => $checks,
 				'serverStats' => $serverStats,

--- a/code/web/services/API/SystemAPI.php
+++ b/code/web/services/API/SystemAPI.php
@@ -370,9 +370,9 @@ class SystemAPI extends AbstractAPI {
 	/** @noinspection PhpUnused */
 	public function getCurrentVersion(): array {
 		global $interface;
-		$gitBranch = $interface->getVariable('gitBranchWithCommit');
+		$aspenVersion = $interface->getVariable('aspenVersion');
 		return [
-			'version' => $gitBranch,
+			'version' => $aspenVersion,
 		];
 	}
 

--- a/code/web/services/Admin/ReleaseNotes.php
+++ b/code/web/services/Admin/ReleaseNotes.php
@@ -14,6 +14,11 @@ class Admin_ReleaseNotes extends Action {
 			if (preg_match('/\d{2}\.\d{2}\.\d{2}\.MD/', $releaseNoteFile)) {
 				$releaseNoteFile = str_replace('.MD', '', $releaseNoteFile);
 				$releaseNotes[$releaseNoteFile] = $releaseNoteFile;
+			} elseif (strcasecmp('Supplemental.MD', $releaseNoteFile) === 0) {
+				if (filesize($releaseNotesPath . '/' . $releaseNoteFile) > 0) {
+					$releaseNoteFile = str_replace('.MD', '', $releaseNoteFile);
+					$releaseNotes[$releaseNoteFile] = $releaseNoteFile;
+				}
 			}
 		}
 

--- a/code/web/sys/CurlWrapper.php
+++ b/code/web/sys/CurlWrapper.php
@@ -14,12 +14,12 @@ class CurlWrapper {
 	public function __construct() {
 		global $interface;
 		if ($interface != null) {
-			$gitBranch = $interface->getVariable('gitBranch');
-			if (substr($gitBranch, -1) == "\n") {
-				$gitBranch = substr($gitBranch, 0, -1);
+			$aspenVersion = $interface->getVariable('aspenVersion');
+			if (substr($aspenVersion, -1) == "\n") {
+				$aspenVersion = substr($aspenVersion, 0, -1);
 			}
 		} else {
-			$gitBranch = 'Primary';
+			$aspenVersion = 'Primary';
 		}
 
 		$header = [];
@@ -28,7 +28,7 @@ class CurlWrapper {
 		$header[] = "Connection: keep-alive";
 		$header[] = "Accept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.7";
 		$header[] = "Accept-Language: en-us,en;q=0.5";
-		$header[] = "User-Agent: Aspen Discovery " . $gitBranch;
+		$header[] = "User-Agent: Aspen Discovery " . $aspenVersion;
 		$this->headers = $header;
 
 		$default_options = [

--- a/code/web/sys/LibraryLocation/Library.php
+++ b/code/web/sys/LibraryLocation/Library.php
@@ -5719,7 +5719,7 @@ class Library extends DataObject {
 			'enableForgotPasswordLink' => $this->enableForgotPasswordLink,
 			'enableForgotBarcode' => $this->enableForgotBarcode,
 			'showShareOnExternalSites' => $this->showShareOnExternalSites,
-			'discoveryVersion' => $interface->getVariable('gitBranchWithCommit'),
+			'discoveryVersion' => $interface->getVariable('aspenVersion'),
 			'usernameLabel' => $this->loginFormUsernameLabel ?? 'Library Card Number',
 			'passwordLabel' => $this->loginFormPasswordLabel ?? 'PIN or Password',
 			'code' => $this->ilsCode,

--- a/code/web/sys/Updates/ScheduledUpdate.php
+++ b/code/web/sys/Updates/ScheduledUpdate.php
@@ -19,7 +19,10 @@ class ScheduledUpdate extends DataObject {
 
 	public static function getObjectStructure($context = ''): array {
 		global $interface;
-		$currentRelease = $interface->getVariable('gitBranch');
+		$currentRelease = $interface->getVariable('aspenVersion');
+		if (str_contains($currentRelease, ' ')) {
+			$currentRelease = substr($currentRelease, 0, strpos($currentRelease, ' '));
+		}
 		$updateTypes = [
 			'patch' => 'Patch',
 			'complete' => 'Complete',

--- a/code/web/version.json
+++ b/code/web/version.json
@@ -1,0 +1,4 @@
+{
+  "version": "25.07.00",
+  "stage": "alpha"
+}

--- a/tests/phpunit/tests/InitializationTests.php
+++ b/tests/phpunit/tests/InitializationTests.php
@@ -11,10 +11,10 @@ class InitializationTests extends TestCase {
 		$this->assertEquals('C:\web\aspen-discovery\code\web', ROOT_DIR);
 	}
 
-	public function test_getGitBranch() {
-		$gitBranch = getGitBranch();
-		$this->assertNotNull($gitBranch);
-		$this->assertMatchesRegularExpression('/\d\d\.\d\d\.\d\d/', $gitBranch);
+	public function test_getAspenVersion() {
+		$aspenVersion = getAspenVersion();
+		$this->assertNotNull($aspenVersion);
+		$this->assertMatchesRegularExpression('/\d\d\.\d\d\.\d\d/', $aspenVersion);
 	}
 
 	public function test_solrRunning() {

--- a/tests/phpunit/tests/services/API/SystemAPITests.php
+++ b/tests/phpunit/tests/services/API/SystemAPITests.php
@@ -63,7 +63,7 @@ class SystemAPITests extends TestCase {
 	}
 
 	public function test_getCurrentVersion() {
-		getGitBranch();
+		getAspenVersion();
 
 		require_once __DIR__ . '/../../../../../code/web/services/API/SystemAPI.php';
 		$systemAPI = new SystemAPI();


### PR DESCRIPTION
- Include stage of release within version information in footer.
  - alpha during development process
  - beta with number during testing period
  - blank for full release
- Add a Supplemental.MD file for to display release notes for supplemental changes for a system that are not part of an official release.
- Load version from version.json rather than by scanning release notes.