### PR TITLE
DIS-1227: Check the maximum age for self registration

### DIFF
--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -4096,6 +4096,11 @@ class Koha extends AbstractIlsDriver {
 			'required' => true,
 			'autocomplete' => false,
 		];
+		// Check if there is a maximum age for Self registration
+		$maxAgeForSelfReg = $kohaPreferences['PatronSelfRegistrationAgeRestriction'] ?? null;
+		if(is_numeric($maxAgeForSelfReg) && (int) $maxAgeForSelfReg > 0) {
+			$fields['identitySection']['properties']['borrower_dateofbirth']['maxAgeForSelfReg'] = $maxAgeForSelfReg;
+		}
 
 		$fields['identitySection']['properties']['borrower_initials'] = [
 			'property' => 'borrower_initials',

--- a/code/web/release_notes/25.09.00.MD
+++ b/code/web/release_notes/25.09.00.MD
@@ -192,8 +192,13 @@
 
 // will
 
+// Brendan
 ### Web Builder Updates
 - Add per library emailResultsTo to Custom Forms. (DIS 1196) (*BL*)
+
+// Lucas
+### Koha Updates
+- Add a new maximum age check for self-registration based on Koha system preference 'PatronSelfRegistrationAgeRestriction'. (DIS-1227) (*LM*)
 
 
 ## This release includes code contributions from

--- a/code/web/services/MyAccount/SelfReg.php
+++ b/code/web/services/MyAccount/SelfReg.php
@@ -112,14 +112,24 @@ class SelfReg extends Action {
 					} else {
 						//Submit form to ILS if age is validated and contact info is not invalid
 						if (!empty($dob)) {
-							if (SystemUtils::validateAge($library->minSelfRegAge, $dob)){
+							$maxSelfRegAge = $selfRegFields['identitySection']['properties']['borrower_dateofbirth']['maxAgeForSelfReg'] ?? null;
+							if (SystemUtils::validateAge($library->minSelfRegAge, $dob, $maxSelfRegAge)){
 								if (!$invalidContactInfo) {
 									$result = $catalog->selfRegister();
 									$interface->assign('selfRegResult', $result);
 								}
 							} else {
+								if((int) $library->minSelfRegAge > 0 && !empty($maxSelfRegAge) && (int) $maxSelfRegAge > 0){
+									$text = "You must be at least $library->minSelfRegAge and no older than $maxSelfRegAge years old. Please enter a valid date of birth";
+								} elseif($library->minSelfRegAge > 0){
+									$text = "You must be at least $library->minSelfRegAge years old. Please enter a valid date of birth";
+								} elseif(!empty($maxSelfRegAge) && (int) $maxSelfRegAge > 0) {
+									$text = "You must be no older than $maxSelfRegAge years old. Please enter a valid date of birth";
+								} else {
+									$text = "Please enter a valid date of birth";
+								}
 								$ageMessage = translate([
-									'text' => 'You must be at least ' . $library->minSelfRegAge . ' years old. Please enter a valid date of birth.',
+									'text' => $text,
 									'isPublicFacing' => true
 								]);
 								$interface->assign('ageMessage', $ageMessage);

--- a/code/web/sys/Utils/SystemUtils.php
+++ b/code/web/sys/Utils/SystemUtils.php
@@ -54,7 +54,7 @@ class SystemUtils {
 		}
 	}
 
-	static function validateAge($minimumAge, $dob): bool {
+	static function validateAge($minimumAge, $dob, $maximumAge = null): bool {
 		$today = date("d-m-Y");//today's date
 
 		$dob = new DateTime($dob);
@@ -65,6 +65,9 @@ class SystemUtils {
 		$age = $interval->y;
 
 		if ($age >= $minimumAge) {
+			if(isset($maximumAge) && $maximumAge <= $age){
+				return false;
+			}
 			return true;
 		}
 		return false;


### PR DESCRIPTION
Now Aspen does honor to the Koha system preference 'PatronSelfRegistrationAgeRestriction' when submitting a new self registration form.

Before the patch: 

1 - Enable the system preference 'PatronSelfRegistrationAgeRestriction' in Koha
2 - Enable the ILS Based Self Registration
3 - Submit a self registration form with an age bigger than the set in 'PatronSelfRegistrationAgeRestriction'
4 - Aspen approves the form

After the patch:

- Repeat steps 1,2,3
- Aspen throws a message about the invalidation of the entered date of birth and submit nothing.