### PR TITLE
DIS-1076: Object Restoration Functionality

### DIFF
--- a/code/web/cron/purgeSoftDeleted.php
+++ b/code/web/cron/purgeSoftDeleted.php
@@ -1,0 +1,24 @@
+<?php
+
+require_once __DIR__ . '/../bootstrap.php';
+require_once __DIR__ . '/../bootstrap_aspen.php';
+
+/**
+ * Purge soft-deleted objects that have been in the "recycle-bin" for more than 30 days.
+ *
+ * This is executed nightly at 23:59 PM server local time
+ * so administrators still have the entire "Final Day" to
+ * restore objects before automatic removal.
+ */
+global $logger;
+require_once ROOT_DIR . '/services/Admin/ObjectRestorations.php';
+$softDeleteClasses = Admin_ObjectRestorations::getManagedClasses();
+
+$totalPurged = 0;
+foreach ($softDeleteClasses as $className) {
+	if (class_exists($className) && method_exists($className, 'purgeExpired')) {
+		$totalPurged += $className::purgeExpired();
+	}
+}
+
+$logger->log("Soft-delete purge complete: $totalPurged rows permanently removed from the database.", Logger::LOG_DEBUG);

--- a/code/web/interface/themes/responsive/Admin/compareObjects.tpl
+++ b/code/web/interface/themes/responsive/Admin/compareObjects.tpl
@@ -9,8 +9,8 @@
 		<thead>
 			<tr>
 				<th>{translate text="Property Name" isAdminFacing=true}</th>
-				<th>{translate text="Value 1" isAdminFacing=true} <a href="{$object1EditUrl}" class="btn btn-sm btn-default">{translate text="Edit" isAdminFacing=true}</a></th>
-				<th>{translate text="Value 2" isAdminFacing=true}  <a href="{$object2EditUrl}" class="btn btn-sm btn-default">{translate text="Edit" isAdminFacing=true}</a></th>
+				<th>{translate text="Value 1" isAdminFacing=true} {if !empty($showEditButtons) && !empty($object1EditUrl)}<a href="{$object1EditUrl}" class="btn btn-sm btn-default">{translate text="Edit" isAdminFacing=true}</a>{/if}</th>
+				<th>{translate text="Value 2" isAdminFacing=true} {if !empty($showEditButtons) && !empty($object2EditUrl)}<a href="{$object2EditUrl}" class="btn btn-sm btn-default">{translate text="Edit" isAdminFacing=true}</a>{/if}</th>
 			</tr>
 		</thead>
 		<tbody>
@@ -25,8 +25,8 @@
 		<tfoot>
 			<tr>
 				<th></th>
-				<th><a href="{$object1EditUrl}" class="btn btn-sm btn-default">{translate text="Edit" isAdminFacing=true}</a></th>
-				<th><a href="{$object2EditUrl}" class="btn btn-sm btn-default">{translate text="Edit" isAdminFacing=true}</a></th>
+				<th>{if !empty($showEditButtons) && !empty($object1EditUrl)}<a href="{$object1EditUrl}" class="btn btn-sm btn-default">{translate text="Edit" isAdminFacing=true}</a>{/if}</th>
+				<th>{if !empty($showEditButtons) && !empty($object2EditUrl)}<a href="{$object2EditUrl}" class="btn btn-sm btn-default">{translate text="Edit" isAdminFacing=true}</a>{/if}</th>
 			</tr>
 		</tfoot>
 	</table>

--- a/code/web/interface/themes/responsive/Admin/objectEditor.tpl
+++ b/code/web/interface/themes/responsive/Admin/objectEditor.tpl
@@ -48,7 +48,7 @@
 					{/if}
 				</div>
 				<div class="btn-group" role="group">
-					{if !empty($id) && $id > 0 && $canDelete && $object->canActiveUserDelete()}<a class="btn btn-danger" href='/{$module}/{$toolName}?id={$id}&amp;objectAction=delete' onclick='return confirm("{translate text='Are you sure you want to delete this %1%?' 1=$objectType inAttribute=true isAdminFacing=true}")'><i class="fas fa-trash" role="presentation"></i> {translate text="Delete" isAdminFacing=true}</a>{/if}
+					{if !empty($id) && $id > 0 && $canDelete && $object->canActiveUserDelete()}<a class="btn btn-danger" href="#" onclick="AspenDiscovery.confirm('Delete {$objectType} #{$id}', '{translate text='Are you sure you want to delete %1% with ID %2%?' 1=$objectType 2=$id inAttribute=true isAdminFacing=true}', '{translate text='Delete' isAdminFacing=true inAttribute=true}', '{translate text='Cancel' isAdminFacing=true inAttribute=true}', true, 'window.location.href=&quot;/{$module}/{$toolName}?id={$id}&objectAction=delete&quot;', 'btn-danger'); return false;"><i class="fas fa-trash" role="presentation"></i> {translate text="Delete" isAdminFacing=true}</a>{/if}
 				</div>
 			</div>
 		</div>

--- a/code/web/interface/themes/responsive/Admin/objectHistory.tpl
+++ b/code/web/interface/themes/responsive/Admin/objectHistory.tpl
@@ -6,7 +6,9 @@
 {if !empty($showReturnToList)}
 	<a class="btn btn-default" href='/{$module}/{$toolName}?objectAction=list'><i class="fas fa-arrow-alt-circle-left" role="presentation"></i> {translate text="Return to List" isAdminFacing=true}</a>
 {/if}
+{if !empty($showEditButtons)}
 <a class="btn btn-default" href='/{$module}/{$toolName}?objectAction=edit&id={$id}'>{translate text="Edit" isAdminFacing=true}</a>
+{/if}
 
 {if count($objectHistory) > 0}
 	<table class="table table-striped table-sticky">

--- a/code/web/interface/themes/responsive/Admin/propertiesList.tpl
+++ b/code/web/interface/themes/responsive/Admin/propertiesList.tpl
@@ -14,7 +14,7 @@
 </div>
 
 {if !empty($updateMessage)}
-	<div class="alert {if !empty($updateMessageIsError)}alert-danger{else}alert-info{/if}">
+	<div class="alert {if !empty($updateMessageIsError)}alert-danger{else}alert-success{/if}">
 		{$updateMessage}
 	</div>
 {/if}
@@ -265,7 +265,7 @@
 		<div class="row" style="padding-top: 1em">
 			<div class="btn-group col-sm-12">
 				{foreach from=$customListActions item=customAction}
-					<button type='submit' value='{$customAction.action}' class="btn btn-default" onclick="$('#objectAction').val('{$customAction.action}'){if !empty($customAction.onclick)};{$customAction.onclick}{/if}">{translate text=$customAction.label isAdminFacing=true}</button>
+					<button type='submit' value='{$customAction.action}' class='btn{if !empty($customAction.class)} {$customAction.class}{else} btn-default{/if}'{if !empty($customAction.onclick)} onclick="$('#objectAction').val('{$customAction.action}');{$customAction.onclick nofilter}"{/if}>{translate text=$customAction.label isAdminFacing=true}</button>
 				{/foreach}
 			</div>
 		</div>

