### PR TITLE
DIS-1149: Added Additional Version Guards Around Koha Preferred Name Feature

### DIFF
--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -1142,7 +1142,11 @@ class Koha extends AbstractIlsDriver {
 		global $library;
 
 		/** @noinspection SqlResolve */
-		$sql = "SELECT *, borrowernumber, cardnumber, surname, firstname, preferred_name, streetnumber, streettype, address, address2, city, state, zipcode, country, email, phone, mobile, categorycode, dateexpiry, password, userid, branchcode, opacnote, privacy, dateofbirth from borrowers where borrowernumber = '" . mysqli_escape_string($this->dbConnection, $patronId) . "';";
+		if ($this->getKohaVersion() >= 24.11) {
+			$sql = "SELECT *, borrowernumber, cardnumber, surname, firstname, preferred_name, streetnumber, streettype, address, address2, city, state, zipcode, country, email, phone, mobile, categorycode, dateexpiry, password, userid, branchcode, opacnote, privacy, dateofbirth from borrowers where borrowernumber = '" . mysqli_escape_string($this->dbConnection, $patronId) . "';";
+		} else {
+			$sql = "SELECT *, borrowernumber, cardnumber, surname, firstname, streetnumber, streettype, address, address2, city, state, zipcode, country, email, phone, mobile, categorycode, dateexpiry, password, userid, branchcode, opacnote, privacy, dateofbirth from borrowers where borrowernumber = '" . mysqli_escape_string($this->dbConnection, $patronId) . "';";
+		}
 
 		$userExistsInDB = false;
 		$lookupUserResult = mysqli_query($this->dbConnection, $sql, MYSQLI_USE_RESULT);
@@ -1199,6 +1203,7 @@ class Koha extends AbstractIlsDriver {
 			} else {
 				$firstName = $userFromDb['firstname'];
 			}
+
 			if ($user->firstname != $firstName) {
 				$user->firstname = $firstName ?? '';
 				$forceDisplayNameUpdate = true;
@@ -1209,6 +1214,7 @@ class Koha extends AbstractIlsDriver {
 					$forceDisplayNameUpdate = true;
 				}
 			}
+
 			$lastName = $userFromDb['surname'];
 			if ($user->lastname != $lastName) {
 				$user->lastname = $lastName ?? '';
@@ -1220,14 +1226,17 @@ class Koha extends AbstractIlsDriver {
 					$forceDisplayNameUpdate = true;
 				}
 			}
-			$userPreferredName = $userFromDb['preferred_name'];
-			if ($user->userPreferredName != $userPreferredName) {
-				$user->userPreferredName = $userPreferredName ?? '';
-				$forceDisplayNameUpdate = true;
-			} else {
-				if (!$user->userPreferredName) {
-					$user->userPreferredName = '';
+
+			if ($this->getKohaVersion() >= 24.11) {
+				$userPreferredName = $userFromDb['preferred_name'];
+				if ($user->userPreferredName != $userPreferredName) {
+					$user->userPreferredName = $userPreferredName ?? '';
 					$forceDisplayNameUpdate = true;
+				} else {
+					if (!$user->userPreferredName) {
+						$user->userPreferredName = '';
+						$forceDisplayNameUpdate = true;
+					}
 				}
 			}
 

--- a/code/web/release_notes/25.08.00.MD
+++ b/code/web/release_notes/25.08.00.MD
@@ -30,6 +30,9 @@
 ### API Updates
 - Fixed error in List API when retrieving user list data for non-LiDA applications. (DIS-1148) (*LS*)
 
+### Koha Updates
+- Added additional version checks around the Koha preferred name feature to prevent compatibility issues on instances running versions prior to 24.11. (DIS-1149) (*LS*)
+
 // yanjun
 
 // laura


### PR DESCRIPTION
- Added additional version checks around the Koha preferred name feature to prevent compatibility issues on instances running versions prior to 24.11.

Test Plan: Load Koha instance before 24.11 and Aspen version 25.06.00+ and see that you cannot log in. Apply the patch and try again.