### PR TITLE
DIS-1226: Use PHP-FPM with Apache instead of the classic mode (mod_php)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,11 +52,11 @@ RUN wget -O- -q https://packages.sury.org/php/apt.gpg \
 RUN apt -y update \
 	&& apt install -y \
 	  php8.4 \
+	  php8.4-fpm \
 	  php8.4-mcrypt \
 	  php8.4-gd \
 	  php8.4-imagick \
 	  php8.4-curl \
-	  php8.4-mysql \
 	  php8.4-zip \
 	  php8.4-xml \
 	  php8.4-intl \
@@ -65,18 +65,20 @@ RUN apt -y update \
 	  php8.4-pgsql \
 	  php8.4-ssh2 \
 	  php8.4-ldap \
-	  php8.4-xdebug \
+	  php8.4-mysql \
 	&& rm -rf /var/cache/apt/archives/* \
 	&& rm -rf /var/lib/apt/lists/*
+
+
+# Enable required Apache modules
+RUN a2enmod proxy_fcgi setenvif rewrite
+RUN a2dissite 000-default
 
 # Adding entrypoint and init scripts
 COPY docker/files/scripts/entrypoint.sh  /entrypoint.sh
 COPY docker/files/scripts/start.sh       /start.sh
 COPY docker/files/scripts/cron.sh        /cron.sh
-
-# Load apache modules
-RUN a2enmod rewrite
-RUN a2dissite 000-default
+COPY docker/files/scripts/apache.sh      /apache.sh
 
 # Add aspen-discovery
 COPY . /usr/local/aspen-discovery
@@ -87,5 +89,6 @@ RUN cd /usr/local/aspen-discovery/sites \
 	&& rm -rf *prod*  \
 	&& rm -rf *dev*   \
 	&& rm -rf template.windows
+
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,8 +8,6 @@ services:
     image: ${BACKEND_IMAGE_TAG:-aspendiscovery/aspen}
     env_file:
       - .env
-    ports:
-      - "80:80"
     networks:
       - net-aspen
     tty: true
@@ -20,6 +18,24 @@ services:
     depends_on:
       db:
         condition: service_healthy
+
+  apache:
+    image: ${BACKEND_IMAGE_TAG:-aspendiscovery/aspen}
+    env_file:
+      - .env
+    ports:
+      - "85:80"
+    networks:
+       - net-aspen
+    volumes:
+      - ${ASPEN_DATA_DIR}/conf:/usr/local/aspen-discovery/sites/${SITE_NAME}
+      - ${ASPEN_DATA_DIR}/data:/data/aspen-discovery/${SITE_NAME}
+      - ${ASPEN_DATA_DIR}/logs:/var/log/aspen-discovery/${SITE_NAME}
+    command:
+      - apache
+    depends_on:
+      - backend
+    tty: true
 
   cron:
     image: ${BACKEND_IMAGE_TAG:-aspendiscovery/aspen}

--- a/docker/files/apache2/setApacheConf.php
+++ b/docker/files/apache2/setApacheConf.php
@@ -1,0 +1,86 @@
+<?php
+
+//Capture any error as ErrorException
+set_error_handler("customErrorHandler");
+
+if (count($argv) < 2) {
+	echo "To create new configuration files, a directory (where the files will be stored) will be necessary as argument.\n";
+	die();
+} elseif (count($argv) > 2) {
+	echo "Too many arguments have been passed. The script just needs a directory to start\n";
+	die(1);
+}
+
+$apacheConfFile = $argv[1];
+
+if (is_dir($apacheConfFile)) {
+	echo "'$apacheConfFile' is a directory.\n";
+	die(1);
+}
+
+echo "%   --> Copying apache configurations...\n";
+
+try {
+    	//Copy the httpd conf file
+	    $apacheDir = "/etc/apache2";
+		$dockerDir = "/usr/local/aspen-discovery/docker";
+        $fileName = basename($apacheConfFile);
+	    copy("$apacheConfFile", "$apacheDir/sites-enabled/$fileName");
+
+		// Copy data-alias.conf to allow apache accessing files that are not in the served path
+		$dataAliasConf = "$apacheDir/conf-enabled/data-alias.conf";
+		copy("$dockerDir/files/apache/data-alias.conf", "$apacheDir/conf-available/data-alias.conf");
+		if (!$dataAliasConf){
+			exec('2enconf data-alias', $output);
+		}
+
+
+} catch (ErrorException $e) {
+	echo "%   ERROR ASSIGNING PERMISSIONS AND OWNERSHIPS\n";
+	echo "%   ERROR MESSAGE : " . $e->getMessage() . "\n";
+	echo "%   IN : " . $e->getFile() . ":" . $e->getLine() . "\n";
+	die(1);
+}
+
+/**
+ * @throws ErrorException
+ */
+function customErrorHandler(int $errno, string $errstr, string $errfile, int $errline): void {
+	if (!(error_reporting() & $errno)) {
+		// This error code is not included in error_reporting.
+		return;
+	}
+	if ($errno === E_DEPRECATED || $errno === E_USER_DEPRECATED) {
+		// Do not throw an Exception for deprecation warnings as new or unexpected
+		// deprecations would break the application.
+		return;
+	}
+	throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
+}
+
+function replaceVariables($filename, $variables): void {
+	$contents = file($filename);
+	$fHnd = fopen($filename, 'w');
+	foreach ($contents as $line) {
+		foreach ($variables as $name => $value) {
+			$line = str_replace('{' . $name . '}', $value, $line);
+		}
+		fwrite($fHnd, $line);
+	}
+	fclose($fHnd);
+}
+
+function recursive_copy($src, $dst): void {
+	$dir = opendir($src);
+	@mkdir($dst);
+	while (($file = readdir($dir))) {
+		if (($file != '.') && ($file != '..')) {
+			if (is_dir($src . '/' . $file)) {
+				recursive_copy($src . '/' . $file, $dst . '/' . $file);
+			} else {
+				copy($src . '/' . $file, $dst . '/' . $file);
+			}
+		}
+	}
+	closedir($dir);
+}

