### PR TITLE
DIS-1252 Delete Entry from Hoopla esistingRecords HashMap

### DIFF
--- a/code/hoopla_export/src/com/turning_leaf_technologies/hoopla/HooplaExportMain.java
+++ b/code/hoopla_export/src/com/turning_leaf_technologies/hoopla/HooplaExportMain.java
@@ -329,6 +329,7 @@ public class HooplaExportMain {
 						//Delete the work from solr and the database
 						getGroupedWorkIndexer().deleteRecord(result.permanentId, result.groupedWorkId);
 					}
+					existingRecords.remove(hooplaTitle.getHooplaId());
 					numDeleted++;
 					logEntry.incDeleted();
 				}
@@ -905,6 +906,7 @@ public class HooplaExportMain {
 					logEntry.incDeleted();
 					deleteHooplaItemStmt.setLong(1, existingTitle.getId());
 					deleteHooplaItemStmt.executeUpdate();
+					existingRecords.remove(hooplaId);
 				}else {
 					if (existingTitle == null){
 						addHooplaTitleToDB.setLong(1, hooplaId);

--- a/code/web/release_notes/25.09.00.MD
+++ b/code/web/release_notes/25.09.00.MD
@@ -127,6 +127,8 @@
 - Added missing 'time' property type handler for OneToMany relationships in DataObjectUtil that prevented manual changes to Library Hours from saving. (DIS-1260) (*LS*)
 
 // yanjun
+### Hoopla Updates
+- Fixed an issue where Flex titles that were extracted from the Instant extraction endpoint would be deleted and fail to be reinserted. (DIS-1252) (*YL*)
 
 // james
 


### PR DESCRIPTION
During the Hoopla metadata extraction happens at 1 am local time, the Hoopla indexer extracts updated instant titles first, then extracts flex titles. A case where Aspen makes API requests by specifying an updated INSTANT title, Hoopla will return updated FLEX titles with `active: false`. Aspen deletes the records. Then, when Aspen makes api requests by specifying an updated FLEX title, Hoopla will return updated FLEX titles again with `active: true`, but Aspen wouldn’t add the records back due to the current existingRecords hashmap. The issue has been reported to Hoopla. But at the same time, Aspen can handle such a case in a better way. 

Difficult to test. After applying the PR, active Flex titles won’t be removed from the catalog during the data extraction. 