### PR TITLE
DIS-1118: Add searchable reading history to LiDA

### DIFF
--- a/code/web/release_notes/25.08.00.MD
+++ b/code/web/release_notes/25.08.00.MD
@@ -9,6 +9,8 @@
 // myranda
 
 // kirstien
+### API Updates
+- Added filter parameter to getPatronReadingHistory to User API to handle searching reading history in LiDA. (DIS-1118) (*KK*)
 
 // kodi
 

--- a/code/web/services/API/UserAPI.php
+++ b/code/web/services/API/UserAPI.php
@@ -3861,7 +3861,8 @@ class UserAPI extends AbstractAPI {
 				$page = $_REQUEST['page'] ?? 1;
 				$pageSize = $_REQUEST['pageSize'] ?? 25;
 				$sort = $_REQUEST['sort_by'] ?? 'checkedOut';
-				$readingHistory = $user->getReadingHistory($page, $pageSize, $sort);
+				$filter = $_REQUEST['filter'] ?? '';
+				$readingHistory = $user->getReadingHistory($page, $pageSize, $sort, $filter);
 
 				$options = [
 					'totalItems' => $readingHistory['numTitles'],


### PR DESCRIPTION
- Added filter parameter to getPatronReadingHistory to User API to handle searching reading history in LiDA.