### PR TITLE
DIS-1192 PHP based cron updates

### DIFF
--- a/code/web/cron/cleanupSharedSessions.php
+++ b/code/web/cron/cleanupSharedSessions.php
@@ -3,15 +3,22 @@ require_once __DIR__ . '/../bootstrap.php';
 require_once __DIR__ . '/../bootstrap_aspen.php';
 
 require_once ROOT_DIR . '/sys/Session/SharedSession.php';
+require_once ROOT_DIR . '/sys/CronLogEntry.php';
+$cronLogEntry = new CronLogEntry();
+$cronLogEntry->startTime = time();
+$cronLogEntry->name = 'Cleanup Shared Sessions';
+$cronLogEntry->insert();
 
 $sharedSessions = new SharedSession();
 
 $sessions = array_filter($sharedSessions->fetchAll('sessionId'));
+$cronLogEntry->notes = "Found " . count($sessions) . " shared sessions to process";
 
 $sharedSessions = null;
 
 $numProcessed = 0;
 
+$numDeleted = 0;
 foreach ($sessions as $session) {
 	$sharedSession = new SharedSession();
 	$sharedSession->setSessionId($session);
@@ -19,6 +26,7 @@ foreach ($sessions as $session) {
 		$createdOn = $sharedSession->getCreated();
 		$oneHourLater = strtotime('+1 hour', $createdOn);
 		if($createdOn <= $oneHourLater) {
+			$numDeleted++;
 			$sharedSession->delete();
 		}
 	}
@@ -26,6 +34,10 @@ foreach ($sessions as $session) {
 	$sharedSession = null;
 	$numProcessed++;
 }
+$cronLogEntry->notes .= "<br/>Deleted $numDeleted shared sessions";
+
+$cronLogEntry->endTime = time();
+$cronLogEntry->update();
 
 global $aspen_db;
 $aspen_db = null;

--- a/code/web/cron/dismissYearInReviewMessages.php
+++ b/code/web/cron/dismissYearInReviewMessages.php
@@ -5,12 +5,19 @@ require_once __DIR__ . '/../bootstrap_aspen.php';
 require_once ROOT_DIR . '/sys/Account/UserMessage.php';
 require_once ROOT_DIR . '/sys/YearInReview/YearInReviewSetting.php';
 
+require_once ROOT_DIR . '/sys/CronLogEntry.php';
+$cronLogEntry = new CronLogEntry();
+$cronLogEntry->startTime = time();
+$cronLogEntry->name = 'Dismiss Year In Review Messages';
+$cronLogEntry->insert();
+
 $today = strtotime("today");
 $tomorrow = strtotime("tomorrow");
 $yearInReviewSetting  = new YearInReviewSetting();
 $yearInReviewSetting->whereAdd('endDate >= ' . $today);
 $yearInReviewSetting->whereAdd('endDate < ' . $tomorrow);
 $yearInReviewSetting->find();
+$numDismissed = 0;
 if ($yearInReviewSetting->fetch()) {
 	$userMessage = new UserMessage();
 	$userMessage->messageType = 'yearInReview';
@@ -19,8 +26,14 @@ if ($yearInReviewSetting->fetch()) {
 	while ($userMessage->fetch()) {
 		$userMessage->isDismissed = 1;
 		$userMessage->update();
+		$numDismissed++;
 	}
 }
+
+$cronLogEntry->notes .= "<br/>Dismissed $numDismissed Year In Review messages";
+
+$cronLogEntry->endTime = time();
+$cronLogEntry->update();
 
 global $aspen_db;
 $aspen_db = null;

--- a/code/web/cron/fetchNotificationReceipts.php
+++ b/code/web/cron/fetchNotificationReceipts.php
@@ -5,6 +5,12 @@ require_once __DIR__ . '/../bootstrap_aspen.php';
 require_once ROOT_DIR . '/sys/Account/UserNotification.php';
 require_once ROOT_DIR . '/sys/Notifications/ExpoNotification.php';
 
+require_once ROOT_DIR . '/sys/CronLogEntry.php';
+$cronLogEntry = new CronLogEntry();
+$cronLogEntry->startTime = time();
+$cronLogEntry->name = 'Fetching Notification Receipts';
+$cronLogEntry->insert();
+
 $userNotification = new UserNotification();
 $userNotification->completed = 0;
 $userNotification->error = 0;
@@ -15,12 +21,17 @@ $userNotification = null;
 
 $numProcessed = 0;
 
+$cronLogEntry->notes = "Found " . count($notifications) . " notifications to process";
+
 $expoNotification = new ExpoNotification();
 foreach ($notifications as $notification) {
 	$expoNotification->getExpoNotificationReceipt($notification);
 	$numProcessed++;
 }
 $expoNotification = null;
+
+$cronLogEntry->endTime = time();
+$cronLogEntry->update();
 
 global $aspen_db;
 $aspen_db = null;

--- a/code/web/cron/generateMaterialRequestHoldCandidates.php
+++ b/code/web/cron/generateMaterialRequestHoldCandidates.php
@@ -3,5 +3,13 @@ require_once __DIR__ . '/../bootstrap.php';
 require_once __DIR__ . '/../bootstrap_aspen.php';
 
 require_once ROOT_DIR . '/sys/MaterialsRequests/MaterialsRequestHoldCandidateGenerator.php';
+require_once ROOT_DIR . '/sys/CronLogEntry.php';
+$cronLogEntry = new CronLogEntry();
+$cronLogEntry->startTime = time();
+$cronLogEntry->name = 'Generate Material Request Hold Candidates';
+$cronLogEntry->insert();
 
 generateMaterialsRequestsHoldCandidates();
+
+$cronLogEntry->endTime = time();
+$cronLogEntry->update();

--- a/code/web/cron/sendCampaignEmails.php
+++ b/code/web/cron/sendCampaignEmails.php
@@ -6,12 +6,18 @@ require_once ROOT_DIR . '/sys/CommunityEngagement/Campaign.php';
 require_once ROOT_DIR . '/sys/CommunityEngagement/UserCampaign.php';
 require_once ROOT_DIR . '/sys/Account/User.php';
 require_once ROOT_DIR . '/sys/Email/EmailTemplate.php';
+require_once ROOT_DIR . '/sys/CronLogEntry.php';
+$cronLogEntry = new CronLogEntry();
+$cronLogEntry->startTime = time();
+$cronLogEntry->name = 'Send Campaign Emails';
+$cronLogEntry->insert();
 
 $today = date('Y-m-d');
 
 $campaign = new Campaign();
 $campaign->startDate = $today;
 
+$numEmailsSent = 0;
 if ($campaign->find()) {
 	while ($campaign->fetch()) {
 		$campaignId = $campaign->id;
@@ -27,6 +33,7 @@ if ($campaign->find()) {
 					$user->id = $userCampaign->userId;
 
 					if ($user->find(true) && !empty($user->email)) {
+						$numEmailsSent++;
 						sendCampaignEmail($user, $campaignId);
 					}
 
@@ -36,8 +43,11 @@ if ($campaign->find()) {
 		}
 	}
 }
+$cronLogEntry->notes .= "Sent $numEmailsSent emails";
+$cronLogEntry->endTime = time();
+$cronLogEntry->update();
 
-function sendCampaignEmail($user, $campaignId) {
+function sendCampaignEmail($user, $campaignId) : void {
 	require_once ROOT_DIR . '/sys/CommunityEngagement/Campaign.php';
 	$emailTemplate = EmailTemplate::getActiveTemplate('campaignStart');
 	if ($emailTemplate) {

--- a/code/web/cron/sendILSMessages.php
+++ b/code/web/cron/sendILSMessages.php
@@ -6,6 +6,11 @@ require_once ROOT_DIR . '/sys/Account/User.php';
 require_once ROOT_DIR . '/sys/Account/UserILSMessage.php';
 require_once ROOT_DIR . '/sys/Notifications/ExpoNotification.php';
 require_once ROOT_DIR . '/sys/AspenLiDA/LocationSetting.php';
+require_once ROOT_DIR . '/sys/CronLogEntry.php';
+$cronLogEntry = new CronLogEntry();
+$cronLogEntry->startTime = time();
+$cronLogEntry->name = 'Send ILS Messages';
+$cronLogEntry->insert();
 
 $allNotifications = new UserILSMessage();
 $allNotifications->status = "pending";
@@ -13,6 +18,8 @@ $notifications = $allNotifications->fetchAll('id');
 $allNotifications->__destruct();
 $allNotifications = null;
 
+$numNotificationsSent = 0;
+$cronLogEntry->notes = "Found " . count($notifications) . " notifications to process";
 foreach ($notifications as $notification) {
 	$tokens = [];
 	$ilsMessage = new UserILSMessage();
@@ -47,6 +54,7 @@ foreach ($notifications as $notification) {
 						$expoNotification = new ExpoNotification();
 						$expoNotification->sendExpoPushNotification($body, $token, $user->id, "ils_message");
 						$expoNotification = null;
+						$numNotificationsSent++;
 					}
 				}
 				$tokens = null;
@@ -57,6 +65,10 @@ foreach ($notifications as $notification) {
 		}
 	}
 }
+
+$cronLogEntry->notes .= "<br/>Sent $numNotificationsSent notifications";
+$cronLogEntry->endTime = time();
+$cronLogEntry->update();
 
 global $aspen_db;
 $aspen_db = null;

--- a/code/web/cron/talpaRecalculationCron.php
+++ b/code/web/cron/talpaRecalculationCron.php
@@ -7,6 +7,11 @@ require_once ROOT_DIR . '/sys/Grouping/GroupedWork.php';
 require_once ROOT_DIR . '/RecordDrivers/GroupedWorkDriver.php';
 require_once ROOT_DIR . '/sys/Talpa/TalpaData.php';
 require_once ROOT_DIR . '/sys/ISBN.php';
+require_once ROOT_DIR . '/sys/CronLogEntry.php';
+$cronLogEntry = new CronLogEntry();
+$cronLogEntry->startTime = time();
+$cronLogEntry->name = 'Talpa Recalculation';
+$cronLogEntry->insert();
 
 $startTime = time();
 $talpaWorkAPI ='https://www.librarything.com/api_aspen_works.php';
@@ -22,7 +27,9 @@ global $logger;
 global $library;
 global $enabledModules;
 if (!array_key_exists('Talpa Search', $enabledModules)) {
-	$logger->log("Talpa module not enabled, quitting", Logger::LOG_NOTICE);
+	$cronLogEntry->notes = "Talpa module not enabled, quitting";
+	$cronLogEntry->endTime = time();
+	$cronLogEntry->update();
 	return;
 }
 
@@ -33,7 +40,8 @@ $talpaSettings->find();
 while ($talpaSettings->fetch(true)) {
 	$token = $talpaSettings->talpaApiToken;
 
-	$logger->log("Running Talpa recalculation cron for settings " . $talpaSettings->id, Logger::LOG_NOTICE);
+	$cronLogEntry->notes .= "<br/>Running Talpa recalculation cron for settings " . $talpaSettings->id;
+	$cronLogEntry->update();
 
 	$noIsbns = 0;
 	$noIsbnA = array();
@@ -46,7 +54,8 @@ while ($talpaSettings->fetch(true)) {
 
 	if ($results) {
 		while ($result = $results->fetch()) {
-			$logger->log('found '. $result['total'] . ' permanent IDs to send to Talpa for recalculation', Logger::LOG_NOTICE);
+			$cronLogEntry->notes .= '<br/>found '. $result['total'] . ' permanent IDs to send to Talpa for recalculation';
+			$cronLogEntry->update();
 		}
 	}
 
@@ -69,7 +78,8 @@ while ($talpaSettings->fetch(true)) {
 			$permanent_ids[] = $result['permanent_id'];
 
 			if( count($permanent_ids) > $BATCH_SIZE ) {
-				$logger->log("getting works for recalculation batch ". $batchN. ' of size:'. $BATCH_SIZE, Logger::LOG_DEBUG);
+				$cronLogEntry->notes .= "<br/>getting works for recalculation batch ". $batchN. ' of size:'. $BATCH_SIZE;
+				$cronLogEntry->update();
 
 				foreach ($permanent_ids as $permanent_id) {
 					$groupedWork = new GroupedWork();
@@ -181,7 +191,8 @@ while ($talpaSettings->fetch(true)) {
 						$groupedWorkDriver = null;
 
 					} else {
-						$logger->log('failed to fetch info for grouped work '.$permanent_id, Logger::LOG_ERROR);
+						$cronLogEntry->notes .= '<br/>failed to fetch info for grouped work '.$permanent_id;
+						$cronLogEntry->update();
 					}
 					$groupedWork = null;
 				}
@@ -196,7 +207,8 @@ while ($talpaSettings->fetch(true)) {
 						'type' => 'monthly',
 					);
 
-					$logger->log('Sending '.count($chunk).' records for recalculation', Logger::LOG_DEBUG);
+					$cronLogEntry->notes .= '<br/>Sending '.count($chunk).' records for recalculation';
+					$cronLogEntry->update();
 
 					$curlConnection = curl_init($talpaWorkAPI);
 					curl_setopt($curlConnection, CURLOPT_CONNECTTIMEOUT, 15);
@@ -211,7 +223,11 @@ while ($talpaSettings->fetch(true)) {
 
 					$curl_result = curl_exec($curlConnection);
 					if ($curl_result === false) {
-						throw new Exception("Error in HTTP Request: " . curl_error($curlConnection));
+						$cronLogEntry->numErrors++;
+						$cronLogEntry->notes .= "<br/>Error in HTTP Request: " . curl_error($curlConnection);
+						$cronLogEntry->endTime = time();
+						$cronLogEntry->update();
+						die();
 					}
 
 					$resA = json_decode($curl_result, true);
@@ -220,7 +236,7 @@ while ($talpaSettings->fetch(true)) {
 					if(!empty($resA['msg']) && !empty($resA['mappedWorkIDs'])) {
 						$mappedWorkIDs = $resA['mappedWorkIDs'];
 						$notFoundA = $resA['notFoundA'];
-						$logger->log('Talpa recalculated  '.count($mappedWorkIDs).' mapped workids. Not found: '.count($notFoundA), Logger::LOG_DEBUG);
+						$logger->log('Talpa recalculated '.count($mappedWorkIDs).' mapped workids. Not found: '.count($notFoundA), Logger::LOG_DEBUG);
 
 						//save to the talpa_lt_to_groupedwork table
 						if($mappedWorkIDs) {
@@ -241,10 +257,12 @@ while ($talpaSettings->fetch(true)) {
 								$talpaData = null;
 							}
 						} else {
-							$logger->log("no works to update during recalculation", Logger::LOG_DEBUG);
+							$cronLogEntry->notes .= "<br/>no works to update during recalculation";
+							$cronLogEntry->update();
 						}
 					} else {
-						$logger->log("something went wrong with the recalculation response", Logger::LOG_DEBUG);
+						$cronLogEntry->notes .= "<br/>something went wrong with the recalculation response";
+						$cronLogEntry->update();
 					}
 				} // foreach chunksA
 
@@ -258,6 +276,8 @@ while ($talpaSettings->fetch(true)) {
 	$results->closeCursor();
 	$endTime = time();
 
-	$logger->log("Recalculation complete - seenN: ".$seenN . " inserted: ".$insertedN . "updated: ".$updatedN, Logger::LOG_NOTICE);
-	$logger->log("total recalculation time: ".($endTime - $startTime), Logger::LOG_NOTICE);
+	$cronLogEntry->notes .= "<br/>Recalculation complete - seenN: ".$seenN . " inserted: ".$insertedN . "updated: ".$updatedN;
+
+	$cronLogEntry->endTime = time();
+	$cronLogEntry->update();
 }

--- a/code/web/cron/updateCommunityTranslations.php
+++ b/code/web/cron/updateCommunityTranslations.php
@@ -5,6 +5,11 @@ require_once __DIR__ . '/../bootstrap_aspen.php';
 require_once ROOT_DIR . '/sys/Translation/TranslationTerm.php';
 require_once ROOT_DIR . '/sys/Translation/Language.php';
 require_once ROOT_DIR . '/sys/Translation/Translation.php';
+require_once ROOT_DIR . '/sys/CronLogEntry.php';
+$cronLogEntry = new CronLogEntry();
+$cronLogEntry->startTime = time();
+$cronLogEntry->name = 'Updating Community Translations';
+$cronLogEntry->insert();
 
 set_time_limit(0);
 
@@ -20,8 +25,8 @@ foreach($languages as $languageId) {
 	$language->id = $languageId;
 	if($language->find(true)) {
 		if ($language->code != 'en' && $language->code != 'pig' && $language->code != 'ubb') {
-			echo ("Updating $language->displayNameEnglish\n");
-			ob_flush();
+			$cronLogEntry->notes .= "<br/>Updating $language->displayNameEnglish";
+			$cronLogEntry->update();
 			//Loop through all terms to be translated
 			$translationTerm = new TranslationTerm();
 			$translationTerm->whereAdd('isMetadata = 0');
@@ -81,8 +86,9 @@ foreach($languages as $languageId) {
 	$language = null;
 }
 
-echo ("Imported a total of " . $numUpdated. " translations\n");
-ob_flush();
+$cronLogEntry->notes .= "<br/>Imported a total of " . $numUpdated. " translations";
+$cronLogEntry->endTime = time();
+$cronLogEntry->update();
 
 global $aspen_db;
 $aspen_db = null;

--- a/code/web/cron/updateSuggesters.php
+++ b/code/web/cron/updateSuggesters.php
@@ -1,5 +1,10 @@
 <?php
 require_once __DIR__ . '/../bootstrap.php';
+require_once ROOT_DIR . '/sys/CronLogEntry.php';
+$cronLogEntry = new CronLogEntry();
+$cronLogEntry->startTime = time();
+$cronLogEntry->name = 'Update Suggesters';
+$cronLogEntry->insert();
 
 global $configArray;
 $solrBaseUrl = $configArray['Index']['url'];
@@ -16,21 +21,41 @@ require_once ROOT_DIR . '/sys/SystemVariables.php';
 $systemVariables = SystemVariables::getSystemVariables();
 if ($systemVariables->searchVersion == 1) {
 	if (!file_get_contents($solrBaseUrl . '/grouped_works/suggest?suggest.build=true', false, $context)) {
-		echo("Could not update suggesters for grouped_works");
+		$cronLogEntry->notes .= "<br/>Could not update suggesters for grouped_works";
+		$cronLogEntry->numErrors++;
+	}else{
+		$cronLogEntry->notes .= "<br/>Updated suggesters for grouped_works";
 	}
 } else {
 	if (!file_get_contents($solrBaseUrl . '/grouped_works_v2/suggest?suggest.build=true', false, $context)) {
-		echo("Could not update suggesters for grouped_works_v2");
+		$cronLogEntry->notes .= "<br/>Could not update suggesters for grouped_works_v2";
+		$cronLogEntry->numErrors++;
+	}else{
+		$cronLogEntry->notes .= "<br/>Updated suggesters for grouped_works_v2";
 	}
 }
+$cronLogEntry->update();
 if (!file_get_contents($solrBaseUrl . '/open_archives/suggest?suggest.build=true', false, $context)) {
-	echo("Could not update suggesters for open_archives");
+	$cronLogEntry->notes .= "<br/>Could not update suggesters for open_archives";
+	$cronLogEntry->numErrors++;
+}else{
+	$cronLogEntry->notes .= "<br/>Updated suggesters for open_archives";
 }
+$cronLogEntry->update();
 if (!file_get_contents($solrBaseUrl . '/genealogy/suggest?suggest.build=true', false, $context)) {
-	echo("Could not update suggesters for genealogy");
+	$cronLogEntry->notes .= "<br/>Could not update suggesters for genealogy";
+	$cronLogEntry->numErrors++;
+}else{
+	$cronLogEntry->notes .= "<br/>Updated suggesters for genealogy";
 }
+$cronLogEntry->update();
 if (!file_get_contents($solrBaseUrl . '/lists/suggest?suggest.build=true', false, $context)) {
-	echo("Could not update suggesters for lists");
+	$cronLogEntry->notes .= "<br/>Could not update suggesters for lists";
+	$cronLogEntry->numErrors++;
+}else{
+	$cronLogEntry->notes .= "<br/>Updated suggesters for lists";
 }
+$cronLogEntry->endTime = time();
+$cronLogEntry->update();
 
 die();

--- a/code/web/interface/themes/responsive/Admin/cronLog.tpl
+++ b/code/web/interface/themes/responsive/Admin/cronLog.tpl
@@ -1,16 +1,17 @@
 {strip}
 	<div id="main-content" class="col-md-12">
 		<h1>{translate text='Cron Log' isAdminFacing=true}</h1>
-		
+
 		<div class="adminTableRegion fixed-height-table">
 			<table class="adminTable table table-condensed table-hover table-condensed smallText table-sticky" aria-label="Cron Log">
 				<thead>
-					<tr><th>{translate text='Id' isAdminFacing=true}</th><th>{translate text='Started' isAdminFacing=true}</th><th>{translate text='Finished' isAdminFacing=true}</th><th>{translate text='Elapsed' isAdminFacing=true}</th><th>{translate text='Processes Run' isAdminFacing=true}</th><th>{translate text='Num Errors' isAdminFacing=true}</th><th>{translate text='Had Errors?' isAdminFacing=true}</th><th>{translate text='Notes' isAdminFacing=true}</th></tr>
+					<tr><th>{translate text='Id' isAdminFacing=true}</th><th>{translate text='Name' isAdminFacing=true}</th><th>{translate text='Started' isAdminFacing=true}</th><th>{translate text='Finished' isAdminFacing=true}</th><th>{translate text='Elapsed' isAdminFacing=true}</th><th>{translate text='Processes Run' isAdminFacing=true}</th><th>{translate text='Num Errors' isAdminFacing=true}</th><th>{translate text='Had Errors?' isAdminFacing=true}</th><th>{translate text='Notes' isAdminFacing=true}</th></tr>
 				</thead>
 				<tbody>
 					{foreach from=$logEntries item=logEntry}
 						<tr{if $logEntry->getHadErrors()} class="danger"{/if}>
-							<td><a href="#" class="accordion-toggle collapsed" id="cronEntry{$logEntry->id}" onclick="AspenDiscovery.Admin.toggleCronProcessInfo('{$logEntry->id}');return false;">{$logEntry->id}</a></td>
+							<td>{if $logEntry->getNumProcesses() > 0}<a href="#" class="accordion-toggle collapsed" id="cronEntry{$logEntry->id}" onclick="AspenDiscovery.Admin.toggleCronProcessInfo('{$logEntry->id}');return false;">{/if}{$logEntry->id}{if $logEntry->getNumProcesses() > 0}</a>{/if}</td>
+							<td>{$logEntry->name}</td>
 							<td>{$logEntry->startTime|date_format:"%D %T"}</td>
 							<td>{$logEntry->endTime|date_format:"%D %T"}</td>
 							<td>{$logEntry->getElapsedTime()}</td>

--- a/code/web/interface/themes/responsive/Admin/cronRunner.tpl
+++ b/code/web/interface/themes/responsive/Admin/cronRunner.tpl
@@ -1,0 +1,48 @@
+{strip}
+	<div id="main-content" class="col-md-12">
+		<div class="row">
+			<div class="col-xs-12">
+				<h1 id="pageTitle">{$pageTitleShort}</h1>
+			</div>
+		</div>
+		{if isset($results)}
+			<div class="row">
+				<div class="col-xs-12">
+					<div class="alert {if !empty($results.success)}alert-success{else}alert-danger{/if}">
+						{$results.message}
+					</div>
+				</div>
+			</div>
+		{elseif isset($error)}
+			<div class="row">
+				<div class="col-xs-12">
+					<div class="alert alert-danger">
+						{$error}
+					</div>
+				</div>
+			</div>
+		{/if}
+	</div>
+	<div class="row">
+		<div class="col-xs-12">
+			<div class="alert alert-info">{translate text="This tool can be used to start a background process. Results can be checked in the Cron Log." isAdminFacing=true}</div>
+		</div>
+	</div>
+	<form id="generateTestUsersForm" method="get" role="form">
+		<div class='editor'>
+			<div class="form-group">
+				<label for="startingBarcode" class="control-label">{translate text='Process To Start' isPublicFacing=true}</label>
+				<select name="processToRun" id="processToRun" class="form-control">
+					<option value="">{translate text='Select a Process' isPublicFacing=true inAttribute=true}</option>
+					{foreach from=$availableCronProcesses key=processName item=processDescription}
+						<option value="{$processName}">{$processDescription}</option>
+					{/foreach}
+				</select>
+			</div>
+
+			<div class="form-group">
+				<button type="submit" id="startProcess" name="startProcess" class="btn btn-primary">{translate text="Start Process" isAdminFacing=true}</button>
+			</div>
+		</div>
+	</form>
+{/strip}

--- a/code/web/release_notes/25.08.00.MD
+++ b/code/web/release_notes/25.08.00.MD
@@ -90,6 +90,37 @@
     - Latin
 - Updated text-wrapping logic to better handle the character structure of various scripts, improving visual presentation on default covers. (DIS-1162) (*LS*)
 
+### Cron Updates
+- Allow PHP-based cron processes to be triggered from the admin interface. (DIS-1192) (*MDN*)
+- Include logging for PHP-based cron processes to be displayed from the admin interface. (DIS-1192) (*MDN*)
+  - Supported cron processes include:
+    - Cleanup Shared Sessions
+    - Create Sitemaps
+    - Dismiss Year-in-Review Messages
+    - Fetch ILS Messages
+    - Fetch Notification Receipts
+    - Generate Material Request Hold Candidates
+    - Load Initial Reading History
+    - Send Campaign Emails
+    - Send Campaign Ending Emails
+    - Send ILS Messages
+    - Send LiDA Notifications
+    - Talpa Recalculation
+    - Talpa Works
+    - Update Community Translations
+    - Update Suggesters
+- Do not allow cron entries to be expanded if they have no sub processes. (DIS-1192) (*MDN*)
+
+<div markdown="1" class="settings">
+
+#### New Permissions
+- Manually Run Cron Processes - Allows the user to manually start cron processes.
+
+#### New Settings
+- System Administration > Manually Run Cron
+
+</div>
+
 ### Deep Linking Updates
 - Allow linking to the Aspen Materials Request forms from LiDA. (DIS-1115) (*MDN*)
 

--- a/code/web/services/Admin/CronLog.php
+++ b/code/web/services/Admin/CronLog.php
@@ -5,7 +5,7 @@ require_once ROOT_DIR . '/services/Admin/Admin.php';
 require_once ROOT_DIR . '/sys/Pager.php';
 
 class Admin_CronLog extends Admin_Admin {
-	function launch() {
+	function launch() : void {
 		global $interface;
 
 		$logEntries = [];
@@ -13,7 +13,7 @@ class Admin_CronLog extends Admin_Admin {
 		$total = $cronLogEntry->count();
 		$cronLogEntry = new CronLogEntry();
 		$cronLogEntry->orderBy('startTime DESC');
-		$page = isset($_REQUEST['page']) ? $_REQUEST['page'] : 1;
+		$page = $_REQUEST['page'] ?? 1;
 		$interface->assign('page', $page);
 		$cronLogEntry->limit(($page - 1) * 30, 30);
 		$cronLogEntry->find();

--- a/code/web/services/Admin/CronRunner.php
+++ b/code/web/services/Admin/CronRunner.php
@@ -1,0 +1,57 @@
+<?php
+
+require_once ROOT_DIR . '/services/Admin/Admin.php';
+
+class Admin_CronRunner extends Admin_Admin {
+
+	function launch() : void {
+		global $interface;
+		//Get a list of cron processes that can be run manually
+		$availableCronProcesses = [
+			'cleanupSharedSessions' => 'Cleanup Shared Sessions',
+			'createSitemaps' => 'Create Sitemaps',
+			'dismissYearInReviewMessages' => 'Dismiss Year-in-Review Messages',
+			'fetchILSMessages' => 'Fetch ILS Messages',
+			'fetchNotificationReceipts' => 'Fetch Notification Receipts',
+			'generateMaterialRequestHoldCandidates' => 'Generate Material Request Hold Candidates',
+			'loadInitialReadingHistory' => 'Load Initial Reading History',
+			'sendCampaignEmails' => 'Send Campaign Emails',
+			'sendCampaignEndingEmails' => 'Send Campaign Ending Emails',
+			'sendILSMessages' => 'Send ILS Messages',
+			'sendLiDANotifications' => 'Send LiDA Notifications',
+			'talpaRecalculationCron' => 'Talpa Recalculation',
+			'talpaWorksCron' => 'Talpa Works',
+			'updateCommunityTranslations' => 'Update Community Translations',
+			'updateSuggesters' => 'Update Suggesters',
+		];
+		$interface->assign('availableCronProcesses', $availableCronProcesses);
+
+		if (isset($_REQUEST['processToRun'])) {
+			if (array_key_exists($_REQUEST['processToRun'], $availableCronProcesses)) {
+				require_once ROOT_DIR . '/sys/Utils/SystemUtils.php';
+				$result = SystemUtils::startBackgroundProcess($_REQUEST['processToRun'], []);
+				$interface->assign('results', $result);
+			}else{
+				$interface->assign('error', 'Invalid process to run');
+			}
+		}
+
+		$this->display('cronRunner.tpl', 'Cron Runner');
+	}
+
+	function getBreadcrumbs(): array {
+		$breadcrumbs = [];
+		$breadcrumbs[] = new Breadcrumb('/Admin/Home', 'Administration Home');
+		$breadcrumbs[] = new Breadcrumb('/Admin/Home#system_admin', 'System Administration');
+		$breadcrumbs[] = new Breadcrumb('', 'Manually Run Cron Processes');
+		return $breadcrumbs;
+	}
+
+	function canView(): bool {
+		return UserAccount::userHasPermission('Manually Run Cron Processes');
+	}
+
+	function getActiveAdminSection(): string {
+		return 'system_admin';
+	}
+}

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -4148,6 +4148,7 @@ class User extends DataObject {
 		$sections['system_admin']->addAction(new AdminAction('USPS Settings', 'Settings to allow Aspen Discovery to validate addresses via USPS API.', '/Admin/USPS'), 'Administer System Variables');
 		$sections['system_admin']->addAction(new AdminAction('Variables', 'Variables set by the Aspen Discovery itself as part of background processes.', '/Admin/Variables'), 'Administer System Variables');
 		$sections['system_admin']->addAction(new AdminAction('System Variables', 'Settings for Aspen Discovery that apply to all libraries on this installation.', '/Admin/SystemVariables'), 'Administer System Variables');
+		$sections['system_admin']->addAction(new AdminAction('Manually Run Cron', 'Manually Start Cron Processes.', '/Admin/CronRunner'), 'Manually Run Cron Processes');
 
 		$sections['system_reports'] = new AdminSection('System Reports');
 		$sections['system_reports']->addAction(new AdminAction('Site Status', 'View Status of Aspen Discovery.', '/Admin/SiteStatus'), 'View System Reports');

--- a/code/web/sys/CronLogEntry.php
+++ b/code/web/sys/CronLogEntry.php
@@ -1,10 +1,11 @@
-<?php
+<?php /** @noinspection PhpMissingFieldTypeInspection */
 
 require_once ROOT_DIR . '/sys/DB/DataObject.php';
 
 class CronLogEntry extends DataObject {
 	public $__table = 'cron_log';   // table name
 	public $id;
+	public $name;
 	public $startTime;
 	public $lastUpdate;
 	public $endTime;
@@ -12,7 +13,7 @@ class CronLogEntry extends DataObject {
 	public $notes;
 	private $_processes = null;
 
-	function processes() {
+	function processes() : array {
 		if (is_null($this->_processes)) {
 			$this->_processes = [];
 			$reindexProcess = new CronProcessLogEntry();
@@ -26,11 +27,13 @@ class CronLogEntry extends DataObject {
 		return $this->_processes;
 	}
 
-	function getNumProcesses() {
+	/** @noinspection PhpUnused */
+	function getNumProcesses() : int {
 		return count($this->processes());
 	}
 
-	function getHadErrors() {
+	/** @noinspection PhpUnused */
+	function getHadErrors() : bool {
 		foreach ($this->processes() as $process) {
 			if ($process->numErrors > 0) {
 				return true;
@@ -39,8 +42,9 @@ class CronLogEntry extends DataObject {
 		return false;
 	}
 
-	function getElapsedTime() {
-		if (!isset($this->endTime) || is_null($this->endTime)) {
+	/** @noinspection PhpUnused */
+	function getElapsedTime() : string {
+		if (empty($this->endTime)) {
 			return "";
 		} else {
 			$elapsedTimeMin = ceil(($this->endTime - $this->startTime) / 60);

--- a/code/web/sys/CronProcessLogEntry.php
+++ b/code/web/sys/CronProcessLogEntry.php
@@ -1,4 +1,4 @@
-<?php
+<?php /** @noinspection PhpMissingFieldTypeInspection */
 
 require_once ROOT_DIR . '/sys/DB/DataObject.php';
 
@@ -15,8 +15,9 @@ class CronProcessLogEntry extends DataObject {
 	public $numSkipped;
 	public $notes;
 
-	function getElapsedTime() {
-		if (!isset($this->endTime) || is_null($this->endTime)) {
+	/** @noinspection PhpUnused */
+	function getElapsedTime() : string {
+		if (empty($this->endTime)) {
 			return "";
 		} else {
 			$elapsedTimeMin = ceil(($this->endTime - $this->startTime) / 60);

--- a/code/web/sys/DBMaintenance/version_updates/25.08.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.08.00.php
@@ -28,6 +28,22 @@ function getUpdates25_08_00(): array {
 				"ALTER TABLE materials_request ADD COLUMN source TINYINT DEFAULT 1"
 			]
 		], //materials_request_add_source
+		'manually_run_cron_permission' => [
+			'title' => 'Add Manually Run Cron Permission',
+			'description' => 'Add permission to manually run cron',
+			'sql' => [
+				"INSERT INTO permissions (sectionName, name, requiredModule, weight, description) VALUES 
+					 ('System Administration', 'Manually Run Cron Processes', '', 60, 'Allows the user to manually start cron processes.')",
+				"INSERT INTO role_permissions(roleId, permissionId) VALUES ((SELECT roleId from roles where name='opacAdmin'), (SELECT id from permissions where name='Manually Run Cron Processes'))",
+			]
+		], //manually_run_cron_permission
+		'add_cron_name' => [
+			'title' => 'Add Cron Name',
+			'description' => 'Add Name to cron table',
+			'sql' => [
+				"ALTER TABLE cron_log ADD COLUMN name varchar(255) default 'Primary Cron'"
+			]
+		], //add_cron_name
 
 		//katherine - Grove
 		'sierra_self_reg_enhancement_settings' => [

--- a/code/web/version.json
+++ b/code/web/version.json
@@ -1,4 +1,4 @@
 {
   "version": "25.08.00",
-  "stage": "alpha"
+  "stage": "beta 1"
 }


### PR DESCRIPTION
- Allow PHP-based cron processes to be triggered from the admin interface.
- Include logging for PHP-based cron processes to be displayed from the admin interface.
  - Supported cron processes include:
    - Cleanup Shared Sessions
    - Create Sitemaps
    - Dismiss Year-in-Review Messages
    - Fetch ILS Messages
    - Fetch Notification Receipts
    - Generate Material Request Hold Candidates
    - Load Initial Reading History
    - Send Campaign Emails
    - Send Campaign Ending Emails
    - Send ILS Messages
    - Send LiDA Notifications
    - Talpa Recalculation
    - Talpa Works
    - Update Community Translations
    - Update Suggesters
- Do not allow cron entries to be expanded if they have no sub processes.
