### PR TITLE
DIS-1277: Increased Browse Category Label Length

### DIFF
--- a/code/web/interface/themes/responsive/Browse/newBrowseCategoryForm.tpl
+++ b/code/web/interface/themes/responsive/Browse/newBrowseCategoryForm.tpl
@@ -23,7 +23,7 @@
 					</a>
 					<span class="label label-danger" style="margin-right: .5em;">{translate text="Required" isAdminFacing=true}</span>
 				</label>
-				<input type="text" id="categoryName" name="categoryName" value="" class="form-control required">
+				<input type="text" id="categoryName" name="categoryName" value="" class="form-control required" maxlength="100">
 			</div>
 			{if !empty($property)} {* If data for Select tag is present, use the object editor template to build the <select> *}
 			<div class="form-group">

--- a/code/web/release_notes/25.09.00.MD
+++ b/code/web/release_notes/25.09.00.MD
@@ -102,6 +102,10 @@
 - When adding new rows to tables within an object, the page now automatically scrolls to show the new row, and empty unsaved rows can be deleted directly without needing to save first. (DIS-1228) (*LS*)
 - The deletion of saved table rows now displays a modal to ask for confirmation of the deletion. (DIS-1228) (*LS*)
 
+### Browse Categories Updates
+- Increased the maximum length of the Browse Category Label from 50 to 100. (DIS-1277) (*LS*)
+  - Added `maxLength` attribute to the fields to prevent users from entering greater than 100 characters.
+
 ### Evergreen Updates
 - Fixed an issue where the initial reading history import could stall if a bad response code or response message was received from Evergreen. (DIS-1222) (*LS*)
 

--- a/code/web/sys/Browse/BrowseCategory.php
+++ b/code/web/sys/Browse/BrowseCategory.php
@@ -40,9 +40,9 @@ class BrowseCategory extends BaseBrowsable {
 	/**
 	 * Note, may return invalid categories
 	 *
-	 * @return SubBrowseCategories[]
+	 * @return ?SubBrowseCategories[]
 	 */
-	public function getSubCategories() : array {
+	public function getSubCategories() : ?array {
 		global $module;
 		if (!isset($this->_subBrowseCategories) && $this->id) {
 			$this->_subBrowseCategories = [];
@@ -254,8 +254,8 @@ class BrowseCategory extends BaseBrowsable {
 				'property' => 'label',
 				'type' => 'text',
 				'label' => 'Label',
-				'description' => 'The label to show to the user',
-				'maxLength' => 50,
+				'description' => 'The label to show to the user.',
+				'maxLength' => 100,
 				'required' => true,
 			],
 			'textId' => [

--- a/code/web/sys/DBMaintenance/version_updates/25.09.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.09.00.php
@@ -77,6 +77,14 @@ function getUpdates25_09_00(): array {
 		//Yanjun Li - ByWater
 
 		// Leo Stoyanov - BWS
+		'increase_browse_category_label_length' => [
+			'title' => 'Increase Browse Category Label Length',
+			'description' => 'Increase the allowed length for browse category labels from 50 to 100 characters.',
+			'continueOnError' => false,
+			'sql' => [
+				'ALTER TABLE browse_category MODIFY label VARCHAR(100) NOT NULL'
+			],
+		], // increase_browse_category_label_length
 
 		//alexander - Open Fifth
 		'increase_location_display_name_allowed_length' => [


### PR DESCRIPTION
- Increased the maximum length of the Browse Category Label from 50 to 100.
  - Added `maxLength` attribute to the fields to prevent users from entering greater than 100 characters.