### PR TITLE
DIS-1148: Fix Error in List API Retrieving List Data for Non-LiDA Applications

### DIFF
--- a/code/web/release_notes/25.08.00.MD
+++ b/code/web/release_notes/25.08.00.MD
@@ -19,6 +19,8 @@
 // imani
 
 // leo
+### API Updates
+- Fixed error in List API when retrieving user list data for non-LiDA applications. (DIS-1148) (*LS*)
 
 // yanjun
 

--- a/code/web/services/API/ListAPI.php
+++ b/code/web/services/API/ListAPI.php
@@ -553,10 +553,11 @@ class ListAPI extends AbstractAPI {
 				}
 			}
 
-			$appVersion = null;
 			$isLida = $this->checkIfLiDA();
-			if($isLida) {
+			if ($isLida) {
 				$appVersion = $this->getLiDAVersion();
+			} else {
+				$appVersion = 0;
 			}
 
 			//if LiDA we don't want to include events list entries in the list count


### PR DESCRIPTION
- Fixed error in List API when retrieving user list data for non-LiDA applications.

Test Plan: 
1. Make an API request to `getUserListTitles()` and notice the following error: `{"success":false,"message":"UserList::getListRecords(): Argument #8 ($appVersion) must be of type int|float, null given`.
2. Apply the patch and repeat step 2. The API request succeeds.