### PR TITLE
DIS-1091: List Entries that do not have a title set for them do not sort properly

### DIFF
--- a/code/web/release_notes/25.08.00.MD
+++ b/code/web/release_notes/25.08.00.MD
@@ -11,6 +11,8 @@
 // kirstien
 
 // kodi
+### User List Updates
+- Updated sorting by title and author to use left joins on relevant tables for list entries (DIS-1091) (*KL*)
 
 // kyle
 


### PR DESCRIPTION
- Add left joins to relevant tables when getting user list entries to get title/author if possible for sorting 
- Update release notes

Tested on my local instance of Aspen