### PR TITLE
DIS-1204: Added 2 Cron Jobs to Cron Runner & Added "Log Frequent Cron Jobs" Setting

### DIFF
--- a/code/web/cron/purgeSoftDeleted.php
+++ b/code/web/cron/purgeSoftDeleted.php
@@ -10,6 +10,12 @@ require_once __DIR__ . '/../bootstrap_aspen.php';
  * so administrators still have the entire "Final Day" to
  * restore objects before automatic removal.
  */
+require_once ROOT_DIR . '/sys/CronLogEntry.php';
+$cronLogEntry = new CronLogEntry();
+$cronLogEntry->startTime = time();
+$cronLogEntry->name = 'Purge Soft Deleted';
+$cronLogEntry->insert();
+
 global $logger;
 require_once ROOT_DIR . '/services/Admin/ObjectRestorations.php';
 $softDeleteClasses = Admin_ObjectRestorations::getManagedClasses();
@@ -21,4 +27,6 @@ foreach ($softDeleteClasses as $className) {
 	}
 }
 
-$logger->log("Soft-delete purge complete: $totalPurged rows permanently removed from the database.", Logger::LOG_DEBUG);
+$cronLogEntry->notes .= "Soft-delete purge complete: $totalPurged rows permanently removed from the database.";
+$cronLogEntry->endTime = time();
+$cronLogEntry->update();

--- a/code/web/cron/updateNYTLists.php
+++ b/code/web/cron/updateNYTLists.php
@@ -10,8 +10,13 @@ require_once ROOT_DIR . '/sys/NYTApi.php';
 require_once ROOT_DIR . '/sys/Enrichment/NewYorkTimesSetting.php';
 require_once ROOT_DIR . '/sys/UserLists/NYTUpdateLogEntry.php';
 require_once ROOT_DIR . '/sys/Grouping/GroupedWork.php';
+require_once ROOT_DIR . '/sys/CronLogEntry.php';
 
-//Create a NYTUpdateLogEntry
+$cronLogEntry = new CronLogEntry();
+$cronLogEntry->startTime = time();
+$cronLogEntry->name = 'Update New York Times Lists';
+$cronLogEntry->insert();
+
 $nytUpdateLog = new NYTUpdateLogEntry();
 $nytUpdateLog->startTime = time();
 $nytUpdateLog->insert();
