### PR TITLE
DIS-1217: Fixed Multi-Level Subdomain Detection for Library/Location Routing

### DIFF
--- a/code/web/release_notes/25.09.00.MD
+++ b/code/web/release_notes/25.09.00.MD
@@ -13,6 +13,8 @@
 // imani
 
 // leo
+### Server Setup Updates
+- Fixed subdomain detection to properly handle multi-level subdomains by extracting all possible subdomain combinations for more flexible library/location matching. (DIS-1217) (*LS*)
 
 // yanjun
 

--- a/code/web/sys/ConfigArray.php
+++ b/code/web/sys/ConfigArray.php
@@ -406,9 +406,19 @@ function getSubdomainsToTestFromServerName($fullServerName, array $subdomainsToT
 	$serverComponents = explode('.', $fullServerName);
 	$tempSubdomain = '';
 	if (count($serverComponents) >= 3) {
-		//URL is probably of the form subdomain.librarysite.org or subdomain.opac.librarysite.org
-		$subdomainsToTest[] = $serverComponents[0];
-		$tempSubdomain = $serverComponents[0];
+		// Handle multi-level subdomains by extracting all subdomain combinations.
+		// For discover.kids.library.org, test: discover.kids, kids, discover.
+		$subdomainParts = array_slice($serverComponents, 0, -2);
+
+		// Add all possible subdomain combinations, starting from the most specific.
+		for ($i = 0; $i < count($subdomainParts); $i++) {
+			$subdomainToTest = implode('.', array_slice($subdomainParts, $i));
+			$subdomainsToTest[] = $subdomainToTest;
+			if ($i == 0) {
+				// Use the full subdomain for test indicator processing.
+				$tempSubdomain = $subdomainToTest;
+			}
+		}
 	} elseif (count($serverComponents) == 2) {
 		//URL could be either subdomain.localhost or librarysite.org. Only use the subdomain
 		//If the second component is localhost.


### PR DESCRIPTION
- Fixed subdomain detection to properly handle multi-level subdomains by extracting all possible subdomain combinations for more flexible library/location matching.

Test Plan:
1. Add a second-level subdomain to the Apache config.
2. Add the subdomain to the respective Locations setting (e.g., discover.kids).
3. Notice that when you travel to that site, the domain resolves to the original domain of the site, likely the consortium catalog.
4. Apply the patch and reload the page to see it resolve to the desired domain.