### PR TITLE
DIS-1123: Document getListTitles from ListAPI in the API docs

### DIFF
--- a/code/web/openapi/aspen_openapi.json
+++ b/code/web/openapi/aspen_openapi.json
@@ -378,7 +378,8 @@
         "properties": {
           "author": {
             "type": "string",
-            "description": "Author of the work"
+            "description": "Author of the work", 
+            "example": "Ellison, Ralph"
           },
           "description": {
             "type": "string",
@@ -389,7 +390,13 @@
             "description": "mediums (book, e-book, cassette) that the work is available",
             "items": {
               "type": "string"
-            }
+            }, 
+            "example": [
+                    "Book",
+                    "eAudiobook",
+                    "Audiobook CD",
+                    "eBook"
+                ]
           },
           "id": {
             "type": "string",
@@ -414,17 +421,22 @@
             "type": "string",
             "description": "publisher of the work"
           },
+          "recordType": {
+            "type": "string",
+            "description": "TO ADD, typically grouped_work"
+          },
           "small_image": {
             "type": "string",
             "description": "URL partial for an image of 100px height"
           },
           "title": {
             "type": "string",
-            "description": "Title of the work"
+            "description": "Title of the work",
+            "example": "Invisible Man"
           },
           "titleURL": {
             "type": "string",
-            "description": "Full URL to access the title in the catalog "
+            "description": "Full URL to access the title in the catalog"
           }
         }
       },
@@ -440,7 +452,8 @@
               },
               "listTitle": {
                 "type": "string",
-                "description": "Title of the user's list"
+                "description": "Title of the user's list", 
+                "example": "Recommended Reads of Summer Classics"
               },
               "listDescription": {
                 "type": "string",

--- a/code/web/openapi/aspen_openapi.json
+++ b/code/web/openapi/aspen_openapi.json
@@ -75,7 +75,7 @@
             },
             "description": "The ID of the list to return information about",
             "required": true, 
-            "example": "42"
+            "example": "44114"
           },
           {
             "in": "query",
@@ -472,8 +472,15 @@
               },
               "defaultSort": {
                 "type": "string",
-                "description": "Unknown", 
-                "example": "dateAdded"
+                "description": "order that the list's items appear, defined within the user list's settings", 
+                "example": "recentlyAdded", 
+                "default": "dateAdded",
+                "enum": [
+                  "dateAdded",
+                  "recentlyAdded",
+                  "title",
+                  "custom"
+                ]
               },
               "totalResults": {
                 "type": "string",

--- a/code/web/openapi/aspen_openapi.json
+++ b/code/web/openapi/aspen_openapi.json
@@ -59,6 +59,62 @@
     }
   ],
   "paths": {
+      "/ListAPI?method=getListTitles": {
+      "get": {
+        "tags": ["ListAPI"],
+        "summary": "Get information of a list",
+        "description": "Returns list of items and list metadata about a particular list made by a patron or staff.",
+        "parameters": [
+          {
+            "in" : "query",
+            "name": "formId",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "The ID of the list to return information about",
+            "example": "42"
+          }, 
+          {
+            "in" : "query",
+            "name": "numTitles",
+            "schema": {
+              "type": "integer", 
+              "default": "25"
+            },
+            "description": "The number of results within the list to return",
+            "example": "42"
+          },
+          {
+            "in" : "query",
+            "name": "page",
+            "schema": {
+              "type": "integer", 
+              "default": "1"
+            },
+            "description": "The page of Results to return (rephrase)",
+            "example": "4"
+          }
+        ],
+        "responses" : {
+          "200" : {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListAPIResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
     "/SystemAPI?method=getLocalIllForm": {
       "get": {
         "tags": ["SystemAPI"],
@@ -302,6 +358,47 @@
               "required" : {
                 "type": "boolean",
                 "description": "Whether the field must be filled out by the patron"
+              }
+            }
+          }
+        }
+      },
+      "ListAPIResult": {
+        "type": "object",
+        "properties": {
+          "result" : {
+            "type": "object",
+            "properties": {
+              "success": {
+                "type": "boolean",
+                "description": "Whether the user method was successful or not",
+                "example": "true"
+              },
+              "listTitle": {
+                "type": "string",
+                "description": "Title of the user's list"
+              },
+              "listDescription": {
+                "type": "string",
+                "nullable": "true",
+                "description": "List description"
+              },
+              "defaultSort": {
+                "type": "string",
+                "description": "Unknown"
+              },
+              "totalResults": {
+                "type": "string",
+                "nullable": "true",
+                "description": "Number of results, but stored as a string"
+              },
+              "titles": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/FormFieldResult"
+                },
+                "nullable": "true",
+                "description": "An array of field information to be displayed"
               }
             }
           }

--- a/code/web/openapi/aspen_openapi.json
+++ b/code/web/openapi/aspen_openapi.json
@@ -363,8 +363,40 @@
           }
         }
       },
