### PR TITLE
DIS-1200: Increased Nightly Reading History Timeouts

### DIFF
--- a/code/cron/src/com/turning_leaf_technologies/cron/reading_history/UpdateReadingHistory.java
+++ b/code/cron/src/com/turning_leaf_technologies/cron/reading_history/UpdateReadingHistory.java
@@ -18,9 +18,9 @@ import java.util.concurrent.*;
 public class UpdateReadingHistory implements IProcessHandler {
 
 	public void doCronProcess(String servername, Ini configIni, Section processSettings, Connection dbConn, CronLogEntry cronEntry, Logger logger) {
-		CronProcessLogEntry processLog = new CronProcessLogEntry(cronEntry, "Updating Reading History", dbConn, logger);
+		CronProcessLogEntry processLog = new CronProcessLogEntry(cronEntry, "Update Reading History", dbConn, logger);
 		processLog.saveResults();
-		processLog.addNote("Starting nightly reading history updates....");
+		processLog.addNote("Starting nightly reading history updates...");
 
 		String aspenUrl = configIni.get("Site", "url");
 		if (aspenUrl == null || aspenUrl.isEmpty()) {

--- a/code/cron/src/com/turning_leaf_technologies/cron/reading_history/UpdateReadingHistoryTask.java
+++ b/code/cron/src/com/turning_leaf_technologies/cron/reading_history/UpdateReadingHistoryTask.java
@@ -69,9 +69,9 @@ public class UpdateReadingHistoryTask implements Runnable {
 				// Call the patron API to get their checked out items.
 				URL patronApiUrl = new URL(aspenUrl + "/API/UserAPI?method=updatePatronReadingHistory&username=" + URLEncoder.encode(ilsBarcode, StandardCharsets.UTF_8));
 				HttpURLConnection conn = (HttpURLConnection) patronApiUrl.openConnection();
-				// Give 5 seconds for connection timeout and 5 minutes for read timeout.
-				conn.setConnectTimeout(5000);
-				conn.setReadTimeout(300000);
+				// Give 10 seconds for connection timeout and 10 minutes for read timeout.
+				conn.setConnectTimeout(10000);
+				conn.setReadTimeout(600000);
 				conn.addRequestProperty("User-Agent", "Aspen Discovery");
 				conn.addRequestProperty("Accept", "*/*");
 				conn.addRequestProperty("Cache-Control", "no-cache");
@@ -131,7 +131,7 @@ public class UpdateReadingHistoryTask implements Runnable {
 			hadError = true;
 		} catch (IOException e) {
 			String errorMessage = e.getMessage();
-			errorMessage = errorMessage.replaceAll(ilsPassword, "XXXX");
+            errorMessage = errorMessage.replaceAll(ilsPassword, "XXXX");
 			processLog.incErrors("Unable to retrieve information from patron API for " + ilsBarcode + "; base URL is " + aspenUrl + ": " + errorMessage);
 			hadError = true;
 		}

--- a/code/web/release_notes/25.08.00.MD
+++ b/code/web/release_notes/25.08.00.MD
@@ -292,6 +292,7 @@
 - Add and remove bad bots from the default list. (DIS-1142) (*JStaub*)
 - Nashville-only: Send staff email when non-resident update fails following out-of-county fee payment. (DIS-1125) (*JStaub*)
 - Minor updates and bug fix for Talpa Works crons (DIS-1195) (*LP*)
+- Increased the connection and read timeouts during nightly reading history updates to prevent occasional errors for patron accounts. (DIS-1200) (*LS*)
 
 ## This release includes code contributions from
 ### ByWater Solutions


### PR DESCRIPTION
- Increased the connection and read timeouts during nightly reading history updates to prevent occasional errors for patron accounts.

Test Plan: Difficult to test as it may occur depending on the API calls made to what ILS and what e-content providers.