### PR TITLE
DIS-1121: Fixed Duplicate Hold Placements for Volumes & Other Display Changes

### DIFF
--- a/code/web/interface/themes/responsive/js/aspen/record.js
+++ b/code/web/interface/themes/responsive/js/aspen/record.js
@@ -1,6 +1,7 @@
 AspenDiscovery.Record = (function () {
 	// noinspection JSUnusedGlobalSymbols
 	return {
+		volumeHoldInProgress: false,
 		showPlaceHold: function (module, source, id, volume, variationId) {
 			if (Globals.loggedIn) {
 				document.body.style.cursor = "wait";
@@ -16,10 +17,15 @@ AspenDiscovery.Record = (function () {
 				targetButton.prop('disabled', true);
 				targetButton.addClass('disabled');
 
+				const spinner = $('<i class="fas fa-spinner fa-spin" style="margin-right: 3px;"></i>');
+				targetButton.prepend(spinner);
+
 				$.getJSON(url, function (data) {
 					document.body.style.cursor = "default";
 					targetButton.prop('disabled', false);
 					targetButton.removeClass('disabled');
+
+					targetButton.find('.fa-spinner').remove();
 					if (data.holdFormBypassed) {
 						if (data.success) {
 							if (data.needsItemLevelHold) {
@@ -51,7 +57,13 @@ AspenDiscovery.Record = (function () {
 						}
 					}
 					AspenDiscovery.Account.reloadHolds();
-				}).fail(AspenDiscovery.ajaxFail);
+				}).fail(function() {
+					document.body.style.cursor = "default";
+					targetButton.prop('disabled', false);
+					targetButton.removeClass('disabled');
+					targetButton.find('.fa-spinner').remove();
+					AspenDiscovery.ajaxFail.apply(this, arguments);
+				});
 			} else {
 				AspenDiscovery.Account.ajaxLogin(null, function () {
 					AspenDiscovery.Record.showPlaceHold(module, source, id, volume);
@@ -199,16 +211,34 @@ AspenDiscovery.Record = (function () {
 
 		showPlaceHoldEditions: function (module, source, id, volume, variationId) {
 			if (Globals.loggedIn) {
-				var url = Globals.path + "/" + module + "/" + id + "/AJAX?method=getPlaceHoldEditionsForm&recordSource=" + source;
+				document.body.style.cursor = "wait";
+				let url = Globals.path + "/" + module + "/" + id + "/AJAX?method=getPlaceHoldEditionsForm&recordSource=" + source;
 				if (volume !== undefined) {
 					url += "&volume=" + volume;
 				}
 				if (variationId !== undefined) {
 					url += "&variationId=" + variationId;
 				}
+
+				const targetButton = $('#actionButton' + id);
+				targetButton.prop('disabled', true);
+				targetButton.addClass('disabled');
+				const spinner = $('<i class="fas fa-spinner fa-spin" style="margin-right: 3px;"></i>');
+				targetButton.prepend(spinner);
+
 				$.getJSON(url, function (data) {
+					document.body.style.cursor = "default";
+					targetButton.prop('disabled', false);
+					targetButton.removeClass('disabled');
+					targetButton.find('.fa-spinner').remove();
 					AspenDiscovery.showMessageWithButtons(data.title, data.modalBody, data.modalButtons);
-				}).fail(AspenDiscovery.ajaxFail);
+				}).fail(function() {
+					document.body.style.cursor = "default";
+					targetButton.prop('disabled', false);
+					targetButton.removeClass('disabled');
+					targetButton.find('.fa-spinner').remove();
+					AspenDiscovery.ajaxFail.apply(this, arguments);
+				});
 			} else {
 				AspenDiscovery.Account.ajaxLogin(null, function () {
 					AspenDiscovery.Record.showPlaceHoldEditions(module, source, id, volume);
@@ -219,10 +249,28 @@ AspenDiscovery.Record = (function () {
 
 		showPlaceHoldVolumes: function (module, source, id) {
 			if (Globals.loggedIn) {
-				var url = Globals.path + "/" + module + "/" + id + "/AJAX?method=getPlaceHoldVolumesForm&recordSource=" + source;
+				document.body.style.cursor = "wait";
+				const url = Globals.path + "/" + module + "/" + id + "/AJAX?method=getPlaceHoldVolumesForm&recordSource=" + source;
+
+				const targetButton = $('#actionButton' + id);
+				targetButton.prop('disabled', true);
+				targetButton.addClass('disabled');
+				const spinner = $('<i class="fas fa-spinner fa-spin" style="margin-right: 3px;"></i>');
+				targetButton.prepend(spinner);
+
 				$.getJSON(url, function (data) {
+					document.body.style.cursor = "default";
+					targetButton.prop('disabled', false);
+					targetButton.removeClass('disabled');
+					targetButton.find('.fa-spinner').remove();
 					AspenDiscovery.showMessageWithButtons(data.title, data.modalBody, data.modalButtons);
-				}).fail(AspenDiscovery.ajaxFail);
+				}).fail(function() {
+					document.body.style.cursor = "default";
+					targetButton.prop('disabled', false);
+					targetButton.removeClass('disabled');
+					targetButton.find('.fa-spinner').remove();
+					AspenDiscovery.ajaxFail.apply(this, arguments);
+				});
 			} else {
 				AspenDiscovery.Account.ajaxLogin(null, function () {
 					AspenDiscovery.Record.showPlaceHoldVolumes(module, source, id);
@@ -237,7 +285,7 @@ AspenDiscovery.Record = (function () {
 			requestTitleButton.addClass('disabled');
 
 			document.body.style.cursor = "wait";
-			document.querySelector('.fa-spinner').classList.remove('hidden');
+			requestTitleButton.find('.fa-spinner').removeClass('hidden');
 			var id = $('#id').val();
 
 			var targetButton = $('#actionButton' + id);
@@ -285,14 +333,14 @@ AspenDiscovery.Record = (function () {
 					requestTitleButton.prop('disabled', false);
 					requestTitleButton.removeClass('disabled');
 					document.body.style.cursor = "pointer";
-					document.querySelector('.fa-spinner').classList.add('hidden');
+					requestTitleButton.find('.fa-spinner').addClass('hidden');
 					return false;
 				} else if (holdType.val() === 'volume' && volume.val().length === 0) {
 					alert("Please select a volume to place your hold on");
 					requestTitleButton.prop('disabled', false);
 					requestTitleButton.removeClass('disabled');
 					document.body.style.cursor = "pointer";
-					document.querySelector('.fa-spinner').classList.add('hidden');
+					requestTitleButton.find('.fa-spinner').addClass('hidden');
 					return false;
 				}
 			} else {
@@ -305,7 +353,7 @@ AspenDiscovery.Record = (function () {
 						requestTitleButton.prop('disabled', false);
 						requestTitleButton.removeClass('disabled');
 						document.body.style.cursor = "pointer";
-						document.querySelector('.fa-spinner').classList.add('hidden');
+						requestTitleButton.find('.fa-spinner').addClass('hidden');
 						return false;
 					}
 				}
@@ -322,7 +370,7 @@ AspenDiscovery.Record = (function () {
 					requestTitleButton.prop('disabled', false);
 					requestTitleButton.removeClass('disabled');
 					document.body.style.cursor = "pointer";
-					document.querySelector('.fa-spinner').classList.add('hidden');
+					requestTitleButton.find('.fa-spinner').addClass('hidden');
 					return false;
 				} else {
 					$("#cancelHoldDateHelpBlock").hide();
@@ -343,7 +391,7 @@ AspenDiscovery.Record = (function () {
 
 						$("#placeHoldForm").show();
 						$("#placingHoldMessage").hide();
-						document.querySelector('.fa-spinner').classList.add('hidden');
+						requestTitleButton.find('.fa-spinner').addClass('hidden');
 						$('.modal-body').html(data.message);
 					} else if (data.needsIllRequest) {
 						AspenDiscovery.showMessageWithButtons(data.title, data.modalBody, data.modalButtons);
@@ -408,6 +456,17 @@ AspenDiscovery.Record = (function () {
 		},
 
 		placeVolumeHold: function () {
+			// Prevent multiple volume hold submissions; button state alone is insufficient.
+			if (this.volumeHoldInProgress) {
+				return false;
+			}
+			this.volumeHoldInProgress = true;
+
+			const $placeHoldButton = $('.modal-footer .btn-primary');
+			$placeHoldButton.prop('disabled', true);
+			$placeHoldButton.addClass('disabled');
+			$placeHoldButton.find('.fa-spinner').removeClass('hidden');
+			
 			const $volumeSelect = $("#selectedVolume");
 			const selectedVolume = $volumeSelect.find("option:selected").val();
 			const $holdTypeBib = $("#holdTypeBib");
@@ -430,19 +489,24 @@ AspenDiscovery.Record = (function () {
 					</div>
 				`;
 				$('#volumeSelection').prepend(errorHtml);
+
+				this.volumeHoldInProgress = false;
+				$placeHoldButton.prop('disabled', false);
+				$placeHoldButton.removeClass('disabled');
+				$placeHoldButton.find('.fa-spinner').addClass('hidden');
 				return false;
 			}
 
-			var requestTitleButton = $('#requestTitleButton');
+			const requestTitleButton = $('#requestTitleButton');
 			requestTitleButton.prop('disabled', true);
 			requestTitleButton.addClass('disabled');
-			document.querySelector('.fa-spinner').classList.remove('hidden');
+			requestTitleButton.find('.fa-spinner').removeClass('hidden');
 
-			var id = $('#id').val();
-			var autoLogOut = $('#autologout').prop('checked');
-			var module = $('#module').val();
+			const id = $('#id').val();
+			const autoLogOut = $('#autologout').prop('checked');
+			const module = $('#module').val();
 
-			var params = {
+			let params = {
 				'method': 'placeHold',
 				pickupBranch: $('#pickupBranch').val(),
 				selectedUser: $('#user').val(),
@@ -459,9 +523,13 @@ AspenDiscovery.Record = (function () {
 			}
 			if (params['pickupBranch'] === 'undefined') {
 				alert("Please select a location to pick up your hold when it is ready.");
+				this.volumeHoldInProgress = false;
+				$placeHoldButton.prop('disabled', false);
+				$placeHoldButton.removeClass('disabled');
+				$placeHoldButton.find('.fa-spinner').addClass('hidden');
 				return false;
 			}
-			var holdType = $('#holdType');
+			const holdType = $('#holdType');
 			if (holdType.length > 0) {
 				params['holdType'] = holdType.val();
 			} else {
@@ -478,24 +546,31 @@ AspenDiscovery.Record = (function () {
 			$.getJSON(Globals.path + "/" + module + "/" + id + "/AJAX", params, function (data) {
 				if (data.success) {
 					if (data.needsItemLevelHold) {
-						var requestTitleButton = $('#requestTitleButton');
+						AspenDiscovery.Record.volumeHoldInProgress = false;
+						const requestTitleButton = $('#requestTitleButton');
 						requestTitleButton.prop('disabled', false);
 						requestTitleButton.removeClass('disabled');
 
 						$("#placeHoldForm").show();
 						$("#placingHoldMessage").hide();
-						document.querySelector('.fa-spinner').classList.add('hidden');
+						requestTitleButton.find('.fa-spinner').addClass('hidden');
 						$('.modal-body').html(data.message);
 					} else if (data.needsIllRequest) {
+						AspenDiscovery.Record.volumeHoldInProgress = false;
 						AspenDiscovery.showMessageWithButtons(data.title, data.modalBody, data.modalButtons);
 					} else {
+						AspenDiscovery.Record.volumeHoldInProgress = false;
 						AspenDiscovery.showMessage(data.title, data.message, false, autoLogOut);
 						AspenDiscovery.Account.loadMenuData();
 					}
 				} else {
+					AspenDiscovery.Record.volumeHoldInProgress = false;
 					AspenDiscovery.showMessage(data.title, data.message, false, autoLogOut);
 				}
-			}).fail(AspenDiscovery.ajaxFail);
+			}).fail(function() {
+				AspenDiscovery.Record.volumeHoldInProgress = false;
+				AspenDiscovery.ajaxFail.apply(this, arguments);
+			});
 		},
 
 		confirmHold: function (module, bibId, confirmationId) {
@@ -509,7 +584,7 @@ AspenDiscovery.Record = (function () {
 						var requestTitleButton = $('#requestTitleButton');
 						requestTitleButton.prop('disabled', false);
 						requestTitleButton.removeClass('disabled');
-						document.querySelector('.fa-spinner').classList.add('hidden');
+						requestTitleButton.find('.fa-spinner').addClass('hidden');
 						$('.modal-body').html(data.message);
 					} else {
 						AspenDiscovery.showMessage(data.title, data.message, false);

--- a/code/web/release_notes/25.08.00.MD
+++ b/code/web/release_notes/25.08.00.MD
@@ -19,6 +19,9 @@
 // imani
 
 // leo
+### Holds Updates
+- Resolved an issue where multiple volume holds could be placed by repeatedly clicking the button to place holds in the loading modal. (DIS-1121) (*LS*)
+- Added spinner icons to place hold buttons across Aspen to indicate modal loading of place-hold forms or hold submission in progress. (DIS-1121) (*LS*)
 
 // yanjun
 


### PR DESCRIPTION
- Resolved an issue where multiple volume holds could be placed by repeatedly clicking the button to place holds in the loading modal.
- Added spinner icons to place hold buttons across Aspen to indicate modal loading of place-hold forms or hold submission in progress.

Test Plan: Refer to the Jira's description.