-      "ListAPIResult": {
+      "ListAPIItemResult": {
         "type": "object",
+        "properties": {
+          "author": {
+                "type": "string",
+                "description": "Author of the work"
+          }, 
+                "description": {
+                "type": "string",
+                "description": "brief synopsis of book"
+          },
+           "id": {
+                "type": "string",
+                "description": "Unique ID"
+          },
+          "image": {
+                "type": "string",
+                "description": "URL partial for an image of 200px height"
+          }, 
+          "small_image": {
+                "type": "string",
+                "description": "URL partial for an image of 100px height"
+          }, 
+          "title": {
+                "type": "string",
+                "description": "Title of the work"
+          }, 
+          "titleURL": {
+                "type": "string",
+                "description": "Full URL to access the title in the catalog "
+          }
+        }
+      },
+      "ListAPIResult": {
         "properties": {
           "result" : {
             "type": "object",
@@ -395,10 +427,19 @@
               "titles": {
                 "type": "array",
                 "items": {
-                  "$ref": "#/components/schemas/FormFieldResult"
+                  "$ref": "#/components/schemas/ListAPIItemResult"
                 },
                 "nullable": "true",
                 "description": "An array of field information to be displayed"
+              }, 
+              "page_current": {
+                "type": "integer", 
+                "description": "The current page of ", 
+                "default": 1
+              },
+              "page_total": {
+                "type": "integer", 
+                "description": "Total pages of results for this list; This is also the number of API calls required to obtain all items in the specified list"
               }
             }
           }

--- a/code/web/openapi/aspen_openapi.json
+++ b/code/web/openapi/aspen_openapi.json
@@ -1,6 +1,6 @@
 {
-  "openapi" : "3.1.0",
-  "info" : {
+  "openapi": "3.1.0",
+  "info": {
     "title": "Aspen Discovery API",
     "version": "1.0.0",
     "license": {
@@ -59,44 +59,46 @@
     }
   ],
   "paths": {
-      "/ListAPI?method=getListTitles": {
+    "/ListAPI?method=getListTitles": {
       "get": {
-        "tags": ["ListAPI"],
+        "tags": [
+          "ListAPI"
+        ],
         "summary": "Get information of a list",
         "description": "Returns list of items and list metadata about a particular list made by a patron or staff.",
         "parameters": [
           {
-            "in" : "query",
-            "name": "formId",
+            "in": "query",
+            "name": "id",
             "schema": {
               "type": "integer"
             },
             "description": "The ID of the list to return information about",
             "example": "42"
-          }, 
+          },
           {
-            "in" : "query",
+            "in": "query",
             "name": "numTitles",
             "schema": {
-              "type": "integer", 
+              "type": "integer",
               "default": "25"
             },
-            "description": "The number of results within the list to return",
+            "description": "The number of work/titles within the list to return",
             "example": "42"
           },
           {
-            "in" : "query",
+            "in": "query",
             "name": "page",
             "schema": {
-              "type": "integer", 
+              "type": "integer",
               "default": "1"
             },
             "description": "The page of Results to return (rephrase)",
             "example": "4"
           }
         ],
-        "responses" : {
-          "200" : {
+        "responses": {
+          "200": {
             "description": "Successful response",
             "content": {
               "application/json": {
@@ -117,12 +119,14 @@
     },
     "/SystemAPI?method=getLocalIllForm": {
       "get": {
-        "tags": ["SystemAPI"],
+        "tags": [
+          "SystemAPI"
+        ],
         "summary": "Get Local ILL Form",
         "description": "Returns information needed to display a Local ILL Form to the user.",
         "parameters": [
           {
-            "in" : "query",
+            "in": "query",
             "name": "formId",
             "schema": {
               "type": "integer"
@@ -131,8 +135,8 @@
             "example": "1"
           }
         ],
-        "responses" : {
-          "200" : {
+        "responses": {
+          "200": {
             "description": "Successful response",
             "content": {
               "application/json": {
@@ -153,11 +157,13 @@
     },
     "/UserAPI?method=isLoggedIn": {
       "get": {
-        "tags": ["UserAPI"],
+        "tags": [
+          "UserAPI"
+        ],
         "summary": "Login status",
         "description": "Determines if a user is logged in based on session information in the active browser. Typically not useful because the calling application will not be using the same browser as the patron.",
-        "responses" : {
-          "200" : {
+        "responses": {
+          "200": {
             "description": "Successful response",
             "content": {
               "application/json": {
@@ -177,13 +183,15 @@
       }
     },
     "/UserAPI?method=login": {
-      "post" : {
-        "tags": ["UserAPI"],
+      "post": {
+        "tags": [
+          "UserAPI"
+        ],
         "summary": "Login user",
         "description": "Logs in the user, sets a cookie indicating that the user is logged in, and returns the session_id for the new session. In general, this method is only useful when called from Aspen itself or from files that share cookies with the Aspen server.",
         "parameters": [
           {
-            "in" : "query",
+            "in": "query",
             "name": "username",
             "schema": {
               "type": "string"
@@ -192,7 +200,7 @@
             "example": "23025003575917"
           },
           {
-            "in" : "query",
+            "in": "query",
             "name": "password",
             "schema": {
               "type": "string"
@@ -222,13 +230,15 @@
       }
     },
     "/UserAPI?method=submitLocalIllRequest": {
-      "post" : {
-        "tags": ["UserAPI"],
+      "post": {
+        "tags": [
+          "UserAPI"
+        ],
         "summary": "Submit Local ILL Request",
         "description": "Submits a Local ILL Request for the user.",
         "parameters": [
           {
-            "in" : "query",
+            "in": "query",
             "name": "username",
             "schema": {
               "type": "string"
@@ -237,7 +247,7 @@
             "example": "23025003575917"
           },
           {
-            "in" : "query",
+            "in": "query",
             "name": "password",
             "schema": {
               "type": "string"
@@ -303,7 +313,7 @@
       "BasicResult": {
         "type": "object",
         "properties": {
-          "result" : {
+          "result": {
             "type": "boolean"
           }
         }
@@ -311,7 +321,7 @@
       "BasicAPIResult": {
         "type": "object",
         "properties": {
-          "result" : {
+          "result": {
             "success": {
               "type": "boolean",
               "description": "Whether the user method was successful or not",
@@ -332,7 +342,7 @@
       "FormFieldResult": {
         "type": "object",
         "properties": {
-          "result" : {
+          "result": {
             "type": "object",
             "properties": {
               "type": {
@@ -351,11 +361,11 @@
                 "type": "string",
                 "description": "The label for the field"
               },
-              "description" : {
+              "description": {
                 "type": "string",
                 "description": "The description for the field, can be shown as a tooltip or under the field"
               },
-              "required" : {
+              "required": {
                 "type": "boolean",
                 "description": "Whether the field must be filled out by the patron"
               }
@@ -367,38 +377,60 @@
         "type": "object",
         "properties": {
           "author": {
-                "type": "string",
-                "description": "Author of the work"
-          }, 
-                "description": {
-                "type": "string",
-                "description": "brief synopsis of book"
+            "type": "string",
+            "description": "Author of the work"
           },
-           "id": {
-                "type": "string",
-                "description": "Unique ID"
+          "description": {
+            "type": "string",
+            "description": "brief synopsis of book"
+          },
+          "format": {
+            "type": "array",
+            "description": "mediums (book, e-book, cassette) that the work is available",
+            "items": {
+              "type": "string"
+            }
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique ID"
           },
           "image": {
-                "type": "string",
-                "description": "URL partial for an image of 200px height"
-          }, 
+            "type": "string",
+            "description": "URL partial for an image of 200px height"
+          },
+          "language": {
+            "type": "array",
+            "description": "language(s) that the work is recorded in",
+            "items": {
+              "type": "string"
+            }
+          },
+          "length": {
+            "type": "string",
+            "description": "unkwown how this is used"
+          },
+          "publisher": {
+            "type": "string",
+            "description": "publisher of the work"
+          },
           "small_image": {
-                "type": "string",
-                "description": "URL partial for an image of 100px height"
-          }, 
+            "type": "string",
+            "description": "URL partial for an image of 100px height"
+          },
           "title": {
-                "type": "string",
-                "description": "Title of the work"
-          }, 
+            "type": "string",
+            "description": "Title of the work"
+          },
           "titleURL": {
-                "type": "string",
-                "description": "Full URL to access the title in the catalog "
+            "type": "string",
+            "description": "Full URL to access the title in the catalog "
           }
         }
       },
       "ListAPIResult": {
         "properties": {
-          "result" : {
+          "result": {
             "type": "object",
             "properties": {
               "success": {
@@ -422,7 +454,7 @@
               "totalResults": {
                 "type": "string",
                 "nullable": "true",
-                "description": "Number of results, but stored as a string"
+                "description": "Number of total items in the list, stored as a string"
               },
               "titles": {
                 "type": "array",
@@ -430,15 +462,15 @@
                   "$ref": "#/components/schemas/ListAPIItemResult"
                 },
                 "nullable": "true",
-                "description": "An array of field information to be displayed"
-              }, 
+                "description": "Works/items in the list"
+              },
               "page_current": {
-                "type": "integer", 
-                "description": "The current page of ", 
+                "type": "integer",
+                "description": "The current page of the list (rephrase)",
                 "default": 1
               },
               "page_total": {
-                "type": "integer", 
+                "type": "integer",
                 "description": "Total pages of results for this list; This is also the number of API calls required to obtain all items in the specified list"
               }
             }
@@ -448,7 +480,7 @@
       "LocalIllFormResult": {
         "type": "object",
         "properties": {
-          "result" : {
+          "result": {
             "type": "object",
             "properties": {
               "success": {
@@ -490,7 +522,7 @@
       "LoginResult": {
         "type": "object",
         "properties": {
-          "result" : {
+          "result": {
             "type": "object",
             "properties": {
               "success": {

--- a/code/web/openapi/aspen_openapi.json
+++ b/code/web/openapi/aspen_openapi.json
@@ -74,6 +74,7 @@
               "type": "integer"
             },
             "description": "The ID of the list to return information about",
+            "required": true, 
             "example": "42"
           },
           {
@@ -383,7 +384,8 @@
           },
           "description": {
             "type": "string",
-            "description": "brief synopsis of book"
+            "description": "brief synopsis of book",
+            "example": "In the course of his wanderings from a Southern Negro college to New York's Harlem, an American black man becomes involved in a series of adventures. Introduction explains circumstances under which the book was written. Ellison won the National Book Award for this searing record of a black man's journey through contemporary America. Unquestionably, Ellison's book is a work of extraordinary intensity -- powerfully imagined and written with a savage, wryly humorous gusto"
           },
           "format": {
             "type": "array",
@@ -411,8 +413,11 @@
             "description": "language(s) that the work is recorded in",
             "items": {
               "type": "string"
-            }
-          },
+            },
+            "example": [
+              "English"
+            ]
+          }, 
           "length": {
             "type": "string",
             "description": "unkwown how this is used"
@@ -422,6 +427,10 @@
             "description": "publisher of the work"
           },
           "recordType": {
+            "type": "string",
+            "description": "TO ADD, typically grouped_work"
+          },
+          "shortID": {
             "type": "string",
             "description": "TO ADD, typically grouped_work"
           },
@@ -458,16 +467,19 @@
               "listDescription": {
                 "type": "string",
                 "nullable": "true",
-                "description": "List description"
+                "description": "List description",
+                "example": "Recommended readed of classic books that taken place in the summer"
               },
               "defaultSort": {
                 "type": "string",
-                "description": "Unknown"
+                "description": "Unknown", 
+                "example": "dateAdded"
               },
               "totalResults": {
                 "type": "string",
                 "nullable": "true",
-                "description": "Number of total items in the list, stored as a string"
+                "description": "Number of total items in the list, stored as a string",
+                "example": "30"
               },
               "titles": {
                 "type": "array",
@@ -480,11 +492,13 @@
               "page_current": {
                 "type": "integer",
                 "description": "The current page of the list (rephrase)",
-                "default": 1
+                "default": 1, 
+                "example": 1
               },
               "page_total": {
                 "type": "integer",
-                "description": "Total pages of results for this list; This is also the number of API calls required to obtain all items in the specified list"
+                "description": "Total pages of results for this list; This is also the number of API calls required to obtain all items in the specified list",
+                "example": 2
               }
             }
           }


### PR DESCRIPTION
Hi, 

This is a draft of creating a documentation for the ListAPI, specifically the getListTitles function, which enables developers to obtain a list of all works and events within a user created list. 

See the list API's getListTitles function in action at https://clevelandreads.com/recommended-reads/ 

Being my first PR and still learning about Aspen, 

I have several questions about OpenAPI formatting and the listAPI: 

**OpenApi formatting questions**

- how to cite items that items may sometimes be a empty string ? 
like  "length": "",
example https://gist.github.com/skora-cpl/76d9b8d0add53ed69d30dbff85a076e3#file-gistfile1-txt-L21

- ~~How to state if a parameter is required or optional ?~~ (see: https://github.com/Aspen-Discovery/aspen-discovery/blob/8defde7966e772e04e9b8ef9001f2f48e9dbaba5/code/web/openapi/aspen_openapi.json#L77) 

- What order should items be placed in the response ? Alphabetical order or in the order that they are in response ? 

For example, at https://github.com/Aspen-Discovery/aspen-discovery/blob/beb0861174e7c74eb059d38a87a8995d6a9423cc/code/web/openapi/aspen_openapi.json#L369 I alphabetized them based on the string name; but the raw api JSON returns them in a different order - e.g. within the titles array, the order appears as so https://gist.github.com/skora-cpl/716ad5396a60c16e4d3cff115db73b4d)


- What kind of type (in OpenAPI speak) are URLs; like at https://gist.github.com/skora-cpl/76d9b8d0add53ed69d30dbff85a076e3#file-gistfile1-txt-L187 

I represented it as a string at https://github.com/Aspen-Discovery/aspen-discovery/blob/beb0861174e7c74eb059d38a87a8995d6a9423cc/code/web/openapi/aspen_openapi.json#L381

**Questions specific to Aspen-Discovery about getListTitles**

- for numtitles parameter, is there a maximum value (i don't have any lists that have a high value) 
- When I added a particular edition to a list; the entire grouped_Work was included; is this intentional ? (see https://search.cpl.org/MyAccount/MyList/84147 when I added a particular edition like https://search.cpl.org/OverDrive/kindle:9816fff8-ff33-4c2f-be39-e87488f685e4/Home to a list; all of the editions were added) (this is more out of curiousity, i guess, i don't necessarily see this as a bug). 
- Are the "grouped_work" and "event" the only possible values for recordType ? 
- are the images in small_image always 100px height ? 
- are the images in image always 200px height  ?
(these names go back to getBookcoverUrl but I couldn't find if the height is always specified) 
- What's the difference between ID and shortID ? In all of my API responses, each title's id and shortID are identical; is that always true ? 

- How should I provide extra contextual information like a list needs to be made public for a successful request; (unless you specify the user's name and password ? otherwise the result will be  `{"success":false,"message":"The user was invalid.  A valid user must be provided for private lists."}}` 

**Other notes:** 

I found how to write for openAPI a bit daunting at first and the learning curve is not easy. 

Having some clearer guidelines would be really helpful and an additional doc would be helpful for future contributors. 

For example, including where the documentation file can be found (code/web/openapi/aspen_openapi.json); 
what the name of the spec is (openAPI 3.1); maybe a couple links to what the OpenAPI is and some examples, recommending editing the raw JSON file itself, @myr-onl also mentioned that they "made a tag for each (necessary for docs) php file in /code/web/services/API/ and was using the notes inside the php files to write things." 

Others can build upon what I've shared for writing other API documentation. 

I have been using and contributing to open source projects for about 15 years so I understand that incentives (monetary, personal) are usually not aligned to work on documentation and that creating (and maintaining) documentation requires considerable more effort and time than most people perceive and its "value" and more energy regarding docs has been towards the general docs around confluence and aspen discovery (Which has a larger audience and is extremely useful!) 

**Resources**

I personally learn best from examples and couldn't find many existing examples out there that are written in JSON (seems that many openAPI examples are in yaml) so I found the following very helpful

https://api.weather.gov/openapi.json
https://www.weather.gov/documentation/services-web-api#/

(NOTE: the weather.gov openAPI uses openAPI 3.0 spec; Aspen uses 3.1 - there are some differences betwen them https://beeceptor.com/docs/concepts/openapi-what-is-new-3.1.0/)

https://json-schema.org/blog/posts/validating-openapi-and-json-schema#what-is-a-json-schema-dialect
