### PR TITLE
DIS-1087: "Share Holdings" Setting for Talpa Search

### DIFF
--- a/code/web/release_notes/25.08.00.MD
+++ b/code/web/release_notes/25.08.00.MD
@@ -36,6 +36,10 @@
 
 // jboyer
 
+//Talpa Search Update (minor)
+- This update adds a setting for Talpa Search that allows Aspen Administrators to manually trigger sending catalog items to Talpa for processing. (DIS-1087) (*LP*)
+
+
 
 ## This release includes code contributions from
 ### ByWater Solutions
@@ -57,7 +61,6 @@
 - Myranda Fuentes (MAF)
 
 ### LibraryThing
-- Chris Catalfo (CC)
 - Lauren Przywara (LP)
 
 ### Nashville Public Library

--- a/code/web/services/Talpa/TalpaSettings.php
+++ b/code/web/services/Talpa/TalpaSettings.php
@@ -3,6 +3,7 @@
 require_once ROOT_DIR . '/Action.php';
 require_once ROOT_DIR . '/sys/Talpa/TalpaSettings.php';
 require_once ROOT_DIR . '/services/Admin/ObjectEditor.php';
+require_once ROOT_DIR . '/sys/Utils/SystemUtils.php';
 
 
 class Talpa_TalpaSettings extends ObjectEditor {
@@ -73,6 +74,169 @@ class Talpa_TalpaSettings extends ObjectEditor {
 
 	function canView(): bool {
 		return UserAccount::userHasPermission('Administer Third Party Enrichment API Keys');
+	}
+
+	/**
+	 * Override the editObject method to trigger the talpa recalculation cron when the setting is enabled
+	 */
+	function editObject($objectAction, $structure) {
+		$errorOccurred = false;
+		$user = UserAccount::getLoggedInUser();
+		$samePatron = true;
+		if (isset($_REQUEST['patronIdCheck']) && $_REQUEST['patronIdCheck'] != 0 && $_REQUEST['patronIdCheck'] != $user->id){
+			$samePatron = false;
+		}
+		if ($samePatron) {
+			//Save or create a new object
+			$id = isset($_REQUEST['id']) ? $_REQUEST['id'] : '';
+			if (empty($id) || $id < 0) {
+				//Insert a new record
+				$curObject = $this->insertObject($structure);
+				if ($curObject == false) {
+					//The session lastError is updated
+					$errorOccurred = true;
+				} else {
+					$id = $curObject->getPrimaryKeyValue();
+					// Check if the insert was successful and if the sendCatalogItemsToTalpaOnSave setting is enabled
+					if ($curObject && isset($_REQUEST['sendCatalogItemsToTalpaOnSave']) && $_REQUEST['sendCatalogItemsToTalpaOnSave'] == 'on') {
+						$this->triggerTalpaRecalculation();
+					}
+				}
+			} else {
+				//Work with an existing record
+				$curObject = $this->getExistingObjectById($id);
+				if (!is_null($curObject)) {
+					if ($objectAction == 'save') {
+						//Update the object
+						$user = UserAccount::getActiveUserObj();
+						$fieldLocks = $this->getFieldLocks();
+						if (UserAccount::userHasPermission('Lock Administration Fields')) {
+							$fieldLocks = null;
+						}
+						$structure = $curObject->updateStructureForEditingObject($structure);
+						$validationResults = $this->updateFromUI($curObject, $structure, $fieldLocks);
+						if ($validationResults['validatedOk']) {
+							//Always save since has changes does not check sub objects for changes (which it should)
+							$ret = $curObject->update($this->getContext());
+							if ($ret === false) {
+								if ($curObject->getLastError()) {
+									$errorDescription = $curObject->getLastError();
+								} else {
+									$errorDescription = translate([
+										'text' => 'Unknown Error',
+										'isPublicFacing' => true,
+									]);
+								}
+								$user->updateMessage = "An error occurred updating {$this->getObjectType()} with id of $id <br/>{$errorDescription}";
+								$user->updateMessageIsError = true;
+								$user->update();
+								$errorOccurred = true;
+							} else {
+								// Check if the update was successful and if the sendCatalogItemsToTalpaOnSave setting is enabled
+								if (isset($_REQUEST['sendCatalogItemsToTalpaOnSave']) && $_REQUEST['sendCatalogItemsToTalpaOnSave'] == 'on') {
+									$this->triggerTalpaRecalculation();
+								}
+							}
+						} else {
+							$errorDescription = implode('<br/>', $validationResults['errors']);
+							$user->updateMessage = "An error occurred validating {$this->getObjectType()} with id of $id <br/>{$errorDescription}";
+							$user->updateMessageIsError = true;
+							$user->update();
+							$errorOccurred = true;
+						}
+					} elseif ($objectAction == 'delete') {
+						//Delete the record
+						$deletionBlockInfo = $curObject->getDeletionBlockInformation($structure);
+						if (!$deletionBlockInfo['preventDeletion']) {
+							$ret = $curObject->delete();
+							if ($ret == 0) {
+								$user = UserAccount::getActiveUserObj();
+								$user->updateMessage = "Unable to delete {$this->getObjectType()} with id of $id";
+								$user->updateMessageIsError = true;
+								$user->update();
+								$errorOccurred = true;
+							}
+						}else{
+							$user = UserAccount::getActiveUserObj();
+							$user->updateMessage = $deletionBlockInfo['message'];
+							$user->updateMessageIsError = true;
+							$user->update();
+							$errorOccurred = true;
+						}
+					}
+				} else {
+					//Couldn't find the record.  Something went haywire.
+					$user = UserAccount::getActiveUserObj();
+					$user->updateMessage = "An error occurred, could not find {$this->getObjectType()} with id of $id";
+					$user->updateMessageIsError = true;
+					$user->update();
+					$errorOccurred = true;
+				}
+			}
+			if (!empty($id) && $objectAction == 'saveCopy') {
+				if (!empty($_REQUEST['sourceId'])) {
+					$sourceId = $_REQUEST['sourceId'];
+					$curObject->finishCopy($sourceId);
+				}
+			}
+		} else {
+			$errorOccurred = true;
+			global $interface;
+			$interface->assign('module', 'Error');
+			$interface->assign('action', 'Handle400');
+			require_once ROOT_DIR . "/services/Error/Handle400.php";
+			$interface->assign('errorMessage', translate(['text' => 'Invalid user information', 'isAdminFacing'=>true]));
+			$actionClass = new Error_Handle400();
+			$actionClass->launch();
+			die();
+		}
+		if (empty($id) && $errorOccurred) {
+			if ($this->canAddNew()) {
+				header("Location: /{$this->getModule()}/{$this->getToolName()}?objectAction=addNew");
+			} else {
+				header("Location: /{$this->getModule()}/{$this->getToolName()}");
+			}
+		} elseif (isset($_REQUEST['submitStay']) || $errorOccurred) {
+			header("Location: /{$this->getModule()}/{$this->getToolName()}?objectAction=edit&id=$id");
+		} elseif (isset($_REQUEST['submitAddAnother'])) {
+			header("Location: /{$this->getModule()}/{$this->getToolName()}?objectAction=addNew");
+		} else {
+			$redirectLocation = $this->getRedirectLocation($objectAction, $curObject);
+			if (is_null($redirectLocation)) {
+				if (isset($_SESSION['redirect_location']) && $objectAction != 'delete') {
+					header("Location: " . $_SESSION['redirect_location']);
+				} else {
+					header("Location: /{$this->getModule()}/{$this->getToolName()}");
+				}
+			} else {
+				header("Location: {$redirectLocation}");
+			}
+		}
+		die();
+	}
+
+
+
+	/**
+	 * Trigger the talpa recalculation process directly
+	 */
+	private function triggerTalpaRecalculation() {
+		$result = SystemUtils::startBackgroundProcess("talpaRecalculationCron");
+
+		$activeUser = UserAccount::getActiveUserObj();
+		if ($result['success']) {
+			$activeUser->__set('updateMessage', translate([
+				'text' => 'Successfully started background process to send holdings to Talpa',
+				1 => $result['backgroundProcessId'],
+				'isAdminFacing' => true
+			]));
+		} else {
+			$activeUser->__set('updateMessage', translate([
+					'text' => 'Could not start background process to recalculate Talpa data.',
+					'isAdminFacing' => true
+				]) . "<br/> " . $result['message']);
+		}
+		$activeUser->update();
 	}
 }
 

--- a/code/web/sys/DBMaintenance/talpa_updates.php
+++ b/code/web/sys/DBMaintenance/talpa_updates.php
@@ -26,7 +26,8 @@ function getTalpaUpdates() {
 					talpaExplainerText MEDIUMTEXT,
 					includeTalpaLogoSwitch TINYINT(1) UNSIGNED DEFAULT 1,
 					includeTalpaOtherResultsSwitch TINYINT(1) UNSIGNED DEFAULT 1,
-					talpaOtherResultsExplainerText VARCHAR(180) DEFAULT 'Talpa Search found these other results not owned by your library.'
+					talpaOtherResultsExplainerText VARCHAR(180) DEFAULT 'Talpa Search found these other results not owned by your library.',
+					sendCatalogItemsToTalpaOnSave TINYINT(1) UNSIGNED DEFAULT 0
 				) ENGINE=INNODB",
 				'ALTER TABLE library ADD COLUMN talpaSettingsId INT(11) DEFAULT -1',
 			],

