### PR TITLE
DIS-657: Prevent Uploaded File Overwrite - Temp_ prefix and Linked Pl…

### DIFF
--- a/code/web/services/WebBuilder/AJAX.php
+++ b/code/web/services/WebBuilder/AJAX.php
@@ -327,13 +327,19 @@ class WebBuilder_AJAX extends JSON_Action {
 	function saveLinkedObject() {
 		//Save Linked Placard
 		require_once ROOT_DIR . '/sys/LocalEnrichment/Placard.php';
-		$imageForPlacard = $_REQUEST['image'];
+		$fileType = substr($_REQUEST['image'], 0, -3);
+		$fileType = match ($fileType) {
+			'gif' => ".gif",
+			'png' => ".png",
+			'svg' => ".svg",
+			default => ".jpg",
+		};
 		$placard = new Placard();
 		$placard->sourceId = $_REQUEST['objectId'];
 		if ($placard->find(true)) {
 			if ($_REQUEST['doFullSave'] == "true"){
 				$placard->title = $_REQUEST['objectName'];
-				$placard->image = $imageForPlacard;
+				$placard->image = "web_resource_image_".$_REQUEST['objectId'].$fileType;
 				$placard->link = $_REQUEST['url'];
 				$placard->body = $_REQUEST['body'];
 				$placard->isCustomized = 0;

--- a/code/web/sys/DataObjectUtil.php
+++ b/code/web/sys/DataObjectUtil.php
@@ -418,7 +418,7 @@ class DataObjectUtil {
 						}
 					}
 					if (isset($property['storagePath'])) {
-						$destFileName = ($object->id != null) ? $objectType."_".$object->id.$fileType : $_FILES[$propertyName]["name"];
+						$destFileName = ($object->id != null) ? $objectType."_".$object->id.$fileType : "Temp_".$_FILES[$propertyName]["name"];
 						$destFolder = $property['storagePath'];
 						$destFullPath = $destFolder . '/' . $destFileName;
 						$copyResult = copy($_FILES[$propertyName]["tmp_name"], $destFullPath);
@@ -427,14 +427,14 @@ class DataObjectUtil {
 						$logger->log("Creating thumbnails for $propertyName", Logger::LOG_DEBUG);
 						if (isset($property['path'])) {
 							$destFolder = $property['path'];
-							$destFileName = ($object->id != null) ? $objectType."_".$object->id.$fileType : $_FILES[$propertyName]["name"];
+							$destFileName = ($object->id != null) ? $objectType."_".$object->id.$fileType : "Temp_".$_FILES[$propertyName]["name"];
 							if (!file_exists($destFolder)) {
 								mkdir($destFolder, 0755, true);
 							}
 							$pathToThumbs = $destFolder . '/thumbnail';
 							$pathToMedium = $destFolder . '/medium';
 						} else {
-							$destFileName = ($object->id != null) ? $objectType."_".$object->id.$fileType : $_FILES[$propertyName]["name"];
+							$destFileName = ($object->id != null) ? $objectType."_".$object->id.$fileType : "Temp_".$_FILES[$propertyName]["name"];
 							$destFolder = $configArray['Site']['local'] . '/files/original';
 							$pathToThumbs = $configArray['Site']['local'] . '/files/thumbnail';
 							$pathToMedium = $configArray['Site']['local'] . '/files/medium';
@@ -442,7 +442,7 @@ class DataObjectUtil {
 
 						$destFullPath = $destFolder . '/' . $destFileName;
 						//check for previous upload that needs to be overwritten to new naming convention
-						$prevUpload = $destFolder . '/' . $_FILES[$propertyName]["name"];
+						$prevUpload = $destFolder . '/' . "Temp_" . $_FILES[$propertyName]["name"];
 						if (file_exists($prevUpload)) {
 							rename($prevUpload, $destFullPath);
 						}
@@ -500,7 +500,7 @@ class DataObjectUtil {
 					$fileType = ".pdf";
 					//Copy the full image to the correct location
 					//Filename is the name of the object + the original filename
-					$destFileName = ($object->id != null) ? $objectType."_".$object->id.$fileType : $_FILES[$propertyName]["name"];
+					$destFileName = ($object->id != null) ? $objectType."_".$object->id.$fileType : "Temp_".$_FILES[$propertyName]["name"];
 					$destFolder = $property['path'];
 					if (!file_exists($destFolder)) {
 						mkdir($destFolder, 0775, true);
@@ -513,7 +513,7 @@ class DataObjectUtil {
 
 					$destFullPath = $destFolder . '/' . $destFileName;
 					//check for previous upload that needs to be overwritten to new naming convention
-					$prevUpload = $destFolder . '/' . $_FILES[$propertyName]["name"];
+					$prevUpload = $destFolder . '/' . "Temp_" . $_FILES[$propertyName]["name"];
 					if (file_exists($prevUpload)) {
 						rename($prevUpload, $destFullPath);
 						// Remove any old thumbnail for this PDF.

--- a/code/web/sys/File/ImageUpload.php
+++ b/code/web/sys/File/ImageUpload.php
@@ -236,7 +236,7 @@ class ImageUpload extends DataObject {
 				}
 				$xLargeFile = $xLargeFilePath . $this->fullSizePath;
 				if (!empty($_FILES['fullSizePath']['full_path'])) {
-					$prevUpload = $xLargeFilePath . $_FILES['fullSizePath']['full_path'];
+					$prevUpload = $xLargeFilePath . "Temp_" . $_FILES['fullSizePath']['full_path'];
 					if (file_exists($prevUpload)) {
 						unlink($prevUpload);
 					}
@@ -252,7 +252,7 @@ class ImageUpload extends DataObject {
 				}
 				$largeFile = $largeFilePath . $this->fullSizePath;
 				if (!empty($_FILES['fullSizePath']['full_path'])) {
-					$prevUpload = $largeFilePath . $_FILES['fullSizePath']['full_path'];
+					$prevUpload = $largeFilePath . "Temp_" . $_FILES['fullSizePath']['full_path'];
 					if (file_exists($prevUpload)) {
 						unlink($prevUpload);
 					}
@@ -268,7 +268,7 @@ class ImageUpload extends DataObject {
 				}
 				$mediumFile = $mediumFilePath . $this->fullSizePath;
 				if (!empty($_FILES['fullSizePath']['full_path'])) {
-					$prevUpload = $mediumFilePath . $_FILES['fullSizePath']['full_path'];
+					$prevUpload = $mediumFilePath . "Temp_" . $_FILES['fullSizePath']['full_path'];
 					if (file_exists($prevUpload)) {
 						unlink($prevUpload);
 					}
@@ -284,7 +284,7 @@ class ImageUpload extends DataObject {
 				}
 				$smallFile = $smallFilePath . $this->fullSizePath;
 				if (!empty($_FILES['fullSizePath']['full_path'])) {
-					$prevUpload = $smallFilePath . $_FILES['fullSizePath']['full_path'];
+					$prevUpload = $smallFilePath . "Temp_" . $_FILES['fullSizePath']['full_path'];
 					if (file_exists($prevUpload)) {
 						unlink($prevUpload);
 					}


### PR DESCRIPTION
…acard Saving

Update logic to prepend a "Temp_" on file names so users cannot overwrite other files using the new naming conventions (i.e. uploading an image named "web_builder_image_3" and having it overwrite the existing image, then be deleted) 

Update the logic for saving linked placards so if the image on the web resource is updated, it will correctly be updated for the linked placard as well


Tested on my local instance of Aspen