### PR TITLE
Dis 1197 audience format class

### DIFF
--- a/code/web/interface/themes/responsive/GroupedWork/full-record.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/full-record.tpl
@@ -85,7 +85,7 @@
 				{/if}
 			
 				{if !empty($showAudience)}
-					<div class="row">
+					<div class="row result-audience result-{str_replace(" ", "-", join(" ", $recordDriver->getFormats()))|lower}">
 						<div class="result-label col-sm-4 col-xs-12">{translate text='Audience' isPublicFacing=true} </div>
 						<div class="result-value col-sm-8 col-xs-12">
 							{if !empty($summAudience)}

--- a/code/web/interface/themes/responsive/Record/view-title-details.tpl
+++ b/code/web/interface/themes/responsive/Record/view-title-details.tpl
@@ -165,7 +165,7 @@
 	{/if}
 
 	{if !empty($showAudience) && $recordDriver->getAudience()}
-		<div class="row">
+		<div class="row result-audience result-{str_replace(" ", "-", join(" ", $recordDriver->getFormats()))|lower}">
 			<div class="result-label col-sm-4 col-xs-12">{translate text='Audience' isPublicFacing=true} </div>
 			<div class="result-value col-sm-8 col-xs-12">
 				{$recordDriver->getAudience()}

--- a/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/result.tpl
@@ -165,13 +165,17 @@
 
 				{if !empty($showAudience)}
 					{if $alwaysShowSearchResultsMainDetails || $summAudience}
-						<div class="result-label col-sm-4 col-xs-12">{translate text='Audience' isPublicFacing=true} </div>
-						<div class="result-value col-sm-8 col-xs-12">
-						{if !empty($summAudience)}
-							{$summAudience}
-						{elseif $alwaysShowSearchResultsMainDetails}
-							{translate text="Not Supplied" isPublicFacing=true}
-						{/if}
+						{assign var=formats value=$recordDriver->getFormats()}
+						{assign var=formats value=array_map('strstr', $formats, array_fill(0, count($formats), "#"))}
+						<div class="result-audience result-{join(" result-", array_unique($formats))|replace:"#":""|replace:" ":"-"|lower}">
+							<div class="result-label col-sm-4 col-xs-12">{translate text='Audience' isPublicFacing=true} </div>
+							<div class="result-value col-sm-8 col-xs-12">
+							{if !empty($summAudience)}
+								{$summAudience}
+							{elseif $alwaysShowSearchResultsMainDetails}
+								{translate text="Not Supplied" isPublicFacing=true}
+							{/if}
+							</div>
 						</div>
 					{/if}
 				{/if}

--- a/code/web/release_notes/25.09.00.MD
+++ b/code/web/release_notes/25.09.00.MD
@@ -11,6 +11,7 @@
 // kodi
 
 // imani
+- Added result-audience and result-<format> classes to audience sections of templates that showed audience information for records or grouped works.
 
 // leo
 


### PR DESCRIPTION
adding audience and format classes to audience information to target with javascript snippets.

To test:
* Search for an item that is currently displaying audience information
* in the search results and on the detail page there should be a result-audience class and a result-<format> class

