### PR TITLE
DIS-1198: Fixed Site Creation FK Errors and Improved Apache2 Handling in Rebuild RAQM Script

### DIFF
--- a/code/web/release_notes/25.08.00.MD
+++ b/code/web/release_notes/25.08.00.MD
@@ -291,7 +291,9 @@
 - Tidy up the default bad bots list. (DIS-1141) (*JStaub*)
 - Add and remove bad bots from the default list. (DIS-1142) (*JStaub*)
 - Nashville-only: Send staff email when non-resident update fails following out-of-county fee payment. (DIS-1125) (*JStaub*)
-- Minor updates and bug fix for Talpa Works crons (DIS-1195) (*LP*)
+- Minor updates and bug fix for Talpa Works crons. (DIS-1195) (*LP*)
+- Fixed foreign key constraint errors during site creation. (DIS-1198) (*LS*)
+- Fixed Apache2 restart warning in rebuild_gd_raqm.sh by adding a check to only restart if Apache2 is already running and improved its PHP source directory detection. (DIS-1198) (*LS*)
 
 ## This release includes code contributions from
 ### ByWater Solutions

--- a/install/aspen.sql
+++ b/install/aspen.sql
@@ -1,3 +1,4 @@
+SET FOREIGN_KEY_CHECKS=0;
 DROP TABLE IF EXISTS accelerated_reading_isbn;
 CREATE TABLE `accelerated_reading_isbn` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -7778,3 +7779,4 @@ INSERT INTO events_facet VALUES (1,1, 'Age Group/Audience', 'Age Groups/Audience
 INSERT INTO open_archives_facet_groups (id, name) VALUES (1, 'default');
 INSERT INTO open_archives_facets VALUES (1,1, 'Collection', 'Collections', 'collection_name', 1, 5, 'num_results', 1, 1, 1, 1, 1),(2,1, 'Creator', 'Creators', 'creator_facet', 2, 5, 'num_results', 1, 1, 1, 1, 1),(3,1, 'Contributor', 'Contributors', 'contributor_facet', 3, 5, 'num_results', 1, 1, 1, 1, 1),(4,1, 'Type', 'Types', 'type', 4, 5, 'num_results', 1, 1, 1, 1, 1),(5,1, 'Subject', 'Subjects', 'subject_facet', 5, 5, 'num_results', 1, 1, 1, 1, 1),(6,1, 'Publisher', 'Publishers', 'publisher_facet', 6, 5, 'num_results', 1, 1, 1, 1, 1),(7,1, 'Source', 'Sources', 'source', 7, 5, 'num_results', 1, 1, 1, 1, 1);
 INSERT INTO grouped_work_format_sort_group (id, name) VALUES (1, 'Default Format Sorting');
+SET FOREIGN_KEY_CHECKS=1;


### PR DESCRIPTION
- Fixed foreign key constraint errors during site creation.
- Fixed Apache2 restart warning in rebuild_gd_raqm.sh by adding a check to only restart if Apache2 is already running and improved its PHP source directory detection.

Test Plan:
1. Run `installer_debian.sh` while Apache2 is stopped. Notice the warning.
2. Run `createSite.php` with an empty database and notice the error when creating the database about foreign key constraints.
3. Apply the patch and repeat steps 1-2. Notice that everything completes well.