### PR TITLE
DIS-1099 Cloud Library Remove Expired Records During Incremental Updates

### DIFF
--- a/code/cloud_library_export/src/com/turning_leaf_technologies/cloud_library/CloudLibraryEventHandler.java
+++ b/code/cloud_library_export/src/com/turning_leaf_technologies/cloud_library/CloudLibraryEventHandler.java
@@ -24,6 +24,10 @@ class CloudLibraryEventHandler extends DefaultHandler {
 	private final long startTimeForLogging;
 	private String nodeContents = "";
 
+	private String currentItemId = "";
+	private String currentEventType = "";
+	private String lastEventDateTimeInUTC = "";
+
 	private static final CRC32 checksumCalculator = new CRC32();
 
 	CloudLibraryEventHandler(CloudLibraryExporter exporter, boolean doFullReload, Long startTimeForLogging, Connection aspenConn, RecordGroupingProcessor recordGroupingProcessor, GroupedWorkIndexer groupedWorkIndexer, CloudLibraryExtractLogEntry logEntry, Logger logger) {
@@ -55,10 +59,47 @@ class CloudLibraryEventHandler extends DefaultHandler {
 	}
 
 	public void endElement(String uri, String localName, String qName) {
-		if (qName.equals("ItemId")){
-			updateAvailabilityForTitle(nodeContents.trim());
+		switch (qName) {
+			case "ItemId":
+				currentItemId = nodeContents.trim();
+				break;
+			case "EventType":
+				currentEventType = nodeContents.trim();
+				break;
+			case "CloudLibraryEvent":
+				// Process the complete event when we reach the end of the event element
+				processCloudLibraryEvent(currentItemId, currentEventType);
+				// Reset for next event
+				currentItemId = "";
+				currentEventType = "";
+				break;
+			case "LastEventDateTimeInUTC":
+				if (nodeContents != null && !nodeContents.trim().isEmpty()) {
+					lastEventDateTimeInUTC = nodeContents.trim();
+					logger.warn("LastEventDateTimeInUTC: " + lastEventDateTimeInUTC);
+				} else {
+					lastEventDateTimeInUTC = null;
+					logger.warn("LastEventDateTimeInUTC is empty, no more events");
+				}
+				break;
 		}
 		nodeContents = "";
+	}
+
+	public String getLastEventDateTimeInUTC() {
+		return lastEventDateTimeInUTC;
+	}
+
+	private void processCloudLibraryEvent(String cloudLibraryId, String eventType) {
+		if (cloudLibraryId.isEmpty()) {
+			return;
+		}
+		if ("REMOVED".equals(eventType)) {
+			// Delete expired titles
+			exporter.deleteRecords(cloudLibraryId);
+		} else {
+			updateAvailabilityForTitle(cloudLibraryId);
+		}
 	}
 
 	private void updateAvailabilityForTitle(String cloudLibraryId) {

--- a/code/cloud_library_export/src/com/turning_leaf_technologies/cloud_library/CloudLibraryEventHandler.java
+++ b/code/cloud_library_export/src/com/turning_leaf_technologies/cloud_library/CloudLibraryEventHandler.java
@@ -67,19 +67,17 @@ class CloudLibraryEventHandler extends DefaultHandler {
 				currentEventType = nodeContents.trim();
 				break;
 			case "CloudLibraryEvent":
-				// Process the complete event when we reach the end of the event element
+				//Process the complete event when we reach the end of the event element
 				processCloudLibraryEvent(currentItemId, currentEventType);
-				// Reset for next event
+				//Reset for next event
 				currentItemId = "";
 				currentEventType = "";
 				break;
 			case "LastEventDateTimeInUTC":
 				if (nodeContents != null && !nodeContents.trim().isEmpty()) {
 					lastEventDateTimeInUTC = nodeContents.trim();
-					logger.warn("LastEventDateTimeInUTC: " + lastEventDateTimeInUTC);
 				} else {
 					lastEventDateTimeInUTC = null;
-					logger.warn("LastEventDateTimeInUTC is empty, no more events");
 				}
 				break;
 		}
@@ -95,7 +93,7 @@ class CloudLibraryEventHandler extends DefaultHandler {
 			return;
 		}
 		if ("REMOVED".equals(eventType)) {
-			// Delete expired titles
+			//Delete expired titles
 			exporter.deleteRecords(cloudLibraryId);
 		} else {
 			updateAvailabilityForTitle(cloudLibraryId);

--- a/code/cloud_library_export/src/com/turning_leaf_technologies/cloud_library/CloudLibraryExporter.java
+++ b/code/cloud_library_export/src/com/turning_leaf_technologies/cloud_library/CloudLibraryExporter.java
@@ -1,3 +1,4 @@
+
 package com.turning_leaf_technologies.cloud_library;
 
 import org.aspen_discovery.grouping.RecordGroupingProcessor;
@@ -91,10 +92,9 @@ public class CloudLibraryExporter {
 		boolean moreRecords = true;
 		while (moreRecords) {
 			moreRecords = false;
-			//Get a list of eBooks and eAudiobooks to process
+			//Get MARC for all records purchased from the start date
 			String apiPath = "/cirrus/library/" + settings.getLibraryId() + "/data/marc?offset=" + curOffset + "&limit=50&startdate=" + startDate;
 
-			//noinspection ConstantConditions
 			for (int curTry = 1; curTry <= 4; curTry++) {
 				WebServiceResponse response = callCloudLibrary(apiPath);
 				if (response == null) {
@@ -143,48 +143,63 @@ public class CloudLibraryExporter {
 
 		//Handle events to determine status changes when the bibs don't change.
 		if (!settings.isDoFullReload()) {
-			//noinspection SpellCheckingInspection
-			String eventsApiPath = "/cirrus/library/" + settings.getLibraryId() + "/data/cloudevents?startdate=" + startDate;
 			CloudLibraryEventHandler eventHandler = new CloudLibraryEventHandler(this, settings.isDoFullReload(), startTimeForLogging, aspenConn, getRecordGroupingProcessor(), getGroupedWorkIndexer(), logEntry, logger);
-			//noinspection ConstantConditions
-			for (int curTry = 1; curTry <= 4; curTry++) {
-				WebServiceResponse response = callCloudLibrary(eventsApiPath);
-				if (response == null) {
-					//Something bad happened, we're done.
-					return numChanges;
-				} else if (!response.isSuccess()) {
-					if (response.getResponseCode() != 502) {
-						logEntry.incErrors("Error " + response.getResponseCode() + " calling " + eventsApiPath + ": " + response.getMessage());
-						break;
-					} else {
-						if (curTry == 4) {
+
+			String currentStartDate = startDate;
+
+			while (true) {
+				String eventsApiPath = "/cirrus/library/" + settings.getLibraryId() + "/data/cloudevents?startdate=" + currentStartDate;
+
+				logger.warn("url ----> " + eventsApiPath);
+
+				for (int curTry = 1; curTry <= 4; curTry++) {
+					WebServiceResponse response = callCloudLibrary(eventsApiPath);
+					if (response == null) {
+						// Something bad happened, we're done.
+						return numChanges;
+					} else if (!response.isSuccess()) {
+						if (response.getResponseCode() != 502) {
 							logEntry.incErrors("Error " + response.getResponseCode() + " calling " + eventsApiPath + ": " + response.getMessage());
 							break;
 						} else {
-							try {
-								Thread.sleep(1000);
-							} catch (InterruptedException e) {
-								logger.error("Thread was interrupted while waiting to retry for cloudLibrary");
+							if (curTry == 4) {
+								logEntry.incErrors("Error " + response.getResponseCode() + " calling " + eventsApiPath + ": " + response.getMessage());
+								break;
+							} else {
+								try {
+									Thread.sleep(1000);
+								} catch (InterruptedException e) {
+									logger.error("Thread was interrupted while waiting to retry for cloudLibrary");
+								}
 							}
 						}
-					}
-				} else {
-					try {
-						SAXParserFactory saxParserFactory = SAXParserFactory.newInstance();
-						SAXParser saxParser = saxParserFactory.newSAXParser();
-						saxParser.parse(new ByteArrayInputStream(response.getMessage().getBytes(StandardCharsets.UTF_8)), eventHandler);
+					} else {
+						try {
+							SAXParserFactory saxParserFactory = SAXParserFactory.newInstance();
+							SAXParser saxParser = saxParserFactory.newSAXParser();
+							saxParser.parse(new ByteArrayInputStream(response.getMessage().getBytes(StandardCharsets.UTF_8)),eventHandler);
 
-						if (handler.getNumDocuments() > 0) {
-							numChanges += handler.getNumDocuments();
+							if (handler.getNumDocuments() > 0) {
+								numChanges += handler.getNumDocuments();
+							}
+							logEntry.saveResults();
+						} catch (SAXException | ParserConfigurationException | IOException e) {
+							logger.error("Error parsing response", e);
+							logEntry.addNote("Error parsing response: " + e);
 						}
-						logEntry.saveResults();
-					} catch (SAXException | ParserConfigurationException | IOException e) {
-						logger.error("Error parsing response", e);
-						logEntry.addNote("Error parsing response: " + e);
+						break;
 					}
+				}
+
+				String lastEventDateTime = eventHandler.getLastEventDateTimeInUTC();
+				if (lastEventDateTime != null && !lastEventDateTime.isEmpty() && !lastEventDateTime.equals(currentStartDate)) {
+					currentStartDate = lastEventDateTime;
+				} else {
+					logger.warn("No more events available");
 					break;
 				}
 			}
+			logger.warn("Events processing completed");
 		}
 
 		if (settings.isDoFullReload() && !logEntry.hasErrors()) {
@@ -198,7 +213,7 @@ public class CloudLibraryExporter {
 			}
 
 			//Mark any records that no longer exist in search results as deleted, but only if we are doing a full update
-			numChanges += deleteItems();
+			numChanges += deleteRemainingItems();
 		}
 
 		//Update the last time we ran the update in settings.  This is always done since cloudLibrary has some expected errors.
@@ -340,53 +355,75 @@ public class CloudLibraryExporter {
 		logEntry = new CloudLibraryExtractLogEntry(aspenConn, settings.getSettingsId(), logger);
 	}
 
-	private int deleteItems() {
+	private int deleteRemainingItems() {
 		int numDeleted = 0;
-		try {
-			for (CloudLibraryTitle cloudLibraryTitle : existingRecords.values()) {
-				if (!cloudLibraryTitle.isDeleted()) {
-					//Make sure that the title does not have copies in another collection
-					if (cloudLibraryTitle.getAvailabilityId() != null){
-						deleteCloudLibraryAvailabilityStmt.setLong(1, cloudLibraryTitle.getAvailabilityId());
-						deleteCloudLibraryAvailabilityStmt.executeUpdate();
-					}
-					cloudLibraryTitleHasAvailabilityStmt.setLong(1, cloudLibraryTitle.getId());
-					ResultSet cloudLibraryTitleHasAvailabilityRS = cloudLibraryTitleHasAvailabilityStmt.executeQuery();
-					boolean deleteTitle = true;
-					if (cloudLibraryTitleHasAvailabilityRS.next()){
-						int numAvailability = cloudLibraryTitleHasAvailabilityRS.getInt("numAvailability");
-						if (numAvailability > 0){
-							deleteTitle = false;
-						}
-					}
-
-					if (deleteTitle) {
-						deleteCloudLibraryItemStmt.setLong(1, cloudLibraryTitle.getId());
-						deleteCloudLibraryItemStmt.executeUpdate();
-						RemoveRecordFromWorkResult result = getRecordGroupingProcessor().removeRecordFromGroupedWork("cloud_library", cloudLibraryTitle.getCloudLibraryId());
-						if (result.reindexWork) {
-							getGroupedWorkIndexer().processGroupedWork(result.permanentId);
-						} else if (result.deleteWork) {
-							//Delete the work from solr and the database
-							getGroupedWorkIndexer().deleteRecord(result.permanentId, result.groupedWorkId);
-						}
-					//else
-						//We need to reindex the record to make sure that the availability changes?.
-					}
-
-					numDeleted++;
-					logEntry.incDeleted();
-				}
+		for (CloudLibraryTitle cloudLibraryTitle : existingRecords.values()) {
+			if (!cloudLibraryTitle.isDeleted()) {
+				deleteRecords(cloudLibraryTitle.getCloudLibraryId());
+				numDeleted++;
 			}
-			if (numDeleted > 0) {
-				logEntry.saveResults();
-				logger.warn("Deleted " + numDeleted + " old titles");
-			}
-		} catch (SQLException e) {
-			logger.error("Error deleting items", e);
-			logEntry.addNote("Error deleting items " + e);
+		}
+		if (numDeleted > 0) {
+			logEntry.saveResults();
+			logger.warn("Deleted " + numDeleted + " old titles");
 		}
 		return numDeleted;
+	}
+
+	public void deleteRecords(String cloudLibraryId) {
+		CloudLibraryTitle cloudLibraryTitle = existingRecords.get(cloudLibraryId);
+		if (cloudLibraryTitle == null) {
+			logger.warn("Title " + cloudLibraryId + " not found in existing records");
+			return;
+		}
+		try {
+			if (!cloudLibraryTitle.isDeleted()) {
+				//Make sure that the title does not have copies in another collection
+				//Delete the availability record if it exists for this setting
+				if (cloudLibraryTitle.getAvailabilityId() != null){
+					deleteCloudLibraryAvailabilityStmt.setLong(1, cloudLibraryTitle.getAvailabilityId());
+					deleteCloudLibraryAvailabilityStmt.executeUpdate();
+				}
+
+				//Check if the title has any availability records in other settings
+				cloudLibraryTitleHasAvailabilityStmt.setLong(1, cloudLibraryTitle.getId());
+				ResultSet cloudLibraryTitleHasAvailabilityRS = cloudLibraryTitleHasAvailabilityStmt.executeQuery();
+				boolean deleteTitle = true;
+				if (cloudLibraryTitleHasAvailabilityRS.next()){
+					//If the title has any availability records in other settings, do not delete it
+					int numAvailability = cloudLibraryTitleHasAvailabilityRS.getInt("numAvailability");
+					if (numAvailability > 0){
+						deleteTitle = false;
+					}
+				}
+
+				if (deleteTitle) {
+					//Delete the title from the database
+					deleteCloudLibraryItemStmt.setLong(1, cloudLibraryTitle.getId());
+					deleteCloudLibraryItemStmt.executeUpdate();
+					logEntry.incDeleted();
+					RemoveRecordFromWorkResult result = getRecordGroupingProcessor().removeRecordFromGroupedWork("cloud_library", cloudLibraryId);
+					logger.warn("Delete record " + cloudLibraryId);
+					if (result.reindexWork) {
+						getGroupedWorkIndexer().processGroupedWork(result.permanentId);
+					} else if (result.deleteWork) {
+						//Delete the work from solr and the database
+						getGroupedWorkIndexer().deleteRecord(result.permanentId, result.groupedWorkId);
+					}
+					logger.warn("Deleted " + cloudLibraryId);
+				} else {
+					//Reindex the record to make sure the availability changes are reflected in the grouped work
+					String groupedWorkId = getRecordGroupingProcessor().getPermanentIdForRecord("cloud_library", cloudLibraryId);
+					if (groupedWorkId != null) {
+						getGroupedWorkIndexer().processGroupedWork(groupedWorkId);
+					}
+					logger.warn("Reindexing " + cloudLibraryId);
+				}
+			}
+		} catch (SQLException e) {
+			logger.error("Error deleting items " + cloudLibraryId, e);
+			logEntry.addNote("Error deleting items " + e);
+		}
 	}
 
 	private void loadExistingTitles(long settingId) {

--- a/code/web/release_notes/25.08.00.MD
+++ b/code/web/release_notes/25.08.00.MD
@@ -40,6 +40,9 @@
 - Added detailed progress tracking and log entries for Open Archives indexing. (DIS-1063) (*LS*)
 
 // yanjun
+### Cloud Library Updates
+- Add deletion process for expired Cloud Library records during Incremental updates. (DIS-1099) (*YL*)
+- Refactor deletion logic for full update and incremental updates. (DIS-1099) (*YL*)
 
 // laura
 


### PR DESCRIPTION
Currently, the expired Cloud library records can’t be removed in the incremental indexing; they can only be removed in a full update. 

This PR adds the deletion for expired records with the Events endpoint, and refactors the deletion logic for full update and incremental updates.

To Test:
1. Mark a Cloud Library record as expired via Cloud Library 
2. Set Last Update of Changed Records to a time earlier than the expired date.  See the record remaining in the catalog after incremental indexing. 
3. Apply PR
4. Set Last Update of Changed Records to a time earlier than the expired date. See the record gets removed from the catalog 