--- a/docker/files/env/default.env
+++ b/docker/files/env/default.env
@@ -7,6 +7,8 @@ TITLE=Test library (title)
 URL=http://aspen.localhost
 SOLR_HOST=solr
 SOLR_PORT=8983
+PHP_FPM_HOST=backend
+PHP_FPM_PORT=9000
 ASPEN_ADMIN_PASSWORD=secretPass123
 
 # DB settings

--- a/docker/files/php_fpm/php-fpm.conf
+++ b/docker/files/php_fpm/php-fpm.conf
@@ -1,0 +1,47 @@
+[php-fpm]
+user = www-data
+group = www-data
+listen = 0.0.0.0:{phpFpmPort}
+listen.owner = www-data
+listen.group = www-data
+
+
+; Process manager settings
+pm = dynamic
+pm.max_children = 6
+pm.start_servers = 2
+pm.min_spare_servers = 2
+pm.max_spare_servers = 5
+chdir = /usr/local/aspen-discovery/code/web
+
+
+; Kill long-running requests after 300s
+request_terminate_timeout = 300
+
+
+; Logging (stdout/stderr for Docker)
+access.log = /proc/self/fd/2
+catch_workers_output = yes
+decorate_workers_output = yes
+php_flag[log_errors] = on
+php_admin_value[error_log] = /proc/self/fd/2
+
+
+; Session Settings
+php_admin_value[session.use_cookies] = 1
+php_admin_value[session.use_only_cookies] = 1
+php_admin_value[session.auto_start] = 0
+; php_admin_value[session.cookie_secure] = 1
+php_admin_value[session.cookie_lifetime] = 0
+php_admin_value[session.gc_maxlifetime] = 6000
+
+
+; Uncomment these lines if you want to show all errors
+; php_admin_value[display_errors] = 1
+; php_admin_value[error_reporting] = 2047
+
+
+; Memory Settings
+php_admin_value[memory_limit] = 512M
+php_admin_value[max_execution_time] = 300
+php_admin_value[default_socket_timeout] = 300

