### PR TITLE
DIS-1076: Set Related Deletion Data for Hard Deleted Lists

### DIFF
--- a/code/web/release_notes/25.08.00.MD
+++ b/code/web/release_notes/25.08.00.MD
@@ -326,6 +326,7 @@
 - Fixed an issue where LiDA would receive an invalid response when attempting to use the “Forgot Barcode or Username” feature because Twilio’s Product APIs only return JSON responses, but Aspen was incorrectly expecting XML responses. (DIS-1206) (*LS*)
 - Fixed an issue where Symphony self registrations in LiDA would fail with a long PHP warning message. (DIS-1206) (*LS*)
 - Allowed 'Q' in the second position of release notes naming. (DIS-1212) (*LS*)
+- Fixed an issue where user lists would continue to display after being hard deleted until they are reindexed. (DIS-1076) (*LS*)
 
 ## This release includes code contributions from
 ### ByWater Solutions

--- a/code/web/sys/UserLists/UserList.php
+++ b/code/web/sys/UserLists/UserList.php
@@ -157,8 +157,11 @@ class UserList extends DataObject {
 
 	function delete($useWhere = false, $hardDelete = false) : int {
 		if ($hardDelete && !empty($this->id) && $this->id >= 1) {
-			// Hard delete by marking for index cleanup.
+			// Hard delete by marking for index cleanup and updating deletion information.
 			$this->deleteFromIndex = 1;
+			$this->deleted = 1;
+			$this->dateDeleted = time();
+			$this->deletedBy = UserAccount::getActiveUserId();
 			$ret = $this->update();
 			if ($ret) {
 				require_once ROOT_DIR . '/sys/UserLists/UserListEntry.php';


### PR DESCRIPTION
- Fixed an issue where user lists would continue to display after being hard deleted until they are reindexed.