### PR TITLE
DIS-1153: Add "Allow Material Requests Branch Choice" for ILS Material Requests

### DIFF
--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -5164,9 +5164,10 @@ class Koha extends AbstractIlsDriver {
 		}
 
 		global $interface;
-		$allowPurchaseSuggestionBranchChoice = $this->getKohaSystemPreference('AllowPurchaseSuggestionBranchChoice');
+		global $library;
+		$allowMaterialRequestsBranchChoice = $library->allowMaterialRequestsBranchChoice;
 		$pickupLocations = [];
-		if ($allowPurchaseSuggestionBranchChoice == 1) {
+		if ($allowMaterialRequestsBranchChoice == 1) {
 			$locations = new Location();
 			$locations->orderBy('displayName');
 			$locations->whereAdd('validHoldPickupBranch != 2');

--- a/code/web/interface/themes/responsive/js/aspen/admin.js
+++ b/code/web/interface/themes/responsive/js/aspen/admin.js
@@ -1000,6 +1000,7 @@ AspenDiscovery.Admin = (function () {
 			const rowsToHide = [
 				"#propertyRowdisplayMaterialsRequestToPublic",
 				"#propertyRowallowDeletingILSRequests",
+				"#propertyRowallowMaterialRequestsBranchChoice",
 				"#propertyRowexternalMaterialsRequestUrl",
 				"#propertyRowmaxRequestsPerYear",
 				"#propertyRowmaxActiveRequests",
@@ -1037,7 +1038,7 @@ AspenDiscovery.Admin = (function () {
 					].forEach(selector => $(selector).show());
 					break;
 				case "2": // ILS Request System
-					["#propertyRowallowDeletingILSRequests", "#propertyRowdisplayMaterialsRequestToPublic"]
+					["#propertyRowallowDeletingILSRequests", "#propertyRowallowMaterialRequestsBranchChoice", "#propertyRowdisplayMaterialsRequestToPublic"]
 						.forEach(selector => $(selector).show());
 					break;
 				case "3": // External Request Link

--- a/code/web/release_notes/25.08.00.MD
+++ b/code/web/release_notes/25.08.00.MD
@@ -30,6 +30,16 @@
 ### API Updates
 - Fixed error in List API when retrieving user list data for non-LiDA applications. (DIS-1148) (*LS*)
 
+### Koha Updates
+- Added "Allow Material Requests Branch Choice" setting for the ILS Request System, allowing patrons to select which branch should receive their materials request instead of defaulting to their home branch. (DIS-1153) (*LS*)
+
+<div markdown="1" class="settings">
+
+#### New Settings
+- Library System > Materials Request > Allow Material Requests Branch Choice
+
+</div>
+
 // yanjun
 
 // laura

--- a/code/web/sys/DBMaintenance/version_updates/25.08.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.08.00.php
@@ -25,6 +25,14 @@ function getUpdates25_08_00(): array {
 		//Yanjun Li - ByWater
 
 		// Leo Stoyanov - BWS
+		'add_allow_material_requests_branch_choice_setting' => [
+			'title' => 'Add Allow Material Requests Branch Choice Setting',
+			'description' => 'Add "Allow Material Requests Branch Choice" setting for the ILS Request System.',
+			'continueOnError' => false,
+			'sql' => [
+				'ALTER TABLE library ADD COLUMN IF NOT EXISTS allowMaterialRequestsBranchChoice tinyint(1) DEFAULT 0;'
+			]
+		],//add_allow_material_requests_branch_choice_setting
 
 		// Laura Escamilla - ByWater Solutions
 

--- a/code/web/sys/LibraryLocation/Library.php
+++ b/code/web/sys/LibraryLocation/Library.php
@@ -219,6 +219,7 @@ class Library extends DataObject {
 	public $enableMaterialsRequest;
 	public $displayMaterialsRequestToPublic;
 	public $allowDeletingILSRequests;
+	public $allowMaterialRequestsBranchChoice;
 	public $externalMaterialsRequestUrl;
 	public /** @noinspection PhpUnused */
 		$eContentLinkRules;
@@ -3385,6 +3386,14 @@ class Library extends DataObject {
 						'hideInLists' => true,
 						'onchange' => 'return AspenDiscovery.Admin.updateMaterialsRequestFields();',
 						'default' => 1,
+					],
+					'allowMaterialRequestsBranchChoice' => [
+						'property' => 'allowMaterialRequestsBranchChoice',
+						'type' => 'checkbox',
+						'label' => 'Allow Material Requests Branch Choice',
+						'description' => 'Whether or not patrons can choose a branch for their Materials Request.',
+						'hideInLists' => true,
+						'default' => 0,
 					],
 					'externalMaterialsRequestUrl' => [
 						'property' => 'externalMaterialsRequestUrl',


### PR DESCRIPTION
- Added "Allow Material Requests Branch Choice" setting for the ILS Request System, allowing patrons to select which branch should receive their materials request instead of defaulting to their home branch.

Test Plan:
1. Apply the patch and enable the “ILS Request System” as the Material Request System.
2. Log in or masquerade as a patron account that can make material requests. Notice that multiple branch locations can be chosen in the form.