--- a/docker/files/scripts/apache.sh
+++ b/docker/files/scripts/apache.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+echo "%   * Starting Apache"
+
+export CONFIG_DIRECTORY="/usr/local/aspen-discovery/sites/${SITE_NAME}"
+
+# Check if site configuration exists
+apacheConfFile="$CONFIG_DIRECTORY/httpd-${SITE_NAME}.conf"
+
+tries=0
+
+while [ ! -f "$apacheConfFile" ]; do
+	sleep 5
+	((tries++))
+
+	if [ $tries -eq 10 ] ; then
+		echo "%   ERROR: Site configuration not initialized. Skipping apache startup and waiting"
+		exit 1
+	fi
+
+done
+
+mkdir -p /var/run/apache2
+chown -R www-data:www-data /var/run/apache2
+source /etc/apache2/envvars
+
+# Move to docker directory
+cd "/usr/local/aspen-discovery/docker/files/apache2/" || exit
+
+# Set Apache configurations 
+echo "%   * Setting Apache configurations";
+if ! php setApacheConf.php $apacheConfFile ; then
+	echo "%   ERROR: Apache initialization failed"
+	exit 1
+fi
+
+# Start Apache in the background
+apache2 -D FOREGROUND &
+
+# Wait for Apache to be ready
+tries=0
+until curl -sf http://"$SITE_NAME" > /dev/null; do
+  echo "%   * Waiting for Apache..."
+  sleep 5
+	((tries++))
+
+	if [ $tries -eq 10 ] ; then
+		echo "ERROR: "
+		exit 1
+	fi
+done
+
+# Run any pending database updates
+echo "%   * Triggering pending database updates"
+curl -v -k http://"$SITE_NAME"/API/SystemAPI?method=runPendingDatabaseUpdates
+
+echo "%"
+echo "%   Aspen Discovery ready to use!"
+echo "%"
+echo "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%"
+
+# Bring Apache to the foreground
+wait
+
+

--- a/docker/files/scripts/apache.sh
+++ b/docker/files/scripts/apache.sh
@@ -45,14 +45,14 @@ until curl -sf http://"$SITE_NAME" > /dev/null; do
 	((tries++))
 
 	if [ $tries -eq 10 ] ; then
-		echo "ERROR: "
+		echo "ERROR: Apache could not initialize correctly"
 		exit 1
 	fi
 done
 
 # Run any pending database updates
 echo "%   * Triggering pending database updates"
-curl -v -k http://"$SITE_NAME"/API/SystemAPI?method=runPendingDatabaseUpdates
+curl -k http://"$SITE_NAME"/API/SystemAPI?method=runPendingDatabaseUpdates
 
 echo "%"
 echo "%   Aspen Discovery ready to use!"