--- a/code/web/sys/DBMaintenance/version_updates/25.08.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.08.00.php
@@ -42,6 +42,13 @@ function getUpdates25_08_00(): array {
 		//other
 
 		//Talpa Search
-		
+		'addSendCatalogItemsToTalpaOnSave' => [
+			'title' => 'Add Send Catalog Items to Talpa Search setting',
+			'description' => 'Add a new setting to allow a one-time, immediate sharing of holdings with Talpa Search.',
+			'continueOnError' => true,
+			'sql' => [
+				"ALTER TABLE talpa_settings ADD COLUMN sendCatalogItemsToTalpaOnSave TINYINT(1) UNSIGNED DEFAULT 0",
+			],
+		], //addSendCatalogItemsToTalpaOnSave
 	];
 }

--- a/code/web/sys/Talpa/TalpaSettings.php
+++ b/code/web/sys/Talpa/TalpaSettings.php
@@ -18,6 +18,8 @@ class TalpaSettings extends DataObject {
 
 	public $includeTalpaOtherResultsSwitch;
 	public $talpaOtherResultsExplainerText;
+	public $sendCatalogItemsToTalpaOnSave;
+
 
 	public static function getObjectStructure($context = ''): array {
 		$buttonOptions = [
@@ -159,6 +161,23 @@ class TalpaSettings extends DataObject {
 						'description' => 'If &rdquo;Other Results&rdquo; is enabled, this text appears under the filter and explains the results that Talpa found that are not held by your library. Leave blank to use the default value (Talpa Search found these other results not owned by your library).',
 						'hideInLists' => true,
 						'default' => 'Talpa Search found these other results not owned by your library.',
+					],
+				],
+			],
+			//Catalog Integration
+			'talpaCatalogIntegrationSection' => [
+				'property' => 'talpaCatalogIntegrationSection',
+				'type' => 'section',
+				'label' => 'Share Holdings',
+				'hideInLists' => true,
+				'properties' => [
+					'sendCatalogItemsToTalpaOnSave' => [
+						'property' => 'sendCatalogItemsToTalpaOnSave',
+						'type' => 'checkbox',
+						'label' => 'Send holdings to Talpa Search upon save',
+						'description' => 'Holdings are sent automatically to Talpa Search once a day. Check this box and save settings to immediately trigger a one-time sending of holdings.',
+						'hideInLists' => true,
+						'default' => 0,
 					],
 				],
 			],


### PR DESCRIPTION
This update is intended to give librarians the ability to manually trigger the talpaRecalculationCron in order to send their catalog/groupedWorkIDs to Talpa for immediate proccessing. This adds a "Share Holdings" section to Talpa Settings. 