### PR TITLE
DIS-1002 Sideload permissions for masquerade

### DIFF
--- a/code/web/release_notes/25.07.00.MD
+++ b/code/web/release_notes/25.07.00.MD
@@ -61,8 +61,9 @@
 - Properly alphabetize values within the Facet Popup to ignore the case of the value. (DIS-960) (*MDN*)
 - Improve handling of searches with part of a title and part of an author name as well as handling searches with part of a series and part of an author name. (DIS-714) (*MDN*)
 
-### Sideload Updates
-- Add Edit Profile and Return to List options when uploading MARC records for a Sideload. (DIS-1003) (*MDN*) 
+### Side Load Updates
+- Add Edit Profile and Return to List options when uploading MARC records for a Side Load. (DIS-1003) (*MDN*)
+- Properly allow access to Side Load functionality when masquerading as a user who has access to manage side loads or side load scopes for their home library from a user that has permission to administer all side loads. (DIS-1002) (*MDN*)
 
 ### User List Updates
 - Remember the last page size and sort order for each list that a user views if they change from the default. (DIS-1017) (*MDN*)

--- a/code/web/release_notes/25.07.00.MD
+++ b/code/web/release_notes/25.07.00.MD
@@ -7,6 +7,7 @@
 // mark
 ### Administration Updates
 - Remember the last page size and sort order for each administration page that a user views if they change from the default. (DIS-1017) (*MDN*)
+- Allow setting up ILS users as Administrators based on the ILS Username rather than barcode. (DIS-1065) (*MDN*)
 
 ### API Updates
 - Return volumeId and volumeName as part of actions to place a hold on a single volume. (DIS-988) (*MDN*)

--- a/code/web/services/Admin/Administrators.php
+++ b/code/web/services/Admin/Administrators.php
@@ -101,15 +101,18 @@ class Admin_Administrators extends ObjectEditor {
 				$newAdmin = UserAccount::findNewUser($login, '');
 				if ($newAdmin === false) {
 					$newAdmin = new User();
-					$newAdmin->username = $login;
+					$newAdmin->ils_username = $login;
 					$newAdmin->find();
 					$numResults = $newAdmin->getNumResults();
 					if($numResults == 0) {
-						$newAdmin = false;
-						$errors[$login] = translate([
-							'text' => 'Could not find a user with that barcode or username.',
-							'isAdminFacing' => true,
-						]);
+						$newAdmin = UserAccount::findNewUser('', $login);
+						if ($newAdmin === false) {
+							$newAdmin = false;
+							$errors[$login] = translate([
+								'text' => 'Could not find a user with that barcode or username.',
+								'isAdminFacing' => true,
+							]);
+						}
 					} elseif ($numResults == 1) {
 						$newAdmin->fetch();
 					} elseif ($numResults > 1) {

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -4888,6 +4888,8 @@ class User extends DataObject {
 					$validPermissions[] = $permissionName;
 				} elseif ($permissionName == 'Administer Home Library' && (in_array('Administer All Libraries', $guidingUserPermissions))) {
 					$validPermissions[] = $permissionName;
+				} elseif (($permissionName == 'Administer Side Loads for Home Library' || 'Administer Side Load Scopes for Home Library') && (in_array('Administer All Side Loads', $guidingUserPermissions))) {
+					$validPermissions[] = $permissionName;
 				}
 			}
 		}


### PR DESCRIPTION
- Properly allow access to Side Load functionality when masquerading as a user who has access to manage side loads or side load scopes for their home library from a user that has permission to administer all side loads.
- also DIS-1065  Allow setting up ILS users as Administrators based on the ILS Username rather than barcode.