### PR TITLE
DIS-1057: Added Maximum Cancellation Date Setting for Holds

### DIFF
--- a/code/web/interface/themes/responsive/Record/hold-popup.tpl
+++ b/code/web/interface/themes/responsive/Record/hold-popup.tpl
@@ -168,11 +168,24 @@
 
 					{if $showHoldCancelDate == 1}
 						<div id="cancelHoldDate" class="form-group">
+							{* Determine default cancellation date based on library settings. *}
+							{assign var='__prepopDays' value=0}
+							{if $defaultNotNeededAfterDays > 0}
+								{assign var='__prepopDays' value=$defaultNotNeededAfterDays}
+								{if $maxHoldCancellationDate > 0 && $defaultNotNeededAfterDays > $maxHoldCancellationDate}
+									{assign var='__prepopDays' value=$maxHoldCancellationDate}
+								{/if}
+							{/if}
 							<label class="control-label" for="cancelDate">{translate text="Automatically cancel this hold if not filled by" isPublicFacing=true}</label>
-							<input type="date" name="cancelDate" id="cancelDate" placeholder="mm/dd/yyyy" class="form-control" size="10" min="{$smarty.now|date_format:"%Y-%m-%d"}">
-							<span id="cancelHoldDateHelpBlock" class="text-danger" style="display:none; padding-bottom: 1em">{translate text="Please select a date later than today." isPublicFacing=true}</span>
-							<div class="loginFormRow">
-								<i>{translate text="If this date is reached, the hold will automatically be cancelled for you. " isPublicFacing=true}</i>
+							<input type="date" name="cancelDate" id="cancelDate" placeholder="mm/dd/yyyy" class="form-control" size="10"{if $__prepopDays > 0} value="{($smarty.now + ($__prepopDays * 24 * 60 * 60))|date_format:"%Y-%m-%d"}"{/if} min="{$smarty.now|date_format:"%Y-%m-%d"}"{if $maxHoldCancellationDate > 0} max="{($smarty.now + ($maxHoldCancellationDate * 24 * 60 * 60))|date_format:"%Y-%m-%d"}"{/if}>
+							<div class="help-block" style="margin-top: 4px;">
+								<small style="color: #666;">
+									<i class="fa fa-info-circle" style="margin-right: 4px;"></i>
+									{translate text="If this date is reached, the hold will automatically be cancelled for you." isPublicFacing=true}
+									{if $maxHoldCancellationDate > 0}
+										{translate text="You can select a cancellation date up to %1% days from today." 1=$maxHoldCancellationDate isPublicFacing=true}
+									{/if}
+								</small>
 							</div>
 						</div>
 					{/if}

--- a/code/web/interface/themes/responsive/Record/hold-select-volume-popup.tpl
+++ b/code/web/interface/themes/responsive/Record/hold-select-volume-popup.tpl
@@ -122,10 +122,24 @@
 
 				{if $showHoldCancelDate == 1}
 					<div id="cancelHoldDate" class="form-group">
+						{* Determine default cancellation date based on library settings. *}
+						{assign var='__prepopDays' value=0}
+						{if $defaultNotNeededAfterDays > 0}
+							{assign var='__prepopDays' value=$defaultNotNeededAfterDays}
+							{if $maxHoldCancellationDate > 0 && $defaultNotNeededAfterDays > $maxHoldCancellationDate}
+								{assign var='__prepopDays' value=$maxHoldCancellationDate}
+							{/if}
+						{/if}
 						<label class="control-label" for="cancelDate">{translate text="Automatically cancel this hold if not filled by" isPublicFacing=true}</label>
-						<input type="date" name="cancelDate" id="cancelDate" placeholder="mm/dd/yyyy" class="form-control" size="10" min="{$smarty.now|date_format:"%Y-%m-%d"}">
-						<div class="loginFormRow">
-							<i>{translate text="If this date is reached, the hold will automatically be cancelled for you." isPublicFacing=true}</i>
+						<input type="date" name="cancelDate" id="cancelDate" placeholder="mm/dd/yyyy" class="form-control" size="10"{if $__prepopDays > 0} value="{($smarty.now + ($__prepopDays * 24 * 60 * 60))|date_format:"%Y-%m-%d"}"{/if} min="{$smarty.now|date_format:"%Y-%m-%d"}"{if $maxHoldCancellationDate > 0} max="{($smarty.now + ($maxHoldCancellationDate * 24 * 60 * 60))|date_format:"%Y-%m-%d"}"{/if}>
+						<div class="help-block" style="margin-top: 4px;">
+							<small style="color: #666;">
+								<i class="fa fa-info-circle" style="margin-right: 4px;"></i>
+								{translate text="If this date is reached, the hold will automatically be cancelled for you." isPublicFacing=true}
+								{if $maxHoldCancellationDate > 0}
+									{translate text="You can select a cancellation date up to %1% days from today." 1=$maxHoldCancellationDate isPublicFacing=true}
+								{/if}
+							</small>
 						</div>
 					</div>
 				{/if}

