### PR TITLE
DIS-1179: Allow .zip File Uploads & Automatic Indexing for Side Loads

### DIFF
--- a/code/web/interface/themes/responsive/SideLoads/marcFiles.tpl
+++ b/code/web/interface/themes/responsive/SideLoads/marcFiles.tpl
@@ -1,18 +1,38 @@
 {strip}
 	<div id="main-content">
-		<div class="btn-group">
-			<a class="btn btn-sm btn-default" href="/SideLoads/SideLoads?objectAction=edit&amp;id={$id}">{translate text="Edit Profile" isAdminFacing=true}</a>
-			{if !empty($additionalObjectActions)}
-				{foreach from=$additionalObjectActions item=action}
-					{if $smarty.server.REQUEST_URI != $action.url}
-						<a class="btn btn-default btn-sm" href='{$action.url}'>{$action.text}</a>
-					{/if}
-				{/foreach}
-			{/if}
-			<a class="btn btn-sm btn-default" href='/SideLoads/SideLoads?objectAction=list'>{translate text="Return to List" isAdminFacing=true}</a>
-		</div>
+		{if !empty($updateMessage)}
+			<div class="alert {if !empty($updateMessageIsError)}alert-danger{else}alert-success{/if}">
+				{$updateMessage}
+			</div>
+		{/if}
 		<h1>{$SideLoadName}</h1>
-		<table class="table table-striped table-bordered">
+		<div class="row">
+			<div class="col-xs-12">
+				<div class="btn-group">
+					<a class="btn btn-default" href='/SideLoads/SideLoads?objectAction=list'><i class="fas fa-arrow-alt-circle-left" role="presentation"></i> {translate text="Return to List" isAdminFacing=true}</a>
+				</div>
+				<div class="btn-group">
+					<a class="btn btn-default" href="/SideLoads/SideLoads?objectAction=edit&amp;id={$id}"><i class="fas fa-edit" role="presentation"></i> {translate text="Edit Side Load" isAdminFacing=true}</a>
+				</div>
+			</div>
+		</div>
+		{if !empty($additionalObjectActions)}
+			<div class="row">
+				<div class="col-xs-12">
+					<div class="btn-group-sm">
+						{foreach from=$additionalObjectActions item=action}
+							{if $smarty.server.REQUEST_URI != $action.url}
+								<a class="btn btn-default" href='{$action.url}'>{translate text=$action.text isAdminFacing=true}</a>
+							{/if}
+						{/foreach}
+					</div>
+				</div>
+			</div>
+		{/if}
+		
+		<div class="row" style="margin-top: 20px;">
+			<div class="col-xs-12">
+				<table class="table table-striped table-bordered">
 			<tr>
 				<th>{translate text="File Name" isAdminFacing=true}</th>
 				<th>{translate text="Date" isAdminFacing=true}</th>
@@ -31,11 +51,13 @@
 					<td>{translate text="No Marc Files Found" isAdminFacing=true}</td>
 				</tr>
 			{/foreach}
-		</table>
-		{if !$sideload->isReadOnly()}
-			<a class="btn btn-primary" href="/SideLoads/UploadMarc?id={$id}">
-				{translate text="Upload MARC file" isAdminFacing=true}
-			</a>
-		{/if}
+				</table>
+				{if !$sideload->isReadOnly()}
+					<a class="btn btn-primary" href="/SideLoads/UploadMarc?id={$id}">
+						{translate text="Upload MARC File" isAdminFacing=true}
+					</a>
+				{/if}
+			</div>
+		</div>
 	</div>
 {/strip}

--- a/code/web/interface/themes/responsive/SideLoads/uploadMarc.tpl
+++ b/code/web/interface/themes/responsive/SideLoads/uploadMarc.tpl
@@ -1,29 +1,44 @@
 {strip}
 	<div id="main-content" class="col-md-12">
