### PR TITLE
DIS-1122: Clear Changed Fields on Update & Fix Updating Home Library

### DIFF
--- a/code/web/CatalogConnection.php
+++ b/code/web/CatalogConnection.php
@@ -961,14 +961,15 @@ class CatalogConnection {
 	 * @param string $homeLibraryCode
 	 * @return array
 	 */
-	function updateHomeLibrary($user, $homeLibraryCode) {
-		$oldHomeLibrary = $user->getHomeLocation()->locationId;
+	function updateHomeLibrary(User $user, string $homeLibraryCode): array {
 		$result = $this->driver->updateHomeLibrary($user, $homeLibraryCode);
 		if ($result['success']) {
 			$location = new Location();
 			$location->code = $homeLibraryCode;
 			if ($location->find(true)) {
-				$user->homeLocationId = $location->locationId;
+				if ($user->homeLocationId != $location->locationId) {
+					$user->__set('homeLocationId', $location->locationId);
+				}
 				$user->_homeLocationCode = $homeLibraryCode;
 				$user->_homeLocation = $location;
 				$user->update();

--- a/code/web/release_notes/25.07.01.MD
+++ b/code/web/release_notes/25.07.01.MD
@@ -1,8 +1,17 @@
 ## Aspen Discovery Updates
 
+### Account Updates
+- Fixed an issue where patrons' updates to Home Library in My Preferences would not be reflected on first save. (DIS-1122) (*LS*)
+
 ### Materials Request Updates
 - Optionally send staff an email after a new Materials Request is created. (DIS-1113) (*MDN*)
 
+### Other Updates
+- Clear `_changedFields` after every `update()` to prevent unexpected side effects. (DIS-1122) (*LS*)
+
 ## This release includes code contributions from
+### ByWater Solutions
+- Leo Stoyanov (*LS*)
+
 ### Grove
 - Mark Noble (*MDN*)

--- a/code/web/sys/DB/DataObject.php
+++ b/code/web/sys/DB/DataObject.php
@@ -520,6 +520,10 @@ abstract class DataObject implements JsonSerializable {
 			$logger->log($updateQuery, Logger::LOG_ERROR);
 		}
 		$timer->logTime($updateQuery);
+		
+		// Clear changed fields after update (successful or failed).
+		$this->_changedFields = [];
+		
 		return $response;
 	}
 


### PR DESCRIPTION
### Account Updates
- Fixed an issue where patrons' updates to Home Library in My Preferences would not be reflected on first save.

### Other Updates
- Clear `_changedFields` after every `update()` to prevent unexpected side effects.