### PR TITLE
DIS-271: QA fix - forgot to include v5 fontawesome.min.css

### DIFF
--- a/code/web/interface/themes/responsive/css/main.css
+++ b/code/web/interface/themes/responsive/css/main.css
@@ -1,4 +1,5 @@
 @import "lib/fa6/fontawesome.min.css";
+@import "lib/fontawesome.min.css";
 @import "lib/fa6/brands.min.css";
 @import "lib/fontawesome-solid.min.css";
 @import "lib/rome.min.css";

--- a/code/web/interface/themes/responsive/css/responsive_base.less
+++ b/code/web/interface/themes/responsive/css/responsive_base.less
@@ -396,6 +396,7 @@ div.striped {
 @import "ratings.less";
 @import "jcarousel.responsive.less";
 @import "lib/fa6/fontawesome.min.css";
+@import "lib/fontawesome.min.css";
 @import "lib/fa6/brands.min.css";
 @import "lib/fontawesome-solid.min.css";
 @import "lib/bootstrap-switch.less";


### PR DESCRIPTION
I noticed the fa-desktop icon disappear on the Help Center. It was because I forgot to import the regular stylesheet to go with v5 solid.min.css.