-		<div class="btn-group">
-			<a class="btn btn-sm btn-default" href="/SideLoads/SideLoads?objectAction=edit&amp;id={$id}">{translate text="Edit Profile" isAdminFacing=true}</a>
-			{if !empty($additionalObjectActions)}
-				{foreach from=$additionalObjectActions item=action}
-					{if $smarty.server.REQUEST_URI != $action.url}
-						<a class="btn btn-default btn-sm" href='{$action.url}'>{$action.text}</a>
-					{/if}
-				{/foreach}
-			{/if}
-			<a class="btn btn-sm btn-default" href='/SideLoads/SideLoads?objectAction=list'>{translate text="Return to List" isAdminFacing=true}</a>
-		</div>
-
-		<h1>{translate text="Upload MARC Record" isAdminFacing=true}</h1>
-
-		{if !empty($error)}
-			<div class="alert alert-warning">
-				{$error}
+		<h1>{translate text="Upload MARC Records" isAdminFacing=true}</h1>
+		<div class="row">
+			<div class="col-xs-12">
+				<div class="btn-group">
+					<a class="btn btn-default" href='/SideLoads/SideLoads?objectAction=list'><i class="fas fa-arrow-alt-circle-left" role="presentation"></i> {translate text="Return to List" isAdminFacing=true}</a>
+				</div>
+				<div class="btn-group">
+					<a class="btn btn-default" href="/SideLoads/SideLoads?objectAction=edit&amp;id={$id}"><i class="fas fa-edit" role="presentation"></i> {translate text="Edit Side Load" isAdminFacing=true}</a>
+				</div>
+				<div class="btn-group">
+					<a class="btn btn-default" href="/SideLoads/SideLoads?objectAction=viewMarcFiles&amp;id={$id}"><i class="fas fa-file-alt" role="presentation"></i> {translate text="View MARC Files" isAdminFacing=true}</a>
+				</div>
 			</div>
-		{elseif !empty($message)}
-			<div class="alert alert-info">
-				{$message}
+		</div>
+		{if !empty($additionalObjectActions)}
+			<div class="row">
+				<div class="col-xs-12">
+					<div class="btn-group-sm">
+						{foreach from=$additionalObjectActions item=action}
+							{if $smarty.server.REQUEST_URI != $action.url}
+								<a class="btn btn-default" href='{$action.url}'>{translate text=$action.text isAdminFacing=true}</a>
+							{/if}
+						{/foreach}
+					</div>
+				</div>
 			</div>
 		{/if}
-		<form enctype="multipart/form-data" name="uploadMarc" method="post">
+
+		<div style="margin-top: 20px;">
+			{if !empty($error)}
+				<div class="alert alert-warning">
+					{$error}
+				</div>
+			{elseif !empty($message)}
+				<div class="alert alert-info">
+					{$message}
+				</div>
+			{/if}
+			<form enctype="multipart/form-data" name="uploadMarc" method="post">
 			<input type="hidden" name="id" value="{$id}"/>
 			<div class="form-group">
 				<div class="input-group">
@@ -42,7 +57,8 @@
 			<div class="form-group">
 				<button type="submit" class="btn btn-primary">{translate text="Upload File" isAdminFacing=true}</button>
 			</div>
-		</form>
+			</form>
+		</div>
 	</div>
 	<script type="application/javascript">
 		{literal}

--- a/code/web/release_notes/25.09.00.MD
+++ b/code/web/release_notes/25.09.00.MD
@@ -13,6 +13,12 @@
 // imani
 
 // leo
+### Side Loads Updates
+- Added the ability for uploaded .zip files of MARC files to be unzipped. (DIS-1179) (*LS*)
+- After successful uploads: (DIS-1179) (*LS*)
+  - Users are redirected to the `viewMarcFiles` page with a displayed success message.
+  - A full update is automatically run to index the newly uploaded MARC files' data.
+- Modified the button styling to match other admin pages, including a "View Marc Files" button on the upload page to direct users to the `viewMarcFiles` page. (DIS-1179) (*LS*)
 
 // yanjun
 

