### PR TITLE
DIS-1210: Allow Parenthetical Content for Wikipedia Author Disambiguation

### DIFF
--- a/code/web/interface/themes/responsive/js/aspen/wikipedia.js
+++ b/code/web/interface/themes/responsive/js/aspen/wikipedia.js
@@ -7,13 +7,17 @@ AspenDiscovery.Wikipedia = (() => {
 				const { success, formatted_article, debugMessage } = data || {};
 				const $placeholder = $("#wikipedia_placeholder");
 				if (success && formatted_article) {
-					$placeholder.html(formatted_article).fadeIn();
-				} else if (debugMessage) {
+					$placeholder.html(formatted_article);
+				}
+				if (debugMessage) {
 					$placeholder.append(
-						'<div ' + 'class="smallText text-muted" style="font-style:italic">' +
+						'<div class="smallText text-muted" style="font-style:italic">' +
 						debugMessage +
 						'</div>'
-					).fadeIn();
+					);
+				}
+				if ((success && formatted_article) || debugMessage) {
+					$placeholder.fadeIn();
 				}
 			})
 			.fail((jqXHR, textStatus) => {

--- a/code/web/services/Author/Home.php
+++ b/code/web/services/Author/Home.php
@@ -196,15 +196,19 @@ class Author_Home extends ResultsAction {
 		// Pull External Author Content
 		$interface->assign('showWikipedia', false);
 		if ($searchObject->getPage() == 1) {
-			// Only load Wikipedia info if turned on in config file:
 			if ($library->showWikipediaContent == 1) {
 				$interface->assign('showWikipedia', true);
 
-				//Strip anything in parenthesis
-				if (strpos($wikipediaAuthorName, '(') > 0) {
+				require_once ROOT_DIR . '/sys/LocalEnrichment/AuthorEnrichment.php';
+				$authorEnrichment = new AuthorEnrichment();
+				$authorEnrichment->authorName = $wikipediaAuthorName;
+				$hasEnrichmentEntry = $authorEnrichment->find(true);
+
+				// Only strip parentheses if there's no enrichment entry for the full name (including parenthetical information).
+				if (!$hasEnrichmentEntry && strpos($wikipediaAuthorName, '(') > 0) {
 					$wikipediaAuthorName = substr($wikipediaAuthorName, 0, strpos($wikipediaAuthorName, '('));
+					$wikipediaAuthorName = trim($wikipediaAuthorName);
 				}
-				$wikipediaAuthorName = trim($wikipediaAuthorName);
 				$interface->assign('wikipediaAuthorName', $wikipediaAuthorName);
 			}
 		}

--- a/code/web/sys/LocalEnrichment/AuthorEnrichment.php
+++ b/code/web/sys/LocalEnrichment/AuthorEnrichment.php
@@ -1,4 +1,5 @@
 <?php
+/** @noinspection PhpMissingFieldTypeInspection */
 
 class AuthorEnrichment extends DataObject {
 	public $__table = 'author_enrichment';
@@ -7,44 +8,48 @@ class AuthorEnrichment extends DataObject {
 	public $hideWikipedia;
 	public $wikipediaUrl;
 
+	static ?array $objectStructure = null;
 	static function getObjectStructure($context = ''): array {
-		return [
-			[
-				'property' => 'id',
-				'type' => 'label',
-				'label' => 'Id',
-				'description' => 'The unique id of this setting.',
-				'storeDb' => true,
-			],
-			[
-				'property' => 'authorName',
-				'type' => 'text',
-				'size' => '255',
-				'maxLength' => 255,
-				'label' => 'Author Name',
-				'description' => 'The exact author name used for Wikipedia lookup.',
-				'note' => 'This must match the author\'s name as cleaned and formatted for the Wikipedia API, with any parentheses and their contents removed. When debug mode is enabled for your <a href="/Admin/IPAddresses" target="_blank">IP Address</a>, you can view the exact search term used on the Author page via the displayed debug message.',
-				'storeDb' => true,
-				'required' => true,
-			],
-			[
-				'property' => 'hideWikipedia',
-				'type' => 'checkbox',
-				'label' => 'Hide Wikipedia Information',
-				'description' => 'Whether to hide Wikipedia data for this author.',
-				'storeDb' => true,
-				'required' => false,
-			],
-			[
-				'property' => 'wikipediaUrl',
-				'type' => 'text',
-				'size' => '255',
-				'maxLength' => 255,
-				'label' => 'Wikipedia URL',
-				'description' => 'The URL from which to load Wikipedia data.',
-				'storeDb' => true,
-				'required' => false,
-			],
-		];
+		if (self::$objectStructure == null) {
+			self::$objectStructure = [
+				[
+					'property' => 'id',
+					'type' => 'label',
+					'label' => 'Id',
+					'description' => 'The unique id of this setting.',
+					'storeDb' => true,
+				],
+				[
+					'property' => 'authorName',
+					'type' => 'text',
+					'size' => '255',
+					'maxLength' => 255,
+					'label' => 'Author Name',
+					'description' => 'The exact author name used for Wikipedia lookup.',
+					'note' => 'This must match the author\'s hyperlinked name on the grouped work. When debug mode is enabled for your <a href="/Admin/IPAddresses" target="_blank">IP Address</a> and the Wikipedia lookup has failed, you can view the exact search term used on the Author page via the displayed debug message.',
+					'storeDb' => true,
+					'required' => true,
+				],
+				[
+					'property' => 'hideWikipedia',
+					'type' => 'checkbox',
+					'label' => 'Hide Wikipedia Information',
+					'description' => 'Whether to hide Wikipedia data for this author.',
+					'storeDb' => true,
+					'required' => false,
+				],
+				[
+					'property' => 'wikipediaUrl',
+					'type' => 'text',
+					'size' => '255',
+					'maxLength' => 255,
+					'label' => 'Wikipedia URL',
+					'description' => 'The URL from which to load Wikipedia data.',
+					'storeDb' => true,
+					'required' => false,
+				],
+			];
+		}
+		return self::$objectStructure;
 	}
 }


### PR DESCRIPTION
- Allow parenthetical content to be used for author disambiguation in the Author Enrichment settings. (DIS-1210) (*LS*)
- Added a debug message to display when Wikipedia provides disambiguation content to help administrators understand what search term was used.

Test Plan:
1. Look up an ambiguous author name.
2. Click on a hyperlinked author name in a grouped work that contains parenthetical information. Notice the disambiguation information from Wikipedia and find the appropriate author link.
3. Enter the author’s full name as displayed in the grouped work and the Wikipedia URL as an Author Enrichment entry.
4. Return to the search and click on the hyperlinked author name again. Notice that the Author Enrichment did not work.
5. Apply the patch and repeat step 4. Notice that the disambiguation with the Author Enrichment worked.