### PR TITLE
DIS-1264: Disabled Register Button to Prevent Multiple Registration Form Submissions

### DIFF
--- a/code/web/interface/themes/responsive/MyAccount/selfReg.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/selfReg.tpl
@@ -113,5 +113,18 @@
 			$borrowPass2.attr('data-rule-equalTo', "#borrower_password");
 			$borrowPass2.attr('data-msg-equalTo', '{translate text="Passwords must match." isPublicFacing=true inAttribute=true}');
 		}
+
+		// Prevent double-submission of self-registration form.
+		let isSubmitting = false;
+		$('form[id^="objectEditor"]').on('submit', (e) => {
+			if (isSubmitting) return e.preventDefault();
+			// Timeout to allow for jQuery validation to check first.
+			setTimeout(() => {
+				if ($(e.target).valid()) {
+					isSubmitting = true;
+					$(e.target).find('button[type="submit"][name="submit"]').prop('disabled', true).html('<i class="fas fa-spinner fa-spin"></i> {translate text="Processing..." isPublicFacing=true}');
+				}
+			}, 10);
+		});
 	});
 </script>

--- a/code/web/release_notes/25.09.00.MD
+++ b/code/web/release_notes/25.09.00.MD
@@ -89,6 +89,9 @@
 ### API Updates
 - Added the boolean `optOutOfSoftDeletion` parameter to the `ListAPI::deleteList` endpoint. (DIS-1214) (*LS*)
 
+### Account Updates
+- When submitting the registration form in Aspen, the "Register" button will be disabled to prevent multiple patron accounts from being created. (DIS-1264) (*LS*)
+
 ### Administration Updates
 - Hide Library Systems settings for Boundless, Community Engagement, EBSCOhost, EBSCO EDS, Palace Project, and Series modules when they are disabled. (DIS-1201) (*LS*)
 - When adding new rows to tables within an object, the page now automatically scrolls to show the new row, and empty unsaved rows can be deleted directly without needing to save first. (DIS-1228) (*LS*)


### PR DESCRIPTION
- When submitting the registration form in Aspen, the "Register" button will be disabled to prevent multiple patron accounts from being created.

Test Plan:
1. Navigate to the page where you register for a library card in Aspen.
2. Fill out the information and click the “Register” button multiple times before the page redirect.
3. Look in the ILS’s records/logs. Notice that multiple patron accounts have been registered.
4. Apply the patch and repeat steps 1-2. Notice that you cannot click “Register” multiple times, so multiple patron accounts will not be made.