### PR TITLE
DIS-1212: Allowed 'Q' in the Second Position of Release Notes

### DIFF
--- a/code/web/release_notes/25.08.00.MD
+++ b/code/web/release_notes/25.08.00.MD
@@ -325,6 +325,7 @@
 - Fixed Apache2 restart warning in rebuild_gd_raqm.sh by adding a check to only restart if Apache2 is already running, improved its PHP source directory detection, and prevented script failures due to apt repository errors. (DIS-1198) (*LS*)
 - Fixed an issue where LiDA would receive an invalid response when attempting to use the “Forgot Barcode or Username” feature because Twilio’s Product APIs only return JSON responses, but Aspen was incorrectly expecting XML responses. (DIS-1206) (*LS*)
 - Fixed an issue where Symphony self registrations in LiDA would fail with a long PHP warning message. (DIS-1206) (*LS*)
+- Allowed 'Q' in the second position of release notes naming. (DIS-1212) (*LS*)
 
 ## This release includes code contributions from
 ### ByWater Solutions

--- a/code/web/services/Admin/ReleaseNotes.php
+++ b/code/web/services/Admin/ReleaseNotes.php
@@ -14,6 +14,9 @@ class Admin_ReleaseNotes extends Action {
 			if (preg_match('/\d{2}\.\d{2}\.\d{2}\.MD/', $releaseNoteFile)) {
 				$releaseNoteFile = str_replace('.MD', '', $releaseNoteFile);
 				$releaseNotes[$releaseNoteFile] = $releaseNoteFile;
+			} elseif (preg_match('/^\d{2}\.Q\d(?:\.\d{2}(?:\.\d{2})?)?\.MD$/i', $releaseNoteFile)) {
+				$releaseNoteFile = preg_replace('/\.MD$/i', '', $releaseNoteFile);
+				$releaseNotes[$releaseNoteFile] = $releaseNoteFile;
 			} elseif (strcasecmp('Supplemental.MD', $releaseNoteFile) === 0) {
 				if (filesize($releaseNotesPath . '/' . $releaseNoteFile) > 0) {
 					$releaseNoteFile = str_replace('.MD', '', $releaseNoteFile);


### PR DESCRIPTION
- Allowed 'Q' in the second position of release notes naming.