### PR TITLE
DIS-1193: Fixed Web Resources Facet Popup Error

### DIFF
--- a/code/web/release_notes/25.09.00.MD
+++ b/code/web/release_notes/25.09.00.MD
@@ -13,6 +13,8 @@
 // imani
 
 // leo
+### Searching Updates
+- Fixed "facet does not exist" error for Web Resource facet popups. (DIS-1193) (*LS*)
 
 // yanjun
 

--- a/code/web/sys/SearchObject/BaseSearcher.php
+++ b/code/web/sys/SearchObject/BaseSearcher.php
@@ -1830,7 +1830,7 @@ abstract class SearchObject_BaseSearcher {
 	public function init($searchSource = null) {
 		// Start the timer
 		$mtime = explode(' ', microtime());
-		$this->initTime = $mtime[1] + $mtime[0];
+		$this->initTime = $mtime[1] . $mtime[0];
 
 		$this->searchSource = $searchSource;
 		return true;

--- a/code/web/sys/SearchObject/WebsitesSearcher.php
+++ b/code/web/sys/SearchObject/WebsitesSearcher.php
@@ -62,7 +62,7 @@ class SearchObject_WebsitesSearcher extends SearchObject_SolrSearcher {
 	 */
 	public function init($searchSource = null) {
 		// Call the standard initialization routine in the parent:
-		parent::init('website_pages');
+		parent::init('websites');
 
 		//********************
 		// Check if we have a saved search to restore -- if restored successfully,


### PR DESCRIPTION
- Fixed "facet does not exist" error for Web Resource facet popups.

Test Plan:
1. With “Use More Facet Popup” enabled for facets in the Website Facets setting, and with more than 12 facets within the facet group, a facet popup will display when “more” is clicked on a facet grouped after Website searching. Notice a “facet does not exist” error displays.
2. Apply the patch, reload the page, and click “more” again. Notice that the facet popup displays with results.