--- a/code/web/interface/themes/responsive/js/aspen/admin.js
+++ b/code/web/interface/themes/responsive/js/aspen/admin.js
@@ -2612,6 +2612,33 @@ AspenDiscovery.Admin = (function () {
 					</div>
 				`);
 			}
+		},
+
+		recycleBinDelete(scope) {
+			const selected = $('.selectedObject:checked');
+			const count = selected.length;
+			let title, body, okLabel;
+
+			if (scope === 'selected') {
+				if (!selected.length) {
+					AspenDiscovery.showMessage('Failed to Delete Selected Objects', 'Please select at least one object to delete.');
+					return false;
+				}
+			}
+			if (scope === 'all') {
+				title = 'Permanently Delete All';
+				body = 'Are you sure you want to permanently delete ALL objects? This action cannot be undone.';
+				okLabel = 'Delete All';
+			} else {
+				title = 'Permanently Delete Selected';
+				body = 'Are you sure you want to permanently delete ' + count + ' object(s)? This action cannot be undone.';
+				okLabel = 'Delete';
+			}
+
+			const confirmJs = "$(\"#objectAction\").val(\"batchHardDelete\"); $(\"#propertiesListForm\").submit();";
+
+			AspenDiscovery.confirm(title, body, okLabel, 'Cancel', true, confirmJs, 'btn-danger');
+			return false;
 		}
 	};
 }(AspenDiscovery.Admin || {}));

--- a/code/web/interface/themes/responsive/js/aspen/lists.js
+++ b/code/web/interface/themes/responsive/js/aspen/lists.js
@@ -33,8 +33,17 @@ AspenDiscovery.Lists = (function(){
 			return this.submitListForm('makePrivate');
 		},
 
-		deleteListAction: function (){
-			AspenDiscovery.confirm("Delete List?", "Are you sure you want to delete this entire list? The list and all titles within it will be permanently deleted.","Yes", "No", true, "AspenDiscovery.Lists.doDeleteList()", "btn-danger");
+		deleteListAction(){
+			const messageTitle = "Delete List?";
+			const messageBody = "Are you sure you want to delete this entire list? The list and all titles within it will be soft-deleted and can be restored within 30 days.<br/><br/>" +
+				"<div>" +
+				"<input type='checkbox' id='optOutSoftDeletion' style='margin-right: 5px;'>" +
+				"<label class='form-check-label' for='optOutSoftDeletion'>Opt Out of Soft Deletion</label>" +
+				"</div>";
+
+			let buttons = "<button id='confirmDeleteList' class='tool btn btn-danger' onclick='AspenDiscovery.Lists.doDeleteList()'><span class='fas fa-spinner fa-spin' style='display:none; margin-right: 4px;'></span>Yes</button>";
+			buttons += "<button id='cancelDeleteList' class='tool btn btn-default' onclick='AspenDiscovery.closeLightbox()'>No</button>";
+			AspenDiscovery.showMessageWithButtons(messageTitle, messageBody, buttons, false, '', false, false, true);
 			return false;
 		},
 
@@ -42,8 +51,16 @@ AspenDiscovery.Lists = (function(){
 			window.location.href = Globals.path + '/MyAccount/MyList/' + listId + '?delete=' + listEntryId;
 		},
 
-		doDeleteList: function () {
-			this.submitListForm('deleteList');
+		doDeleteList() {
+			$('#confirmDeleteList .fa-spinner').show();
+			$('#confirmDeleteList').prop('disabled', true);
+			const hardDelete = $('#optOutSoftDeletion').is(':checked');
+
+			if (hardDelete) {
+				this.submitListForm('deleteListHard');
+			} else {
+				this.submitListForm('deleteList');
+			}
 		},
 
 		updateListAction: function (){

--- a/code/web/interface/themes/responsive/js/aspen/web-builder.js
+++ b/code/web/interface/themes/responsive/js/aspen/web-builder.js
@@ -228,39 +228,52 @@ AspenDiscovery.WebBuilder = function () {
 			return false;
 		},
 
-		deleteCell: function (id) {
-			if (!confirm("Are you sure you want to delete this cell?")){
-				return false;
-			}
-			var url = Globals.path + '/WebBuilder/AJAX';
-			var params = {
+		deleteCell(id) {
+			AspenDiscovery.confirm('Delete Cell', `Are you sure you want to delete this cell (ID: ${id})?`, 'Delete', 'Cancel', true, `AspenDiscovery.WebBuilder.deleteCellConfirmed("${id}")`, 'btn-danger');
+			return false;
+		},
+
+		deleteCellConfirmed(id) {
+			const url = `${Globals.path}/WebBuilder/AJAX`;
+			const params = {
 				method: 'deleteCell',
-				id: id
+				id
 			};
-			$.getJSON(url, params, function (data) {
-				if (data.success){
-					$('#portalRow' + data.rowId).replaceWith(data.newRow);
+
+			$.getJSON(url, params, (data) => {
+				const { success, rowId, newRow,  message} = data || [];
+				if (success) {
+					const $targetRow = $(`#portalRow${rowId}`);
+					if ($targetRow.length) {
+						$targetRow.replaceWith(newRow);
+					}
+					AspenDiscovery.closeLightbox();
 				} else {
-					AspenDiscovery.showMessage('An error occurred', data.message);
+					AspenDiscovery.showMessage('Error Deleting Cell', data.message);
 				}
 			});
 			return false;
 		},
 