--- a/docker/files/scripts/createConfig.php
+++ b/docker/files/scripts/createConfig.php
@@ -34,6 +34,8 @@ $variables = [
 	'configDir' => $siteDir,
 	'solrHost' => getenv('SOLR_HOST') ?? 'localhost',
 	'solrPort' => getenv('SOLR_PORT') ?? 8983,
+	'phpFpmHost' => getenv('PHP_FPM_HOST') ?? 'localhost',
+	'phpFpmPort' => getenv('PHP_FPM_PORT') ?? '9000',
 	'timezone' => getenv('TIMEZONE') ?? 'US/Central',
 	'aspenAdminPassword' => getenv('ASPEN_ADMIN_PASSWORD'),
 	'databaseHost' => getenv('DATABASE_HOST') ?? 'localhost',
@@ -61,7 +63,7 @@ if ($variables['enableKoha'] === "yes") {
 	$variables['ilsDriver'] = ucfirst(getenv('ILS_DRIVER'));
 }
 
-$mandatory = ['sitename', 'servername', 'solrHost', 'solrPort', 'configDir', 'timezone', 'aspenAdminPassword', 'databaseHost', 'databasePort', 'databaseName', 'databaseUser', 'databasePassword'];
+$mandatory = ['sitename', 'servername', 'solrHost', 'solrPort', 'phpFpmHost', 'phpFpmPort', 'configDir', 'timezone', 'aspenAdminPassword', 'databaseHost', 'databasePort', 'databaseName', 'databaseUser', 'databasePassword'];
 
 if ($variables['enableKoha'] === "yes") {
 	$kohaKeys = ['ilsDriver', 'ilsUrl', 'ilsStaffUrl', 'ilsDatabaseName', 'ilsDatabaseHost', 'ilsDatabasePort', 'ilsDatabaseUser', 'ilsDatabasePassword', 'ilsDatabaseTimeZone'];
@@ -119,8 +121,11 @@ try {
 	copy($defaultDir . "/conf/badBotsDefault.conf", $siteDir . "/conf/badBotsDefault.conf");
 
 //Copy from docker directory
+	copy("$dockerDir/files/php_fpm/php-fpm.conf",$siteDir . "/conf/php-fpm.conf");
 	copy("$dockerDir/files/cron/crontab", "$siteDir/conf/crontab");
 	copy("$dockerDir/files/apache/data-alias.conf", "$apacheDir/conf-available/data-alias.conf");
+
+	replaceVariables($siteDir . "/conf/php-fpm.conf", $variables);
 	replaceVariables($siteDir . "/conf/crontab", $variables);
 	replaceVariables($apacheDir . "/conf-available/data-alias.conf", $variables);
 

--- a/docker/files/scripts/createConfig.php
+++ b/docker/files/scripts/createConfig.php
@@ -123,11 +123,9 @@ try {
 //Copy from docker directory
 	copy("$dockerDir/files/php_fpm/php-fpm.conf",$siteDir . "/conf/php-fpm.conf");
 	copy("$dockerDir/files/cron/crontab", "$siteDir/conf/crontab");
-	copy("$dockerDir/files/apache/data-alias.conf", "$apacheDir/conf-available/data-alias.conf");
 
 	replaceVariables($siteDir . "/conf/php-fpm.conf", $variables);
 	replaceVariables($siteDir . "/conf/crontab", $variables);
-	replaceVariables($apacheDir . "/conf-available/data-alias.conf", $variables);
 
 //Set timezone
 	exec('sudo timedatectl set-timezone "' . $variables['timezone'] . '"');

--- a/docker/files/scripts/createDirs.php
+++ b/docker/files/scripts/createDirs.php
@@ -133,6 +133,7 @@ try {
 	exec("chmod -R 755 $configDir/conf");
 	exec("chown $newOwner $configDir/conf");
 	exec("chown $newOwner $configDir/conf/config*");
+	exec("chown $newOwner $configDir/conf/php-fpm.conf");
 	exec("chown root:root $configDir/httpd-$siteName.conf");
 	exec("chown root:root $configDir/conf/crontab_settings.txt");
 	exec("chmod 0644 $configDir/conf/crontab_settings.txt");
@@ -149,6 +150,11 @@ try {
 	//Copy the httpd conf file
 	$apacheDir = "/etc/apache2";
 	copy("$configDir/httpd-$siteName.conf", "$apacheDir/sites-enabled/httpd-$siteName.conf");
+	
+	//Copy the php-fpm config file
+	$phpVersion = PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION;
+	$phpDir = "/etc/php/$phpVersion";
+	copy("$configDir/conf/php-fpm.conf", $phpDir . "/fpm/pool.d/php-fpm.conf");
 
 } catch (ErrorException $e) {
 	echo "%   ERROR ASSIGNING PERMISSIONS AND OWNERSHIPS\n";

--- a/docker/files/scripts/entrypoint.sh
+++ b/docker/files/scripts/entrypoint.sh
@@ -2,6 +2,17 @@
 set -e
 
 if [ "$#" -eq 0 ]; then
+    
+    # Adjust permissions if required
+    if [[ ! -z "${LOCAL_USER_ID}" && "${LOCAL_USER_ID}" != "33" ]]; then
+    	echo "%   Setting www-data to UID=${LOCAL_USER_ID}"
+        usermod -o -u ${LOCAL_USER_ID} "www-data"
+    fi
+    chown -R www-data /usr/local/aspen-discovery
+    exec /start.sh
+
+elif [ "$1" = 'apache' ]; then
+
     # Adjust permissions if required
     if [[ ! -z "${LOCAL_USER_ID}" && "${LOCAL_USER_ID}" != "33" ]]; then
     	echo "%   Setting www-data to UID=${LOCAL_USER_ID}"
@@ -10,8 +21,10 @@ if [ "$#" -eq 0 ]; then
         chown -R "www-data" "/var/log/apache2"
     fi
     chown -R www-data /usr/local/aspen-discovery
-    exec /start.sh
+    exec /apache.sh
+
 elif [ "$1" = 'cron' ]; then
+    
     # Adjust permissions if required
     if [[ ! -z "${LOCAL_USER_ID}" && "${LOCAL_USER_ID}" != "33" ]]; then
     	echo "%   Setting www-data to UID=${LOCAL_USER_ID}"
@@ -19,6 +32,7 @@ elif [ "$1" = 'cron' ]; then
     fi
     chown -R www-data /usr/local/aspen-discovery
     exec /cron.sh
+
 else
     exec "$@"
 fi

--- a/docker/files/scripts/initDatabase.php
+++ b/docker/files/scripts/initDatabase.php
@@ -62,3 +62,6 @@ $updateUserStmt->execute();
 
 $postSupportingCompanyStmt = $aspenDatabase->prepare("UPDATE system_variables set supportingCompany=" . $aspenDatabase->quote($supportingCompany));
 $postSupportingCompanyStmt->execute();
+
+// Close connection 
+$aspenDatabase = null;

--- a/docker/files/scripts/start.sh
+++ b/docker/files/scripts/start.sh
@@ -116,29 +116,16 @@ for dir in "${directories[@]}"; do
 	echo "%   * Created symlink: $source → $dest"
 done
 
-# Check if data-alias.conf is enabled 
-file="/etc/apache2/conf-enabled/data-alias.conf"
-if [ ! -f "$file"  ]; then
-	a2enconf data-alias
+# Ensure the hostname is only added once
+if ! grep -q "$SITE_NAME" /etc/hosts; then
+    echo "127.0.0.1    $SITE_NAME" >> /etc/hosts
 fi
 
-echo "%   * Starting Apache"
-# Start apache
-service apache2 start
-
 # Run any pending database updates
-echo "127.0.0.1    $SITE_NAME" >> /etc/hosts
-echo "%   * Triggering pending database updates"
-curl -k http://"$SITE_NAME"/API/SystemAPI?method=runPendingDatabaseUpdates
+#echo "%   * Triggering pending database updates"
+#curl -v -k http://"$SITE_NAME"/API/SystemAPI?method=runPendingDatabaseUpdates
 
 sudo -u www-data	php /usr/local/aspen-discovery/docker/files/cron/checkBackgroundProcessesDocker.php $SITE_NAME >/proc/1/fd/1 2>/proc/1/fd/2
 
-echo "%"
-echo "%   Aspen Discovery ready to use!"
-echo "%"
-echo "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%"
-
-
-# FIXME: We should probably run Apache in foreground instead. We need to
-#        figure an approach to the curl above in order to do it
-/bin/bash -c "trap : TERM INT; sleep infinity & wait"
+echo "Starting PHP-FPM..."
+php-fpm8.4 --test && exec php-fpm8.4 -F

--- a/docker/files/scripts/start.sh
+++ b/docker/files/scripts/start.sh
@@ -116,15 +116,6 @@ for dir in "${directories[@]}"; do
 	echo "%   * Created symlink: $source → $dest"
 done
 
-# Ensure the hostname is only added once
-if ! grep -q "$SITE_NAME" /etc/hosts; then
-    echo "127.0.0.1    $SITE_NAME" >> /etc/hosts
-fi
-
-# Run any pending database updates
-#echo "%   * Triggering pending database updates"
-#curl -v -k http://"$SITE_NAME"/API/SystemAPI?method=runPendingDatabaseUpdates
-
 sudo -u www-data	php /usr/local/aspen-discovery/docker/files/cron/checkBackgroundProcessesDocker.php $SITE_NAME >/proc/1/fd/1 2>/proc/1/fd/2
 
 echo "Starting PHP-FPM..."

--- a/sites/template.linux/httpd-{sitename}.conf
+++ b/sites/template.linux/httpd-{sitename}.conf
@@ -1,5 +1,5 @@
 <VirtualHost *:80>
-    <IfModule mod_rewrite.c>
+	<IfModule mod_rewrite.c>
 		RewriteEngine On
 	</IfModule>
 	ServerName {servername}
@@ -27,31 +27,31 @@
 			RewriteRule  ^sitemapindex\.xml$ /sitemapindex.php [NC,L]
 			RewriteRule  ^grouped_work_site_map(.+)$ /sitemaps/grouped_work_site_map$1 [NC,L]
 
-			# Anything that is a direct php file still goes to that
-			RewriteRule  ^(.*?\.php).*$         $1  [NC,L]
+			<IfModule mod_proxy_fcgi.c>
+				<FilesMatch "\.php(/.*)?$">
+					SetHandler "proxy:fcgi://{phpFpmHost}:{phpFpmPort}"
+				</FilesMatch>
+			</IfModule>
+
+			<IfModule !mod_proxy_fcgi.c>
+				RewriteRule ^(.*?\.php).*$ $1 [NC,L]
+
+				# Session Settings
+				php_value session.use_cookies  1
+				php_value session.use_only_cookies 1
+				php_value session.auto_start 0
+				# php_value session.cookie_secure 1
+
+				# we should check session lifetime in "read" methods
+				# since PHP cookies do not "refresh" them during activity
+				# hence we leave them alive until browser closes
+				php_value session.cookie_lifetime  0
+				php_value session.gc_maxlifetime 6000
+			</IfModule>
 
 			# Rewrite everything else to go through index.php
-			RewriteRule   ^(.*)$                index.php  [NC,L]
+			RewriteRule   ^(.*)$                index.php  [QSA,L]
 		</IfModule>
-
-		# Disable Magic Quotes
-		php_value magic_quotes_gpc false
-
-		# Session Settings
-		php_value session.use_cookies  1
-		php_value session.use_only_cookies 1
-		# important: we want to serialize objects
-		php_value session.auto_start 0
-		#php_value session.cookie_secure 1
-		# we should check session lifetime in "read" methods
-		# since PHP cookies do not "refresh" them during activity
-		# hence we leave them alive until browser closes
-		php_value session.cookie_lifetime  0
-		php_value session.gc_maxlifetime 6000
-
-		## Uncomment these lines if you wish to show all errors on the screen.
-		#php_value display_errors 1
-		#php_value error_reporting 2047
 
 		# enable expirations
 		<IfModule mod_expires.c>


### PR DESCRIPTION
This patch includes the use of php-fpm with Apache. They are treated as two separated services ( backend & apache ).
The use of this technology brings many advantages. 
Among them we can mention:
- Apache only loads PHP when necessary
- Apache processes are lighter for static content
- PHP-FPM can automatically recycle processes instead of creating a new one each time
- Independent tuning of Apache vs PHP process numbers
- Etc.