--- a/code/web/interface/themes/responsive/js/aspen/admin.js
+++ b/code/web/interface/themes/responsive/js/aspen/admin.js
@@ -1050,6 +1050,23 @@ AspenDiscovery.Admin = (function () {
 
 			return false;
 		},
+
+		updateHoldCancellationDateFields() {
+			const showCancelDateEnabled = $("#showHoldCancelDate:checked").val();
+			const fieldsToToggle = [
+				"#propertyRowdefaultNotNeededAfterDays",
+				"#propertyRowmaxHoldCancellationDate"
+			];
+
+			if (showCancelDateEnabled) {
+				fieldsToToggle.forEach(selector => $(selector).show());
+			} else {
+				fieldsToToggle.forEach(selector => $(selector).hide());
+			}
+
+			return false;
+		},
+
 		updateDonationFields: function () {
 			var donationsEnabled = $("#enableDonations");
 			var donationsEnabledValue = $("#enableDonations:checked").val()

--- a/code/web/release_notes/25.08.00.MD
+++ b/code/web/release_notes/25.08.00.MD
@@ -17,6 +17,18 @@
 // imani
 
 // leo
+### Holds Update
+- Implemented new "Maximum Hold Cancellation Date" setting under Library System to restrict future hold cancellations. (DIS-1057) (*LS*)
+  - Patrons cannot place holds with a cancellation date beyond the configured maximum.
+  - If "Show Hold Cancellation Date" is disabled, related settings are hidden to reduce confusion.
+  - Updated names and descriptions for all related settings to better reflect their behavior.
+
+<div markdown="1" class="settings">
+
+#### New Settings
+- Library System > ILS/Account Integration > Holds > Maximum Hold Cancellation Date
+
+</div>
 
 // yanjun
 

--- a/code/web/release_notes/25.08.00.MD
+++ b/code/web/release_notes/25.08.00.MD
@@ -17,7 +17,7 @@
 // imani
 
 // leo
-### Holds Update
+### Holds Updates
 - Implemented new "Maximum Hold Cancellation Date" setting under Library System to restrict future hold cancellations. (DIS-1057) (*LS*)
   - Patrons cannot place holds with a cancellation date beyond the configured maximum.
   - If "Show Hold Cancellation Date" is disabled, related settings are hidden to reduce confusion.

--- a/code/web/services/API/UserAPI.php
+++ b/code/web/services/API/UserAPI.php
@@ -2027,6 +2027,22 @@ class UserAPI extends AbstractAPI {
 
 					if (!empty($_REQUEST['cancelDate'])) {
 						$cancelDate = $_REQUEST['cancelDate'];
+
+						if ($homeLibrary->maxHoldCancellationDate > 0) {
+							$maxAllowedTimestamp = time() + ($homeLibrary->maxHoldCancellationDate * 24 * 60 * 60);
+							$cancelDateTimestamp = strtotime($cancelDate);
+
+							if ($cancelDateTimestamp > $maxAllowedTimestamp) {
+								return [
+									'success' => false,
+									'message' => translate([
+										'text' => 'The cancellation date cannot be more than %1% days from today.',
+										1 => $homeLibrary->maxHoldCancellationDate,
+										'isPublicFacing' => true,
+									]),
+								];
+							}
+						}
 					} elseif ($homeLibrary->defaultNotNeededAfterDays <= 0) {
 						$cancelDate = null;
 					} else {

--- a/code/web/services/Admin/Libraries.php
+++ b/code/web/services/Admin/Libraries.php
@@ -159,7 +159,7 @@ class Admin_Libraries extends ObjectEditor {
 	}
 
 	function getInitializationJs(): string {
-		return 'AspenDiscovery.Admin.updateMaterialsRequestFields();';
+		return 'AspenDiscovery.Admin.updateMaterialsRequestFields(); return AspenDiscovery.Admin.updateHoldCancellationDateFields();';
 	}
 
 	function getBreadcrumbs(): array {

--- a/code/web/services/Record/AJAX.php
+++ b/code/web/services/Record/AJAX.php
@@ -979,6 +979,26 @@ class Record_AJAX extends Action {
 
 					if (!empty($_REQUEST['cancelDate'])) {
 						$cancelDate = $_REQUEST['cancelDate'];
+
+						if ($homeLibrary->maxHoldCancellationDate > 0) {
+							$maxAllowedTimestamp = time() + ($homeLibrary->maxHoldCancellationDate * 24 * 60 * 60);
+							$cancelDateTimestamp = strtotime($cancelDate);
+
+							if ($cancelDateTimestamp > $maxAllowedTimestamp) {
+								return [
+									'success' => false,
+									'title' => translate([
+										'text' => 'Invalid Cancellation Date',
+										'isPublicFacing' => true,
+									]),
+									'message' => translate([
+										'text' => 'The cancellation date cannot be more than %1% days from today.',
+										1 => $homeLibrary->maxHoldCancellationDate,
+										'isPublicFacing' => true,
+									]),
+								];
+							}
+						}
 					} else {
 						if ($homeLibrary->defaultNotNeededAfterDays <= 0) {
 							$cancelDate = null;
@@ -1902,6 +1922,7 @@ class Record_AJAX extends Action {
 
 		$interface->assign('showHoldCancelDate', $library->showHoldCancelDate);
 		$interface->assign('defaultNotNeededAfterDays', $library->defaultNotNeededAfterDays);
+		$interface->assign('maxHoldCancellationDate', $library->maxHoldCancellationDate);
 		$interface->assign('allowRememberPickupLocation', $library->allowRememberPickupLocation && !$promptForHoldNotifications);
 		$interface->assign('showLogMeOut', $library->showLogMeOutAfterPlacingHolds);
 

--- a/code/web/sys/LibraryLocation/Library.php
+++ b/code/web/sys/LibraryLocation/Library.php
@@ -234,6 +234,7 @@ class Library extends DataObject {
 	public /** @noinspection PhpUnused */
 		$showGoDeeper;
 	public $defaultNotNeededAfterDays;
+	public $maxHoldCancellationDate;
 
 	public /** @noinspection PhpUnused */
 		$publicListsToInclude;
@@ -2015,10 +2016,28 @@ class Library extends DataObject {
 							'showHoldCancelDate' => [
 								'property' => 'showHoldCancelDate',
 								'type' => 'checkbox',
-								'label' => 'Show Cancellation Date',
-								'description' => 'Whether or not the patron should be able to set a cancellation date (not needed after date) when placing holds.',
+								'label' => 'Show Hold Cancellation Date',
+								'description' => 'Whether or not patrons should be able to set a cancellation date (i.e., not needed after date) when placing holds on their home library catalog.',
 								'hideInLists' => true,
 								'default' => 1,
+								'onchange' => 'return AspenDiscovery.Admin.updateHoldCancellationDateFields();',
+							],
+							'defaultNotNeededAfterDays' => [
+								'property' => 'defaultNotNeededAfterDays',
+								'type' => 'integer',
+								'label' => 'Default Hold Cancellation Date',
+								'description' => 'Number of days to use for not needed after date by default. Use -1 for no default.',
+								'hideInLists' => true,
+								'permissions' => ['Library ILS Connection'],
+							],
+							'maxHoldCancellationDate' => [
+								'property' => 'maxHoldCancellationDate',
+								'type' => 'integer',
+								'label' => 'Maximum Hold Cancellation Date',
+								'description' => 'Maximum number of days patrons can set for hold cancellation date on their home library catalog. Use -1 for no limit.',
+								'hideInLists' => true,
+								'default' => -1,
+								'permissions' => ['Library ILS Connection'],
 							],
 							'showHoldPosition' => [
 								'property' => 'showHoldPosition',
@@ -2100,14 +2119,6 @@ class Library extends DataObject {
 								'description' => 'Number of days that a user can suspend a hold for. Use -1 for no limit.',
 								'hideInLists' => true,
 								'default' => 365,
-								'permissions' => ['Library ILS Connection'],
-							],
-							'defaultNotNeededAfterDays' => [
-								'property' => 'defaultNotNeededAfterDays',
-								'type' => 'integer',
-								'label' => 'Default Not Needed After Days',
-								'description' => 'Number of days to use for not needed after date by default. Use -1 for no default.',
-								'hideInLists' => true,
 								'permissions' => ['Library ILS Connection'],
 							],
 							'inSystemPickupsOnly' => [


### PR DESCRIPTION
- Implemented new "Maximum Hold Cancellation Date" setting under Library System to restrict future hold cancellations.
  - Patrons cannot place holds with a cancellation date beyond the configured maximum.
  - If "Show Hold Cancellation Date" is disabled, related settings are hidden to reduce confusion.
  - Updated names and descriptions for all related settings to better reflect their behavior.

Test Plan:
1. Apply the patch.
2. Navigate to the Library System of the home library of the patron account with which you will be testing.
3. Enable the “Show Hold Cancellation Date” option and set a “Default Hold Cancellation Date” and a “Maximum Hold Cancellation Date”.
4. Log into or masquerade as the test patron account.
5. Locate a title on which you will place a hold. Notice that you cannot select a date beyond the set maximum date in the calendar picker.
   - If you manually input a date greater than the maximum allowed cancellation date and attempt to place the hold, a modal with an error message will display noting that this is not allowed.
   - Test the other behaviors in the Jira description as you see fit.