### PR TITLE
DIS-1219: Fixed Themes Losing Images If They Reference Same File

### DIFF
--- a/code/web/release_notes/25.08.00.MD
+++ b/code/web/release_notes/25.08.00.MD
@@ -329,6 +329,7 @@
 - Allowed 'Q' in the second position of release notes naming. (DIS-1212) (*LS*)
 - Fixed an issue where user lists would continue to display after being hard deleted until they are reindexed. (DIS-1076) (*LS*)
 - Fixed error preventing self-registration form submission when validating USPS address information. (DIS-1215) (*LS*)
+- Fixed issue where multiple themes using images with identical filenames would lose their images during database upgrade to version 25.07.00 and beyond. (DIS-1219) (*LS*)
 
 ## This release includes code contributions from
 ### ByWater Solutions


### PR DESCRIPTION
- Fixed issue where multiple themes using images with identical filenames would lose their images during database upgrade to version 25.07.00 and beyond.

Test Plan:
1. Boot up or find an Aspen instance on a version before 25.07.00.
2. Upload the same image to various fields in different Themes.
3. Copy over the original `renameUploadedThemeImages()` function and the entry that runs it into a DB maintenance files (e.g., put in `25.06.00.php`).
4. Run it and notice that only one theme retains reference to the renamed file while the others still reference the old file name that no longer exists.
5. Repeat step 2 and copy the modified version of the function from this PR. Run it and notice that they retain different references to copies of the same image.