### PR TITLE
DIS-1233: Fixed Undefined Array Key Warning on MyCampaigns Page

### DIFF
--- a/code/web/release_notes/25.09.00.MD
+++ b/code/web/release_notes/25.09.00.MD
@@ -47,7 +47,7 @@
 
 ### Other Updates
 - Resolved errors caused by locations referencing deleted parent libraries by filtering out orphaned locations when viewing SelectInterface page. (DIS-1221) (*LS*)
-
+- Fixed undefined array key warnings in Community Engagement campaigns when sorting milestone progress data by checkout date. (DIS-1233) (*LS*)
 
 // yanjun
 

--- a/code/web/sys/CommunityEngagement/Campaign.php
+++ b/code/web/sys/CommunityEngagement/Campaign.php
@@ -1141,7 +1141,9 @@ class Campaign extends DataObject {
 					$milestoneProgress = CampaignMilestone::getMilestoneProgress($campaignId, $userId, $milestone->id);
 					$progressData = CampaignMilestoneProgressEntry::getUserProgressDataByMilestoneId($userId, $milestoneId, $campaignId);
 					usort($progressData, function ($a, $b) {
-						return $a['checkoutDate'] <=> $b['checkoutDate'];
+						$aDate = $a['checkoutDate'] ?? '';
+						$bDate = $b['checkoutDate'] ?? '';
+						return $aDate <=> $bDate;
 					});
 					$milestone->progress = $milestoneProgress['progress'];
 					$milestone->extraProgress = $milestoneProgress['extraProgress'];
@@ -1272,7 +1274,9 @@ class Campaign extends DataObject {
 						$totalGoals = CampaignMilestone::getMilestoneGoalCountByCampaign($campaign->id, $milestone->id);
 						$progressData = CampaignMilestoneProgressEntry::getUserProgressDataByMilestoneId($linkedUser->id, $milestone->id, $campaign->id);
 						usort($progressData, function ($a, $b) {
-							return $a['checkoutDate'] <=> $b['checkoutDate'];
+							$aDate = $a['checkoutDate'] ?? '';
+							$bDate = $b['checkoutDate'] ?? '';
+							return $aDate <=> $bDate;
 						});
 
 						$milestoneRewardGiven = CampaignMilestoneUsersProgress::getRewardGivenForMilestone($milestone->id, $linkedUser->id, $campaign->id);


### PR DESCRIPTION
- Fixed undefined array key warnings in Community Engagement campaigns when sorting milestone progress data by checkout date.

Test Plan: Create campaigns with milestones that would not have a checkout date and notice the errors.