--- a/code/web/services/SideLoads/SideLoads.php
+++ b/code/web/services/SideLoads/SideLoads.php
@@ -8,10 +8,20 @@ require_once ROOT_DIR . '/sys/Indexing/SideLoad.php';
 class SideLoads_SideLoads extends ObjectEditor {
 	function launch() : void {
 		global $interface;
-		$objectAction = isset($_REQUEST['objectAction']) ? $_REQUEST['objectAction'] : null;
+		$objectAction = $_REQUEST['objectAction'] ?? null;
 		if ($objectAction == 'viewMarcFiles') {
 			$id = $_REQUEST['id'];
 			$interface->assign('id', $id);
+
+			$user = UserAccount::getActiveUserObj();
+			if (!empty($user->updateMessage)) {
+				$interface->assign('updateMessage', $user->updateMessage);
+				$interface->assign('updateMessageIsError', $user->updateMessageIsError);
+				$user->updateMessage = '';
+				$user->updateMessageIsError = 0;
+				$user->update();
+			}
+			
 			$files = [];
 			$sideLoadConfiguration = new SideLoad();
 			$sideLoadConfiguration->id = $id;
@@ -108,7 +118,7 @@ class SideLoads_SideLoads extends ObjectEditor {
 			}
 			if ($existingObject->id != '' && !$existingObject->isReadOnly()) {
 				$actions[] = [
-					'text' => 'Upload MARC file',
+					'text' => 'Upload MARC File',
 					'url' => '/SideLoads/UploadMarc?id=' . $existingObject->id,
 				];
 			}

--- a/code/web/services/SideLoads/UploadMarc.php
+++ b/code/web/services/SideLoads/UploadMarc.php
@@ -3,7 +3,7 @@ require_once ROOT_DIR . '/services/Admin/Admin.php';
 require_once ROOT_DIR . '/sys/Indexing/SideLoad.php';
 
 class SideLoads_UploadMarc extends Admin_Admin {
-	function launch() {
+	function launch(): void {
 		global $interface;
 
 		//Figure out the maximum upload size
@@ -38,8 +38,8 @@ class SideLoads_UploadMarc extends Admin_Admin {
 					}
 					$destFileName = $uploadedFile["name"];
 					$destFullPath = $uploadPath . '/' . $destFileName;
-					if ($fileType == 'application/x-zip-compressed') {
-						$zip = new ZipArchive;
+					if ($fileType == 'application/x-zip-compressed' || $fileType == 'application/zip' || strtolower(pathinfo($destFileName, PATHINFO_EXTENSION)) == 'zip') {
+						$zip = new ZipArchive();
 						$res = $zip->open($uploadedFile["tmp_name"]);
 						if ($res === TRUE) {
 							// extract it to the path we determined above
@@ -53,7 +53,16 @@ class SideLoads_UploadMarc extends Admin_Admin {
 									chmod($fullFileName, 0664);
 								}
 							}
-							$interface->assign('message', "File uploaded and unzipped");
+							$sideload->runFullUpdate = true;
+							$sideload->update();
+							
+							$user = UserAccount::getActiveUserObj();
+							$user->updateMessage = "File uploaded and unzipped. Indexing has been scheduled to run automatically.";
+							$user->updateMessageIsError = 0;
+							$user->update();
+							
+							header('Location: /SideLoads/SideLoads?objectAction=viewMarcFiles&id=' . $id);
+							exit();
 						} else {
 							$interface->assign('error', "Could not unzip the file");
 						}
@@ -79,13 +88,31 @@ class SideLoads_UploadMarc extends Admin_Admin {
 								chmod($fullFileName, 0664);
 							}
 						}
-						$interface->assign('message', "The file was uploaded and unzipped successfully");
+						$sideload->runFullUpdate = true;
+						$sideload->update();
+						
+						$user = UserAccount::getActiveUserObj();
+						$user->updateMessage = "The file was uploaded and unzipped successfully. Indexing has been scheduled to run automatically.";
+						$user->updateMessageIsError = 0;
+						$user->update();
+						
+						header('Location: /SideLoads/SideLoads?objectAction=viewMarcFiles&id=' . $id);
+						exit();
 					} else {
 						$copyResult = copy($uploadedFile["tmp_name"], $destFullPath);
 						if ($copyResult) {
 							chgrp($destFullPath, 'aspen_apache');
 							chmod($destFullPath, 0774);
-							$interface->assign('message', "The file was uploaded successfully");
+							$sideload->runFullUpdate = true;
+							$sideload->update();
+							
+							$user = UserAccount::getActiveUserObj();
+							$user->updateMessage = "The file was uploaded successfully. Indexing has been scheduled to run automatically.";
+							$user->updateMessageIsError = 0;
+							$user->update();
+							
+							header('Location: /SideLoads/SideLoads?objectAction=viewMarcFiles&id=' . $id);
+							exit();
 						} else {
 							$interface->assign('error', "Could not copy the file to $uploadPath");
 						}


### PR DESCRIPTION
- Added the ability for uploaded .zip files of MARC files to be unzipped.
- After successful uploads: 
  - Users are redirected to the `viewMarcFiles` page with a displayed success message.
  - A full update is automatically run to index the newly uploaded MARC files' data.
- Modified the button styling to match other admin pages, including a "View Marc Files" button on the upload page to direct users to the `viewMarcFiles` page.

Test Plan:
1. Navigate to the Side Loads settings and attempt to upload a `.zip` file. Notice that is not unzipped.
2. Apply the patch and repeat step 1. Notice that the `.zip` file is unzipped and the MARC files are listed as uploaded.
3. Navigate back to the settings and notice that “Run Full Update” is already enabled.