### PR TITLE
DIS-1151: Fixed Placing Overdrive Holds, Library Scoping, and Pagination on Requests Needing Holds Interface

### DIFF
--- a/code/web/Drivers/OverDriveDriver.php
+++ b/code/web/Drivers/OverDriveDriver.php
@@ -884,9 +884,15 @@ class OverDriveDriver extends AbstractEContentDriver {
 		}
 		$settings = $librarySettings->getOverDriveSettings();
 
-		$url = $settings->patronApiUrl . '/v1/patrons/me/holds/' . $recordId;
+		$overDriveId = $recordId;
+		if (str_contains($recordId, ':')) {
+			$parts = explode(':', $recordId);
+			$overDriveId = end($parts);
+		}
+
+		$url = $settings->patronApiUrl . '/v1/patrons/me/holds/' . $overDriveId;
 		$params = [
-			'reserveId' => $recordId,
+			'reserveId' => $overDriveId,
 			'emailAddress' => trim((empty($patron->overdriveEmail) ? $patron->email : $patron->overdriveEmail)),
 		];
 		$response = $this->_callPatronUrl($settings, $patron, $url, "placeHold", $params);
@@ -950,7 +956,7 @@ class OverDriveDriver extends AbstractEContentDriver {
 			$patron->forceReloadOfHolds();
 		} else {
 			$holdResult['message'] = translate([
-				'text' => 'Sorry, but we could not place a hold for you on this title.',
+				'text' => 'Sorry, but we could not place a hold for you on this Overdrive title.',
 				'isPublicFacing' => true,
 			]);
 			if (isset($response->message)) {
@@ -963,7 +969,7 @@ class OverDriveDriver extends AbstractEContentDriver {
 				'isPublicFacing' => true,
 			]);
 			$holdResult['api']['message'] = translate([
-				'text' => 'Sorry, but we could not place a hold for you on this title.',
+				'text' => 'Sorry, but we could not place a hold for you on this Overdrive title.',
 				'isPublicFacing' => true,
 			]);
 

--- a/code/web/release_notes/25.08.00.MD
+++ b/code/web/release_notes/25.08.00.MD
@@ -30,6 +30,13 @@
 ### API Updates
 - Fixed error in List API when retrieving user list data for non-LiDA applications. (DIS-1148) (*LS*)
 
+### Materials Requests Updates
+- Resolved an issue where placing holds on OverDrive titles through the Requests Needing Holds interface would fail when record IDs contained source and/or format prefixes. (DIS-1151) (*LS*)
+- Fixed a library scoping issue that allowed staff to see Requests Needing Holds from other Library Systems. (DIS-1151) (*LS*)
+
+### Other Updates
+- Corrected DataObject framework bug where zero values in database queries were incorrectly excluded from count operations due to PHP's loose equality comparison, affecting any interface using `count()` with zero-value conditions. (DIS-1151) (*LS*)
+
 // yanjun
 
 // laura

--- a/code/web/services/MaterialsRequest/RequestsNeedingHolds.php
+++ b/code/web/services/MaterialsRequest/RequestsNeedingHolds.php
@@ -16,6 +16,15 @@ class MaterialsRequest_RequestsNeedingHolds extends ObjectEditor {
 		$object->holdsCreated = 0;
 		//TODO: Filter by assignee as well?
 
+		$homeLibrary = Library::getPatronHomeLibrary();
+		if (is_null($homeLibrary)) {
+			global $library;
+			$homeLibrary = $library;
+		}
+		if ($homeLibrary != null) {
+			$object->libraryId = $homeLibrary->libraryId;
+		}
+
 		$object->orderBy($this->getSort());
 		$this->applyFilters($object);
 		$object->limit(($page - 1) * $recordsPerPage, $recordsPerPage);
@@ -33,6 +42,15 @@ class MaterialsRequest_RequestsNeedingHolds extends ObjectEditor {
 			$object->readyForHolds = 1;
 			$object->holdsCreated = 0;
 			//TODO: Filter by assignee as well?
+
+			$homeLibrary = Library::getPatronHomeLibrary();
+			if (is_null($homeLibrary)) {
+				global $library;
+				$homeLibrary = $library;
+			}
+			if ($homeLibrary != null) {
+				$object->libraryId = $homeLibrary->libraryId;
+			}
 
 			$this->applyFilters($object);
 			$this->_numObjects = $object->count();

--- a/code/web/sys/DB/DataObject.php
+++ b/code/web/sys/DB/DataObject.php
@@ -836,7 +836,7 @@ abstract class DataObject implements JsonSerializable {
 		$properties = get_object_vars($this);
 		$where = '';
 		foreach ($properties as $name => $value) {
-			if ($value != null && $name[0] != '_') {
+			if ($value !== null && $name[0] != '_') {
 				if (strlen($where) != 0) {
 					$where .= ' AND ';
 				}


### PR DESCRIPTION
- Resolved an issue where placing holds on OverDrive titles through the Requests Needing Holds interface would fail when record IDs contained source and/or format prefixes.
- Corrected DataObject framework bug where zero values in database queries were incorrectly excluded from count operations due to PHP's loose equality comparison, affecting any interface using `count()` with zero-value conditions.
- Fixed a library scoping issue that allowed staff to see Requests Needing Holds from other Library Systems.

Test Plan:
1. Assuming there are requests needing holds, navigate to the Requests Needing Holds admin interface.
2. Attempt to place a hold on an Overdrive title and notice that it fails with an error.
3. If you have greater than 25 total requests that either need holds or needed holds, but fewer than that total currently need holds, notice that there are too many pages listed at the bottom. In particular, if you click on a numerically high page, you will notice that it is empty.
4. If another Library System has Materials Requests enabled, and they have requests needing holds, notice that you can see their requests needing holds on your library’s Requests Needing Holds interface.
5. Apply the patch and confirm that Overdrive holds work, that pagination works, and that library scoping works.