### PR TITLE
DIS-1215: Fixed Unsupported Operand Types During Self Registration with USPS

### DIFF
--- a/code/web/release_notes/25.08.00.MD
+++ b/code/web/release_notes/25.08.00.MD
@@ -326,6 +326,7 @@
 - Fixed an issue where LiDA would receive an invalid response when attempting to use the “Forgot Barcode or Username” feature because Twilio’s Product APIs only return JSON responses, but Aspen was incorrectly expecting XML responses. (DIS-1206) (*LS*)
 - Fixed an issue where Symphony self registrations in LiDA would fail with a long PHP warning message. (DIS-1206) (*LS*)
 - Allowed 'Q' in the second position of release notes naming. (DIS-1212) (*LS*)
+- Fixed error preventing self-registration form submission when validating USPS address information. (DIS-1215) (*LS*)
 
 ## This release includes code contributions from
 ### ByWater Solutions

--- a/code/web/services/MyAccount/SelfReg.php
+++ b/code/web/services/MyAccount/SelfReg.php
@@ -83,7 +83,7 @@ class SelfReg extends Action {
 						}
 					}
 					//if there's no USPS info or email or phone are invalid, don't bother trying to validate
-					if ($uspsInfo & !$invalidContactInfo){
+					if ($uspsInfo && !$invalidContactInfo){
 						//Submit form to ILS if address is validated
 						if (SystemUtils::validateAddress($streetAddress, $city, $state, $zip)){
 							//Submit form to ILS if age is validated


### PR DESCRIPTION
- Fixed error preventing self-registration form submission when validating USPS address information.

Test Plan:
1. With USPS settings enabled, attempt to submit a self registration. Notice the error.
2. Apply the patch and try again. The submission is successful.