### PR TITLE
DIS-1268: Fixed Navigation Links Missing on Grouped Works Beyond Page One

### DIFF
--- a/code/web/release_notes/25.09.00.MD
+++ b/code/web/release_notes/25.09.00.MD
@@ -106,6 +106,7 @@
 
 ### Searching Updates
 - Fixed "facet does not exist" error for Web Resource facet popups. (DIS-1193) (*LS*)
+- Fixed an issue where navigation links "Previous" and "Next" would not display on grouped works beyond the first page of search results. (DIS-1268) (*LS*)
 
 ### Server Setup Updates
 - Fixed subdomain detection to properly handle multi-level subdomains by extracting all possible subdomain combinations for more flexible library/location matching. (DIS-1217) (*LS, MDN*)

--- a/code/web/sys/SearchObject/AbstractGroupedWorkSearcher.php
+++ b/code/web/sys/SearchObject/AbstractGroupedWorkSearcher.php
@@ -330,7 +330,8 @@ abstract class SearchObject_AbstractGroupedWorkSearcher extends SearchObject_Sol
 					unset($current['explain']);
 					unset($current['score']);
 				}
-				$interface->assign('recordIndex', $x + 1);
+				// Use absolute positioning for navigation links to display on grouped works spanning across pages.
+				$interface->assign('recordIndex', $x + 1 + (($this->page - 1) * $this->limit));
 				$interface->assign('resultIndex', $x + 1 + (($this->page - 1) * $this->limit));
 				if ($isSaved || $alwaysFlagNewTitles) {
 					if (isset($current["local_time_since_added_$solrScope"])) {


### PR DESCRIPTION
- Fixed an issue where navigation links "Previous" and "Next" would not display on grouped works beyond the first page of search results.

Test Plan:
1. Navigate to a page beyond page one when searching the catalog.
2. Click on a grouped work and notice that the “Previous” and “Next” links are missing.
3. Apply the patch.
4. Go back to the search results and click a grouped work. Notice that the links are there.