### PR TITLE
DIS-1180 Add Hoopla error handling when placing holds

### DIFF
--- a/code/web/interface/themes/responsive/js/aspen/hoopla.js
+++ b/code/web/interface/themes/responsive/js/aspen/hoopla.js
@@ -95,6 +95,8 @@ AspenDiscovery.Hoopla = (function(){
 					result = data;
 					if (data.promptNeeded) {
 						AspenDiscovery.showMessageWithButtons(data.promptTitle, data.prompts, data.buttons);
+					} else if (!data.success) {
+						AspenDiscovery.showMessageWithButtons(data.title, data.body, data.buttons);
 					}
 				},
 				dataType: 'json',
@@ -109,7 +111,7 @@ AspenDiscovery.Hoopla = (function(){
 		placeHold: function(id) {
 			if (Globals.loggedIn) {
 				var promptInfo = AspenDiscovery.Hoopla.getHoldPrompts(id);
-				if (!promptInfo.promptNeeded){
+				if (promptInfo.success && !promptInfo.promptNeeded){
 					AspenDiscovery.Hoopla.doHold(promptInfo.patronId, id);
 				}
 			} else {

--- a/code/web/release_notes/25.08.00.MD
+++ b/code/web/release_notes/25.08.00.MD
@@ -192,6 +192,7 @@
 
 ### Hoopla Updates
 - Allow Hoopla records to display with 'Access Online' button if in Library Systems, Hoopla Library ID set to 0. (DIS-1178) (*YL*)
+- Add error handling for placing holds for Hoopla Flex titles.  (DIS-1180) (*YL*)
 
 ### OverDrive Updates
 -  Limit OverDrive hold suspension to 365 days max. If no date is selected or if the selected date is more than 365 days in the future, the suspension will automatically default to 365 days.(DIS-1086) (*YL*)

--- a/code/web/services/Hoopla/AJAX.php
+++ b/code/web/services/Hoopla/AJAX.php
@@ -202,9 +202,18 @@ class Hoopla_AJAX extends Action {
 					'buttons' => '<button class="btn btn-primary" onclick="' . $buttonOnClick . '">' . translate(['text' => 'Place Hold', 'isPublicFacing' => true]) . '</button>'
 				];
 			} else {
+				$invalidAccountMessage = translate([
+					'text' => 'The barcode or library for this account is not valid for Hoopla. Please contact your local library for more information.',
+					'isPublicFacing' => true,
+				]);
 				return [
 					'success' => false,
-					'message' => translate(['text' => 'No valid Hoopla account found.', 'isPublicFacing' => true])
+					'title' => translate([
+						'text' => 'Invalid Hoopla Account',
+						'isPublicFacing' => true,
+					]),
+					'body' => '<p class="alert alert-danger">' . $invalidAccountMessage . '</p>',
+					'buttons' => '',
 				];
 			}
 		}
@@ -216,7 +225,7 @@ class Hoopla_AJAX extends Action {
 	function placeHold() {
 		$user = UserAccount::getLoggedInUser();
 		if ($user) {
-			$patronId = $_REQUEST['patronId'];
+			$patronId = !empty($_REQUEST['patronId']) ? $_REQUEST['patronId'] : $user->id;
 			$id = $_REQUEST['id'];
 			$patron = $user->getUserReferredTo($patronId);
 


### PR DESCRIPTION
When Library system > Hoopla Library ID was not set, and this library’s patrons tried to place a hold on Hoopla Flex titles through other catalog. It will display an error 
`User::getUserReferredTo(): Argument #1 ($patronId) must be of type string|int, null given, called in /usr/local/aspen-discovery/code/web/services/Hoopla/AJAX.php on line 221`


To reproduce and test: 
1. Member Library A and B are in the scope has “Include Flex” selected 
2. Go to Library System for Library A, set Hoopla Library ID to 0. 
3. Logging in as a patron from Library A, go to Library B catalog, and place a hold on Hoopla Flex records
4. See error: `User::getUserReferredTo(): Argument #1 ($patronId) must be of type string|int, null given, called in /usr/local/aspen-discovery/code/web/services/Hoopla/AJAX.php on line 221`
5. Apply the patch 
6. Try to place a hold again, see message: `The barcode or library for this account is not valid for Hoopla. Please contact your local library for more information.`

