### PR TITLE
DIS-1279: series numbers will not update

### DIFF
--- a/code/web/release_notes/25.09.00.MD
+++ b/code/web/release_notes/25.09.00.MD
@@ -76,6 +76,9 @@
 ### Holds Updates
 - If Sierra loan rules for a particular record limit hold pickups to specific locations, only show those locations as options in Aspen. (DIS-790) (*KP*)
 
+### Series Updates
+- Fix Administer Series bug where volume number could not be changed if it started with a zero. (DIS-1279) (*KP*) 
+
 // myranda
 ### Hoopla Updates
 - Update Hoopla Setting tooltips for API Username and API Password fields to clarify these values are typically provided by an Aspen support vendor (DIS-295) (*MAF*)

--- a/code/web/sys/DB/DataObject.php
+++ b/code/web/sys/DB/DataObject.php
@@ -1097,7 +1097,7 @@ abstract class DataObject implements JsonSerializable {
 	 * @noinspection PhpUnused
 	 */
 	public function setProperty(string $propertyName, $newValue, ?array $propertyStructure): bool {
-		$propertyChanged = $this->$propertyName != $newValue || (is_null($this->$propertyName) && !is_null($newValue));
+		$propertyChanged = $this->$propertyName !== $newValue || (is_null($this->$propertyName) && !is_null($newValue));
 		if ($propertyChanged) {
 			$this->_changedFields[] = $propertyName;
 			$oldValue = $this->$propertyName;


### PR DESCRIPTION
- Fixes bug where if the volume number of a series was '03', it could not be changed to '3', because 03 and 3 were considered the same value.  
- I changed the check for whether a property has changed in setProperty in DataObject.php, so it might have unintended consequences, but I was having trouble thinking of any that would be bad -- it should just make it easier to edit fields and fix unwanted zeros and extra spaces.  But I'm happy to find a different, more limited way where it only impacts Administer Series if this seems like a bad idea.