### PR TITLE
DIS-990 Correct sorting of facets when searching within popup

### DIFF
--- a/code/web/services/Search/AJAX.php
+++ b/code/web/services/Search/AJAX.php
@@ -656,7 +656,7 @@ class AJAX extends Action {
 					$appliedFacetValues = [];
 					if (array_key_exists($facetTitle, $appliedFacets)) {
 						$appliedFacetValues = $appliedFacets[$facetTitle];
-						asort($appliedFacetValues);
+						ksort($appliedFacetValues);
 					}
 					$interface->assign('appliedFacetValues', $appliedFacetValues);
 
@@ -760,14 +760,14 @@ class AJAX extends Action {
 					$appliedFacetValues = [];
 					if (array_key_exists($facetTitle, $appliedFacets)) {
 						$appliedFacetValues = $appliedFacets[$facetTitle];
-						asort($appliedFacetValues);
+						ksort($appliedFacetValues, SORT_NATURAL | SORT_FLAG_CASE);
 					}
 					$interface->assign('appliedFacetValues', $appliedFacetValues);
 
 					$allFacets = $newSearch->getFacetList();
 					if (isset($allFacets[$facetName])) {
 						$facetSearchResults = $allFacets[$facetName];
-						asort($facetSearchResults['list']);
+						ksort($facetSearchResults['list'], SORT_NATURAL | SORT_FLAG_CASE);
 						$interface->assign('facetSearchResults', $facetSearchResults['list']);
 						return [
 							'success' => true,


### PR DESCRIPTION
The initial list of facets were correct in the popup, but searching them resulted in the order being incorrect (most obvious when clearing a search)