### PR TITLE
DIS-1211: Reduce Reading History Thread Count & Change Koha Reading History Patron Activity

### DIFF
--- a/code/cron/src/com/turning_leaf_technologies/cron/reading_history/UpdateReadingHistory.java
+++ b/code/cron/src/com/turning_leaf_technologies/cron/reading_history/UpdateReadingHistory.java
@@ -31,8 +31,8 @@ public class UpdateReadingHistory implements IProcessHandler {
 		}
 
 		// Get the thread settings from the configuration, if any.
-		int minThreads = 8;
-		int maxThreads = 16;
+		int minThreads = 4;
+		int maxThreads = 8;
 		try {
 			String minThreadsStr = processSettings.get("minThreads");
 			if (minThreadsStr != null && !minThreadsStr.isEmpty()) {

--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -8585,8 +8585,8 @@ class Koha extends AbstractIlsDriver {
 			must be kept up to date in the background; otherwise, patrons will report gaps in their reading history. */
 			//$lastReadingHistoryUpdate = $patron->lastReadingHistoryUpdate;
 			//if ($lastSeenDate <= $lastReadingHistoryUpdate) {}
-			// Bypass reading history update if the patron hasn't been seen in the last 2 weeks (inactive patron).
-			if ($lastSeenDate <= (time() - 2 * 7 * 24 * 60 * 60)) {
+			// Bypass reading history update if the patron hasn't been seen in the last 23 hours (inactive patron for the day).
+			if ($lastSeenDate <= (time() - 82800)) {
 				return true;
 			}
 		}

--- a/code/web/release_notes/25.08.00.MD
+++ b/code/web/release_notes/25.08.00.MD
@@ -203,6 +203,7 @@
   - Fixed an issue where new Locations could not be imported from Koha to Aspen.
 - Renamed the "Automatically Update with Closures from the ILS" to "Automatically Update with Library Hours and Closures from the ILS" to reflect its additional behavior of automatically updating Library Hours during indexing. (DIS-1137) (*LS*)
 - Added "Allow Material Requests Branch Choice" setting for the ILS Request System, allowing patrons to select which branch should receive their materials request instead of defaulting to their home branch. (DIS-1153) (*LS*)
+- Patrons who have not performed any patron operations (e.g., checking out a record) within 23 hours will not have their reading histories updated during the nightly run. (DIS-1211) (*LS*)
 
 <div markdown="1" class="settings">
 
@@ -229,6 +230,10 @@
 
 ### Performance Updates
 - Optimize Loading Lists of libraries and Indexing Profiles. (DIS-1182) (*MDN*)
+
+### Reading History Updates
+- Increased the connection and read timeouts during nightly reading history updates to prevent occasional errors for patron accounts. (DIS-1200) (*LS*)
+- Reduced the Java thread count for nightly reading history updates to slow down the number of API calls within intervals of time. (DIS-1211) (*LS*)
 
 ### Searching Updates
 - Search suggestions now correctly exclude records that are outside the current library or location scope, preventing titles not available in the searched catalog from appearing. (DIS-1167) (*LS*, *YL*)
@@ -318,7 +323,6 @@
 - Minor updates and bug fix for Talpa Works crons. (DIS-1195) (*LP*)
 - Fixed foreign key constraint errors during site creation. (DIS-1198) (*LS*, *MDN*)
 - Fixed Apache2 restart warning in rebuild_gd_raqm.sh by adding a check to only restart if Apache2 is already running, improved its PHP source directory detection, and prevented script failures due to apt repository errors. (DIS-1198) (*LS*)
-- Increased the connection and read timeouts during nightly reading history updates to prevent occasional errors for patron accounts. (DIS-1200) (*LS*)
 - Fixed an issue where LiDA would receive an invalid response when attempting to use the “Forgot Barcode or Username” feature because Twilio’s Product APIs only return JSON responses, but Aspen was incorrectly expecting XML responses. (DIS-1206) (*LS*)
 - Fixed an issue where Symphony self registrations in LiDA would fail with a long PHP warning message. (DIS-1206) (*LS*)
 

--- a/sites/default/conf/config.cron.ini
+++ b/sites/default/conf/config.cron.ini
@@ -45,8 +45,8 @@ librariesToCreateReportsFor =
 [UpdateReadingHistory]
 description = Updates Reading History for the patron based on what is currently checked out.
 frequencyHours = 0
-minThreads = 8
-maxThreads = 16
+minThreads = 4
+maxThreads = 8
 batchSize = 1000
 
 [BackupAspen]


### PR DESCRIPTION
- Increased the connection and read timeouts during nightly reading history updates to prevent occasional errors for patron accounts.
- Reduced the Java thread count for nightly reading history updates to slow down the number of API calls within intervals of time.
- Patrons who have not performed any patron operations (e.g., checking out a record) within 23 hours will not have their reading histories updated during the nightly run.