### PR TITLE
DIS-1260: Fixed Library Hours Not Saving

### DIFF
--- a/code/web/release_notes/25.09.00.MD
+++ b/code/web/release_notes/25.09.00.MD
@@ -97,6 +97,7 @@
 ### Other Updates
 - Resolved errors caused by locations referencing deleted parent libraries by filtering out orphaned locations when viewing SelectInterface page. (DIS-1221) (*LS*)
 - Fixed undefined array key warnings in Community Engagement campaigns when sorting milestone progress data by checkout date. (DIS-1233) (*LS*)
+- Added missing 'time' property type handler for OneToMany relationships in DataObjectUtil that prevented manual changes to Library Hours from saving. (DIS-1260) (*LS*)
 
 // yanjun
 

--- a/code/web/sys/DataObjectUtil.php
+++ b/code/web/sys/DataObjectUtil.php
@@ -697,6 +697,29 @@ class DataObjectUtil {
 										$history->changeDate = time();
 										$history->insert();
 									}
+								} elseif ($subProperty['type'] == 'time') {
+									$oldValue = $subObject->$subPropertyName;
+									if (empty(strlen($_REQUEST[$requestKey][$id])) || $_REQUEST[$requestKey][$id] == '00:00:00') {
+										$changed = $subObject->setProperty($subPropertyName, null, $subProperty);
+									} else {
+										$dateParts = date_parse($_REQUEST[$requestKey][$id]);
+										$time = str_pad($dateParts['hour'], 2, '0', STR_PAD_LEFT) . ':' . str_pad($dateParts['minute'], 2, '0', STR_PAD_LEFT) . ':' . str_pad($dateParts['second'], 2, '0', STR_PAD_LEFT);
+										$changed = $subObject->setProperty($subPropertyName, $time, $subProperty);
+									}
+
+									if (!empty($changed) && !empty($object->{$object->__primaryKey}) && $object->objectHistoryEnabled()) {
+										require_once ROOT_DIR . '/sys/DB/DataObjectHistory.php';
+										$history = new DataObjectHistory();
+										$history->objectType = get_class($object);
+										$primaryKey = $object->__primaryKey;
+										$history->objectId = $object->$primaryKey;
+										$history->propertyName = DataObjectUtil::getHistoryPropertyName($object, $propertyName . '.' . $subPropertyName);
+										$history->oldValue = (string)$oldValue;
+										$history->newValue = (string)($subObject->$subPropertyName ?? '');
+										$history->changedBy = UserAccount::getActiveUserId();
+										$history->changeDate = time();
+										$history->insert();
+									}
 								} elseif (!in_array($subProperty['type'], [
 									'label',
 									'foreignKey',


### PR DESCRIPTION
- Added missing 'time' property type handler for OneToMany relationships in DataObjectUtil that prevented manual changes to Library Hours from saving.

Test Plan:
1. Edit the Library Hours under the Locations settings.
2. Save the page and notice that the hours do not save.
3. Apply the patch and repeat steps 1-2. Notice that they save.