### PR TITLE
DIS-1058: Improve Object History Tracking

### DIFF
--- a/code/web/release_notes/25.08.00.MD
+++ b/code/web/release_notes/25.08.00.MD
@@ -30,6 +30,14 @@
 ### API Updates
 - Fixed error in List API when retrieving user list data for non-LiDA applications. (DIS-1148) (*LS*)
 
+### Administration Updates
+- Object History Improvements: (DIS-1058) (*LS*)
+  - Improved change tracking for child objects so edits to settings now capture individual field changes such as renames, toggles, and date edits.
+  - Added deletion tracking so removing a child object creates a clear history entry showing which item was deleted.
+  - Made history entries display human-readable names instead of raw IDs to make changes easier to understand.
+  - Adjusted history logging to only record updates when related items are actually added, removed, or reordered, thus reducing unnecessary entries.
+  - Fixed an issue where Library and Location records defaulted to "none" on every save, preventing spurious history entries.
+
 // yanjun
 
 // laura

--- a/code/web/sys/DB/DataObject.php
+++ b/code/web/sys/DB/DataObject.php
@@ -1069,7 +1069,8 @@ abstract class DataObject implements JsonSerializable {
 						$history->actionType = 2;
 						$history->objectId = $this->$primaryKey;
 						$history->oldValue = $oldValue;
-						$history->propertyName = $propertyName;
+						require_once ROOT_DIR . '/sys/DataObjectUtil.php';
+						$history->propertyName = DataObjectUtil::getHistoryPropertyName($this, $propertyName);
 						$history->newValue = $newValue;
 						$history->changedBy = UserAccount::getActiveUserId();
 						$history->changeDate = time();

--- a/code/web/sys/LibraryLocation/Library.php
+++ b/code/web/sys/LibraryLocation/Library.php
@@ -4904,8 +4904,8 @@ class Library extends DataObject {
 		return $this->_libraryLinks;
 	}
 
-	public function getCloudLibraryScope() : null|string|int {
-		if ($this->_cloudLibraryScope == null && $this->libraryId) {
+	public function getCloudLibraryScope() : int {
+		if ($this->_cloudLibraryScope === null && $this->libraryId) {
 			require_once ROOT_DIR . '/sys/CloudLibrary/LibraryCloudLibraryScope.php';
 			$libraryCloudLibraryScope = new LibraryCloudLibraryScope();
 			$libraryCloudLibraryScope->libraryId = $this->libraryId;
@@ -4916,6 +4916,10 @@ class Library extends DataObject {
 				if ($cloudLibraryScope->find(true)) {
 					$this->_cloudLibraryScope = $cloudLibraryScope->id;
 				}
+			}
+			// If still not set, default to '-1', which corresponds to 'none'.
+			if ($this->_cloudLibraryScope === null) {
+				$this->_cloudLibraryScope = -1;
 			}
 		}
 		return $this->_cloudLibraryScope;

--- a/code/web/sys/LibraryLocation/Location.php
+++ b/code/web/sys/LibraryLocation/Location.php
@@ -2167,8 +2167,8 @@ class Location extends DataObject {
 		}
 	}
 
-	public function getCloudLibraryScope(): null|string|int {
-		if ($this->_cloudLibraryScope == null && $this->locationId) {
+	public function getCloudLibraryScope(): int {
+		if ($this->_cloudLibraryScope === null && $this->locationId) {
 			require_once ROOT_DIR . '/sys/CloudLibrary/LocationCloudLibraryScope.php';
 			$locationCloudLibraryScope = new LocationCloudLibraryScope();
 			$locationCloudLibraryScope->locationId = $this->locationId;
@@ -2179,6 +2179,10 @@ class Location extends DataObject {
 				if ($cloudLibraryScope->find(true)) {
 					$this->_cloudLibraryScope = $cloudLibraryScope->id;
 				}
+			}
+			// If still not set, default to '-1', which corresponds to 'none'.
+			if ($this->_cloudLibraryScope === null) {
+				$this->_cloudLibraryScope = -1;
 			}
 		}
 		return $this->_cloudLibraryScope;


### PR DESCRIPTION
- Object History Improvements:
  - Improved change tracking for child objects so edits to settings now capture individual field changes such as renames, toggles, and date edits.
  - Added deletion tracking so removing a child object creates a clear history entry showing which item was deleted.
  - Made history entries display human-readable names instead of raw IDs to make changes easier to understand.
  - Adjusted history logging to only record updates when related items are actually added, removed, or reordered, thus reducing unnecessary entries.
  - Fixed an issue where Library and Location records defaulted to "none" on every save, preventing spurious history entries.

Test Plan: Edit various fields in various settings and view their Object Histories.