### PR TITLE
DIS-1278: Fixed Web Builder Custom Form Duplicate Resubmissions

### DIFF
--- a/code/web/release_notes/25.09.00.MD
+++ b/code/web/release_notes/25.09.00.MD
@@ -121,6 +121,9 @@
   - A full update is automatically run to index the newly uploaded MARC files' data.
 - Modified the button styling to match other admin pages, including a "View Marc Files" button on the upload page to direct users to the `viewMarcFiles` page. (DIS-1179) (*LS*)
 
+### Web Builder Updates
+- Fixed form resubmission issue where refreshing the results page would create duplicate submissions. (DIS-1278) (*LS*)
+
 ### Wikipedia Integration Updates
 - Allow parenthetical content to be used for author disambiguation in the Author Enrichment settings. (DIS-1210) (*LS*)
 - Added a debug message to display when Wikipedia provides disambiguation content to help administrators understand what search term was used. (DIS-1210) (*LS*)


### PR DESCRIPTION
- Fixed form resubmission issue where refreshing the results page would create duplicate submissions.

Test Plan:
1. Submit a Custom Form.
2. Refresh the `SubmitForm` page with an ID. Notice that the form has been resubmitted.
3. Apply the patch and repeat steps 1-2. Notice that the form is not resubmitted and an error displays.