### PR TITLE
DIS-1117 Allow self check for users with low fines

### DIFF
--- a/code/web/release_notes/25.08.00.MD
+++ b/code/web/release_notes/25.08.00.MD
@@ -4,6 +4,9 @@
 ### Materials Request Updates
 - Optionally send staff an email after a new Materials Request is created. (DIS-1113) (*MDN*)
 
+### Symphony Updates
+- Allow checking out titles using Scan and Go to patrons that have fines or fees, but the total fines have not reached the bill threshold for their patron type. (DIS-1117)
+
 ### User List Updates
 - Correctly set the list entry title when adding Aspen Native Events to a list. (DIS-1150) (*MDN*)
 


### PR DESCRIPTION
- Allow checking out titles using Scan and Go to patrons that have fines or fees, but the total fines have not reached the bill threshold for their patron type by providing an override code for the checkout.