### PR TITLE
DIS-1280: better 'Include in Search' checkbox functionality for series

### DIFF
--- a/code/web/RecordDrivers/GroupedWorkDriver.php
+++ b/code/web/RecordDrivers/GroupedWorkDriver.php
@@ -2308,6 +2308,7 @@ class GroupedWorkDriver extends IndexRecordDriver {
 
 				$first = true;
 				$seriesInfo = [];
+				$allHidden = true;
 				foreach ($seriesMembers as $seriesMember) {
 					$series = $seriesMember->getSeries();
 					if ($series != null) {
@@ -2317,7 +2318,8 @@ class GroupedWorkDriver extends IndexRecordDriver {
 								'seriesId' => $series->id,
 								'volume' => $seriesMember->volume,
 								'fromNovelist' => false,
-								'fromSeriesIndex' => true
+								'fromSeriesIndex' => true,
+								'hidden' => !$series->isIndexed,
 							];
 							$first = false;
 						} else {
@@ -2326,11 +2328,16 @@ class GroupedWorkDriver extends IndexRecordDriver {
 								'seriesId' => $series->id,
 								'volume' => $seriesMember->volume,
 								'fromNovelist' => false,
-								'fromSeriesIndex' => true
+								'fromSeriesIndex' => true,
+								'hidden' => !$series->isIndexed,
 							];
+						}
+						if ($series->isIndexed) {
+							$allHidden = false;
 						}
 					}
 				}
