### PR TITLE
DIS-1066: Fixed Broken Delete MARC File Action Due to Un-escaped Apostrophes in File Names

### DIFF
--- a/code/web/interface/themes/responsive/SideLoads/marcFiles.tpl
+++ b/code/web/interface/themes/responsive/SideLoads/marcFiles.tpl
@@ -24,7 +24,7 @@
 					<td><a href="/SideLoads/DownloadMarc?id={$id}&file={$file|urlencode}">{$file}</a></td>
 					<td>{$fileData.date|date_format:"%D %T"}</td>
 					<td>{$fileData.size|number_format}</td>
-					<td><a class="btn btn-sm btn-danger" onclick="return AspenDiscovery.SideLoads.deleteMarc('{$id}', '{$file}', {$fileData.index});">{translate text="Delete" isAdminFacing=true}</a> </td>
+					<td><a class="btn btn-sm btn-danger" onclick="return AspenDiscovery.SideLoads.deleteMarc('{$id}', '{$file|escape:"javascript"}', {$fileData.index});">{translate text="Delete" isAdminFacing=true}</a></td>
 				</tr>
 			{foreachelse}
 				<tr>

--- a/code/web/interface/themes/responsive/js/aspen/sideloads.js
+++ b/code/web/interface/themes/responsive/js/aspen/sideloads.js
@@ -1,23 +1,40 @@
-AspenDiscovery.SideLoads = (function(){
+AspenDiscovery.SideLoads = (() => {
 	return {
-		deleteMarc: function (sideLoadId, fileName, fileIndex) {
-			if (!confirm('Are you sure you want to delete this ' + fileName + '?')){
-				return false;
-			}
-			var params = {
+		deleteMarc(sideLoadId, fileName, fileIndex) {
+			/*
+				Because the modal button’s onclick attribute is enclosed in single quotes,
+				removing literal apostrophes prevents the attribute from being prematurely closed,
+				and the entity is decoded back to an apostrophe when the JavaScript runs.
+			 */
+			const fileNameHtmlSafe = fileName.replace(/'/g, "&#39;");
+			AspenDiscovery.confirm(
+				'Confirm Delete',
+				`Are you sure you want to delete this <strong>${fileName}</strong>?`,
+				'Delete',
+				'Cancel',
+				true,
+				`AspenDiscovery.closeLightbox();AspenDiscovery.SideLoads.deleteMarcConfirmed(${sideLoadId}, \"${fileNameHtmlSafe}\", ${fileIndex});`,
+				'btn-danger'
+			);
+
+			return false;
+		},
+
+		deleteMarcConfirmed(sideLoadId, fileName, fileIndex) {
+			const params = {
 				method : 'deleteMarc',
 				id: sideLoadId,
 				file: fileName
 			};
-
-			$.getJSON(Globals.path + "/SideLoads/AJAX",params, function(data){
-				if (data.success){
+			$.getJSON(Globals.path + "/SideLoads/AJAX", params, function(data) {
+				const { success, message } = data;
+				if (success){
 					$("#file" + fileIndex).hide();
 				}else{
-					AspenDiscovery.showMessage('Delete Failed', data.message, false, autoLogOut);
+					AspenDiscovery.showMessage('Delete Failed', message, false);
 				}
 			}).fail(AspenDiscovery.ajaxFail);
 			return false;
 		}
 	}
-}(AspenDiscovery.SideLoads || {}));
+})();

--- a/code/web/release_notes/25.08.00.MD
+++ b/code/web/release_notes/25.08.00.MD
@@ -17,6 +17,9 @@
 // imani
 
 // leo
+### Side Loads Updates
+- Fixed an issue where the "Delete" button in Side Load >>> MARC Files did not work for filenames that include an apostrophe. (DIS-1066) (*LS*)
+- As a part of standardization, a confirmation modal will now display when deleting side-loaded MARC files. (DIS-1066) (*LS*)
 
 // yanjun
 


### PR DESCRIPTION
- Fixed an issue where the "Delete" button in Side Load >>> MARC Files did not work for filenames that include an apostrophe.
- As a part of standardization, a confirmation modal will now display when deleting side-loaded MARC files.

Test Plan:
1. In the Side Load Settings, upload a MARC file with an apostrophe in its name (e.g., `TEST's.mrc`).
2. Click the “Delete” button and notice that nothing happens.
3. Apply the patch and repeat step 2. A modal will display asking you to confirm the deletion; confirm the deletion and the file will disappear.