### PR TITLE
DIS-1276: Do Not Hide New Request Summary for ILS Request System

### DIFF
--- a/code/web/interface/themes/responsive/js/aspen/admin.js
+++ b/code/web/interface/themes/responsive/js/aspen/admin.js
@@ -1012,6 +1012,7 @@ AspenDiscovery.Admin = (function () {
 				"#propertyRowmaterialsRequestSendStaffEmailOnNew",
 				"#propertyRowmaterialsRequestNewEmail",
 				"#propertyRowmaterialsRequestSendStaffEmailOnAssign",
+				"#propertyRownewMaterialsRequestSummary",
 				"#propertyRowyearlyRequestLimitType",
 				"#propertyRowcheckRequestsForExistingTitles"
 			];
@@ -1025,6 +1026,7 @@ AspenDiscovery.Admin = (function () {
 						"#propertyRowyearlyRequestLimitType",
 						"#propertyRowmaxActiveRequests",
 						"#propertyRowrequestCalendarStartDate",
+						"#propertyRownewMaterialsRequestSummary",
 						"#propertyRowmaterialsRequestDaysToPreserve",
 						"#propertyRowmaterialsRequestFieldsToDisplay",
 						"#propertyRowmaterialsRequestFormats",

--- a/code/web/interface/themes/responsive/js/aspen/admin.js
+++ b/code/web/interface/themes/responsive/js/aspen/admin.js
@@ -1012,7 +1012,6 @@ AspenDiscovery.Admin = (function () {
 				"#propertyRowmaterialsRequestSendStaffEmailOnNew",
 				"#propertyRowmaterialsRequestNewEmail",
 				"#propertyRowmaterialsRequestSendStaffEmailOnAssign",
-				"#propertyRownewMaterialsRequestSummary",
 				"#propertyRowyearlyRequestLimitType",
 				"#propertyRowcheckRequestsForExistingTitles"
 			];
@@ -1026,7 +1025,6 @@ AspenDiscovery.Admin = (function () {
 						"#propertyRowyearlyRequestLimitType",
 						"#propertyRowmaxActiveRequests",
 						"#propertyRowrequestCalendarStartDate",
-						"#propertyRownewMaterialsRequestSummary",
 						"#propertyRowmaterialsRequestDaysToPreserve",
 						"#propertyRowmaterialsRequestFieldsToDisplay",
 						"#propertyRowmaterialsRequestFormats",
@@ -1038,7 +1036,7 @@ AspenDiscovery.Admin = (function () {
 					].forEach(selector => $(selector).show());
 					break;
 				case "2": // ILS Request System
-					["#propertyRowallowDeletingILSRequests", "#propertyRowallowMaterialRequestsBranchChoice", "#propertyRowdisplayMaterialsRequestToPublic"]
+					["#propertyRowallowDeletingILSRequests", "#propertyRowallowMaterialRequestsBranchChoice", "#propertyRowdisplayMaterialsRequestToPublic", "#propertyRownewMaterialsRequestSummary"]
 						.forEach(selector => $(selector).show());
 					break;
 				case "3": // External Request Link

--- a/code/web/release_notes/25.09.00.MD
+++ b/code/web/release_notes/25.09.00.MD
@@ -105,6 +105,9 @@
 ### Evergreen Updates
 - Fixed an issue where the initial reading history import could stall if a bad response code or response message was received from Evergreen. (DIS-1222) (*LS*)
 
+### Materials Request Updates
+- The New Request Summary field is no longer hidden in Library Systems settings when the "ILS Request System" is enabled. (DIS-1276) (*LS*)
+
 ### Performance Updates
 - Optimized `getHistoryPropertyName` method to reduce memory consumption and decrease save times. (DIS-1225) (*LS*)
 


### PR DESCRIPTION
- The New Request Summary field is no longer hidden in Library Systems settings when the "ILS Request System" is enabled.