+				$seriesInfo['allHidden'] = $allHidden;
 				$this->seriesData = $seriesInfo;
 			} else {
 				//Get a list of isbns from the record and existing display info if any

--- a/code/web/interface/themes/responsive/GroupedWork/series-summary.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/series-summary.tpl
@@ -1,20 +1,24 @@
-{strip}{if !empty($showSeries)}
+{strip}{if !empty($showSeries) && empty($series.allHidden)}
 	<div class="result-label col-sm-4 col-xs-12">{translate text='Series' isPublicFacing=true}</div>
 	<div class="result-value col-sm-8 col-xs-12">
 		{assign var=summSeries value=$series}
 		{if !empty($summSeries.fromNovelist)}
 			<a href="/GroupedWork/{$recordDriver->getPermanentId()}/Series">{$summSeries.seriesTitle}</a>{if !empty($summSeries.volume)}<strong> {translate text="volume %1%" 1=$summSeries.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}
 		{elseif !empty($summSeries.fromSeriesIndex)}
-			<a href="/Series/{$summSeries.seriesId}">{$summSeries.seriesTitle}</a>{if !empty($summSeries.volume)}<strong> {translate text="volume %1%" 1=$summSeries.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}<br>
+			{if !$summSeries.hidden}
+				<a href="/Series/{$summSeries.seriesId}">{$summSeries.seriesTitle}</a>{if !empty($summSeries.volume)}<strong> {translate text="volume %1%" 1=$summSeries.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}<br>
+			{/if}
 			{if !empty($summSeries.additionalSeries)}
 				{assign var=numSeriesShown value=1}
 				{foreach from=$summSeries.additionalSeries item=additional}
-					{assign var=numSeriesShown value=$numSeriesShown+1}
-					{if $numSeriesShown == 4}
-						<a onclick="$('#moreSeries').show();$('#moreSeriesLink').hide();" id="moreSeriesLink">{translate text='More Series...' isPublicFacing=true}</a>
-						<div id="moreSeries" style="display:none">
+					{if !$additional.hidden}
+						{assign var=numSeriesShown value=$numSeriesShown+1}
+						{if $numSeriesShown == 4}
+							<a onclick="$('#moreSeries').show();$('#moreSeriesLink').hide();" id="moreSeriesLink">{translate text='More Series...' isPublicFacing=true}</a>
+							<div id="moreSeries" style="display:none">
+						{/if}
+						<a href="/Series/{$additional.seriesId}">{$additional.seriesTitle}</a>{if !empty($additional.volume)}<strong> {translate text="volume %1%" 1=$additional.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}<br>
 					{/if}
-					<a href="/Series/{$additional.seriesId}">{$additional.seriesTitle}</a>{if !empty($additional.volume)}<strong> {translate text="volume %1%" 1=$additional.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}<br>
 				{/foreach}
 				{if $numSeriesShown >= 4}
 					</div>

--- a/code/web/interface/themes/responsive/GroupedWork/work-details.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/work-details.tpl
@@ -10,23 +10,27 @@
 		{/if}
 		{if $recordDriver->hasCachedSeries()}
 			{assign var=summSeries value=$recordDriver->getSeries(false)}
-			{if !empty($summSeries)}
+			{if !empty($summSeries) && empty($summSeries.allHidden)}
 				<div class="series row">
 					<div class="result-label col-md-3">{translate text="Series" isPublicFacing=true} </div>
 					<div class="col-md-9 result-value">
 						{if !empty($summSeries.fromNovelist)}
 							<a href="/GroupedWork/{$recordDriver->getPermanentId()}/Series">{$summSeries.seriesTitle}</a>{if !empty($summSeries.volume)}<strong> {translate text="volume %1%" 1=$summSeries.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}
 						{elseif !empty($summSeries.fromSeriesIndex)}
-							<a href="/Series/{$summSeries.seriesId}">{$summSeries.seriesTitle}</a>{if !empty($summSeries.volume)}<strong> {translate text="volume %1%" 1=$summSeries.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}<br>
+							{if !$summSeries.hidden}
+								<a href="/Series/{$summSeries.seriesId}">{$summSeries.seriesTitle}</a>{if !empty($summSeries.volume)}<strong> {translate text="volume %1%" 1=$summSeries.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}<br>
+							{/if}
 							{if !empty($summSeries.additionalSeries)}
 								{assign var=numSeriesShown value=1}
 								{foreach from=$summSeries.additionalSeries item=additional}
-									{assign var=numSeriesShown value=$numSeriesShown+1}
-									{if $numSeriesShown == 4}
-										<a onclick="$('#moreSeries').show();$('#moreSeriesLink').hide();" id="moreSeriesLink">{translate text='More Series...' isPublicFacing=true}</a>
-										<div id="moreSeries" style="display:none">
+									{if !$additional.hidden}
+										{assign var=numSeriesShown value=$numSeriesShown+1}
+										{if $numSeriesShown == 4}
+											<a onclick="$('#moreSeries').show();$('#moreSeriesLink').hide();" id="moreSeriesLink">{translate text='More Series...' isPublicFacing=true}</a>
+											<div id="moreSeries" style="display:none">
+										{/if}
+										<a href="/Series/{$additional.seriesId}">{$additional.seriesTitle}</a>{if !empty($additional.volume)}<strong> {translate text="volume %1%" 1=$additional.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}<br>
 									{/if}
-									<a href="/Series/{$additional.seriesId}">{$additional.seriesTitle}</a>{if !empty($additional.volume)}<strong> {translate text="volume %1%" 1=$additional.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}<br>
 								{/foreach}
 								{if $numSeriesShown >= 4}
 									</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/result.tpl
@@ -55,7 +55,7 @@
 
 					{if !empty($showSeries)}
 						{assign var=indexedSeries value=$recordDriver->getIndexedSeries()}
-						{if $summSeries || $indexedSeries}
+						{if ($summSeries && empty($summSeries.allHidden)) || ($indexedSeries && empty($summSeries.fromSeriesIndex))}
 							<div class="series{$summISBN}">
 								<div class="result-label col-sm-4 col-xs-12">{translate text="Series" isPublicFacing=true} </div>
 								<div class="result-value col-sm-8 col-xs-12">
@@ -63,16 +63,20 @@
 										{if !empty($summSeries.fromNovelist)}
 											<a href="/GroupedWork/{$summId}/Series">{$summSeries.seriesTitle}</a>{if !empty($summSeries.volume)} <strong>{translate text=volume isPublicFacing=true} {$summSeries.volume|format_float_with_min_decimals}</strong>{/if}<br>
 										{elseif !empty($summSeries.fromSeriesIndex)}
-											<a href="/Series/{$summSeries.seriesId}">{$summSeries.seriesTitle}</a>{if !empty($summSeries.volume)}<strong> {translate text="volume %1%" 1=$summSeries.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}<br>
+											{if !$summSeries.hidden}
+												<a href="/Series/{$summSeries.seriesId}">{$summSeries.seriesTitle}</a>{if !empty($summSeries.volume)}<strong> {translate text="volume %1%" 1=$summSeries.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}<br>
+											{/if}
 											{if !empty($summSeries.additionalSeries)}
 												{assign var=numSeriesShown value=1}
 												{foreach from=$summSeries.additionalSeries item=additional}
-													{assign var=numSeriesShown value=$numSeriesShown+1}
-													{if $numSeriesShown == 4}
-														<a onclick="$('#moreSeries_{$summId}').show();$('#moreSeriesLink_{$summId}').hide();" id="moreSeriesLink_{$summId}">{translate text='More Series...' isPublicFacing=true}</a>
-														<div id="moreSeries_{$summId}" style="display:none">
+													{if !$additional.hidden}
+														{assign var=numSeriesShown value=$numSeriesShown+1}
+														{if $numSeriesShown == 4}
+															<a onclick="$('#moreSeries_{$summId}').show();$('#moreSeriesLink_{$summId}').hide();" id="moreSeriesLink_{$summId}">{translate text='More Series...' isPublicFacing=true}</a>
+															<div id="moreSeries_{$summId}" style="display:none">
+														{/if}
+														<a href="/Series/{$additional.seriesId}">{$additional.seriesTitle}</a>{if !empty($additional.volume)}<strong> {translate text="volume %1%" 1=$additional.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}<br>
 													{/if}
-													<a href="/Series/{$additional.seriesId}">{$additional.seriesTitle}</a>{if !empty($additional.volume)}<strong> {translate text="volume %1%" 1=$additional.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}<br>
 												{/foreach}
 												{if $numSeriesShown >= 4}
 													</div>

--- a/code/web/release_notes/25.09.00.MD
+++ b/code/web/release_notes/25.09.00.MD
@@ -76,6 +76,9 @@
 ### Holds Updates
 - If Sierra loan rules for a particular record limit hold pickups to specific locations, only show those locations as options in Aspen. (DIS-790) (*KP*)
 
+### Series Updates
+- Unchecking 'Include in Search' in Administer Series will also prevent the series from appearing in the list of series for a record group. (DIS-1280) (*KP*)
+
 // myranda
 ### Hoopla Updates
 - Update Hoopla Setting tooltips for API Username and API Password fields to clarify these values are typically provided by an Aspen support vendor (DIS-295) (*MAF*)


### PR DESCRIPTION
- If the 'Include in Search' checkbox is unchecked in Administer Series, then don't include that series in the list of series for a grouped record.