@@ -59,6 +64,10 @@ if (!$nytSettings->find(true)) {
 $nytUpdateLog->addNote("Finished updating lists");
 $nytUpdateLog->endTime = time();
 $nytUpdateLog->update();
+
+$cronLogEntry->notes .= "New York Times Lists update completed (<a href='/UserLists/NYTUpdatesLog'>View detailed NYT Log</a>).";
+$cronLogEntry->endTime = time();
+$cronLogEntry->update();
 
 $nytSettings->__destruct();
 $nytSettings = null;

--- a/code/web/interface/themes/responsive/Admin/cronRunner.tpl
+++ b/code/web/interface/themes/responsive/Admin/cronRunner.tpl
@@ -1,31 +1,30 @@
 {strip}
-	<div id="main-content" class="col-md-12">
-		<div class="row">
-			<div class="col-xs-12">
-				<h1 id="pageTitle">{$pageTitleShort}</h1>
-			</div>
-		</div>
-		{if isset($results)}
-			<div class="row">
-				<div class="col-xs-12">
-					<div class="alert {if !empty($results.success)}alert-success{else}alert-danger{/if}">
-						{$results.message}
-					</div>
-				</div>
-			</div>
-		{elseif isset($error)}
-			<div class="row">
-				<div class="col-xs-12">
-					<div class="alert alert-danger">
-						{$error}
-					</div>
-				</div>
-			</div>
-		{/if}
-	</div>
+<div id="main-content" class="col-xs-12">
 	<div class="row">
 		<div class="col-xs-12">
-			<div class="alert alert-info">{translate text="This tool can be used to start a background process. Results can be checked in the Cron Log." isAdminFacing=true}</div>
+			<h1 id="pageTitle">{$pageTitleShort}</h1>
+		</div>
+	</div>
+	{if isset($results)}
+		<div class="row">
+			<div class="col-xs-12">
+				<div class="alert {if !empty($results.success)}alert-success{else}alert-danger{/if}">
+					{$results.message}
+				</div>
+			</div>
+		</div>
+	{elseif isset($error)}
+		<div class="row">
+			<div class="col-xs-12">
+				<div class="alert alert-danger">
+					{$error}
+				</div>
+			</div>
+		</div>
+	{/if}
+	<div class="row">
+		<div class="col-xs-12">
+			<div class="alert alert-info">{translate text="This tool can be used to start a background cron process. Results can be checked in the %1%Cron Log%2%." 1='<a href="/Admin/CronLog">' 2='</a>' isAdminFacing=true}</div>
 		</div>
 	</div>
 	<form id="generateTestUsersForm" method="get" role="form">
@@ -45,4 +44,5 @@
 			</div>
 		</div>
 	</form>
+</div>
 {/strip}

--- a/code/web/release_notes/25.08.00.MD
+++ b/code/web/release_notes/25.08.00.MD
@@ -125,7 +125,7 @@
     - Update Suggesters
 - Do not allow cron entries to be expanded if they have no sub processes. (DIS-1192) (*MDN*)
 - Added Purge Soft-Deleted Objects and Update NYT Lists as supported cron processes to be run from the admin interface. (DIS-1204) (*LS*)
-- Added "Log Frequent Cron Jobs" to System Variables and default it to be disabled to prevent frequently run cron jobs from cluttering the cron logs. (DIS-1204) (*LS*)
+- Added "Log Frequent Cron Jobs" to System Variables and defaulted it to be disabled to prevent frequently run cron jobs from cluttering the cron logs. (DIS-1204) (*LS*)
 
 <div markdown="1" class="settings">
 
@@ -134,6 +134,7 @@
 
 #### New Settings
 - System Administration > Manually Run Cron
+- System Administration > System Variables > Log Frequent Cron Jobs
 
 </div>
 
@@ -312,7 +313,6 @@
 - Minor updates and bug fix for Talpa Works crons. (DIS-1195) (*LP*)
 - Fixed foreign key constraint errors during site creation. (DIS-1198) (*LS*, *MDN*)
 - Fixed Apache2 restart warning in rebuild_gd_raqm.sh by adding a check to only restart if Apache2 is already running and improved its PHP source directory detection. (DIS-1198) (*LS*)
-- Minor updates and bug fix for Talpa Works crons (DIS-1195) (*LP*)
 - Increased the connection and read timeouts during nightly reading history updates to prevent occasional errors for patron accounts. (DIS-1200) (*LS*)
 
 ## This release includes code contributions from

--- a/code/web/release_notes/25.08.00.MD
+++ b/code/web/release_notes/25.08.00.MD
@@ -124,6 +124,8 @@
     - Update Community Translations
     - Update Suggesters
 - Do not allow cron entries to be expanded if they have no sub processes. (DIS-1192) (*MDN*)
+- Added Purge Soft-Deleted Objects and Update NYT Lists as supported cron processes to be run from the admin interface. (DIS-1204) (*LS*)
+- Added "Log Frequent Cron Jobs" to System Variables and default it to be disabled to prevent frequently run cron jobs from cluttering the cron logs. (DIS-1204) (*LS*)
 
 <div markdown="1" class="settings">
 

--- a/code/web/services/Admin/CronRunner.php
+++ b/code/web/services/Admin/CronRunner.php
@@ -15,6 +15,7 @@ class Admin_CronRunner extends Admin_Admin {
 			'fetchNotificationReceipts' => 'Fetch Notification Receipts',
 			'generateMaterialRequestHoldCandidates' => 'Generate Material Request Hold Candidates',
 			'loadInitialReadingHistory' => 'Load Initial Reading History',
+			'purgeSoftDeleted' => 'Purge Soft-Deleted Objects',
 			'sendCampaignEmails' => 'Send Campaign Emails',
 			'sendCampaignEndingEmails' => 'Send Campaign Ending Emails',
 			'sendILSMessages' => 'Send ILS Messages',
@@ -22,6 +23,7 @@ class Admin_CronRunner extends Admin_Admin {
 			'talpaRecalculationCron' => 'Talpa Recalculation',
 			'talpaWorksCron' => 'Talpa Works',
 			'updateCommunityTranslations' => 'Update Community Translations',
+			'updateNYTLists' => 'Update New York Times Lists',
 			'updateSuggesters' => 'Update Suggesters',
 		];
 		$interface->assign('availableCronProcesses', $availableCronProcesses);
@@ -53,5 +55,15 @@ class Admin_CronRunner extends Admin_Admin {
 
 	function getActiveAdminSection(): string {
 		return 'system_admin';
+	}
+
+	/**
+	 * Get list of cron jobs that are considered "frequent" (e.g., run every few minutes).
+	 * These jobs can be controlled by the logFrequentCrons system variable.
+	 */
+	public static function getFrequentCronJobs(): array {
+		return [
+			'Load Initial Reading History',
+		];
 	}
 }

--- a/code/web/sys/DBMaintenance/version_updates/25.08.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.08.00.php
@@ -213,6 +213,14 @@ function getUpdates25_08_00(): array {
 				'ALTER TABLE library ADD COLUMN IF NOT EXISTS maxHoldCancellationDate int(11) DEFAULT -1 AFTER defaultNotNeededAfterDays;'
 			]
 		], //add_max_hold_cancellation_date_field
+		'log_frequent_crons_system_variable' => [
+			'title' => 'Add Log Frequent Crons System Variable',
+			'description' => 'Add system variable to control logging of frequently running cron jobs.',
+			'continueOnError' => false,
+			'sql' => [
+				"ALTER TABLE system_variables ADD COLUMN logFrequentCrons TINYINT(1) DEFAULT 0"
+			]
+		], //log_frequent_crons_system_variable
 
 		// Laura Escamilla - ByWater Solutions
 

--- a/code/web/sys/SystemVariables.php
+++ b/code/web/sys/SystemVariables.php
@@ -41,9 +41,13 @@ class SystemVariables extends DataObject {
 	public $lidaGitHubRepository;
 	public $numBoundlessSettingsToProcessInParallel;
 	public $disable_user_agent_logging;
+	public $logFrequentCrons;
 
 
 	static function getObjectStructure($context = ''): array {
+		require_once ROOT_DIR . '/services/Admin/CronRunner.php';
+		$frequentJobs = Admin_CronRunner::getFrequentCronJobs();
+
 		$objectStructure = [
 			'id' => [
 				'property' => 'id',
@@ -370,6 +374,14 @@ class SystemVariables extends DataObject {
 				'type' => 'checkbox',
 				'label' => 'Disable User Agent Tracking',
 				'description' => 'When enabled, disables all user agent tracking including logging, spam detection, and blocking.',
+				'default' => false,
+			],
+			'logFrequentCrons' => [
+				'property' => 'logFrequentCrons',
+				'type' => 'checkbox',
+				'label' => 'Log Frequent Cron Jobs',
+				'description' => 'Whether or not to log frequently running cron jobs (e.g., runs every few minutes).',
+				'note' => 'Frequent jobs include: ' . implode(', ', $frequentJobs) . '.',
 				'default' => false,
 			],
 		];


### PR DESCRIPTION
- Added Purge Soft-Deleted Objects and Update NYT Lists as supported cron processes to be run from the admin interface.
- Added "Log Frequent Cron Jobs" to System Variables and default it to be disabled to prevent frequently run cron jobs from cluttering the cron logs.

Test Plan:
1. Apply the patch.
2. Run the Purge Soft-Deleted Objects and Update NYT Lists from the Cron Runner. Notice they run successfully.
3. Notice that the "Log Frequent Cron Jobs" option on the System Variables page is disabled. There should be no logs of the Load Initial Reading History cron job.
4. If you enable it, notice the logs of the Load Initial Reading History cron job every 5 minutes.