### PR TITLE
DIS-1247: Added Stickiness to Manage Requests Date Filters

### DIFF
--- a/code/web/release_notes/25.09.00.MD
+++ b/code/web/release_notes/25.09.00.MD
@@ -101,6 +101,9 @@
 ### Evergreen Updates
 - Fixed an issue where the initial reading history import could stall if a bad response code or response message was received from Evergreen. (DIS-1222) (*LS*)
 
+### Materials Request Updates
+- Fixed Materials Request date filters reverting after navigation because their values did not persist like other filters. (DIS-1247) (*LS*)
+
 ### Performance Updates
 - Optimized `getHistoryPropertyName` method to reduce memory consumption and decrease save times. (DIS-1225) (*LS*)
 

--- a/code/web/services/MaterialsRequest/ManageRequests.php
+++ b/code/web/services/MaterialsRequest/ManageRequests.php
@@ -132,6 +132,39 @@ class MaterialsRequest_ManageRequests extends Admin_Admin {
 				}
 			}
 
+			$startDateFilter = new StickyFilter();
+			$startDateFilter->userId = $user->id;
+			$startDateFilter->filterFor = "MaterialsRequest_StartDate";
+			if (!$startDateFilter->find(true)) {
+				if (!empty($_REQUEST['startDate'])) {
+					$startDateFilter->filterValue = $_REQUEST['startDate'];
+					$startDateFilter->insert();
+				}
+			} else {
+				if (!empty($_REQUEST['startDate'])) {
+					$startDateFilter->filterValue = $_REQUEST['startDate'];
+					$startDateFilter->update();
+				} else {
+					$startDateFilter->delete();
+				}
+			}
+
+			$endDateFilter = new StickyFilter();
+			$endDateFilter->userId = $user->id;
+			$endDateFilter->filterFor = "MaterialsRequest_EndDate";
+			if (!$endDateFilter->find(true)) {
+				if (!empty($_REQUEST['endDate'])) {
+					$endDateFilter->filterValue = $_REQUEST['endDate'];
+					$endDateFilter->insert();
+				}
+			} else {
+				if (!empty($_REQUEST['endDate'])) {
+					$endDateFilter->filterValue = $_REQUEST['endDate'];
+					$endDateFilter->update();
+				} else {
+					$endDateFilter->delete();
+				}
+			}
 		}
 
 
@@ -226,6 +259,26 @@ class MaterialsRequest_ManageRequests extends Admin_Admin {
 			$formatsToShow = $defaultFormatsToShow;
 		}
 		$interface->assign('formatFilter', $formatsToShow);
+
+		if (empty($_REQUEST['startDate'])) {
+			$savedStartDate = new StickyFilter();
+			$savedStartDate->userId = $user->id;
+			$savedStartDate->filterFor = "MaterialsRequest_StartDate";
+			if ($savedStartDate->find(true)) {
+				$_REQUEST['startDate'] = $savedStartDate->filterValue;
+				$interface->assign('startDate', $savedStartDate->filterValue);
+			}
+		}
+
+		if (empty($_REQUEST['endDate'])) {
+			$savedEndDate = new StickyFilter();
+			$savedEndDate->userId = $user->id;
+			$savedEndDate->filterFor = "MaterialsRequest_EndDate";
+			if ($savedEndDate->find(true)) {
+				$_REQUEST['endDate'] = $savedEndDate->filterValue;
+				$interface->assign('endDate', $savedEndDate->filterValue);
+			}
+		}
 
 		//Get a list of all material requests for the user
 		$allRequests = [];


### PR DESCRIPTION
- Fixed Materials Request date filters reverting after navigation because their values did not persist like other filters.

Test Plan:
1. Navigate to Manage Requests page in the admin interface.
2. Apply the date filter.
3. After page reload or after updating a patron’s request, notice that the filter does not persist like the others.
4. Apply the patch and repeat steps 2-3. Notice that the date filter does persist.