### PR TITLE
DIS-1192 allow filtering cron log

### DIFF
--- a/code/web/interface/themes/responsive/Admin/cronLog.tpl
+++ b/code/web/interface/themes/responsive/Admin/cronLog.tpl
@@ -2,6 +2,51 @@
 	<div id="main-content" class="col-md-12">
 		<h1>{translate text='Cron Log' isAdminFacing=true}</h1>
 
+		<form>
+			<div class="row">
+				<div class="col-sm-5 col-md-4">
+					<div class="form-group">
+						<label for="pageSize">{translate text='Entries Per Page' isAdminFacing=true}</label>
+						<select id="pageSize" name="pageSize" class="pageSize form-control input-sm">
+							<option value="30"{if $recordsPerPage == 30} selected="selected"{/if}>30</option>
+							<option value="50"{if $recordsPerPage == 50} selected="selected"{/if}>50</option>
+							<option value="75"{if $recordsPerPage == 75} selected="selected"{/if}>75</option>
+							<option value="100"{if $recordsPerPage == 100} selected="selected"{/if}>100</option>
+						</select>
+					</div>
+				</div>
+				<div class="col-sm-4 col-md-4 col-lg-3">
+					<div class="form-group">
+						<label for="cronNamesToShow">{translate text='Show names containing' isAdminFacing=true}</label>
+						<div class="input-group-sm input-group">
+							<input id="cronNamesToShow" name="cronNamesToShow" class="form-control input-sm" {if !empty($cronNamesToShow)} value="{$cronNamesToShow}"{/if}>
+						</div>
+					</div>
+				</div>
+				<div class="col-sm-3 col-md-4 col-lg-4">
+					<div class="form-group">
+						<label for="showErrorsOnly">{translate text='Show Errors Only' isAdminFacing=true}</label>
+						<div class="input-group-sm input-group">
+							<input type='checkbox' name='showErrorsOnly' id='showErrorsOnly' data-on-text="{translate text='Errors Only' inAttribute=true isAdminFacing=true}" data-off-text="{translate text='All Records' inAttribute=true isAdminFacing=true}" data-switch="" {if !empty($showErrorsOnly)}checked{/if}/>
+						</div>
+					</div>
+				</div>
+
+			</div>
+			<div class="row">
+				<div class="col-sm-2 col-md-4">
+					<div class="form-group">
+						<button class="btn btn-primary btn-sm" type="submit">{translate text="Apply" isAdminFacing=true}</button>
+					</div>
+				</div>
+			</div>
+		</form>
+		<script type="text/javascript">
+			{literal}
+			$(function(){ $('input[type="checkbox"][data-switch]').bootstrapSwitch()});
+			{/literal}
+		</script>
+
 		<div class="adminTableRegion fixed-height-table">
 			<table class="adminTable table table-condensed table-hover table-condensed smallText table-sticky" aria-label="Cron Log">
 				<thead>

--- a/code/web/release_notes/25.08.00.MD
+++ b/code/web/release_notes/25.08.00.MD
@@ -51,7 +51,7 @@
 - Fixed error in List API when retrieving user list data for non-LiDA applications. (DIS-1148) (*LS*)
 - Improved error handling when updating a Browse Category with the same settings; now shows a clear message explaining the update isn't allowed. (DIS-1095) (*LS*)
 - Sort options are now shown or hidden based on source type to prevent selecting unsupported sorting methods. (DIS-1095) (*LS*)
-- Fix warning in searchLite with certain data when a variation exists with an invalid manifestation for the current instance. (DIS-1207) (*MDN*)
+- Fix warning message in searchLite and getGroupedWork with certain data when a variation exists with an invalid manifestation for the current instance. (DIS-1207) (*MDN*)
 
 ### Browse Category Updates
 - Fixed an issue where browse categories created through the admin interface did not save the creator's user ID. (DIS-1135) (*LS*)

--- a/code/web/release_notes/25.08.00.MD
+++ b/code/web/release_notes/25.08.00.MD
@@ -125,6 +125,7 @@
     - Update Community Translations
     - Update Suggesters
 - Do not allow cron entries to be expanded if they have no sub processes. (DIS-1192) (*MDN*)
+- Allow cron entries to be filtered by searched by name, to only show entries with errors, and allow page size to be set. (DIS-1192) (*MDN*)
 - Added Purge Soft-Deleted Objects and Update NYT Lists as supported cron processes to be run from the admin interface. (DIS-1204) (*LS*)
 - Added "Log Frequent Cron Jobs" to System Variables and defaulted it to be disabled to prevent frequently run cron jobs from cluttering the cron logs. (DIS-1204) (*LS*)
 

--- a/code/web/services/API/WorkAPI.php
+++ b/code/web/services/API/WorkAPI.php
@@ -112,7 +112,7 @@ class WorkAPI extends AbstractAPI {
 			$relatedManifestations = $groupedWorkDriver->getRelatedManifestations();
 			foreach ($relatedManifestations as $relatedManifestation) {
 				foreach ($relatedManifestation->getVariations() as $obj) {
-					if(!array_key_exists($obj->manifestation->format, $itemData['formats'])) {
+					if(!is_null($obj->manifestation) && !array_key_exists($obj->manifestation->format, $itemData['formats'])) {
 						$format = $obj->manifestation->format;
 						$itemData['formats'][$format] = [];
 						$itemData['formats'][$format]['label'] = translate(['text' => $format, 'isPublicFacing' => true]);

--- a/code/web/services/Admin/CronLog.php
+++ b/code/web/services/Admin/CronLog.php
@@ -10,8 +10,29 @@ class Admin_CronLog extends Admin_Admin {
 
 		$logEntries = [];
 		$cronLogEntry = new CronLogEntry();
+		if (isset($_REQUEST['showErrorsOnly'])) {
+			$interface->assign('showErrorsOnly', true);
+			$cronLogEntry->whereAdd('numErrors > 0');
+		}
 		$total = $cronLogEntry->count();
+
 		$cronLogEntry = new CronLogEntry();
+		$page = isset($_REQUEST['page']) ? $_REQUEST['page'] : 1;
+		$pageSize = isset($_REQUEST['pageSize']) ? $_REQUEST['pageSize'] : 30; // to adjust number of items listed on a page
+		$interface->assign('recordsPerPage', $pageSize);
+		$interface->assign('page', $page);
+		$cronLogEntry->limit(($page - 1) * $pageSize, $pageSize);
+		$cronNamesToShow = isset($_REQUEST['cronNamesToShow']) ? $_REQUEST['cronNamesToShow'] : '';
+
+		if (!isSpammySearchTerm($cronNamesToShow)) {
+			$interface->assign('cronNamesToShow', $cronNamesToShow);
+			$escapedFilter = $cronLogEntry->escape('%' . $cronNamesToShow . '%');
+			$cronLogEntry->whereAdd("name LIKE $escapedFilter");
+		}
+		if (isset($_REQUEST['showErrorsOnly'])) {
+			$interface->assign('showErrorsOnly', true);
+			$cronLogEntry->whereAdd('numErrors > 0');
+		}
 		$cronLogEntry->orderBy('startTime DESC');
 		$page = $_REQUEST['page'] ?? 1;
 		$interface->assign('page', $page);


### PR DESCRIPTION
- Allow cron entries to be filtered by searched by name, to only show entries with errors, and allow page size to be set.