-		deleteRow: function (id) {
-			if (!confirm("Are you sure you want to delete this row?")){
-				return false;
-			}
-			var url = Globals.path + '/WebBuilder/AJAX';
-			var params = {
+		deleteRow(id) {
+			AspenDiscovery.confirm('Delete Row', `Are you sure you want to delete this row (ID: ${id})?`, 'Delete', 'Cancel', true, `AspenDiscovery.WebBuilder.deleteRowConfirmed("${id}")`, 'btn-danger');
+			return false;
+		},
+
+		deleteRowConfirmed(id) {
+			const url = `${Globals.path}/WebBuilder/AJAX`;
+			const params = {
 				method: 'deleteRow',
-				id: id
+				id
 			};
-			$.getJSON(url, params, function (data) {
-				if (data.success){
+
+			$.getJSON(url, params, (data) => {
+				const { success, message } = data;
+				if (success){
 					$("#portalRow" + id).hide();
+					AspenDiscovery.closeLightbox();
 				} else {
-					AspenDiscovery.showMessage('An error occurred', data.message);
+					AspenDiscovery.showMessage('Error Deleting Row', data.message);
 				}
 			});
 			return false;

--- a/code/web/release_notes/25.08.00.MD
+++ b/code/web/release_notes/25.08.00.MD
@@ -39,6 +39,26 @@
 - Fixed an issue where dates shown in Open Archives collections would differ from the dates displayed on external archive websites. (DIS-1063) (*LS*)
 - Added detailed progress tracking and log entries for Open Archives indexing. (DIS-1063) (*LS*)
 
+### Administration Updates
+- Object Restorations
+  - The following objects can be restored after their deletion:
+    - User Lists
+      - Patrons may choose "Opt Out of Soft Deletion" to permanently delete them immediately.
+    - Basic Pages 
+    - Custom Pages (Portal Pages)
+    - Custom Forms 
+    - Web Resource Pages 
+    - Web Resources 
+    - Image Uploads (hard-deleting removes the file from the server)
+    - File Uploads (hard-deleting removes the file from the server)
+    - Placards
+  - A daily process permanently deletes any items that have been soft-deleted for more than 30 days.
+  - A new permission, "Administer Object Restoration," is required to access the Restore Deleted Objects page.
+
+### Other Updates
+- Edit buttons on compare and history pages can be controlled by a new utility method: `ObjectEditor::showEditButtons()`.
+- All portal row, portal cell, and object deletions on their respective pages now use the standard confirmation modal.
+
 // yanjun
 
 // laura

--- a/code/web/services/Admin/ObjectEditor.php
+++ b/code/web/services/Admin/ObjectEditor.php
@@ -869,13 +869,17 @@ abstract class ObjectEditor extends Admin_Admin {
 			foreach ($_REQUEST['selectedObject'] as $id => $value) {
 				if ($index == 1) {
 					$object1 = $this->getExistingObjectById($id);
-					$object1EditUrl = "/{$this->getModule()}/{$this->getToolName()}?objectAction=edit&id=$id";
-					$interface->assign('object1EditUrl', $object1EditUrl);
+					if ($this->showEditButtons()) {
+						$object1EditUrl = "/{$this->getModule()}/{$this->getToolName()}?objectAction=edit&id=$id";
+						$interface->assign('object1EditUrl', $object1EditUrl);
+					}
 					$index = 2;
 				} else {
 					$object2 = $this->getExistingObjectById($id);
-					$object2EditUrl = "/{$this->getModule()}/{$this->getToolName()}?objectAction=edit&id=$id";
-					$interface->assign('object2EditUrl', $object2EditUrl);
+					if ($this->showEditButtons()) {
+						$object2EditUrl = "/{$this->getModule()}/{$this->getToolName()}?objectAction=edit&id=$id";
+						$interface->assign('object2EditUrl', $object2EditUrl);
+					}
 				}
 			}
 			if ($object1 == null || $object2 == null) {
@@ -890,6 +894,10 @@ abstract class ObjectEditor extends Admin_Admin {
 			$interface->assign('error', 'Please select two objects to compare');
 		}
 
+		$interface->assign('showEditButtons', $this->showEditButtons());
+		$interface->assign('showReturnToList', $this->getToolName() === 'ObjectRestorations');
+		$interface->assign('module', $this->getModule());
+		$interface->assign('toolName', $this->getToolName());
 		$interface->setTemplate('../Admin/compareObjects.tpl');
 	}
 
@@ -1020,6 +1028,9 @@ abstract class ObjectEditor extends Admin_Admin {
 			//Work with an existing record
 			global $interface;
 			$curObject = $this->getExistingObjectById($id);
+			if (!$curObject) {
+				AspenError::raiseError('The object with ID ' . $id . ' does not exist.');
+			}
 			$interface->assign('curObject', $curObject);
 			$interface->assign('id', $id);
 			$displayNameColumn = $curObject->__displayNameColumn;
@@ -1049,6 +1060,9 @@ abstract class ObjectEditor extends Admin_Admin {
 				$objectHistory[] = clone $historyEntry;
 			}
 			$interface->assign('objectHistory', $objectHistory);
+			$interface->assign('showEditButtons', $this->showEditButtons());
+			$interface->assign('module', $this->getModule());
+			$interface->assign('toolName', $this->getToolName());
 			$this->display('../Admin/objectHistory.tpl', $title);
 			exit();
 		}
@@ -1373,6 +1387,15 @@ abstract class ObjectEditor extends Admin_Admin {
 	}
 
 	protected function showHistoryLinks() {
+		return true;
+	}
+
+	/**
+	 * Control whether edit buttons should be shown in history and compare views.
+	 * Purpose: Override it to hide edit functionality when appropriate.
+	 * @return bool True if edit buttons are enabled, false otherwise.
+	 */
+	protected function showEditButtons(): bool {
 		return true;
 	}
 

--- a/code/web/services/Admin/ObjectRestorations.php
+++ b/code/web/services/Admin/ObjectRestorations.php
@@ -1,0 +1,514 @@
+<?php
+
+use JetBrains\PhpStorm\NoReturn;
+
+require_once ROOT_DIR . '/services/Admin/ObjectEditor.php';
+require_once ROOT_DIR . '/sys/ObjectRestoration.php';
+
+/**
+ * Displays every soft-deleted row across a curated set of classes
+ * and lets privileged staff restore or permanently purge them.
+ *
+ * To add a new object for restoration:
+ * 1. Ensure the target DataObject implements `supportsSoftDelete()` returning
+ *    `true` and that its table contains `deleted` (TINYINT(1)), `dateDeleted` (INT),
+ *    and `deletedBy` (INT(11)) columns.  The base `DataObject` already handles
+ *    the logic.
+ * 2. Append an entry to `self::$managedClasses` below:
+ *        `'NewClass' => [
+ *            'titleColumn' => 'title',
+ *            'classFile'   => '/sys/Path/To/NewClass.php',
+ *        ],`
+ *    Use the path from `ROOT_DIR` so the class can be lazy-required.
+ * 3. Modify the target DataObject's `delete()` method to prevent deletions of
+ *    object dependencies unless `$useWhere` is `true`, which indicates a hard deletion.
+ *    If the target DataObject has no `delete()`, you may have to override `purgeExpired`
+ *    for proper hard-deletion cleanup (e.g., ImageUpload).
+ * 4. The batch-purge cron and UI will pick it up the next time the admin page is loaded.
+ */
+class Admin_ObjectRestorations extends ObjectEditor {
+	private static array $managedClasses = [
+		'UserList'              => ['titleColumn' => 'title', 'classFile' => '/sys/UserLists/UserList.php'],
+		'BasicPage'             => ['titleColumn' => 'title', 'classFile' => '/sys/WebBuilder/BasicPage.php'],
+		'PortalPage'            => ['titleColumn' => 'title', 'classFile' => '/sys/WebBuilder/PortalPage.php'],
+		'CustomForm'            => ['titleColumn' => 'title', 'classFile' => '/sys/WebBuilder/CustomForm.php'],
+		'CustomWebResourcePage' => ['titleColumn' => 'title', 'classFile' => '/sys/WebBuilder/CustomWebResourcePage.php'],
+		'WebResource'           => ['titleColumn' => 'name',  'classFile' => '/sys/WebBuilder/WebResource.php'],
+		'ImageUpload'           => ['titleColumn' => 'title', 'classFile' => '/sys/File/ImageUpload.php'],
+		'FileUpload'            => ['titleColumn' => 'title', 'classFile' => '/sys/File/FileUpload.php'],
+		'Placard'               => ['titleColumn' => 'title', 'classFile' => '/sys/LocalEnrichment/Placard.php'],
+	];
+	private array $cachedRows;
+
+	public function __construct() {
+		parent::__construct();
+		$this->cachedRows = $this->buildRows();
+	}
+
+	function getObjectType(): string { return 'ObjectRestoration'; }
+	function getToolName(): string  { return 'ObjectRestorations'; }
+	function getModule(): string    { return 'Admin'; }
+	function getPageTitle(): string { return 'Restore Deleted Objects'; }
+	function getDefaultSort(): string { return 'deletedOn desc'; }
+	function getPrimaryKeyColumn(): string { return 'compositeId'; }
+	function getIdKeyColumn(): string { return 'compositeId'; }
+	function canView(): bool { return UserAccount::userHasPermission('Administer Object Restoration'); }
+	function canAddNew(): bool { return false; }
+	function canDelete(): bool { return true; }
+	function canEdit(DataObject $object): bool { return false; }
+	function canCopy(): bool { return false; }
+	function canBatchDelete(): bool { return false; }
+	function canBatchEdit(): bool { return false; }
+	function canCompare(): bool { return true; }
+	protected function showHistoryLinks(): bool { return false; }
+	protected function showEditButtons(): bool { return false; }
+	public function canActiveUserEdit() : bool { return false; }
+	public function canExportToCSV() : bool { return false; }
+
+	function getAllObjects($page, $recordsPerPage): array {
+		$offset = ($page - 1) * $recordsPerPage;
+		return array_slice($this->cachedRows, $offset, $recordsPerPage, true);
+	}
+	function getNumObjects(): int { return count($this->cachedRows); }
+
+	function getObjectStructure($context = ''): array {
+		// For comparison, use the actual object's structure instead of ObjectRestoration's minimal structure.
+		if ($context === 'compare' && isset($_REQUEST['selectedObject'])) {
+			$selectedObjects = array_keys($_REQUEST['selectedObject']);
+			if (!empty($selectedObjects)) {
+				$id = $selectedObjects[0];
+				if (str_contains($id, '_')) {
+					[$objectType, $actualId] = explode('_', $id, 2);
+					if (class_exists($objectType)) {
+						$managedClasses = self::$managedClasses;
+						if (isset($managedClasses[$objectType])) {
+							require_once ROOT_DIR . self::$managedClasses[$objectType]['classFile'];
+							$tempObject = new $objectType();
+							$structure = $tempObject->getObjectStructure($context);
+							$structure['dateDeleted'] = [
+								'property' => 'dateDeleted',
+								'type' => 'timestamp',
+								'label' => 'Deleted',
+								'hideInLists' => true,
+							];
+							$structure['deletedBy'] = [
+								'property' => 'deletedBy',
+								'type' => 'label',
+								'label' => 'Deleted By',
+								'hideInLists' => true,
+							];
+							return $structure;
+						}
+					}
+				}
+			}
+		}
+		return ObjectRestoration::getObjectStructure($context);
+	}
+
+	/**
+	 * Scan all managed classes for rows where `deleted = 1` and `dateDeleted > 0`.
+	 *
+	 * Because the list is virtual, build it once per request and cache the
+	 * resulting `ObjectRestoration` objects in `$this->cachedRows`.
+	 *
+	 * @return ObjectRestoration[] Keyed by composite ID `<Class>_<pk>`.
+	 */
+	private function buildRows(): array {
+		$rows = [];
+		foreach (self::$managedClasses as $class => $info) {
+			// Lazy-load class definition only when iterating.
+			require_once ROOT_DIR . $info['classFile'];
+			$sample = new $class();
+			// Select only necessary columns for faster lookup.
+			$sample->selectAdd();
+			$sample->selectAdd($sample->getPrimaryKey());
+			$sample->selectAdd($info['titleColumn']);
+			$sample->selectAdd('dateDeleted');
+			$sample->selectAdd('deletedBy');
+			if ($class === 'UserList') {
+				$sample->selectAdd('user_id');
+			}
+			if (!method_exists($sample, 'supportsSoftDelete') || !$sample->supportsSoftDelete()) continue;
+
+			$sample->_includeDeleted = true;
+			$sample->deleted = 1;
+			$sample->whereAdd('dateDeleted > 0');
+			$sample->find();
+			while ($sample->fetch()) {
+				$rows[$class . '_' . $sample->getPrimaryKeyValue()] = $this->createRestorationItem($sample, $class, $info['titleColumn']);
+			}
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * Convert a real soft-deleted DataObject into an `ObjectRestoration`
+	 * virtual object that the list can display.
+	 *
+	 * @param DataObject $orig Original soft-deleted object.
+	 * @param string $class Class name (same as object type).
+	 * @param string $titleColumn Column holding the human-readable title.
+	 * @return ObjectRestoration Populated virtual row.
+	 */
+	private function createRestorationItem(DataObject $orig, string $class, string $titleColumn): ObjectRestoration {
+		$item = new ObjectRestoration();
+		$item->objectType = $class;
+		$item->id = $orig->getPrimaryKeyValue();
+		$item->compositeId = $class . '_' . $item->id;
+		$item->title = $orig->$titleColumn ?? '';
+
+		// User info enrich (only for UserList).
+		if ($class === 'UserList' && property_exists($orig, 'user_id') && !empty($orig->user_id)) {
+			require_once ROOT_DIR . '/sys/Account/User.php';
+			$user = new User();
+			$user->id = $orig->user_id;
+			if ($user->find(true)) {
+				$item->userInfo = trim($user->getBarcode() . ' - ' . $user->getDisplayName(), ' -');
+			} else {
+				$item->userInfo = 'User ID: ' . $orig->user_id;
+			}
+		}
+
+		if (!empty($orig->dateDeleted)) {
+			$item->deletedOn = date('Y-m-d H:i', $orig->dateDeleted);
+			$expires = $orig->dateDeleted + 2592000; // 30 days
+			$item->daysRemaining = max(0, floor(($expires - time()) / 86400));
+			if ($item->daysRemaining <= 0) {
+				$item->daysRemaining = 'Final Day!';
+			}
+		}
+
+		if (!empty($orig->deletedBy)) {
+			require_once ROOT_DIR . '/sys/Account/User.php';
+			$deletingUser = new User();
+			$deletingUser->id = $orig->deletedBy;
+			if ($deletingUser->find(true)) {
+				$item->deletedBy = trim($deletingUser->getBarcode() . ' - ' . $deletingUser->getDisplayName(), ' -');
+			} else {
+				$item->deletedBy = 'User ID: ' . $orig->deletedBy;
+			}
+		} else {
+			$item->deletedBy = 'Unknown';
+		}
+
+		return $item;
+	}
+
+	/**
+	 * Restore a single object from the "recycle-bin" back to an active state.
+	 */
+	#[NoReturn] public function restore(): void {
+		$compositeId = $_REQUEST['id'] ?? '';
+		$user = UserAccount::getActiveUserObj();
+		if (str_contains($compositeId, '_')) {
+			[$class, $id] = explode('_', $compositeId, 2);
+			if (class_exists($class)) {
+				$obj = new $class();
+				$pk = $obj->getPrimaryKey();
+				$obj->$pk = $id;
+				$obj->_includeDeleted = true;
+				if ($obj->find(true)) {
+					if ($obj->restore()) {
+						$user->updateMessage = "Restored $class #$id.";
+						$user->updateMessageIsError = false;
+					} else {
+						$user->updateMessage = "Failed to restore $class #$id.";
+						$user->updateMessageIsError = true;
+					}
+					$user->update();
+				}
+			}
+		}
+		header('Location: /Admin/ObjectRestorations');
+		exit;
+	}
+
+	#[NoReturn] public function history(): void {
+		$this->showHistory();
+	}
+
+	/**
+	 * Permanently delete one soft-deleted row (hard delete).
+	 *
+	 * @noinspection PhpUnused
+	 */
+	#[NoReturn] public function hardDeleteSingle(): void {
+		$compositeId = $_REQUEST['id'] ?? '';
+		$user = UserAccount::getActiveUserObj();
+		if (str_contains($compositeId, '_')) {
+			[$class, $id] = explode('_', $compositeId, 2);
+			if (class_exists($class)) {
+				$deleteObj = new $class();
+				$pk = $deleteObj->getPrimaryKey();
+				$deleteObj->$pk = $id;
+				$deleteObj->_includeDeleted = true;
+
+				if ($deleteObj->find(true)) {
+					if ($deleteObj->delete(true)) {
+						$user->updateMessage = "Permanently deleted $class #$id.";
+						$user->updateMessageIsError = false;
+					} else {
+						$user->updateMessage = "Failed to delete $class #$id.";
+						$user->updateMessageIsError = true;
+					}
+				} else {
+					$user->updateMessage = "Could not find $class #$id for deletion.";
+					$user->updateMessageIsError = true;
+				}
+				$user->update();
+			}
+		}
+		header('Location: /Admin/ObjectRestorations');
+		exit;
+	}
+
+	/**
+	 * Permanently delete many (or all) soft-deleted rows.
+	 * If no checkboxes are selected, assume "delete all".
+	 *
+	 * @noinspection PhpUnused
+	 */
+	#[NoReturn] public function batchHardDelete(): void {
+		$selected = $_REQUEST['selectedObject'] ?? [];
+		if (empty($selected)) {
+			$selected = array_keys($this->cachedRows);
+		}
+
+		$deletedCnt = 0;
+		foreach ($selected as $compositeId => $unused) {
+			$key = is_numeric($compositeId) ? $unused : $compositeId;
+			if (!str_contains($key, '_')) continue;
+			[$class, $id] = explode('_', $key, 2);
+			if (!class_exists($class)) continue;
+			$obj = new $class();
+			$pk = $obj->getPrimaryKey();
+			$obj->$pk = $id;
+			$obj->_includeDeleted = true;
+			if ($obj->find(true)) {
+				if ($obj->delete(true)) $deletedCnt++;
+			}
+		}
+
+		$user = UserAccount::getActiveUserObj();
+		$user->updateMessage = "Permanently deleted $deletedCnt object(s).";
+		$user->updateMessageIsError = false;
+		$user->update();
+
+		header('Location: /Admin/ObjectRestorations');
+		exit;
+	}
+
+	/**
+	 * ObjectEditor override that retrieves an object even if it is soft-deleted
+	 * so the history and comparison screens still work.
+	 *
+	 * @param $id
+	 * @return ?DataObject
+	 */
+	function getExistingObjectById($id): ?DataObject {
+		if (!str_contains($id, '_')) {
+			return null;
+		}
+		[$objectType, $actualId] = explode('_', $id, 2);
+		if (!class_exists($objectType)) { return null; }
+
+		$object = new $objectType();
+		$pk = $object->getPrimaryKey();
+		$object->$pk = $actualId;
+		$object->_includeDeleted = true;
+		if ($object->find(true)) {
+			if (isset(self::$managedClasses[$objectType])) {
+				$titleColumn = self::$managedClasses[$objectType]['titleColumn'];
+				// Map labeling fields (e.g., name) to title for comparison display.
+				if ($titleColumn !== 'title' && isset($object->$titleColumn)) {
+					$object->title = $object->$titleColumn;
+				}
+			}
+			return $object;
+		}
+		return null;
+	}
+
+	/**
+	 * Override to handle special property value formatting for ObjectRestoration fields.
+	 *
+	 * @param $property
+	 * @param $propertyValue
+	 * @param $propertyType
+	 * @return string
+	 */
+	public function getPropertyValue($property, $propertyValue, $propertyType): string {
+		if ($property['property'] === 'deletedBy' && !empty($propertyValue)) {
+			require_once ROOT_DIR . '/sys/Account/User.php';
+			$deletingUser = new User();
+			$deletingUser->id = $propertyValue;
+			if ($deletingUser->find(true)) {
+				return trim($deletingUser->getBarcode() . ' - ' . $deletingUser->getDisplayName(), ' -');
+			} else {
+				return 'User ID: ' . $propertyValue;
+			}
+		}
+
+		if ($property['property'] === 'dateDeleted' && !empty($propertyValue)) {
+			return date('Y-m-d H:i', $propertyValue);
+		}
+
+		$result = parent::getPropertyValue($property, $propertyValue, $propertyType);
+		return $result ?? '';
+	}
+
+	public function customListActions(): array {
+		$selectedOnclick = "return AspenDiscovery.Admin.recycleBinDelete('selected');";
+		$allOnclick = "return AspenDiscovery.Admin.recycleBinDelete('all');";
+
+		return [
+			[
+				'label' => '<i class="fas fa-trash"></i> Permanently Delete Selected',
+				'action' => 'batchHardDelete',
+				'class' => 'btn-danger',
+				'onclick' => $selectedOnclick,
+			],
+			[
+				'label' => '<i class="fas fa-trash"></i> Permanently Delete All',
+				'action' => 'batchHardDelete',
+				'class' => 'btn-danger',
+				'onclick' => $allOnclick,
+			],
+		];
+	}
+
+	/**
+	 * ObjectEditor override because ObjectRestoration is a virtual object, so the standard
+	 * SQL-based filtering/sorting in the parent viewExistingObjects() doesn't apply.
+	 *
+	 * @param $structure
+	 */
+	public function viewExistingObjects($structure): void {
+		global $interface;
+		$interface->assign('instructions', $this->getListInstructions());
+		$interface->assign('sortableFields', $this->getSortableFields($structure));
+		$sort = $_REQUEST['sort'] ?? $this->getDefaultSort();
+		$interface->assign('sort', $sort);
+		$filterFields = $this->getFilterFields($structure);
+		$interface->assign('filterFields', $filterFields);
+		$appliedFilters = $this->getAppliedFilters($filterFields);
+		$interface->assign('appliedFilters', $appliedFilters);
+		$interface->assign('hiddenFields', $this->getHiddenFields());
+
+		$rows = $this->cachedRows;
+		foreach ($appliedFilters as $filter) {
+			$field = $filter['field']['property'];
+			$type = $filter['filterType'] ?? 'contains';
+			$value = (string)($filter['filterValue'] ?? '');
+			$value2 = (string)($filter['filterValue2'] ?? '');
+
+			$timestamp1 = null;
+			$timestamp2 = null;
+			if (in_array($type, ['beforeTime', 'afterTime', 'betweenTimes'])) {
+				if ($value !== '') {
+					$timestamp1 = strtotime($value);
+				}
+				if ($value2 !== '') {
+					$timestamp2 = strtotime($value2);
+				}
+			}
+
+			foreach ($rows as $key => $item) {
+				$fieldValueRaw = $item->$field;
+
+				if (in_array($type, ['beforeTime', 'afterTime', 'betweenTimes'])) {
+					// Handle both numeric timestamps and formatted date strings gracefully.
+					if (is_numeric($fieldValueRaw)) {
+						$fieldTimestamp = (int)$fieldValueRaw;
+					} else {
+						$fieldTimestamp = strtotime((string)$fieldValueRaw);
+					}
+				}
+
+				$fieldValue = (string)$fieldValueRaw;
+				$match = match ($type) {
+					'matches' => ($fieldValue === $value),
+					'startsWith' => (stripos($fieldValue, $value) === 0),
+					'beforeTime' => ($timestamp2 !== null && isset($fieldTimestamp) && $fieldTimestamp < $timestamp2),
+					'afterTime' => ($timestamp1 !== null && isset($fieldTimestamp) && $fieldTimestamp > $timestamp1),
+					'betweenTimes' => (
+						$timestamp1 !== null && $timestamp2 !== null && isset($fieldTimestamp) &&
+						$fieldTimestamp > $timestamp1 && $fieldTimestamp < $timestamp2
+					),
+					default => (stripos($fieldValue, $value) !== false),
+				};
+				if (!$match) {
+					unset($rows[$key]);
+				}
+			}
+		}
+
+		[$fieldName, $direction] = array_pad(explode(' ', $sort), 2, 'desc');
+		uasort($rows, function($a, $b) use ($fieldName, $direction) {
+			$valA = $a->$fieldName;
+			$valB = $b->$fieldName;
+			if ($valA == $valB) return 0;
+			$cmp = ($valA < $valB) ? -1 : 1;
+			return (strtolower($direction) === 'desc') ? -$cmp : $cmp;
+		});
+
+		$page = isset($_REQUEST['page']) && is_numeric($_REQUEST['page']) ? (int)$_REQUEST['page'] : 1;
+		$recordsPerPage = isset($_REQUEST['pageSize']) ? (int)$_REQUEST['pageSize'] : $this->getDefaultRecordsPerPage();
+		$totalItems = count($rows);
+		$offset = ($page - 1) * $recordsPerPage;
+		$pagedRows = array_slice($rows, $offset, $recordsPerPage, true);
+
+		if ($this->supportsPagination()) {
+			$options = [
+				'totalItems' => $totalItems,
+				'perPage' => $recordsPerPage,
+				'canChangeRecordsPerPage' => true,
+				'canJumpToPage' => true,
+			];
+			$pager = new Pager($options);
+			$interface->assign('pageLinks', $pager->getLinks());
+		}
+
+		$interface->assign('dataList', $pagedRows);
+		$interface->assign('showQuickFilterOnPropertiesList', $this->showQuickFilterOnPropertiesList());
+		$interface->setTemplate('../Admin/propertiesList.tpl');
+	}
+
+	/**
+	 * Return a list of class names actively managed by the "recycle-bin."
+	 *
+	 * @return string[] Class names.
+	 */
+	public static function getManagedClasses(): array {
+		foreach (self::$managedClasses as $className => $info) {
+			require_once ROOT_DIR . $info['classFile'];
+		}
+		return array_keys(self::$managedClasses);
+	}
+
+	function getActiveAdminSection(): string {
+		return 'system_admin';
+	}
+
+	public function getSortableFields($structure): array {
+		$fields = parent::getSortableFields($structure);
+		unset($fields['Key']);
+		return $fields;
+	}
+
+	public function getFilterFields($structure): array {
+		$fields = parent::getFilterFields($structure);
+		unset($fields['compositeId']);
+		return $fields;
+	}
+
+	function getBreadcrumbs(): array {
+		return [
+			new Breadcrumb('/Admin/Home','Administration Home'),
+			new Breadcrumb('/Admin/Home#system_admin', 'System Administration'),
+			new Breadcrumb('','Restore Deleted Objects')
+		];
+	}
+}

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -3735,8 +3735,6 @@ class MyAccount_AJAX extends JSON_Action {
 				$page = isset($_REQUEST['page']) ? (int)$_REQUEST['page'] : 1;
 				$recordsPerPage = 100; // Could be made configurable in the future if requested.
 				$totalCheckouts = count($allCheckedOut);
-				global $logger;
-				$logger->log("Total checkouts: $totalCheckouts", Logger::LOG_ERROR);
 				if ($recordsPerPage != -1) {
 					$interface->assign('page', $page);
 					$link = $_SERVER['REQUEST_URI'];

--- a/code/web/services/MyAccount/MyList.php
+++ b/code/web/services/MyAccount/MyList.php
@@ -113,6 +113,11 @@ class MyAccount_MyList extends MyAccount {
 
 					header("Location: /MyAccount/Lists");
 					die();
+				} elseif ($actionToPerform == 'deleteListHard') {
+					$list->delete(true);
+
+					header("Location: /MyAccount/Lists");
+					die();
 				} elseif ($actionToPerform == 'bulkAddTitles') {
 					$notes = $this->bulkAddTitles($list);
 					$this->reloadCover();

--- a/code/web/services/WebBuilder/AJAX.php
+++ b/code/web/services/WebBuilder/AJAX.php
@@ -609,10 +609,9 @@ class WebBuilder_AJAX extends JSON_Action {
 	}
 
 	/** @noinspection PhpUnused */
-	function deleteCell() {
+	function deleteCell(): array {
 		$result = [
 			'success' => false,
-			'message' => 'Unknown error deleting cell',
 		];
 		if (UserAccount::isLoggedIn()) {
 			if (UserAccount::userHasPermission([
@@ -625,7 +624,7 @@ class WebBuilder_AJAX extends JSON_Action {
 					$portalCell = new PortalCell();
 					$portalCell->id = $_REQUEST['id'];
 					if ($portalCell->find(true)) {
-						//Update the widths of the cells based on the number of cells in the row
+						// Update the widths of the cells based on the number of cells in the row.
 						$portalRow = new PortalRow();
 						$portalRow->id = $portalCell->portalRowId;
 						$portalCell->delete();
@@ -633,32 +632,31 @@ class WebBuilder_AJAX extends JSON_Action {
 							$portalRow->resizeColumnWidths();
 						}
 						$result['success'] = true;
-						$result['message'] = 'The cell was deleted successfully';
+						//$result['message'] = 'The cell was deleted successfully.';
 						global $interface;
 						$interface->assign('portalRow', $portalRow);
 						$interface->assign('inPageEditor', false);
 						$result['rowId'] = $portalCell->portalRowId;
 						$result['newRow'] = $interface->fetch('DataObjectUtil/portalRow.tpl');
 					} else {
-						$result['message'] = 'Unable to find that cell, it may have been deleted already';
+						$result['message'] = 'Unable to find that cell; it may have been already deleted.';
 					}
 				} else {
-					$result['message'] = 'No cell id was provided';
+					$result['message'] = 'No cell id was provided.';
 				}
 			} else {
-				$result['message'] = 'You don\'t have the correct permissions to delete a cell';
+				$result['message'] = 'You don\'t have the correct permissions to delete a cell.';
 			}
 		} else {
-			$result['message'] = 'You must be logged in to delete a cell';
+			$result['message'] = 'You must be logged in to delete a cell.';
 		}
 		return $result;
 	}
 
 	/** @noinspection PhpUnused */
-	function deleteRow() {
+	function deleteRow(): array {
 		$result = [
 			'success' => false,
-			'message' => 'Unknown error deleting row',
 		];
 		if (UserAccount::isLoggedIn()) {
 			if (UserAccount::userHasPermission([
@@ -672,18 +670,18 @@ class WebBuilder_AJAX extends JSON_Action {
 					if ($portalRow->find(true)) {
 						$portalRow->delete();
 						$result['success'] = true;
-						$result['message'] = 'The row was deleted successfully';
+						//$result['message'] = 'The row was deleted successfully.';
 					} else {
-						$result['message'] = 'Unable to find that row, it may have been deleted already';
+						$result['message'] = 'Unable to find that row; it may have been already deleted.';
 					}
 				} else {
-					$result['message'] = 'No row id was provided';
+					$result['message'] = 'No row id was provided.';
 				}
 			} else {
-				$result['message'] = 'You don\'t have the correct permissions to delete a row';
+				$result['message'] = 'You don\'t have the correct permissions to delete a row.';
 			}
 		} else {
-			$result['message'] = 'You must be logged in to delete a row';
+			$result['message'] = 'You must be logged in to delete a row.';
 		}
 		return $result;
 	}

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -4160,6 +4160,7 @@ class User extends DataObject {
 		$sections['system_admin']->addAction(new AdminAction('USPS Settings', 'Settings to allow Aspen Discovery to validate addresses via USPS API.', '/Admin/USPS'), 'Administer System Variables');
 		$sections['system_admin']->addAction(new AdminAction('Variables', 'Variables set by the Aspen Discovery itself as part of background processes.', '/Admin/Variables'), 'Administer System Variables');
 		$sections['system_admin']->addAction(new AdminAction('System Variables', 'Settings for Aspen Discovery that apply to all libraries on this installation.', '/Admin/SystemVariables'), 'Administer System Variables');
+		$sections['system_admin']->addAction(new AdminAction('Object Restorations', 'Restore soft-deleted objects from the recycle bin.', '/Admin/ObjectRestorations'), 'Administer Object Restoration');
 
 		$sections['system_reports'] = new AdminSection('System Reports');
 		$sections['system_reports']->addAction(new AdminAction('Site Status', 'View Status of Aspen Discovery.', '/Admin/SiteStatus'), 'View System Reports');

--- a/code/web/sys/Administration/PermissionGroup.php
+++ b/code/web/sys/Administration/PermissionGroup.php
@@ -1,4 +1,5 @@
 <?php
+/** @noinspection PhpMissingFieldTypeInspection */
 
 require_once ROOT_DIR . '/sys/DB/DataObject.php';
 

--- a/code/web/sys/Administration/PermissionGroupPermission.php
+++ b/code/web/sys/Administration/PermissionGroupPermission.php
@@ -1,4 +1,5 @@
 <?php
+/** @noinspection PhpMissingFieldTypeInspection */
 
 require_once ROOT_DIR . '/sys/DB/DataObject.php';
 

--- a/code/web/sys/DB/DataObject.php
+++ b/code/web/sys/DB/DataObject.php
@@ -37,6 +37,11 @@ abstract class DataObject implements JsonSerializable {
 
 	public $_deleteOnSave;
 
+	public $deleted;
+	public $dateDeleted;
+	public $deletedBy;
+	public bool $_includeDeleted = false; // When true, find()/count() will include deleted rows.
+
 	function objectHistoryEnabled() : bool {
 		return true;
 	}
@@ -126,6 +131,19 @@ abstract class DataObject implements JsonSerializable {
 		}
 
 		global $aspen_db;
+		if (!isset($aspen_db)) {
+			return false;
+		}
+
+		// Soft-delete support: automatically hide rows where deleted = 1 unless caller opted-in.
+		if (method_exists($this, 'supportsSoftDelete') && $this->supportsSoftDelete()) {
+			$includeDeleted = property_exists($this, '_includeDeleted') ? $this->_includeDeleted : false;
+			$deletedPropIsSet = property_exists($this, 'deleted') && ($this->deleted !== null);
+			if (!$includeDeleted && !$deletedPropIsSet) {
+				$this->whereAdd($this->__table . '.deleted = 0');
+			}
+		}
+
 		global $timer;
 		$query = $this->getSelectQuery($aspen_db);
 		$this->__lastQuery = $query;
@@ -541,8 +559,15 @@ abstract class DataObject implements JsonSerializable {
 		if (!isset($aspen_db)) {
 			return false;
 		}
-		//TODO: Check to see if we need to do any cascading deletes
 
+		if (!$useWhere && $this->supportsSoftDelete()) {
+			$this->deleted = 1;
+			$this->dateDeleted = time();
+			$this->deletedBy = UserAccount::getActiveUserId();
+			return $this->update();
+		}
+
+		//TODO: Check to see if we need to do any cascading deletes
 
 		$primaryKey = $this->__primaryKey;
 
@@ -614,6 +639,16 @@ abstract class DataObject implements JsonSerializable {
 		if (!isset($aspen_db)) {
 			return false;
 		}
+
+		// Soft-delete support: automatically hide rows where deleted = 1 unless caller opted-in.
+		if (method_exists($this, 'supportsSoftDelete') && $this->supportsSoftDelete()) {
+			$includeDeleted = property_exists($this, '_includeDeleted') ? $this->_includeDeleted : false;
+			$deletedPropIsSet = property_exists($this, 'deleted') && ($this->deleted !== null);
+			if (!$includeDeleted && !$deletedPropIsSet) {
+				$this->whereAdd($this->__table . '.deleted = 0');
+			}
+		}
+
 		$query = 'SELECT COUNT(*) from ' . $this->__table;
 		foreach ($this->__joins as $join) {
 			$query .= $this->getJoinQuery($join);
@@ -984,6 +1019,8 @@ abstract class DataObject implements JsonSerializable {
 			if ($name[0] == '_' && strlen($name) > 1 && $name[1] != '_') {
 				if ($name == '_data') {
 					$this->_data = [];
+				} elseif ($name == '_includeDeleted') {
+					$this->_includeDeleted = false;
 				} else {
 					$this->$name = null;
 				}
@@ -1538,5 +1575,47 @@ abstract class DataObject implements JsonSerializable {
 				$logger->log("Forcing regrouping because $propertyName on $objectType ($objectId) was $operation from '$safeOldValue' to '$safeNewValue' by user $userId$additionalContext.", Logger::LOG_ALERT);
 			}
 		}
+	}
+
+	/**
+	 * Override in subclasses that support soft-deletion.
+	 *
+	 * @return bool
+	 */
+	public function supportsSoftDelete(): bool {
+		return false;
+	}
+
+	/**
+	 * Restore a previously soft-deleted record (sets deleted = 0).
+	 *
+	 * @return bool|int
+	 */
+	public function restore(): bool|int {
+		if (!$this->supportsSoftDelete()) return false;
+		$this->deleted = 0;
+		$this->dateDeleted = 0;
+		return $this->update();
+	}
+
+	/**
+	 * Permanently remove soft-deleted rows older than the given age.
+	 *
+	 * @param int $olderThanSecs
+	 * @return int
+	 *
+	 * @noinspection PhpUnused
+	 */
+	public static function purgeExpired(int $olderThanSecs = 2592000): int {
+		$obj = new static();
+		if (!$obj->supportsSoftDelete()) return 0;
+		$obj->deleted = 1;
+		$cutOff = time() - $olderThanSecs;
+		// User Lists deleted (i.e., deleted = 1) before the Object Restorations implementation will be
+		// given dateDeleted = 0 by default in 25.08.00, so make sure to avoid deleting them during purges.
+		// Technically, the dateDeleted > 0 safeguard should be unnecessary because those soft-deleted lists
+		// contain no titles anyway.
+		$obj->whereAdd("dateDeleted > 0 AND dateDeleted < $cutOff");
+		return $obj->delete(true);
 	}
 }

--- a/code/web/sys/DBMaintenance/version_updates/25.08.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.08.00.php
@@ -70,6 +70,20 @@ function getUpdates25_08_00(): array {
 				"ALTER TABLE placards ADD COLUMN IF NOT EXISTS deletedBy INT(11) DEFAULT NULL",
 			],
 		],// add_soft_delete_columns
+		'user_list_deleted_index_cleanup' => [
+			'title' => 'User List Deleted Index Cleanup Table',
+			'description' => 'Create table to track permanently deleted user lists for Solr index cleanup.',
+			'continueOnError' => true,
+			'sql' => [
+				"CREATE TABLE user_list_deleted_index_cleanup (
+					id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+					listId BIGINT NOT NULL,
+					dateDeleted INT(11) NOT NULL,
+					INDEX listId (listId),
+					INDEX dateDeleted (dateDeleted)
+				) ENGINE = InnoDB"
+			]
+		], //user_list_deleted_index_cleanup
 
 		// Laura Escamilla - ByWater Solutions
 

--- a/code/web/sys/DBMaintenance/version_updates/25.08.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.08.00.php
@@ -25,6 +25,51 @@ function getUpdates25_08_00(): array {
 		//Yanjun Li - ByWater
 
 		// Leo Stoyanov - BWS
+		'object_restoration_permission' => [
+			'title' => 'Add Object Restoration Permission',
+			'description' => 'Add new permission to allow administrators to restore soft-deleted objects.',
+			'continueOnError' => true,
+			'sql' => [
+				"INSERT INTO permissions (sectionName, name, requiredModule, weight, description) VALUES ('System Administration', 'Administer Object Restoration', '', 13, 'Allows the user to view and restore soft-deleted objects (e.g., User Lists) within Aspen.')",
+			],
+		],// object_restoration_permission
+		'add_soft_delete_columns' => [
+			'title' => 'Add Soft-Delete Columns to Supported Tables',
+			'description' => 'Ensure tables for soft-deletable objects have deleted and dateDeleted columns.',
+			'continueOnError' => true,
+			'sql' => [
+				"ALTER TABLE user_list ADD COLUMN IF NOT EXISTS deleted TINYINT(1) DEFAULT 0",
+				"ALTER TABLE user_list ADD COLUMN IF NOT EXISTS dateDeleted INT(11) DEFAULT 0",
+				"ALTER TABLE user_list ADD COLUMN IF NOT EXISTS deletedBy INT(11) DEFAULT NULL",
+				"ALTER TABLE user_list_entry ADD COLUMN IF NOT EXISTS deleted TINYINT(1) DEFAULT 0",
+				"ALTER TABLE user_list_entry ADD COLUMN IF NOT EXISTS dateDeleted INT(11) DEFAULT 0",
+				"ALTER TABLE user_list_entry ADD COLUMN IF NOT EXISTS deletedBy INT(11) DEFAULT NULL",
+				"ALTER TABLE web_builder_basic_page ADD COLUMN IF NOT EXISTS deleted TINYINT(1) DEFAULT 0",
+				"ALTER TABLE web_builder_basic_page ADD COLUMN IF NOT EXISTS dateDeleted INT(11) DEFAULT 0",
+				"ALTER TABLE web_builder_basic_page ADD COLUMN IF NOT EXISTS deletedBy INT(11) DEFAULT NULL",
+				"ALTER TABLE web_builder_portal_page ADD COLUMN IF NOT EXISTS deleted TINYINT(1) DEFAULT 0",
+				"ALTER TABLE web_builder_portal_page ADD COLUMN IF NOT EXISTS dateDeleted INT(11) DEFAULT 0",
+				"ALTER TABLE web_builder_portal_page ADD COLUMN IF NOT EXISTS deletedBy INT(11) DEFAULT NULL",
+				"ALTER TABLE web_builder_custom_form ADD COLUMN IF NOT EXISTS deleted TINYINT(1) DEFAULT 0",
+				"ALTER TABLE web_builder_custom_form ADD COLUMN IF NOT EXISTS dateDeleted INT(11) DEFAULT 0",
+				"ALTER TABLE web_builder_custom_form ADD COLUMN IF NOT EXISTS deletedBy INT(11) DEFAULT NULL",
+				"ALTER TABLE web_builder_custom_web_resource_page ADD COLUMN IF NOT EXISTS deleted TINYINT(1) DEFAULT 0",
+				"ALTER TABLE web_builder_custom_web_resource_page ADD COLUMN IF NOT EXISTS dateDeleted INT(11) DEFAULT 0",
+				"ALTER TABLE web_builder_custom_web_resource_page ADD COLUMN IF NOT EXISTS deletedBy INT(11) DEFAULT NULL",
+				"ALTER TABLE web_builder_resource ADD COLUMN IF NOT EXISTS deleted TINYINT(1) DEFAULT 0",
+				"ALTER TABLE web_builder_resource ADD COLUMN IF NOT EXISTS dateDeleted INT(11) DEFAULT 0",
+				"ALTER TABLE web_builder_resource ADD COLUMN IF NOT EXISTS deletedBy INT(11) DEFAULT NULL",
+				"ALTER TABLE image_uploads ADD COLUMN IF NOT EXISTS deleted TINYINT(1) DEFAULT 0",
+				"ALTER TABLE image_uploads ADD COLUMN IF NOT EXISTS dateDeleted INT(11) DEFAULT 0",
+				"ALTER TABLE image_uploads ADD COLUMN IF NOT EXISTS deletedBy INT(11) DEFAULT NULL",
+				"ALTER TABLE file_uploads ADD COLUMN IF NOT EXISTS deleted TINYINT(1) DEFAULT 0",
+				"ALTER TABLE file_uploads ADD COLUMN IF NOT EXISTS dateDeleted INT(11) DEFAULT 0",
+				"ALTER TABLE file_uploads ADD COLUMN IF NOT EXISTS deletedBy INT(11) DEFAULT NULL",
+				"ALTER TABLE placards ADD COLUMN IF NOT EXISTS deleted TINYINT(1) DEFAULT 0",
+				"ALTER TABLE placards ADD COLUMN IF NOT EXISTS dateDeleted INT(11) DEFAULT 0",
+				"ALTER TABLE placards ADD COLUMN IF NOT EXISTS deletedBy INT(11) DEFAULT NULL",
+			],
+		],// add_soft_delete_columns
 
 		// Laura Escamilla - ByWater Solutions
 

--- a/code/web/sys/LocalEnrichment/Placard.php
+++ b/code/web/sys/LocalEnrichment/Placard.php
@@ -289,7 +289,7 @@ class Placard extends DB_LibraryLocationLinkedObject {
 
 	public function delete($useWhere = false) : int {
 		$ret = parent::delete($useWhere);
-		if ($ret && !empty($this->id)) {
+		if ($ret && $useWhere && !empty($this->id)) {
 			$triggers = new PlacardTrigger();
 			$triggers->placardId = $this->id;
 			$triggers->delete(true);
@@ -562,5 +562,9 @@ class Placard extends DB_LibraryLocationLinkedObject {
 				}
 			}
 		}
+	}
+
+	public function supportsSoftDelete(): bool {
+		return true;
 	}
 }

--- a/code/web/sys/ObjectRestoration.php
+++ b/code/web/sys/ObjectRestoration.php
@@ -1,0 +1,108 @@
+<?php
+/** @noinspection PhpMissingFieldTypeInspection */
+
+require_once ROOT_DIR . '/sys/DB/DataObject.php';
+
+/**
+ * Virtual DataObject used by the Object Restoration admin tool.
+ *
+ * Each instance represents ONE soft-deleted row coming from any managed class.
+ * There is no backing database table; simply store properties in-memory so
+ * ObjectEditor/templates can treat the item like a normal DataObject.
+ */
+class ObjectRestoration extends DataObject {
+	// No physical table; placeholder to satisfy DataObject’s requirement that the property exist.
+	public $__table = 'object_restoration_virtual';
+	public $__primaryKey = 'compositeId';
+
+	public $compositeId;
+	public $objectType;
+	public $id;
+	public $title = '';
+	public $userInfo = '';
+	public $deletedOn = '';
+	public $deletedBy = '';
+	public $daysRemaining = 0;
+
+	public static function getObjectStructure($context = '') : array {
+		return [
+			'compositeId' => [
+				'property' => 'compositeId',
+				'type' => 'label',
+				'label' => 'Key',
+				'hideInLists' => true,
+			],
+			'id' => [
+				'property' => 'id',
+				'type' => 'label',
+				'label' => 'ID',
+			],
+			'title' => [
+				'property' => 'title',
+				'type' => 'label',
+				'label' => 'Title',
+			],
+			'userInfo' => [
+				'property' => 'userInfo',
+				'type' => 'label',
+				'label' => 'Created By',
+			],
+			'objectType' => [
+				'property' => 'objectType',
+				'type' => 'label',
+				'label' => 'Type',
+			],
+			'deletedOn' => [
+				'property' => 'deletedOn',
+				'type' => 'timestamp',
+				'label' => 'Deleted',
+			],
+			'deletedBy' => [
+				'property' => 'deletedBy',
+				'type' => 'label',
+				'label' => 'Deleted By',
+			],
+			'daysRemaining' => [
+				'property' => 'daysRemaining',
+				'type' => 'integer',
+				'label' => 'Days Remaining',
+			],
+		];
+	}
+
+	public function getUniquenessFields(): array { return ['compositeId']; }
+	public function find($fetchFirst = false, $requireOneMatchToReturn = false): bool { return false; }
+	public function fetch(): bool|DataObject|null { return null; }
+	public function insert($context = ''): bool { return false; }
+	public function update($context = ''): bool { return false; }
+	public function delete($useWhere = false) : int { return 0; }
+	public function canActiveUserEdit() : bool { return false; }
+	public function canActiveUserDelete() : bool { return false; }
+
+	public function getAdditionalListActions(): array {
+		$actions = [];
+		$basePath = '/Admin/ObjectRestorations';
+		$composite = $this->compositeId;
+
+		$actions[] = [
+			'text' => 'Restore',
+			'url' => "$basePath?objectAction=restore&id=$composite",
+			'class' => 'btn-primary',
+		];
+		$actions[] = [
+			'text' => 'History',
+			'url' => "$basePath?objectAction=history&id=$composite",
+		];
+		$deleteUrl = "$basePath?objectAction=hardDeleteSingle&id=$composite";
+		// Use HTML-escaped double quotes so the snippet can be embedded inside a single-quoted parameter.
+		$escapedDeleteUrl = htmlspecialchars($deleteUrl, ENT_QUOTES);
+		$confirmJs = "window.location.href=&quot;" . $escapedDeleteUrl . "&quot;";
+		$actions[] = [
+			'text' => 'Delete',
+			'url' => $deleteUrl,
+			'class' => 'btn-danger',
+			'onclick' => "AspenDiscovery.confirm('Permanently Delete', 'Are you sure you want to permanently delete this object? This action cannot be undone.', 'Delete', 'Cancel', true, '$confirmJs', 'btn-danger'); return false;",
+		];
+		return $actions;
+	}
+}

--- a/code/web/sys/UserLists/UserList.php
+++ b/code/web/sys/UserLists/UserList.php
@@ -152,19 +152,12 @@ class UserList extends DataObject {
 	}
 
 	function delete($useWhere = false) : int {
-		if (!$useWhere && $this->id >= 1) {
-			$this->deleted = 1;
-			$this->dateUpdated = time();
-			$ret = parent::update();
-
+		$ret = parent::delete($useWhere);
+		if ($ret && $useWhere && !empty($this->id) && $this->id >= 1) {
 			require_once ROOT_DIR . '/sys/UserLists/UserListEntry.php';
 			$listEntry = new UserListEntry();
 			$listEntry->listId = $this->id;
 			$listEntry->delete(true);
-
-			$ret = true;
-		} else {
-			$ret = parent::delete($useWhere);
 		}
 
 		global $memCache;
@@ -1522,5 +1515,9 @@ class UserList extends DataObject {
 			global $logger;
 			$logger->log("Unable to create RIS file " . $e, Logger::LOG_ERROR);
 		}
+	}
+
+	public function supportsSoftDelete(): bool {
+		return true;
 	}
 }

--- a/code/web/sys/UserLists/UserListEntry.php
+++ b/code/web/sys/UserLists/UserListEntry.php
@@ -58,9 +58,9 @@ class UserListEntry extends DataObject {
 	/**
 	 * @param bool $useWhere
 	 * @param bool $updateBrowseCategories
-	 * @return bool|int|mixed
+	 * @return int
 	 */
-	function delete($useWhere = false, $updateBrowseCategories = true) : int {
+	function delete($useWhere = false, bool $updateBrowseCategories = true) : int {
 		$result = parent::delete($useWhere);
 		global $memCache;
 		$memCache->delete('user_list_data_' . UserAccount::getActiveUserId());

--- a/code/web/sys/WebBuilder/BasicPage.php
+++ b/code/web/sys/WebBuilder/BasicPage.php
@@ -212,7 +212,7 @@ class BasicPage extends DB_LibraryLinkedObject {
 
 	public function delete($useWhere = false) : int {
 		$ret = parent::delete($useWhere);
-		if ($ret && !empty($this->id)) {
+		if ($ret && $useWhere && !empty($this->id)) {
 			$this->clearLibraries();
 			$this->clearAudiences();
 			$this->clearCategories();
@@ -589,5 +589,9 @@ class BasicPage extends DB_LibraryLinkedObject {
 		$this->getAudiences();
 		$this->getAllowableHomeLocations();
 		$this->getAccess();
+	}
+
+	public function supportsSoftDelete(): bool {
+		return true;
 	}
 }

--- a/code/web/sys/WebBuilder/CustomForm.php
+++ b/code/web/sys/WebBuilder/CustomForm.php
@@ -160,7 +160,7 @@ class CustomForm extends DB_LibraryLinkedObject {
 
 	public function delete($useWhere = false) : int {
 		$ret = parent::delete($useWhere);
-		if ($ret && !empty($this->id)) {
+		if ($ret && $useWhere && !empty($this->id)) {
 			$this->clearLibraries();
 			$this->clearFormFields();
 		}
@@ -333,5 +333,9 @@ class CustomForm extends DB_LibraryLinkedObject {
 		}
 
 		return $result;
+	}
+
+	public function supportsSoftDelete(): bool {
+		return true;
 	}
 }

--- a/code/web/sys/WebBuilder/CustomWebResourcePage.php
+++ b/code/web/sys/WebBuilder/CustomWebResourcePage.php
@@ -187,10 +187,9 @@ class CustomWebResourcePage extends DB_LibraryLinkedObject {
 		}
 	}
 
-	public function delete($useWhere = false): int
-	{
+	public function delete($useWhere = false): int {
 		$ret = parent::delete($useWhere);
-		if ($ret && !empty($this->id)) {
+		if ($ret && $useWhere && !empty($this->id)) {
 			$this->clearLibraries();
 			$this->clearAudiences();
 			$this->clearCategories();
@@ -530,5 +529,9 @@ class CustomWebResourcePage extends DB_LibraryLinkedObject {
 		$this->getCategories();
 		$this->getAudiences();
 		$this->getAccess();
+	}
+
+	public function supportsSoftDelete(): bool {
+		return true;
 	}
 }

--- a/code/web/sys/WebBuilder/PortalPage.php
+++ b/code/web/sys/WebBuilder/PortalPage.php
@@ -233,15 +233,13 @@ class PortalPage extends DB_LibraryLinkedObject {
 
 	public function delete($useWhere = false) : int {
 		$ret = parent::delete($useWhere);
-		if ($ret && !empty($this->id)) {
+		if ($ret && $useWhere && !empty($this->id)) {
 			$this->clearLibraries();
 			$this->clearAudiences();
 			$this->clearCategories();
 			$this->clearAccess();
-			if ($useWhere == false) {
-				foreach ($this->getRows() as $row) {
-					$row->delete();
-				}
+			foreach ($this->getRows() as $row) {
+				$row->delete();
 			}
 		}
 		return $ret;
@@ -620,5 +618,9 @@ class PortalPage extends DB_LibraryLinkedObject {
 			}
 		}
 		parent::finishCopy($sourceId);
+	}
+
+	public function supportsSoftDelete(): bool {
+		return true;
 	}
 }

--- a/code/web/sys/WebBuilder/WebResource.php
+++ b/code/web/sys/WebBuilder/WebResource.php
@@ -257,7 +257,7 @@ class WebResource extends DB_LibraryLinkedObject {
 
 	public function delete($useWhere = false) : int {
 		$ret = parent::delete($useWhere);
-		if ($ret && !empty($this->id)) {
+		if ($ret && $useWhere && !empty($this->id)) {
 			$this->clearLibraries();
 			$this->clearAudiences();
 			$this->clearCategories();
@@ -540,5 +540,9 @@ class WebResource extends DB_LibraryLinkedObject {
 			$placard->generatedFromSource = 'web_resource:' . $this->id;
 			$placard->insert();
 		}
+	}
+
+	public function supportsSoftDelete(): bool {
+		return true;
 	}
 }

--- a/install/updateCron_25.08.00.php
+++ b/install/updateCron_25.08.00.php
@@ -1,0 +1,57 @@
+<?php
+
+if (count($_SERVER['argv']) > 1) {
+	$serverName = $_SERVER['argv'][1];
+	// Check to see if the update already exists properly.
+	$fhnd = fopen('/usr/local/aspen-discovery/sites/' . $serverName . '/conf/crontab_settings.txt', 'r');
+	if ($fhnd) {
+		$lines = [];
+		$insertPurgeSoftDeleted = true;
+		$purgeSoftDeletedInserted = false;
+		while (($line = fgets($fhnd)) !== false) {
+			// Detect if the cron job is already present.
+			if (str_contains($line, 'purgeSoftDeleted.php')) {
+				$insertPurgeSoftDeleted = false;
+				$line = "59 23 * * * root php /usr/local/aspen-discovery/code/web/cron/purgeSoftDeleted.php $serverName\n";
+			}
+			// Insert before Debian end-of-file marker.
+			if ($insertPurgeSoftDeleted && str_contains($line, 'Debian needs a blank line at the end of cron')) {
+				if (!empty($lines) && trim(end($lines)) !== '') {
+					$lines[] = "\n";
+				}
+				$lines[] = "#######################################\n";
+				$lines[] = "# Purge Soft-Deleted Database Objects #\n";
+				$lines[] = "#######################################\n";
+				$lines[] = "59 23 * * * root php /usr/local/aspen-discovery/code/web/cron/purgeSoftDeleted.php $serverName\n";
+				$lines[] = "\n";
+				$purgeSoftDeletedInserted = true;
+			}
+			$lines[] = $line;
+		}
+		fclose($fhnd);
+
+		// Fallback: If marker was not found, add at the end.
+		if ($insertPurgeSoftDeleted && !$purgeSoftDeletedInserted) {
+			if (!empty($lines) && trim(end($lines)) !== '') {
+				$lines[] = "\n";
+			}
+			$lines[] = "#######################################\n";
+			$lines[] = "# Purge Soft-Deleted Database Objects #\n";
+			$lines[] = "#######################################\n";
+			$lines[] = "59 23 * * * root php /usr/local/aspen-discovery/code/web/cron/purgeSoftDeleted.php $serverName\n";
+			$lines[] = "\n";
+			$purgeSoftDeletedInserted = true;
+		}
+
+		// Write the file only if the new cron job was inserted.
+		if ($purgeSoftDeletedInserted) {
+			$newContent = implode('', $lines);
+			file_put_contents('/usr/local/aspen-discovery/sites/' . $serverName . '/conf/crontab_settings.txt', $newContent);
+		}
+	} else {
+		echo '- Could not find cron settings file.' . PHP_EOL;
+	}
+} else {
+	echo 'Must provide server name as first argument.' . PHP_EOL;
+	exit();
+}

--- a/sites/template.linux/conf/crontab_settings.txt
+++ b/sites/template.linux/conf/crontab_settings.txt
@@ -147,4 +147,9 @@
 ######################
 */59 8-19 * * * root php /usr/local/aspen-discovery/code/web/cron/sendILSMessages.php {sitename}
 
+#######################################
+# Purge Soft-Deleted Database Objects #
+#######################################
+59 23 * * * root php /usr/local/aspen-discovery/code/web/cron/purgeSoftDeleted.php {sitename}
+
 # Debian needs a blank line at the end of cron, make sure to add additional cron lines above this.


### PR DESCRIPTION
- Object Restorations
  - The following objects can be restored after their deletion:
    - User Lists
      - Patrons may choose "Opt Out of Soft Deletion" to permanently delete them immediately.
    - Basic Pages 
    - Custom Pages (Portal Pages)
    - Custom Forms 
    - Web Resource Pages 
    - Web Resources 
    - Image Uploads (hard-deleting removes the file from the server)
    - File Uploads (hard-deleting removes the file from the server)
    - Placards
  - A daily process permanently deletes any items that have been soft-deleted for more than 30 days.
  - A new permission, "Administer Object Restoration," is required to access the Restore Deleted Objects page.