### PR TITLE
DIS-1244: Make Certain Material Request Format Fields Required

### DIFF
--- a/code/web/release_notes/25.09.00.MD
+++ b/code/web/release_notes/25.09.00.MD
@@ -54,6 +54,9 @@
 ### Administration Updates
 - Hide Library Systems settings for Boundless, Community Engagement, EBSCOhost, EBSCO EDS, Palace Project, and Series modules when they are disabled. (DIS-1201) (*LS*)
 
+### Materials Requests Updates
+- Modified the Format, Format Label, and Author Label fields to be required under the Formats of Materials that can be Requested table, as they are necessary functionality. (DIS-1244) (*LS*)
+
 ### Searching Updates
 - Fixed "facet does not exist" error for Web Resource facet popups. (DIS-1193) (*LS*)
 

--- a/code/web/sys/MaterialsRequests/MaterialsRequestFormat.php
+++ b/code/web/sys/MaterialsRequests/MaterialsRequestFormat.php
@@ -43,18 +43,21 @@ class MaterialsRequestFormat extends DataObject {
 				'type' => 'text',
 				'label' => 'Format',
 				'description' => 'internal value for format, please use camelCase and no spaces ie. cdAudio',
+				'required' => true,
 			],
 			'formatLabel' => [
 				'property' => 'formatLabel',
 				'type' => 'text',
 				'label' => 'Format Label',
 				'description' => 'Label for the format that will be displayed to users.',
+				'required' => true,
 			],
 			'authorLabel' => [
 				'property' => 'authorLabel',
 				'type' => 'text',
 				'label' => 'Author Label',
 				'description' => 'Label for the author field associated with this format that will be displayed to users.',
+				'required' => true,
 			],
 			'specialFields' => [
 				'property' => 'specialFields',


### PR DESCRIPTION
- Modified the Format, Format Label, and Author Label fields to be required under the Formats of Materials that can be Requested table, as they are necessary functionality.

Test Plan:
1. Apply the patch.
2. Add a new row to the Formats of Materials that can be Requested table under Library Systems.
3. Try to save and notice that the fields are required.