### PR TITLE
DIS-1282: Add print options dialog for lists

### DIFF
--- a/code/web/Action.php
+++ b/code/web/Action.php
@@ -35,7 +35,7 @@ abstract class Action
 		$minimalInterface = $_REQUEST['minimalInterface'] ?? false;
 		$interface->assign('minimalInterface', $minimalInterface);
 
-		$printInterface = isset($_REQUEST['print']) ? (bool)$_REQUEST['print'] : false;
+		$printInterface = isset($_REQUEST['print']) ? filter_var($_REQUEST['print'], FILTER_VALIDATE_BOOLEAN) : false;
 		$interface->assign('printInterface', $printInterface);
 		$printLibraryName = isset($_REQUEST['printLibraryName']) ? filter_var($_REQUEST['printLibraryName'], FILTER_VALIDATE_BOOLEAN) : false;
 		$interface->assign('printLibraryName', $printLibraryName);

--- a/code/web/Action.php
+++ b/code/web/Action.php
@@ -35,6 +35,13 @@ abstract class Action
 		$minimalInterface = $_REQUEST['minimalInterface'] ?? false;
 		$interface->assign('minimalInterface', $minimalInterface);
 
+		$printInterface = isset($_REQUEST['print']) ? (bool)$_REQUEST['print'] : false;
+		$interface->assign('printInterface', $printInterface);
+		$printLibraryName = isset($_REQUEST['printLibraryName']) ? (bool)$_REQUEST['printLibraryName'] : false;
+		$interface->assign('printLibraryName', $printLibraryName);
+		$printLibraryLogo = isset($_REQUEST['printLibraryLogo']) ? (bool)$_REQUEST['printLibraryLogo'] : false;
+		$interface->assign('printLibraryLogo', $printLibraryLogo);
+
 		global $isAJAX;
 		if (!$isAJAX && UserAccount::isLoggedIn()){
 			$this->loadAccountSidebarVariables();
@@ -45,9 +52,11 @@ abstract class Action
 				//Messages table doesn't exist, ignore
 			}
 		}
-		if ($this->isStandalonePage){
+		if ($this->isStandalonePage) {
 			$interface->display('standalone-layout.tpl');
-		}else {
+		} elseif ($printInterface) {
+			$interface->display('print-layout.tpl');
+		} else {
 			$interface->display('layout.tpl');
 		}
 	}

--- a/code/web/Action.php
+++ b/code/web/Action.php
@@ -37,9 +37,9 @@ abstract class Action
 
 		$printInterface = isset($_REQUEST['print']) ? (bool)$_REQUEST['print'] : false;
 		$interface->assign('printInterface', $printInterface);
-		$printLibraryName = isset($_REQUEST['printLibraryName']) ? (bool)$_REQUEST['printLibraryName'] : false;
+		$printLibraryName = isset($_REQUEST['printLibraryName']) ? filter_var($_REQUEST['printLibraryName'], FILTER_VALIDATE_BOOLEAN) : false;
 		$interface->assign('printLibraryName', $printLibraryName);
-		$printLibraryLogo = isset($_REQUEST['printLibraryLogo']) ? (bool)$_REQUEST['printLibraryLogo'] : false;
+		$printLibraryLogo = isset($_REQUEST['printLibraryLogo']) ? filter_var($_REQUEST['printLibraryLogo'], FILTER_VALIDATE_BOOLEAN) : false;
 		$interface->assign('printLibraryLogo', $printLibraryLogo);
 
 		global $isAJAX;

--- a/code/web/interface/themes/responsive/Events/calendar.tpl
+++ b/code/web/interface/themes/responsive/Events/calendar.tpl
@@ -5,7 +5,7 @@
 		<img src="{$headerImage}" {if !empty($headerAlt)}alt="{translate text=$headerAlt inAttribute=true isPublicFacing=true}" title="{translate text=$headerAlt inAttribute=true isPublicFacing=true}"{/if} id="calendar-header">
 	</div>
 {/if}
-<h1>{translate text='Events Calendar' isPublicFacing=true}</h1>
+<h1 class="calendar-event-h1">{translate text='Events Calendar' isPublicFacing=true}</h1>
 	<div class="calendar {if $useWeek}week-view{/if}">
 		<div class="row calendar-nav">
 			<div class="calendar-nav-cell col-tn-2 col-sm-1 align"><a class="btn btn-default" href="{$prevLink}" style="position:absolute;left: 0;"><i class="fas fa-caret-left" role="presentation"></i> {translate text="Previous" isPublicFacing=true}</a></div>

--- a/code/web/interface/themes/responsive/GroupedWork/multipleVariationManifestion.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/multipleVariationManifestion.tpl
@@ -7,38 +7,46 @@
 	</div>
 	{foreach from=$relatedManifestation->getVariations() item=variation}
 		<div class="row {if $variation->isHideByDefault()}hiddenManifestation_{$summId}{else} displayed striped-{cycle values="odd,even"}{/if}" {if $variation->isHideByDefault()}style="display: none"{/if}>
-			<div class="col-tn-4 col-xs-4{if empty($viewingCombinedResults) || !$viewingCombinedResults} col-md-3{/if} manifestation-format">
-				<a class="btn btn-xs btn-primary btn-variation btn-wrap" href="{$variation->getUrl()}" onclick="return AspenDiscovery.ResultsList.showRelatedManifestations('{$workId|escapeCSS}','{$relatedManifestation->format|escapeCSS}','{$variation->databaseId|escapeCSS}');" aria-label="{translate text="View Manifestations for %1% %2 of %3" 1=$relatedManifestation->format 2=$variation->label 3=$summTitle inAttribute=true isPublicFacing=true}">
-					{translate text=$variation->label isPublicFacing=true}
-				</a>
-				<br>
-				<a href="#" onclick="return AspenDiscovery.ResultsList.showRelatedManifestations('{$workId|escapeCSS}','{$relatedManifestation->format|escapeCSS}','{$variation->databaseId|escapeCSS}');">
-					<span class="manifestation-toggle-text btn btn-xs btn-wrap btn-editions" id='manifestation-toggle-text-{$workId|escapeCSS}_{$relatedManifestation->format|escapeCSS}_{$variation->databaseId|escapeCSS}'><i class='fas fa-spinner fa-spin hidden' role='status' aria-hidden='true'></i>&nbsp;{if $variation->getNumRelatedRecords() == 1}{translate text='Show Edition' isPublicFacing=true}{else}{translate text='Show Editions' isPublicFacing=true}{/if}</span>
-				</a>
-			</div>
+            {if $printInterface === false || ($printInterface === true && $printEntryFormats === true)}
+				<div class="col-tn-4 col-xs-4{if empty($viewingCombinedResults) || !$viewingCombinedResults} col-md-3{/if} manifestation-format">
+					<a class="btn btn-xs btn-primary btn-variation btn-wrap" href="{$variation->getUrl()}" onclick="return AspenDiscovery.ResultsList.showRelatedManifestations('{$workId|escapeCSS}','{$relatedManifestation->format|escapeCSS}','{$variation->databaseId|escapeCSS}');" aria-label="{translate text="View Manifestations for %1% %2 of %3" 1=$relatedManifestation->format 2=$variation->label 3=$summTitle inAttribute=true isPublicFacing=true}">
+						{translate text=$variation->label isPublicFacing=true}
+					</a>
+					<br>
+					<a href="#" onclick="return AspenDiscovery.ResultsList.showRelatedManifestations('{$workId|escapeCSS}','{$relatedManifestation->format|escapeCSS}','{$variation->databaseId|escapeCSS}');">
+						<span class="manifestation-toggle-text btn btn-xs btn-wrap btn-editions" id='manifestation-toggle-text-{$workId|escapeCSS}_{$relatedManifestation->format|escapeCSS}_{$variation->databaseId|escapeCSS}'><i class='fas fa-spinner fa-spin hidden' role='status' aria-hidden='true'></i>&nbsp;{if $variation->getNumRelatedRecords() == 1}{translate text='Show Edition' isPublicFacing=true}{else}{translate text='Show Editions' isPublicFacing=true}{/if}</span>
+					</a>
+				</div>
+			{/if}
 			<div class="col-tn-5 col-xs-8{if empty($viewingCombinedResults) || !$viewingCombinedResults} col-md-5 col-lg-6{/if}">
-				{include file='GroupedWork/statusIndicator.tpl' statusInformation=$variation->getStatusInformation() viewingIndividualRecord=0}
-				{if $variation->showCopySummary()}
-					{if $variation->getNumRelatedRecords() == 1}
-						{include file='GroupedWork/copySummary.tpl' summary=$variation->getItemsDisplayedByDefault() totalCopies=$variation->getCopies() itemSummaryId="`$workId`_`$variation->label`" recordViewUrl=$variation->getUrl() format=$relatedManifestation->format isEContent=$variation->isEContent()}
-					{else}
-						{include file='GroupedWork/copySummary.tpl' summary=$variation->getItemsDisplayedByDefault() totalCopies=$variation->getCopies() itemSummaryId="`$workId`_`$variation->label`" format=$relatedManifestation->format isEContent=$variation->isEContent()}
+                {if $printInterface === false}
+	                {include file='GroupedWork/statusIndicator.tpl' statusInformation=$variation->getStatusInformation() viewingIndividualRecord=0}
+                {/if}
+                {if $printInterface === false || ($printInterface === true && $printEntryHoldings === true)}
+					{if $variation->showCopySummary()}
+						{if $variation->getNumRelatedRecords() == 1}
+							{include file='GroupedWork/copySummary.tpl' summary=$variation->getItemsDisplayedByDefault() totalCopies=$variation->getCopies() itemSummaryId="`$workId`_`$variation->label`" recordViewUrl=$variation->getUrl() format=$relatedManifestation->format isEContent=$variation->isEContent()}
+						{else}
+							{include file='GroupedWork/copySummary.tpl' summary=$variation->getItemsDisplayedByDefault() totalCopies=$variation->getCopies() itemSummaryId="`$workId`_`$variation->label`" format=$relatedManifestation->format isEContent=$variation->isEContent()}
+						{/if}
 					{/if}
 				{/if}
 			</div>
-			<div class="col-tn-8 col-tn-offset-4 col-xs-8 col-xs-offset-4{if empty($viewingCombinedResults) || !$viewingCombinedResults} col-md-4 col-md-offset-0 col-lg-3{/if} manifestation-actions">
-				<div class="btn-toolbar">
-					<div class="btn-group btn-group-vertical btn-block">
-						{foreach from=$variation->getActions() item=curAction}
-							{if !empty($curAction.url) && strlen($curAction.url) > 0}
-								<a href="{$curAction.url}" class="btn btn-sm {if empty($curAction.btnType)}btn-action{else}{$curAction.btnType}{/if} btn-wrap" {if !empty($curAction.target)}target="{$curAction.target}"{/if} id="actionButton" onclick="{if !empty($curAction.requireLogin)}return AspenDiscovery.Account.followLinkIfLoggedIn(this, '{$curAction.url}');{/if}" {if !empty($curAction.alt)}title="{translate text=$curAction.alt inAttribute=true isPublicFacing=true}"{/if}>{if !empty($curAction.target) && $curAction.target == "_blank"}<i class="fas fa-external-link-alt" role="presentation"></i> {/if}{$curAction.title}</a>
-							{else}
-								<a href="#" class="btn btn-sm {if empty($curAction.btnType)}btn-action{else}{$curAction.btnType}{/if} btn-wrap" {if !empty($curAction.target)}target="{$curAction.target}"{/if} {if !empty($curAction.id)}id="{$curAction.id}"{/if} onclick="{$curAction.onclick}" {if !empty($curAction.alt)}title="{translate text=$curAction.alt inAttribute=true}"{/if}>{if !empty($curAction.target) && $curAction.target == "_blank"}<i class="fas fa-external-link-alt" role="presentation"></i> {/if}{$curAction.title}</a>
-							{/if}
-						{/foreach}
+            {if $printInterface === false}
+				<div class="col-tn-8 col-tn-offset-4 col-xs-8 col-xs-offset-4{if empty($viewingCombinedResults) || !$viewingCombinedResults} col-md-4 col-md-offset-0 col-lg-3{/if} manifestation-actions">
+					<div class="btn-toolbar">
+						<div class="btn-group btn-group-vertical btn-block">
+							{foreach from=$variation->getActions() item=curAction}
+								{if !empty($curAction.url) && strlen($curAction.url) > 0}
+									<a href="{$curAction.url}" class="btn btn-sm {if empty($curAction.btnType)}btn-action{else}{$curAction.btnType}{/if} btn-wrap" {if !empty($curAction.target)}target="{$curAction.target}"{/if} id="actionButton" onclick="{if !empty($curAction.requireLogin)}return AspenDiscovery.Account.followLinkIfLoggedIn(this, '{$curAction.url}');{/if}" {if !empty($curAction.alt)}title="{translate text=$curAction.alt inAttribute=true isPublicFacing=true}"{/if}>{if !empty($curAction.target) && $curAction.target == "_blank"}<i class="fas fa-external-link-alt" role="presentation"></i> {/if}{$curAction.title}</a>
+								{else}
+									<a href="#" class="btn btn-sm {if empty($curAction.btnType)}btn-action{else}{$curAction.btnType}{/if} btn-wrap" {if !empty($curAction.target)}target="{$curAction.target}"{/if} {if !empty($curAction.id)}id="{$curAction.id}"{/if} onclick="{$curAction.onclick}" {if !empty($curAction.alt)}title="{translate text=$curAction.alt inAttribute=true}"{/if}>{if !empty($curAction.target) && $curAction.target == "_blank"}<i class="fas fa-external-link-alt" role="presentation"></i> {/if}{$curAction.title}</a>
+								{/if}
+							{/foreach}
+						</div>
 					</div>
 				</div>
-			</div>
+			{/if}
 		</div>
 		<div class="row">
 			<div class="col-sm-12" id="relatedRecordPopup_{$workId|escapeCSS}_{$relatedManifestation->format|escapeCSS}_{$variation->databaseId|escapeCSS}" style="display:none">

--- a/code/web/interface/themes/responsive/GroupedWork/singleVariationManifestion.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/singleVariationManifestion.tpl
@@ -1,6 +1,7 @@
 {strip}
 <div class="col-xs-12">
 	<div class="row">
+		{if $printInterface === false || ($printInterface === true && $printEntryFormats === true)}
 		<div class="col-tn-4 col-xs-4{if empty($viewingCombinedResults)} col-md-3{/if} manifestation-format">
 			<a class="btn btn-xs btn-primary btn-wrap" href="{$relatedManifestation->getUrl()}" {if $relatedManifestation->getNumRelatedRecords() > 1}onclick="return AspenDiscovery.ResultsList.showRelatedManifestations('{$workId|escapeCSS}','{$relatedManifestation->format|escapeCSS}','{$relatedManifestation->getFirstVariation()->databaseId|escapeCSS}');" aria-label="View Manifestations for {translate text=$relatedManifestation->format inAttribute=true isPublicFacing=true}"{else} aria-label="View {translate text=$relatedManifestation->format inAttribute=true}"{/if}>
 				{translate text=$relatedManifestation->format isPublicFacing=true}
@@ -10,8 +11,12 @@
 				<span class="manifestation-toggle-text btn btn-xs btn-wrap btn-editions" id='manifestation-toggle-text-{$workId|escapeCSS}_{$relatedManifestation->format|escapeCSS}_{$relatedManifestation->getFirstVariation()->databaseId|escapeCSS}'><i class='fas fa-spinner fa-spin hidden' role='status' aria-hidden='true'></i>&nbsp;{if $relatedManifestation->getNumRelatedRecords() == 1}{translate text='Show Edition' isPublicFacing=true}{else}{translate text='Show Editions' isPublicFacing=true}{/if}</span>
 			</a>
 		</div>
+		{/if}
 		<div class="col-tn-8 col-xs-8{if empty($viewingCombinedResults)} col-md-5 col-lg-6{/if}">
+			{if $printInterface === false}
 			{include file='GroupedWork/statusIndicator.tpl' statusInformation=$relatedManifestation->getStatusInformation() viewingIndividualRecord=0}
+			{/if}
+            {if $printInterface === false || ($printInterface === true && $printEntryHoldings === true)}
 			{if $relatedManifestation->showCopySummary()}
 				{if $relatedManifestation->getNumRelatedRecords() == 1}
 					{include file='GroupedWork/copySummary.tpl' summary=$relatedManifestation->getItemsDisplayedByDefault() totalCopies=$relatedManifestation->getCopies() itemSummaryId=$workId recordViewUrl=$relatedManifestation->getUrl() format=$relatedManifestation->format isEContent=$relatedManifestation->isEContent()}
@@ -19,7 +24,9 @@
 					{include file='GroupedWork/copySummary.tpl' summary=$relatedManifestation->getItemsDisplayedByDefault() totalCopies=$relatedManifestation->getCopies() itemSummaryId=$workId format=$relatedManifestation->format isEContent=$relatedManifestation->isEContent()}
 				{/if}
 			{/if}
+			{/if}
 		</div>
+		{if $printInterface === false}
 		<div class="col-tn-8 col-tn-offset-4 col-xs-8 col-xs-offset-4{if empty($viewingCombinedResults)} col-md-4 col-md-offset-0 col-lg-3{/if} manifestation-actions">
 			<div class="btn-toolbar">
 				<div class="btn-group btn-group-vertical btn-block">
@@ -35,6 +42,7 @@
 				</div>
 			</div>
 		</div>
+		{/if}
 	</div>
 	<div class="row">
 		<div class="col-xs-12" id="relatedRecordPopup_{$workId|escapeCSS}_{$relatedManifestation->format|escapeCSS}_{$relatedManifestation->getFirstVariation()->databaseId}" style="display:none">

--- a/code/web/interface/themes/responsive/GroupedWork/title-rating.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/title-rating.tpl
@@ -10,7 +10,7 @@
 				{/if}
 			</span>
 		</div>
-		{if $showNotInterested == true}
+		{if $showNotInterested == true && $printInterface === false}
 			<button id="notInterested{$summId}" style="word-break: keep-all; white-space: inherit" class="btn btn-warning btn-sm notInterested" title="{translate text="Select if you don't want to see this title recommended to you." inAttribute=true isPublicFacing=true }" onclick="return AspenDiscovery.GroupedWork.markNotInterested('{$summId}');">{translate text="Don't Recommend" isPublicFacing=true}</button>
 		{/if}
 	</div>

--- a/code/web/interface/themes/responsive/MyAccount/list-print-options.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/list-print-options.tpl
@@ -1,0 +1,84 @@
+{strip}
+	<input type="hidden" name="print" id="print" value="true">
+	<input type="hidden" name="listId" id="listId" value="{$printListId}">
+	<div class="row">
+		<div class="col-xs-12">
+			<p>{translate text="Select the elements you'd like to print" isPublicFacing=true}</p>
+		</div>
+		<div class="col-md-4">
+			<h4 class="bold">Layout Options</h4>
+			<div class="form-group checkbox">
+				<label for="printLibraryName">
+					<input type="checkbox" name="printLibraryName" id="printLibraryName" checked>
+					<strong>{translate text="Library Name" isPublicFacing=true}</strong>
+				</label>
+			</div>
+			<div class="form-group checkbox">
+				<label for="printLibraryLogo">
+					<input type="checkbox" name="printLibraryLogo" id="printLibraryLogo" checked>
+					<strong>{translate text="Library Logo" isPublicFacing=true}</strong>
+				</label>
+			</div>
+		</div>
+		<div class="col-md-4">
+			<h4 class="bold">List Options</h4>
+			<div class="form-group checkbox">
+				<label for="listAuthor">
+					<input type="checkbox" name="listAuthor" id="listAuthor" checked>
+					<strong>{translate text="List Author" isPublicFacing=true}</strong>
+				</label>
+			</div>
+			<div class="form-group checkbox">
+				<label for="listDescription">
+					<input type="checkbox" name="listDescription" id="listDescription" checked>
+					<strong>{translate text="List Description" isPublicFacing=true}</strong>
+				</label>
+			</div>
+		</div>
+		<div class="col-md-4">
+			<h4 class="bold">Entry Options</h4>
+			<div class="form-group checkbox">
+				<label for="covers">
+					<input type="checkbox" name="covers" id="covers" checked>
+					<strong>{translate text="Covers" isPublicFacing=true}</strong>
+				</label>
+			</div>
+			<div class="form-group checkbox">
+				<label for="series">
+					<input type="checkbox" name="series" id="series" checked>
+					<strong>{translate text="Series Information" isPublicFacing=true}</strong>
+				</label>
+			</div>
+			<div class="form-group checkbox">
+				<label for="formats">
+					<input type="checkbox" name="formats" id="formats" checked>
+					<strong>{translate text="Formats" isPublicFacing=true}</strong>
+				</label>
+			</div>
+			<div class="form-group checkbox">
+				<label for="description">
+					<input type="checkbox" name="description" id="description" checked>
+					<strong>{translate text="Descriptions" isPublicFacing=true}</strong>
+				</label>
+			</div>
+			<div class="form-group checkbox">
+				<label for="notes">
+					<input type="checkbox" name="notes" id="notes" checked>
+					<strong>{translate text="Notes" isPublicFacing=true}</strong>
+				</label>
+			</div>
+			<div class="form-group checkbox">
+				<label for="rating">
+					<input type="checkbox" name="rating" id="rating">
+					<strong>{translate text="Star Rating" isPublicFacing=true}</strong>
+				</label>
+			</div>
+			<div class="form-group checkbox">
+				<label for="holdings">
+					<input type="checkbox" name="holdings" id="holdings">
+					<strong>{translate text="Holdings" isPublicFacing=true}</strong>
+				</label>
+			</div>
+		</div>
+	</div>
+{/strip}

--- a/code/web/interface/themes/responsive/MyAccount/list.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/list.tpl
@@ -1,5 +1,22 @@
 {strip}
 
+	{if $printInterface === true}
+		<div class="row">
+			<div class="col-xs-12">
+				<h2>{$userList->title|escape:"html"}</h2>
+				{if $printListAuthor === true}
+					<p><strong>{$userList->getListAuthor()}</strong></p>
+				{/if}
+                {if !empty($enableListDescriptions) && $printListDescription === true}
+	                <p>{$userList->getCleanDescription()|escape:"html"}</p>
+				{/if}
+			<p><small>{translate text='Created on' isPublicFacing=true}  {$dateCreated}<br/>
+			{translate text='Last Updated' isPublicFacing=true}  {$dateUpdated}</small></p>
+			</div>
+		</div>
+	{/if}
+
+	{if $printInterface === false}
 	<div class="row">
 		<div class="col-xs-12">
 			<form action="/MyAccount/MyList/{$userList->id}" id="myListFormHead">
@@ -139,15 +156,7 @@
 									{if !empty($showEmailThis)}
 									<button value="emailList" id="FavEmail" class="btn btn-sm btn-default listViewButton" onclick='return AspenDiscovery.Lists.emailListAction("{$userList->id}")'>{translate text='Email List' isPublicFacing=true}</button>
 									{/if}
-									<div class="btn-group">
-										<button id="PrintOptions" type="button" class="btn btn-sm btn-default dropdown-toggle listViewButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-											{translate text='Print List Options' isPublicFacing=true} <span class="caret"></span>
-										</button>
-										<ul class="dropdown-menu">
-											<li><a href="#" onclick="return AspenDiscovery.Lists.printListWithoutDescriptions()">{translate text='Print Without Descriptions' isPublicFacing=true}</a></li>
-											<li><a href="#" onclick="return AspenDiscovery.Lists.printListWithDescriptions()">{translate text='Print With Descriptions' isPublicFacing=true}</a></li>
-										</ul>
-									</div>
+									<button value="printOptions" id="printOptions" class="btn btn-sm btn-default" onclick='return AspenDiscovery.Lists.getPrintListOptions("{$userList->id}")'>{translate text='Print Options' isPublicFacing=true}</button>
 									<a id="FavExport" class="btn btn-sm btn-default listViewButton" href="/MyAccount/AJAX?method=exportUserList&listId={$userList->id}">{translate text='Export List to CSV' isPublicFacing=true}</a>
 									<a id="FavExportRis" class="btn btn-sm btn-default listViewButton" href="/MyAccount/AJAX?method=exportUserListRIS&listId={$userList->id}">{translate text='Export List to RIS' isPublicFacing=true}</a>
 									<button value="citeList" id="FavCite" class="btn btn-sm btn-default listViewButton" onclick='return AspenDiscovery.Lists.citeListAction("{$userList->id}")'>{translate text='Generate Citations' isPublicFacing=true}</button>
@@ -190,13 +199,14 @@
 			</form>
 		</div>
 	</div>
+	{/if}
 
 	{if $userList->deleted == 0}
 		{if !empty($resourceList)}
+            {if $printInterface === false}
 			<div class="row">
 				<form class="navbar form-inline">
 					<div class="col-xs-4">
-
 						{if $recordCount > 20}
 						<label for="pageSize" class="control-label">{translate text='Records Per Page' isPublicFacing=true}</label>&nbsp;
 						<select id="pageSize" class="pageSize form-control-sm" onchange="AspenDiscovery.changePageSize()">
@@ -225,11 +235,12 @@
 							</div>
 						{/if}
 					</div>
-					<div class="col-xs-4">
+                    <div class="col-xs-4">
 						<label for="hideCovers" class="control-label checkbox pull-right"> {translate text='Hide Covers' isPublicFacing=true} <input id="hideCovers" type="checkbox" onclick="AspenDiscovery.Account.toggleShowCovers(!$(this).is(':checked'))" {if $showCovers == false}checked="checked"{/if}></label>
 					</div>
 				</form>
 			</div>
+            {/if}
 
 			<input type="hidden" name="myListActionItem" id="myListActionItem">
 			<div id="UserList">{*Keep only list entries in div for custom sorting functions*}

--- a/code/web/interface/themes/responsive/RecordDrivers/CourseReserve/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/CourseReserve/listEntry.tpl
@@ -1,12 +1,12 @@
 {strip}
 <div id="listEntry{$listEntryId}" class="resultsList listEntry" data-order="{$resultIndex}" data-list_entry_id="{$listEntryId}">
 	<div class="row">
-		{if !empty($listEditAllowed)}
+        {if !empty($listEditAllowed) && $printInterface === false}
 			<div class="selectTitle col-xs-12 col-sm-1">
 				<input type="checkbox" name="selected[{$listEntryId}]" class="titleSelect" id="selected{$listEntryId}">
 			</div>
 		{/if}
-		{if !empty($showCovers)}
+        {if (!empty($showCovers) && $printInterface === false) || ($printInterface === true && $printEntryCovers === true)}
 			<div class="col-xs-3 col-sm-3 col-md-3 col-lg-2 text-center">
 				{if $disableCoverArt != 1}
 					<a href="/MyAccount/MyList/{$summShortId}" class="alignleft listResultImage">
@@ -17,7 +17,7 @@
 		{/if}
 
 
-		<div class="{if empty($showCovers)}col-xs-9 col-sm-9 col-md-9 col-lg-10{elseif $listEditAllowed}col-xs-6 col-sm-6 col-md-6 col-lg-7{else}col-xs-6 col-sm-6 col-md-6 col-lg-8{/if}">
+		<div class="{if empty($showCovers) && $printInterface === false}col-xs-9 col-sm-9 col-md-9 col-lg-10{elseif $listEditAllowed && $printInterface === false}col-xs-6 col-sm-6 col-md-6 col-lg-7{elseif $printInterface === true && $printEntryCovers === false}col-xs-12{elseif $printInterface === true && $printEntryCovers === true}col-xs-9 col-sm-9 col-md-9 col-lg-10{else}col-xs-6 col-sm-6 col-md-6 col-lg-8{/if}">
 			{* Title Row *}
 
 			<div class="row">
@@ -56,7 +56,7 @@
 				</div>
 			{/if}
 
-			{if !empty($listEntryNotes)}
+            {if (!empty($listEntryNotes) && $printInterface === false) || (!empty($listEntryNotes) && $printInterface === true && $printEntryNotes === true)}
 				<div class="row">
 					<div class="result-label col-md-3">{translate text="Notes" isPublicFacing=true} </div>
 					<div class="user-list-entry-note result-value col-md-9">
@@ -66,12 +66,14 @@
 			{/if}
 
 			{* Description Section *}
-			{if !empty($summDescription)}
+            {if !empty($summDescription) && $printInterface === false}
 				<div class="row visible-xs">
 					<div class="result-label col-tn-3 col-xs-3">{translate text="Description" isPublicFacing=true}</div>
 					<div class="result-value col-tn-9 col-xs-9"><a id="descriptionLink{$summId|escape}" href="#" onclick="$('#descriptionValue{$summId|escape},#descriptionLink{$summId|escape}').toggleClass('hidden-xs');return false;">{translate text="Click to view" isPublicFacing=true}</a></div>
 				</div>
+			{/if}
 
+            {if (!empty($summDescription) && $printInterface === false) || ($printInterface === true && $printEntryDescription === true)}
 				<div class="row">
 					{* Hide in mobile view *}
 					<div class="result-value hidden-xs col-sm-12" id="descriptionValue{$summId|escape}">
@@ -81,12 +83,14 @@
 			{/if}
 
 
+            {if $printInterface === false}
 			<div class="resultActions row">
 				{include file='Lists/result-tools.tpl' id=$summId shortId=$shortId module=$summModule summTitle=$summTitle ratingData=$summRating recordUrl=$summUrl}
 			</div>
+			{/if}
 		</div>
 
-		{if !empty($listEditAllowed)}
+        {if !empty($listEditAllowed) && $printInterface === false}
 			<div class="col-xs-2 col-sm-2 col-md-2 col-lg-2 text-right">
 				<div class="btn-group-vertical" role="group">
 					{if !empty($userSort) && $resultIndex != '1'}<span class="btn btn-xs btn-default" onclick="return AspenDiscovery.Lists.changeWeight('{$listEntryId}', 'up');" title="{translate text="Move Up" isPublicFacing=true}">&#x25B2;</span>{/if}

--- a/code/web/interface/themes/responsive/RecordDrivers/EBSCO/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/EBSCO/listEntry.tpl
@@ -1,12 +1,12 @@
 {strip}
 <div id="listEntry{$listEntryId}" class="resultsList listEntry" data-order="{$resultIndex}" data-list_entry_id="{$listEntryId}">
 	<div class="row">
-		{if !empty($listEditAllowed)}
+        {if !empty($listEditAllowed) && $printInterface === false}
 			<div class="selectTitle col-xs-12 col-sm-1">
 				<input type="checkbox" name="selected[{$listEntryId}]" class="titleSelect" id="selected{$listEntryId}">
 			</div>
 		{/if}
-		{if !empty($showCovers)}
+        {if (!empty($showCovers) && $printInterface === false) || ($printInterface === true && $printEntryCovers === true)}
 			<div class="col-xs-3 col-sm-3 col-md-3 col-lg-2 text-center">
 				{if $disableCoverArt != 1 && !empty($bookCoverUrlMedium)}
 					<a href="{$summUrl}" onclick="AspenDiscovery.EBSCO.trackEdsUsage('{$summId}')" target="_blank" aria-hidden="true">
@@ -16,7 +16,7 @@
 			</div>
 		{/if}
 
-		<div class="{if empty($showCovers)}col-xs-9 col-sm-9 col-md-9 col-lg-10{elseif $listEditAllowed}col-xs-6 col-sm-6 col-md-6 col-lg-7{else}col-xs-6 col-sm-6 col-md-6 col-lg-8{/if}">
+		<div class="{if empty($showCovers) && $printInterface === false}col-xs-9 col-sm-9 col-md-9 col-lg-10{elseif $listEditAllowed && $printInterface === false}col-xs-6 col-sm-6 col-md-6 col-lg-7{elseif $printInterface === true && $printEntryCovers === false}col-xs-12{elseif $printInterface === true && $printEntryCovers === true}col-xs-9 col-sm-9 col-md-9 col-lg-10{else}col-xs-6 col-sm-6 col-md-6 col-lg-8{/if}">
 			<div class="row">
 				<div class="col-xs-12">
 					<span class="result-index">{$resultIndex})</span>&nbsp;
@@ -71,7 +71,7 @@
 				<div class="col-sm-9 result-value">{if !empty($summHasFullText)}{translate text="Yes" isPublicFacing=true}{else}{translate text="No" isPublicFacing=true}{/if}</div>
 			</div>
 
-			{if !empty($listEntryNotes)}
+            {if (!empty($listEntryNotes) && $printInterface === false) || (!empty($listEntryNotes) && $printInterface === true && $printEntryNotes === true)}
 				<div class="row">
 					<div class="result-label col-sm-3">{translate text="Notes" isPublicFacing=true} </div>
 					<div class="user-list-entry-note result-value col-sm-9">
@@ -80,14 +80,16 @@
 				</div>
 			{/if}
 
-			{if !empty($summDescription)}
+            {if !empty($summDescription) && $printInterface === false}
 				{* Standard Description *}
 				<div class="row visible-xs">
 					<div class="result-label col-tn-3">{translate text='Description' isPublicFacing=true}</div>
 					<div class="result-value col-tn-8"><a id="descriptionLink{$summId|escape}" href="#" onclick="$('#descriptionValue{$summId|escape},#descriptionLink{$summId|escape}').toggleClass('hidden-xs');return false;">Click to view</a></div>
 				</div>
+            {/if}
 
 				{* Mobile Description *}
+            {if (!empty($summDescription) && $printInterface === false) || ($printInterface === true && $printEntryDescription === true)}
 				<div class="row">
 					{* Hide in mobile view *}
 					<div class="hidden-xs result-value col-sm-12" id="descriptionValue{$summId|escape}">
@@ -96,14 +98,16 @@
 				</div>
 			{/if}
 
+            {if $printInterface === false}
 			<div class="row">
 				<div class="col-xs-12">
 					{include file='EBSCO/result-tools-horizontal.tpl' recordUrl=$summUrl showMoreInfo=true}
 				</div>
 			</div>
+			{/if}
 		</div> {* End of main section *}
 
-		{if !empty($listEditAllowed)}
+        {if !empty($listEditAllowed) && $printInterface === false}
 			<div class="col-xs-2 col-sm-2 col-md-2 col-lg-2 text-right">
 				<div class="btn-group-vertical" role="group">
 					{if !empty($userSort) && ($resultIndex != '1')}<span class="btn btn-xs btn-default" onclick="return AspenDiscovery.Lists.changeWeight('{$listEntryId}', 'up');" title="{translate text="Move Up" isPublicFacing=true}">&#x25B2;</span>{/if}

--- a/code/web/interface/themes/responsive/RecordDrivers/EBSCOhost/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/EBSCOhost/listEntry.tpl
@@ -1,12 +1,12 @@
 {strip}
 <div id="listEntry{$listEntryId}" class="resultsList listEntry" data-order="{$resultIndex}" data-list_entry_id="{$listEntryId}">
 	<div class="row">
-		{if !empty($listEditAllowed)}
+        {if !empty($listEditAllowed) && $printInterface === false}
 			<div class="selectTitle col-xs-12 col-sm-1">
 				<input type="checkbox" name="selected[{$listEntryId}]" class="titleSelect" id="selected{$listEntryId}">
 			</div>
 		{/if}
-		{if !empty($showCovers)}
+        {if (!empty($showCovers) && $printInterface === false) || ($printInterface === true && $printEntryCovers === true)}
 			<div class="col-xs-3 col-sm-3 col-md-3 col-lg-2 text-center">
 				{if $disableCoverArt != 1 && !empty($bookCoverUrlMedium)}
 					<a href="{$summUrl}" target="_blank" aria-hidden="true">
@@ -16,7 +16,7 @@
 			</div>
 		{/if}
 
-		<div class="{if empty($showCovers)}col-xs-9 col-sm-9 col-md-9 col-lg-10{elseif $listEditAllowed}col-xs-6 col-sm-6 col-md-6 col-lg-7{else}col-xs-6 col-sm-6 col-md-6 col-lg-8{/if}">
+		<div class="{if empty($showCovers) && $printInterface === false}col-xs-9 col-sm-9 col-md-9 col-lg-10{elseif $listEditAllowed && $printInterface === false}col-xs-6 col-sm-6 col-md-6 col-lg-7{elseif $printInterface === true && $printEntryCovers === false}col-xs-12{elseif $printInterface === true && $printEntryCovers === true}col-xs-9 col-sm-9 col-md-9 col-lg-10{else}col-xs-6 col-sm-6 col-md-6 col-lg-8{/if}">
 			<div class="row">
 				<div class="col-xs-12">
 					<span class="result-index">{$resultIndex})</span>&nbsp;
@@ -66,7 +66,7 @@
 				</div>
 			{/if}
 
-			{if !empty($listEntryNotes)}
+            {if (!empty($listEntryNotes) && $printInterface === false) || (!empty($listEntryNotes) && $printInterface === true && $printEntryNotes === true)}
 				<div class="row">
 					<div class="result-label col-sm-3">{translate text="Notes" isPublicFacing=true} </div>
 					<div class="user-list-entry-note result-value col-sm-9">
@@ -75,14 +75,16 @@
 				</div>
 			{/if}
 
-			{if !empty($summDescription)}
+            {if !empty($summDescription) && $printInterface === false}
 				{* Standard Description *}
 				<div class="row visible-xs">
 					<div class="result-label col-tn-3">{translate text='Description' isPublicFacing=true}</div>
 					<div class="result-value col-tn-8"><a id="descriptionLink{$summId|escape}" href="#" onclick="$('#descriptionValue{$summId|escape},#descriptionLink{$summId|escape}').toggleClass('hidden-xs');return false;">Click to view</a></div>
 				</div>
+			{/if}
 
 				{* Mobile Description *}
+            {if (!empty($summDescription) && $printInterface === false) || ($printInterface === true && $printEntryDescription === true)}
 				<div class="row">
 					{* Hide in mobile view *}
 					<div class="hidden-xs result-value col-sm-12" id="descriptionValue{$summId|escape}">
@@ -91,14 +93,16 @@
 				</div>
 			{/if}
 
+            {if $printInterface === false}
 			<div class="row">
 				<div class="col-xs-12">
 					{include file='EBSCOhost/result-tools-horizontal.tpl' recordUrl=$summUrl showMoreInfo=true}
 				</div>
 			</div>
+			{/if}
 		</div> {* End of main section *}
 
-		{if !empty($listEditAllowed)}
+        {if !empty($listEditAllowed) && $printInterface === false}
 			<div class="col-xs-2 col-sm-2 col-md-2 col-lg-2 text-right">
 				<div class="btn-group-vertical" role="group">
 					{if !empty($userSort) && ($resultIndex != '1')}<span class="btn btn-xs btn-default" onclick="return AspenDiscovery.Lists.changeWeight('{$listEntryId}', 'up');" title="{translate text="Move Up" isPublicFacing=true}">&#x25B2;</span>{/if}

--- a/code/web/interface/themes/responsive/RecordDrivers/Events/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Events/listEntry.tpl
@@ -1,12 +1,12 @@
 {strip}
 <div id="listEntry{$listEntryId}" class="resultsList listEntry" data-order="{$resultIndex}" data-list_entry_id="{$listEntryId}">
 	<div class="row">
-		{if !empty($listEditAllowed)}
+        {if !empty($listEditAllowed) && $printInterface === false}
 			<div class="selectTitle col-xs-12 col-sm-1">
 				<input type="checkbox" name="selected[{$listEntryId}]" class="titleSelect" id="selected{$listEntryId}">
 			</div>
 		{/if}
-		{if !empty($showCovers)}
+        {if (!empty($showCovers) && $printInterface === false) || ($printInterface === true && $printEntryCovers === true)}
 			<div class="col-xs-3 col-sm-3 col-md-3 col-lg-2 text-center">
 				{if $disableCoverArt != 1}
 					<a href="{$eventUrl}" class="alignleft listResultImage">
@@ -16,7 +16,7 @@
 			</div>
 		{/if}
 
-		<div class="{if empty($showCovers)}col-xs-9 col-sm-9 col-md-9 col-lg-10{elseif $listEditAllowed}col-xs-6 col-sm-6 col-md-6 col-lg-7{else}col-xs-6 col-sm-6 col-md-6 col-lg-8{/if}">
+		<div class="{if empty($showCovers) && $printInterface === false}col-xs-9 col-sm-9 col-md-9 col-lg-10{elseif $listEditAllowed && $printInterface === false}col-xs-6 col-sm-6 col-md-6 col-lg-7{elseif $printInterface === true && $printEntryCovers === false}col-xs-12{elseif $printInterface === true && $printEntryCovers === true}col-xs-9 col-sm-9 col-md-9 col-lg-10{else}col-xs-6 col-sm-6 col-md-6 col-lg-8{/if}">
 			{* Title Row *}
 
 			<div class="row">
@@ -29,12 +29,14 @@
 			</div>
 
 			{* Description Section *}
-			{if !empty($description)}
+            {if !empty($description) && $printInterface === false}
 				<div class="row visible-xs">
 					<div class="result-label col-tn-3 col-xs-3">{translate text="Description" isPublicFacing=true}</div>
 					<div class="result-value col-tn-9 col-xs-9"><a id="descriptionLink{$id|escape}" href="#" onclick="$('#descriptionValue{$id|escape},#descriptionLink{$id|escape}').toggleClass('hidden-xs');return false;">{translate text="Click to view" isPublicFacing=true}</a></div>
 				</div>
+            {/if}
 
+            {if (!empty($description) && $printInterface === false) || ($printInterface === true && $printEntryDescription === true)}
 				<div class="row">
 					{* Hide in mobile view *}
 					<div class="result-value hidden-xs col-sm-8" id="descriptionValue{$id|escape}">
@@ -77,12 +79,14 @@
 			{/if}
 
 
+            {if $printInterface === false}
 			<div class="resultActions row">
 				{include file='Events/result-tools-horizontal.tpl' id=$id summTitle=$title recordUrl=$eventUrl showMoreInfo=1}
 			</div>
+			{/if}
 		</div>
 
-		{if !empty($listEditAllowed)}
+        {if !empty($listEditAllowed) && $printInterface === false}
 			<div class="col-xs-2 col-sm-2 col-md-2 col-lg-2 text-right">
 				<div class="btn-group-vertical" role="group">
 					{if !empty($userSort) && ($resultIndex != '1')}<span class="btn btn-xs btn-default" onclick="return AspenDiscovery.Lists.changeWeight('{$listEntryId}', 'up');" title="{translate text="Move Up" isPublicFacing=true}">&#x25B2;</span>{/if}

--- a/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/listEntry.tpl
@@ -27,6 +27,10 @@
 				</div>
 			</div>
 
+            {if !empty($showRatings) && $printInterface === true && $printEntryRating === true && $printEntryCovers === false}
+                {include file="GroupedWork/title-rating.tpl" id=$summId ratingData=$summRating showNotInterested=false}
+            {/if}
+
 			{if !empty($summAuthor)}
 				<div class="row">
 					<div class="result-label col-tn-3 col-xs-3">{translate text="Author" isPublicFacing=true} </div>

--- a/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/listEntry.tpl
@@ -1,22 +1,22 @@
 {strip}
 <div id="listEntry{$listEntryId}" class="resultsList listEntry" data-order="{$resultIndex}" data-list_entry_id="{$listEntryId}">
 	<div class="row">
-		{if !empty($listEditAllowed)}
+		{if !empty($listEditAllowed) && $printInterface === false}
 			<div class="selectTitle col-xs-12 col-sm-1">
 				<input type="checkbox" name="selected[{$listEntryId}]" class="titleSelect" id="selected{$listEntryId}">
 			</div>
 		{/if}
-		{if !empty($showCovers)}
+		{if (!empty($showCovers) && $printInterface === false) || ($printInterface === true && $printEntryCovers === true)}
 			<div class="col-xs-3 col-sm-3 col-md-3 col-lg-2 text-center">
 				<a href="{$summUrl}" aria-hidden="true">
 					<img src="{$bookCoverUrlMedium}" class="listResultImage img-thumbnail{* img-responsive*} {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 				</a>
-				{if !empty($showRatings)}
+				{if (!empty($showRatings) && $printInterface === false) || ($printInterface === true && $printEntryRating === true)}
 					{include file="GroupedWork/title-rating.tpl" id=$summId ratingData=$summRating showNotInterested=false}
 				{/if}
 			</div>
 		{/if}
-		<div class="{if empty($showCovers)}col-xs-9 col-sm-9 col-md-9 col-lg-10{elseif $listEditAllowed}col-xs-6 col-sm-6 col-md-6 col-lg-7{else}col-xs-6 col-sm-6 col-md-6 col-lg-8{/if}">
+		<div class="{if empty($showCovers) && $printInterface === false}col-xs-9 col-sm-9 col-md-9 col-lg-10{elseif $listEditAllowed && $printInterface === false}col-xs-6 col-sm-6 col-md-6 col-lg-7{elseif $printInterface === true && $printEntryCovers === false}col-xs-12{elseif $printInterface === true && $printEntryCovers === true}col-xs-9 col-sm-9 col-md-9 col-lg-10{else}col-xs-6 col-sm-6 col-md-6 col-lg-8{/if}">
 			<div class="row">
 				<div class="col-xs-12">
 					<span class="result-index">{$resultIndex})</span>&nbsp;
@@ -42,7 +42,8 @@
 				</div>
 			{/if}
 
-			{if !empty($summSeries)}
+			{if (!empty($summSeries) && $printInterface === false) || (!empty($summSeries) && $printInterface === true && $printEntrySeries === true)}
+				{* If the series has an ISBN, use it to make the class unique to this series *}
 				<div class="series{$summISBN} row">
 					<div class="result-label col-xs-3">{translate text="Series" isPublicFacing=true} </div>
 					<div class="result-value col-xs-9">
@@ -51,7 +52,7 @@
 				</div>
 			{/if}
 
-			{if !empty($listEntryNotes)}
+			{if (!empty($listEntryNotes) && $printInterface === false) || (!empty($listEntryNotes) && $printInterface === true && $printEntryNotes === true)}
 				<div class="row">
 					<div class="result-label col-md-3">{translate text="Notes" isPublicFacing=true} </div>
 					<div class="user-list-entry-note result-value col-md-9">
@@ -98,7 +99,8 @@
 			</div>
 
 			{* Description Section *}
-			{if !empty($summDescription)}
+			{if !empty($summDescription) && $printInterface === false}
+				{* Show link to view description in mobile view *}
 				<div class="row visible-xs list-entry-desc-toggle">
 					<div class="result-label col-tn-3 col-xs-3">{translate text="Description" isPublicFacing=true}</div>
 					<div class="result-value col-tn-9 col-xs-9"><a id="descriptionLink{$summId|escape}" href="#" onclick="$('#descriptionValue{$summId|escape},#descriptionLink{$summId|escape}').toggleClass('hidden-xs');return false;">{translate text="Click to view" isPublicFacing=true}</a></div>
@@ -106,7 +108,7 @@
 			{/if}
 
 			{* Description Section *}
-			{if !empty($summDescription)}
+			{if (!empty($summDescription) && $printInterface === false) || ($printInterface === true && $printEntryDescription === true)}
 				<div class="row">
 					{* Hide in mobile view *}
 					<div class="list-entry-hidden-desc result-value hidden-xs col-sm-12" id="descriptionValue{$summId|escape}">
@@ -116,12 +118,14 @@
 			{/if}
 
 
+			{if $printInterface === false}
 			<div class="resultActions row">
 				{include file='GroupedWork/result-tools-horizontal.tpl' ratingData=$summRating recordUrl=$summUrl showMoreInfo=true showNotInterested=false}
 			</div>
+            {/if}
 		</div>
 
-		{if !empty($listEditAllowed)}
+		{if !empty($listEditAllowed) && $printInterface === false}
 			<div class="col-xs-2 col-sm-2 col-md-2 col-lg-2 text-right">
 				<div class="btn-group-vertical" role="group">
 					{if !empty($userSort) && ($resultIndex != '1')}<span class="btn btn-xs btn-default" onclick="return AspenDiscovery.Lists.changeWeight('{$listEntryId}', 'up');" title="{translate text="Move Up" isPublicFacing=true}">&#x25B2;</span>{/if}

--- a/code/web/interface/themes/responsive/RecordDrivers/List/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/List/listEntry.tpl
@@ -1,12 +1,12 @@
 {strip}
 <div id="listEntry{$listEntryId}" class="resultsList listEntry" data-order="{$resultIndex}" data-list_entry_id="{$listEntryId}">
 	<div class="row">
-		{if !empty($listEditAllowed)}
+        {if !empty($listEditAllowed) && $printInterface === false}
 			<div class="selectTitle col-xs-12 col-sm-1">
 				<input type="checkbox" name="selected[{$listEntryId}]" class="titleSelect" id="selected{$listEntryId}">
 			</div>
 		{/if}
-		{if !empty($showCovers)}
+        {if (!empty($showCovers) && $printInterface === false) || ($printInterface === true && $printEntryCovers === true)}
 			<div class="col-xs-3 col-sm-3 col-md-3 col-lg-2 text-center">
 				{if $disableCoverArt != 1}
 					<a href="/MyAccount/MyList/{$summShortId}" class="alignleft listResultImage">
@@ -17,7 +17,7 @@
 		{/if}
 
 
-		<div class="{if empty($showCovers)}col-xs-9 col-sm-9 col-md-9 col-lg-10{elseif $listEditAllowed}col-xs-6 col-sm-6 col-md-6 col-lg-7{else}col-xs-6 col-sm-6 col-md-6 col-lg-8{/if}">
+		<div class="{if empty($showCovers) && $printInterface === false}col-xs-9 col-sm-9 col-md-9 col-lg-10{elseif $listEditAllowed && $printInterface === false}col-xs-6 col-sm-6 col-md-6 col-lg-7{elseif $printInterface === true && $printEntryCovers === false}col-xs-12{elseif $printInterface === true && $printEntryCovers === true}col-xs-9 col-sm-9 col-md-9 col-lg-10{else}col-xs-6 col-sm-6 col-md-6 col-lg-8{/if}">
 			{* Title Row *}
 
 			<div class="row">
@@ -56,7 +56,7 @@
 				</div>
 			{/if}
 
-			{if !empty($listEntryNotes)}
+            {if (!empty($listEntryNotes) && $printInterface === false) || (!empty($listEntryNotes) && $printInterface === true && $printEntryNotes === true)}
 				<div class="row">
 					<div class="result-label col-md-3">{translate text="Notes" isPublicFacing=true} </div>
 					<div class="user-list-entry-note result-value col-md-9">
@@ -66,12 +66,14 @@
 			{/if}
 
 			{* Description Section *}
-			{if !empty($summDescription)}
+            {if !empty($summDescription) && $printInterface === false}
 				<div class="row visible-xs">
 					<div class="result-label col-tn-3 col-xs-3">{translate text="Description" isPublicFacing=true}</div>
 					<div class="result-value col-tn-9 col-xs-9"><a id="descriptionLink{$summId|escape}" href="#" onclick="$('#descriptionValue{$summId|escape},#descriptionLink{$summId|escape}').toggleClass('hidden-xs');return false;">{translate text="Click to view" isPublicFacing=true}</a></div>
 				</div>
+            {/if}
 
+            {if (!empty($summDescription) && $printInterface === false) || ($printInterface === true && $printEntryDescription === true)}
 				<div class="row">
 					{* Hide in mobile view *}
 					<div class="result-value hidden-xs col-sm-12" id="descriptionValue{$summId|escape}">
@@ -80,13 +82,14 @@
 				</div>
 			{/if}
 
-
+            {if $printInterface === false}
 			<div class="resultActions row">
 				{include file='Lists/result-tools.tpl' recordUrl=$summUrl}
 			</div>
+			{/if}
 		</div>
 
-		{if !empty($listEditAllowed)}
+        {if !empty($listEditAllowed) && $printInterface === false}
 			<div class="col-xs-2 col-sm-2 col-md-2 col-lg-2 text-right">
 				<div class="btn-group-vertical" role="group">
 					{if !empty($userSort) && $resultIndex != '1'}<span class="btn btn-xs btn-default" onclick="return AspenDiscovery.Lists.changeWeight('{$listEntryId}', 'up');" title="{translate text="Move Up" isPublicFacing=true}">&#x25B2;</span>{/if}

--- a/code/web/interface/themes/responsive/RecordDrivers/OpenArchives/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/OpenArchives/listEntry.tpl
@@ -1,12 +1,12 @@
 {strip}
 <div id="listEntry{$listEntryId}" class="resultsList listEntry" data-order="{$resultIndex}" data-list_entry_id="{$listEntryId}">
 	<div class="row">
-		{if !empty($listEditAllowed)}
+        {if !empty($listEditAllowed) && $printInterface === false}
 			<div class="selectTitle col-xs-12 col-sm-1">
 				<input type="checkbox" name="selected[{$listEntryId}]" class="titleSelect" id="selected{$listEntryId}">
 			</div>
 		{/if}
-		{if !empty($showCovers)}
+        {if (!empty($showCovers) && $printInterface === false) || ($printInterface === true && $printEntryCovers === true)}
 			<div class="col-xs-3 col-sm-3 col-md-3 col-lg-2 text-center">
 				{if $disableCoverArt != 1}
 					<a href="{$openArchiveUrl}" class="alignleft listResultImage" onclick="AspenDiscovery.OpenArchives.trackUsage('{$id}')" target="_blank" aria-hidden="true">
@@ -17,7 +17,7 @@
 		{/if}
 
 
-		<div class="{if empty($showCovers)}col-xs-9 col-sm-9 col-md-9 col-lg-10{elseif $listEditAllowed}col-xs-6 col-sm-6 col-md-6 col-lg-7{else}col-xs-6 col-sm-6 col-md-6 col-lg-8{/if}">
+		<div class="{if empty($showCovers) && $printInterface === false}col-xs-9 col-sm-9 col-md-9 col-lg-10{elseif $listEditAllowed && $printInterface === false}col-xs-6 col-sm-6 col-md-6 col-lg-7{elseif $printInterface === true && $printEntryCovers === false}col-xs-12{elseif $printInterface === true && $printEntryCovers === true}col-xs-9 col-sm-9 col-md-9 col-lg-10{else}col-xs-6 col-sm-6 col-md-6 col-lg-8{/if}">
 			{* Title Row *}
 
 			<div class="row">
@@ -68,7 +68,7 @@
 				</div>
 			{/if}
 
-			{if !empty($listEntryNotes)}
+            {if (!empty($listEntryNotes) && $printInterface === false) || (!empty($listEntryNotes) && $printInterface === true && $printEntryNotes === true)}
 				<div class="row">
 					<div class="result-label col-md-3">{translate text="Notes" isPublicFacing=true} </div>
 					<div class="user-list-entry-note result-value col-md-9">
@@ -78,12 +78,14 @@
 			{/if}
 
 			{* Description Section *}
-			{if !empty($description)}
+            {if !empty($description) && $printInterface === false}
 				<div class="row visible-xs">
 					<div class="result-label col-tn-3 col-xs-3">{translate text="Description" isPublicFacing=true}</div>
 					<div class="result-value col-tn-9 col-xs-9"><a id="descriptionLink{$resultIndex|escape}" href="#" onclick="$('#descriptionValue{$resultIndex|escape},#descriptionLink{$resultIndex|escape}').toggleClass('hidden-xs');return false;">Click to view</a></div>
 				</div>
+            {/if}
 
+            {if (!empty($description) && $printInterface === false) || ($printInterface === true && $printEntryDescription === true)}
 				<div class="row">
 					{* Hide in mobile view *}
 					<div class="result-value hidden-xs col-sm-12" id="descriptionValue{$resultIndex|escape}">
@@ -92,15 +94,17 @@
 				</div>
 			{/if}
 
+            {if $printInterface === false}
 			<div class="row">
 				<div class="col-xs-12">
 					{include file='OpenArchives/result-tools-horizontal.tpl' recordUrl=$openArchiveUrl showMoreInfo=true}
 				</div>
 			</div>
+			{/if}
 		</div>
 
 		<div class="col-xs-2 col-sm-2 col-md-2 col-lg-2 text-right">
-			{if !empty($listEditAllowed)}
+            {if !empty($listEditAllowed) && $printInterface === false}
 				<div class="btn-group-vertical" role="group">
 					{if !empty($userSort) && $resultIndex != '1'}<span class="btn btn-xs btn-default" onclick="return AspenDiscovery.Lists.changeWeight('{$listEntryId}', 'up');" title="{translate text="Move Up" isPublicFacing=true}">&#x25B2;</span>{/if}
 					<a href="/MyAccount/Edit?listEntryId={$listEntryId|escape:"url"}{if !is_null($listSelected)}&amp;listId={$listSelected|escape:"url"}{/if}" class="btn btn-default">{translate text='Edit' isPublicFacing=true}</a>

--- a/code/web/interface/themes/responsive/RecordDrivers/Person/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Person/listEntry.tpl
@@ -1,12 +1,12 @@
 {strip}
 <div id="listEntry{$listEntryId}" class="resultsList listEntry" data-order="{$resultIndex}" data-list_entry_id="{$listEntryId}">
 	<div class="row">
-		{if !empty($listEditAllowed)}
+        {if !empty($listEditAllowed) && $printInterface === false}
 			<div class="selectTitle col-xs-12 col-sm-1">
 				<input type="checkbox" name="selected[{$listEntryId}]" class="titleSelect" id="selected{$listEntryId}">
 			</div>
 		{/if}
-		{if !empty($showCovers)}
+        {if (!empty($showCovers) && $printInterface === false) || ($printInterface === true && $printEntryCovers === true)}
 			<div class="col-xs-3 col-sm-3 col-md-3 col-lg-2 text-center">
 				<a href="/Person/{$summId}">
 					{if !empty($summPicture)}
@@ -19,7 +19,7 @@
 		{/if}
 
 
-		<div class="{if empty($showCovers)}col-xs-9 col-sm-9 col-md-9 col-lg-10{elseif $listEditAllowed}col-xs-6 col-sm-6 col-md-6 col-lg-7{else}col-xs-6 col-sm-6 col-md-6 col-lg-8{/if}">
+		<div class="{if empty($showCovers) && $printInterface === false}col-xs-9 col-sm-9 col-md-9 col-lg-10{elseif $listEditAllowed && $printInterface === false}col-xs-6 col-sm-6 col-md-6 col-lg-7{elseif $printInterface === true && $printEntryCovers === false}col-xs-12{elseif $printInterface === true && $printEntryCovers === true}col-xs-9 col-sm-9 col-md-9 col-lg-10{else}col-xs-6 col-sm-6 col-md-6 col-lg-8{/if}">
 		<div class="row">
 				<div class="col-xs-12">
 					<span class="result-index">{$resultIndex})</span>&nbsp;
@@ -66,7 +66,7 @@
 				{/if}
 			</div>
 
-			{if empty($viewingCombinedResults)}
+			{if empty($viewingCombinedResults) && $printInterface === false}
 				<div class="row">
 					<div class="col-xs-12">
 						{include file='Genealogy/result-tools-horizontal.tpl' recordUrl=$summUrl showMoreInfo=true}
@@ -76,7 +76,7 @@
 		</div>
 
 		<div class="col-xs-2 col-sm-2 col-md-2 col-lg-2 text-right">
-			{if !empty($listEditAllowed)}
+            {if !empty($listEditAllowed) && $printInterface === false}
 				<div class="btn-group-vertical" role="group">
 					{if !empty($userSort) && $resultIndex != '1'}<span class="btn btn-xs btn-default" onclick="return AspenDiscovery.Lists.changeWeight('{$listEntryId}', 'up');" title="{translate text="Move Up" isPublicFacing=true}">&#x25B2;</span>{/if}
 					<a href="/MyAccount/Edit?listEntryId={$listEntryId|escape:"url"}{if !is_null($listSelected)}&amp;listId={$listSelected|escape:"url"}{/if}" class="btn btn-default">{translate text='Edit' isPublicFacing=true}</a>

--- a/code/web/interface/themes/responsive/RecordDrivers/Series/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Series/listEntry.tpl
@@ -1,12 +1,12 @@
 {strip}
 <div id="listEntry{$listEntryId}" class="resultsList listEntry" data-order="{$resultIndex}" data-list_entry_id="{$listEntryId}">
 	<div class="row">
-		{if !empty($listEditAllowed)}
+        {if !empty($listEditAllowed) && $printInterface === false}
 			<div class="selectTitle col-xs-12 col-sm-1">
 				<input type="checkbox" name="selected[{$listEntryId}]" class="titleSelect" id="selected{$listEntryId}">
 			</div>
 		{/if}
-		{if !empty($showCovers)}
+        {if (!empty($showCovers) && $printInterface === false) || ($printInterface === true && $printEntryCovers === true)}
 			<div class="col-xs-3 col-sm-3 col-md-3 col-lg-2 text-center">
 				{if $disableCoverArt != 1}
 					<a href="/MyAccount/MyList/{$summShortId}" class="alignleft listResultImage">
@@ -18,7 +18,7 @@
 		{/if}
 
 
-		<div class="{if empty($showCovers)}col-xs-9 col-sm-9 col-md-9 col-lg-10{elseif $listEditAllowed}col-xs-6 col-sm-6 col-md-6 col-lg-7{else}col-xs-6 col-sm-6 col-md-6 col-lg-8{/if}">
+		<div class="{if empty($showCovers) && $printInterface === false}col-xs-9 col-sm-9 col-md-9 col-lg-10{elseif $listEditAllowed && $printInterface === false}col-xs-6 col-sm-6 col-md-6 col-lg-7{elseif $printInterface === true && $printEntryCovers === false}col-xs-12{elseif $printInterface === true && $printEntryCovers === true}col-xs-9 col-sm-9 col-md-9 col-lg-10{else}col-xs-6 col-sm-6 col-md-6 col-lg-8{/if}">
 			{* Title Row *}
 
 			<div class="row">
@@ -64,7 +64,7 @@
 				</div>
 			{/if}
 
-			{if !empty($listEntryNotes)}
+            {if (!empty($listEntryNotes) && $printInterface === false) || (!empty($listEntryNotes) && $printInterface === true && $printEntryNotes === true)}
 				<div class="row">
 					<div class="result-label col-md-3">{translate text="Notes" isPublicFacing=true} </div>
 					<div class="user-list-entry-note result-value col-md-9">
@@ -74,12 +74,14 @@
 			{/if}
 
 			{* Description Section *}
-			{if !empty($summDescription)}
+            {if !empty($summDescription) && $printInterface === false}
 				<div class="row visible-xs">
 					<div class="result-label col-tn-3 col-xs-3">{translate text="Description" isPublicFacing=true}</div>
 					<div class="result-value col-tn-9 col-xs-9"><a id="descriptionLink{$summId|escape}" href="#" onclick="$('#descriptionValue{$summId|escape},#descriptionLink{$summId|escape}').toggleClass('hidden-xs');return false;">{translate text="Click to view" isPublicFacing=true}</a></div>
 				</div>
+            {/if}
 
+            {if (!empty($summDescription) && $printInterface === false) || ($printInterface === true && $printEntryDescription === true)}
 				<div class="row">
 					{* Hide in mobile view *}
 					<div class="result-value hidden-xs col-sm-12" id="descriptionValue{$summId|escape}">
@@ -88,13 +90,14 @@
 				</div>
 			{/if}
 
-
+            {if $printInterface === false}
 			<div class="resultActions row">
 				{include file='Series/result-tools.tpl' id=$summId summShortId=$summShortId summTitle=$summTitle recordUrl=$summUrl}
 			</div>
+			{/if}
 		</div>
 
-		{if !empty($listEditAllowed)}
+        {if !empty($listEditAllowed) && $printInterface === false}
 			<div class="col-xs-2 col-sm-2 col-md-2 col-lg-2 text-right">
 				<div class="btn-group-vertical" role="group">
 					{if !empty($userSort) && $resultIndex != '1'}<span class="btn btn-xs btn-default" onclick="return AspenDiscovery.Lists.changeWeight('{$listEntryId}', 'up');" title="{translate text="Move Up" isPublicFacing=true}">&#x25B2;</span>{/if}

--- a/code/web/interface/themes/responsive/RecordDrivers/Summon/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Summon/listEntry.tpl
@@ -1,12 +1,12 @@
 {strip}
 	<div id="listEntry{$listEntryId}" class="resultsList listEntry" data-order="{$resultIndex}" data-list_entry_id="{$listEntryId}">
 		<div class="row">
-			{if !empty($listEditAllowed)}
+            {if !empty($listEditAllowed) && $printInterface === false}
 				<div class="selectTitle col-xs-12 col-sm-1">
 					<input type="checkbox" name="selected[{$listEntryId}]" class="titleSelect" id="selected{$listEntryId}">
 				</div>
 			{/if}
-			{if !empty($showCovers)}
+            {if (!empty($showCovers) && $printInterface === false) || ($printInterface === true && $printEntryCovers === true)}
 				<div class="col-xs-3 col-sm-3 col-md-3 col-lg-2 text-center">
 					{if $disableCoverArt != 1 && !empty($bookCoverUrlMedium)}
 						<a href="{$summUrl}" target="_blank" aria-hidden="true">
@@ -16,7 +16,7 @@
 				</div>
 			{/if}
 
-			<div class="{if empty($showCovers)}col-xs-9 col-sm-9 col-md-9 col-lg-10{elseif $listEditAllowed}col-xs-6 col-sm-6 col-md-6 col-lg-7{else}col-xs-6 col-sm-6 col-md-6 col-lg-8{/if}">
+			<div class="{if empty($showCovers) && $printInterface === false}col-xs-9 col-sm-9 col-md-9 col-lg-10{elseif $listEditAllowed && $printInterface === false}col-xs-6 col-sm-6 col-md-6 col-lg-7{elseif $printInterface === true && $printEntryCovers === false}col-xs-12{elseif $printInterface === true && $printEntryCovers === true}col-xs-9 col-sm-9 col-md-9 col-lg-10{else}col-xs-6 col-sm-6 col-md-6 col-lg-8{/if}">
 				<div class="row">
 					<div class="col-xs-12">
 						<span class="result-index">{$resultIndex})</span>&nbsp;
@@ -66,7 +66,7 @@
 					</div>
 				{/if}
 
-				{if !empty($listEntryNotes)}
+                {if (!empty($listEntryNotes) && $printInterface === false) || (!empty($listEntryNotes) && $printInterface === true && $printEntryNotes === true)}
 					<div class="row">
 						<div class="result-label col-sm-3">{translate text="Notes" isPublicFacing=true} </div>
 						<div class="user-list-entry-note result-value col-sm-9">
@@ -75,14 +75,16 @@
 					</div>
 				{/if}
 
-				{if !empty($summDescription)}
+                {if !empty($summDescription) && $printInterface === false}
 					{* Standard Description *}
 					<div class="row visible-xs">
 						<div class="result-label col-tn-3">{translate text='Description' isPublicFacing=true}</div>
 						<div class="result-value col-tn-8"><a id="descriptionLink{$summId|escape}" href="#" onclick="$('#descriptionValue{$summId|escape},#descriptionLink{$summId|escape}').toggleClass('hidden-xs');return false;">Click to view</a></div>
 					</div>
+                {/if}
 
 					{* Mobile Description *}
+                {if (!empty($summDescription) && $printInterface === false) || ($printInterface === true && $printEntryDescription === true)}
 					<div class="row">
 						{* Hide in mobile view *}
 						<div class="hidden-xs result-value col-sm-12" id="descriptionValue{$summId|escape}">
@@ -91,14 +93,16 @@
 					</div>
 				{/if}
 
+                {if $printInterface === false}
 				<div class="row">
 					<div class="col-xs-12">
 						{include file='Summon/result-tools-horizontal.tpl' recordUrl=$summUrl showMoreInfo=true}
 					</div>
 				</div>
+				{/if}
 			</div> {* End of main section *}
 
-			{if !empty($listEditAllowed)}
+            {if !empty($listEditAllowed) && $printInterface === false}
 				<div class="col-xs-2 col-sm-2 col-md-2 col-lg-2 text-right">
 					<div class="btn-group-vertical" role="group">
 						{if !empty($userSort) && ($resultIndex != '1')}<span class="btn btn-xs btn-default" onclick="return AspenDiscovery.Lists.changeWeight('{$listEntryId}', 'up');" title="{translate text="Move Up" isPublicFacing=true}">&#x25B2;</span>{/if}

--- a/code/web/interface/themes/responsive/css/calendar.less
+++ b/code/web/interface/themes/responsive/css/calendar.less
@@ -138,7 +138,7 @@
 			display: none;
 		}
 
-		h1 {
+		h1.calendar-event-h1 {
 			display: none;
 		}
 

--- a/code/web/interface/themes/responsive/css/main.css
+++ b/code/web/interface/themes/responsive/css/main.css
@@ -11728,7 +11728,7 @@ input[type="radio"][name="colorScheme"]:checked + label::after {
 }
 [data-context="print-layout"] .ui-rater-starsOff,
 [data-context="print-layout"] .ui-rater-starsOn {
-  background: url(/interface/themes/responsive/images/star/stars.png) repeat-x 0 0 !important;
+  background: url('/interface/themes/responsive/images/star/stars.png') repeat-x 0 0 !important;
 }
 [data-context="print-layout"] .ui-rater-starsOn {
   background-position: 0 -36px !important;

--- a/code/web/interface/themes/responsive/css/main.css
+++ b/code/web/interface/themes/responsive/css/main.css
@@ -11726,6 +11726,13 @@ input[type="radio"][name="colorScheme"]:checked + label::after {
   background: transparent !important;
   box-shadow: none !important;
 }
+[data-context="print-layout"] .ui-rater-starsOff,
+[data-context="print-layout"] .ui-rater-starsOn {
+  background: url(/interface/themes/responsive/images/star/stars.png) repeat-x 0 0 !important;
+}
+[data-context="print-layout"] .ui-rater-starsOn {
+  background-position: 0 -36px !important;
+}
 [data-context="print-layout"] .label {
   border: 1px solid #000;
 }

--- a/code/web/interface/themes/responsive/css/print.css
+++ b/code/web/interface/themes/responsive/css/print.css
@@ -1,32 +1,25 @@
 /* Only apply to /MyAccount/list.tpl. */
-[data-context="print-layout"] {
-  * {
-    text-shadow: none !important;
-    color: #000 !important; // Black prints faster: h5bp.com/s
-    background: transparent !important;
-    box-shadow: none !important;
-  }
-
-  .label {
-    border: 1px solid #000;
-  }
-
-  span.btn-editions {
-    display: none;
-  }
-
-  .related-manifestation.grouped {
-    border: none !important;
-  }
+[data-context="print-layout"] * {
+  text-shadow: none !important;
+  color: #000 !important;
+  background: transparent !important;
+  box-shadow: none !important;
 }
-
+[data-context="print-layout"] .label {
+  border: 1px solid #000;
+}
+[data-context="print-layout"] span.btn-editions {
+  display: none;
+}
+[data-context="print-layout"] .related-manifestation.grouped {
+  border: none !important;
+}
 @media print {
   /* Make sure descriptions and multiple manifestations are visible . */
   body#MyAccount-MyList .list-entry-hidden-desc.hidden-xs,
   body#MyAccount-MyList .list-entry-hidden-format.hidden-xs {
     display: block !important;
   }
-
   /* Make sure list title is prominently displayed. */
   body#MyAccount-MyList #listTitle {
     font-size: 24px;
@@ -34,46 +27,41 @@
     margin-bottom: 10px;
     display: block !important;
   }
-
   /* Hide buttons and controls that aren't needed. */
   body#MyAccount-MyList .btn-toolbar,
   body#MyAccount-MyList .btn-group,
   body#MyAccount-MyList .resultActions {
     display: none !important;
   }
-
   /* Hide mobile-only toggle rows "Description" and "Click to view". */
   body#MyAccount-MyList .list-entry-desc-toggle {
     display: none !important;
   }
-
   /* Hide the back-to-top arrow. */
   body#MyAccount-MyList .top-link {
     display: none !important;
   }
-
   /* Prevent page breaks inside list items and their descriptions. */
   body#MyAccount-MyList .result,
   body#MyAccount-MyList .resultsList.listEntry,
   body#MyAccount-MyList .list-entry-hidden-desc,
   body#MyAccount-MyList .result-value,
   body#MyAccount-MyList .user-list-entry-note {
-    page-break-inside: avoid !important; /* For old browsers */
+    page-break-inside: avoid !important;
+    /* For old browsers */
     break-inside: avoid !important;
   }
-
   /* Allow page breaks in list items when descriptions are omitted. */
   body#MyAccount-MyList.no-print-descriptions .result,
   body#MyAccount-MyList.no-print-descriptions .resultsList.listEntry {
-    page-break-inside: auto !important; /* For old browsers */
+    page-break-inside: auto !important;
+    /* For old browsers */
     break-inside: auto !important;
   }
-
   /* Optionally hide descriptions when selected. */
   body#MyAccount-MyList.no-print-descriptions .list-entry-hidden-desc {
     display: none !important;
   }
-
   /* Strip out any screen‐only height/overflow rules to allow landscape printing. */
   body#MyAccount-MyList {
     height: auto !important;
@@ -81,3 +69,4 @@
     overflow: visible !important;
   }
 }
+/*# sourceMappingURL=print.css.map */

--- a/code/web/interface/themes/responsive/css/print.css
+++ b/code/web/interface/themes/responsive/css/print.css
@@ -7,7 +7,7 @@
 }
 [data-context="print-layout"] .ui-rater-starsOff,
 [data-context="print-layout"] .ui-rater-starsOn {
-  background: url(/interface/themes/responsive/images/star/stars.png) repeat-x 0 0 !important;
+  background: url('/interface/themes/responsive/images/star/stars.png') repeat-x 0 0 !important;
 }
 [data-context="print-layout"] .ui-rater-starsOn {
   background-position: 0 -36px !important;

--- a/code/web/interface/themes/responsive/css/print.css
+++ b/code/web/interface/themes/responsive/css/print.css
@@ -5,6 +5,13 @@
   background: transparent !important;
   box-shadow: none !important;
 }
+[data-context="print-layout"] .ui-rater-starsOff,
+[data-context="print-layout"] .ui-rater-starsOn {
+  background: url(/interface/themes/responsive/images/star/stars.png) repeat-x 0 0 !important;
+}
+[data-context="print-layout"] .ui-rater-starsOn {
+  background-position: 0 -36px !important;
+}
 [data-context="print-layout"] .label {
   border: 1px solid #000;
 }

--- a/code/web/interface/themes/responsive/css/print.less
+++ b/code/web/interface/themes/responsive/css/print.less
@@ -8,7 +8,7 @@
   }
 
   .ui-rater-starsOff, .ui-rater-starsOn {
-    background: url(/interface/themes/responsive/images/star/stars.png) repeat-x 0 0 !important;
+    background: url('/interface/themes/responsive/images/star/stars.png') repeat-x 0 0 !important;
   }
 
   .ui-rater-starsOn {

--- a/code/web/interface/themes/responsive/css/print.less
+++ b/code/web/interface/themes/responsive/css/print.less
@@ -7,6 +7,14 @@
     box-shadow: none !important;
   }
 
+  .ui-rater-starsOff, .ui-rater-starsOn {
+    background: url(/interface/themes/responsive/images/star/stars.png) repeat-x 0 0 !important;
+  }
+
+  .ui-rater-starsOn {
+    background-position: 0 -36px !important;
+  }
+
   .label {
     border: 1px solid #000;
   }

--- a/code/web/interface/themes/responsive/css/responsive_base.css
+++ b/code/web/interface/themes/responsive/css/responsive_base.css
@@ -11728,7 +11728,7 @@ input[type="radio"][name="colorScheme"]:checked + label::after {
 }
 [data-context="print-layout"] .ui-rater-starsOff,
 [data-context="print-layout"] .ui-rater-starsOn {
-  background: url(/interface/themes/responsive/images/star/stars.png) repeat-x 0 0 !important;
+  background: url('/interface/themes/responsive/images/star/stars.png') repeat-x 0 0 !important;
 }
 [data-context="print-layout"] .ui-rater-starsOn {
   background-position: 0 -36px !important;

--- a/code/web/interface/themes/responsive/css/responsive_base.css
+++ b/code/web/interface/themes/responsive/css/responsive_base.css
@@ -2681,8 +2681,8 @@ input[type="button"].btn-block {
 }
 @font-face {
   font-family: 'Glyphicons Halflings';
-  src: url('/fonts/glyphicons-halflings-regular.eot');
-  src: url('/fonts/glyphicons-halflings-regular.eot?#iefix') format('embedded-opentype'), url('/fonts/glyphicons-halflings-regular.woff') format('woff'), url('/fonts/glyphicons-halflings-regular.ttf') format('truetype'), url('/fonts/glyphicons-halflings-regular.svg#glyphicons-halflingsregular') format('svg');
+  src: url('../../../../fonts/glyphicons-halflings-regular.eot');
+  src: url('../../../../fonts/glyphicons-halflings-regular.eot?#iefix') format('embedded-opentype'), url('../../../../fonts/glyphicons-halflings-regular.woff') format('woff'), url('../../../../fonts/glyphicons-halflings-regular.ttf') format('truetype'), url('../../../../fonts/glyphicons-halflings-regular.svg#glyphicons-halflingsregular') format('svg');
 }
 .glyphicon {
   position: relative;
@@ -11790,4 +11790,4 @@ input[type="radio"][name="colorScheme"]:checked + label::after {
     overflow: visible !important;
   }
 }
-/*# sourceMappingURL=main.css.map */
+/*# sourceMappingURL=responsive_base.css.map */

--- a/code/web/interface/themes/responsive/css/responsive_base.css
+++ b/code/web/interface/themes/responsive/css/responsive_base.css
@@ -11726,6 +11726,13 @@ input[type="radio"][name="colorScheme"]:checked + label::after {
   background: transparent !important;
   box-shadow: none !important;
 }
+[data-context="print-layout"] .ui-rater-starsOff,
+[data-context="print-layout"] .ui-rater-starsOn {
+  background: url(/interface/themes/responsive/images/star/stars.png) repeat-x 0 0 !important;
+}
+[data-context="print-layout"] .ui-rater-starsOn {
+  background-position: 0 -36px !important;
+}
 [data-context="print-layout"] .label {
   border: 1px solid #000;
 }

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -9725,7 +9725,7 @@ AspenDiscovery.Admin = (function () {
 					].forEach(selector => $(selector).show());
 					break;
 				case "2": // ILS Request System
-					["#propertyRowallowDeletingILSRequests", "#propertyRowallowMaterialRequestsBranchChoice", "#propertyRowdisplayMaterialsRequestToPublic"]
+					["#propertyRowallowDeletingILSRequests", "#propertyRowallowMaterialRequestsBranchChoice", "#propertyRowdisplayMaterialsRequestToPublic", "#propertyRownewMaterialsRequestSummary"]
 						.forEach(selector => $(selector).show());
 					break;
 				case "3": // External Request Link
@@ -14903,6 +14903,62 @@ AspenDiscovery.Lists = (function(){
 				}
 			});
 			return false;
+		},
+
+		getPrintListOptions: function (listId) {
+			AspenDiscovery.Account.ajaxLightbox(Globals.path + '/MyAccount/AJAX?method=getListPrintOptions&listId=' + listId);
+			return false;
+		},
+
+		buildAndOpenPrintUrl: function () {
+			const print = document.getElementById('print').value;
+			const listId = document.getElementById('listId').value;
+
+			const baseUrl = Globals.path + '/MyAccount/MyList/' + listId;
+
+
+			// Checkbox names (in order as in the form)
+			const checkboxIds = [
+				'printLibraryName',
+				'printLibraryLogo',
+				'listAuthor',
+				'listDescription',
+				'covers',
+				'series',
+				'formats',
+				'description',
+				'notes',
+				'rating',
+				'holdings'
+			];
+
+			// Build URL params object
+			const params = {
+				print
+			};
+
+			checkboxIds.forEach(id => {
+				const el = document.getElementById(id);
+				if (el) {
+					// Only include if checked, send value "true" (or customize as needed)
+					params[id] = el.checked ? 'true' : 'false';
+				}
+			});
+
+			// Build search string
+			const urlSearchParams = new URLSearchParams(params).toString();
+
+			// Final URL
+			const printUrl = `${baseUrl}?${urlSearchParams}`;
+
+			// Open print window and prompt print dialog once loaded
+			const win = window.open(printUrl, '_blank', 'width=900,height=900');
+			if (win) {
+				// Wait for the new window to load content, then trigger print
+				win.onload = function () {
+					win.print();
+				};
+			}
 		}
 	};
 }(AspenDiscovery.Lists || {}));

--- a/code/web/interface/themes/responsive/js/aspen/lists.js
+++ b/code/web/interface/themes/responsive/js/aspen/lists.js
@@ -238,6 +238,62 @@ AspenDiscovery.Lists = (function(){
 				}
 			});
 			return false;
+		},
+
+		getPrintListOptions: function (listId) {
+			AspenDiscovery.Account.ajaxLightbox(Globals.path + '/MyAccount/AJAX?method=getListPrintOptions&listId=' + listId);
+			return false;
+		},
+
+		buildAndOpenPrintUrl: function () {
+			const print = document.getElementById('print').value;
+			const listId = document.getElementById('listId').value;
+
+			const baseUrl = Globals.path + '/MyAccount/MyList/' + listId;
+
+
+			// Checkbox names (in order as in the form)
+			const checkboxIds = [
+				'printLibraryName',
+				'printLibraryLogo',
+				'listAuthor',
+				'listDescription',
+				'covers',
+				'series',
+				'formats',
+				'description',
+				'notes',
+				'rating',
+				'holdings'
+			];
+
+			// Build URL params object
+			const params = {
+				print
+			};
+
+			checkboxIds.forEach(id => {
+				const el = document.getElementById(id);
+				if (el) {
+					// Only include if checked, send value "true" (or customize as needed)
+					params[id] = el.checked ? 'true' : 'false';
+				}
+			});
+
+			// Build search string
+			const urlSearchParams = new URLSearchParams(params).toString();
+
+			// Final URL
+			const printUrl = `${baseUrl}?${urlSearchParams}`;
+
+			// Open print window and prompt print dialog once loaded
+			const win = window.open(printUrl, '_blank', 'width=900,height=900');
+			if (win) {
+				// Wait for the new window to load content, then trigger print
+				win.onload = function () {
+					win.print();
+				};
+			}
 		}
 	};
 }(AspenDiscovery.Lists || {}));

--- a/code/web/interface/themes/responsive/print-layout.tpl
+++ b/code/web/interface/themes/responsive/print-layout.tpl
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="{$userLang->code}" data-context="print-layout">
+<head prefix="og: http://ogp.me/ns#">
+    {strip}
+		<title>{$pageTitleShortAttribute|truncate:64:"..."}{if empty($isMobile)} | {$librarySystemName|escape}{/if}</title>
+		<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+        {if !empty($google_verification_key)}
+			<meta name="google-site-verification" content="{$google_verification_key}">
+        {/if}
+
+        {if !empty($metadataTemplate)}
+            {include file=$metadataTemplate}
+        {/if}
+		<meta property="og:site_name" content="{$site.title|removeTrailingPunctuation|escape:html}"/>
+        {if !empty($og_title)}
+			<meta property="og:title" content="{$og_title|removeTrailingPunctuation|escape:html}"/>
+        {/if}
+        {if !empty($og_type)}
+			<meta property="og:type" content="{$og_type|escape:html}"/>
+        {/if}
+        {if !empty($og_image)}
+			<meta property="og:image" content="{$og_image|escape:html}"/>
+        {/if}
+        {if !empty($og_url)}
+			<meta property="og:url" content="{$og_url|escape:html}"/>
+        {/if}
+		<link type="image/x-icon" href="{$favicon}" rel="shortcut icon">
+        {include file="cssAndJsIncludes.tpl"}
+    {/strip}
+</head>
+<body class="module_{$module} action_{$action}{if !empty($masqueradeMode)} masqueradeMode{/if}{if !empty($loggedIn)} loggedIn{else} loggedOut{/if}" id="{$module}-{$action}">
+{strip}
+	<div id="page-container">
+		{if $printLibraryName || $printLibraryLogo}
+		<div class="container-fluid">
+			<div class="row">
+				<div>
+					{if $printLibraryLogo}
+                    <div class="col-xs-12">
+	                    <img src="{if !empty($responsiveLogo)}{$responsiveLogo}{else}{img filename="logo_responsive.png"}{/if}" alt="{$librarySystemName|escape}" title="{translate text=$logoAlt inAttribute=true isPublicFacing=true}" style="max-height: 150px;">
+                    </div>
+                    {/if}
+					{if $printLibraryName}
+                    <div class="col-xs-12">
+	                    <h1>{$librarySystemName|escape}</h1>
+                        {if !empty($headerText)}
+	                        <p>{translate text=$headerText isPublicFacing=true isAdminEnteredData=true}</p>
+                        {/if}
+                    </div>
+					{/if}
+				</div>
+			</div>
+		</div>
+		{/if}
+
+       <div>
+			<div id="content-container">
+				<div class="row">
+					<div class="col-xs-12" id="main-content">
+						<div role="main">
+                            {if !empty($module)}
+                                {include file="$module/$pageTemplate"}
+                            {else}
+                                {include file="$pageTemplate"}
+                            {/if}
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+
+	</div>
+    {include file="modal_dialog.tpl"}
+
+    {include file="tracking.tpl"}
+
+    {if !empty($semanticData)}
+        {include file="jsonld.tpl"}
+    {/if}
+{/strip}
+
+</body>
+</html>

--- a/code/web/release_notes/25.09.00.MD
+++ b/code/web/release_notes/25.09.00.MD
@@ -96,6 +96,9 @@
 - Added support for Aspen Events to be a valid source when calling getAppBrowseCategoryResults in Search API. (DIS-1262) (*KK*)
 - Added support for Aspen Events to be a valid source when calling getEventDetails in Event API. (DIS-1262) (*KK*)
 
+### List Updates
+- Added updated Print List to prompt the user to select which elements they want to include in the printout. (DIS-1282) (*KK*)
+
 // kodi
 
 // imani

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -10409,4 +10409,22 @@ class MyAccount_AJAX extends JSON_Action {
 		];
 	}
 
+	/** @noinspection PhpUnused */
+	function getListPrintOptions() {
+		global $interface;
+		$interface->assign('printListId', strip_tags($_REQUEST['listId']));
+
+		return [
+			'title' => translate([
+				'text' => 'Print Options',
+				'isAdminFacing' => 'true',
+			]),
+			'modalBody' => $interface->fetch('MyAccount/list-print-options.tpl'),
+			'modalButtons' => "<button class='tool btn btn-primary' onclick='AspenDiscovery.Lists.buildAndOpenPrintUrl()'>" . translate([
+					'text' => 'Print',
+					'isAdminFacing' => 'true',
+				]) . "</button>",
+		];
+	}
+
 }

--- a/code/web/services/MyAccount/MyList.php
+++ b/code/web/services/MyAccount/MyList.php
@@ -46,6 +46,28 @@ class MyAccount_MyList extends MyAccount {
 		$list = new UserList();
 		$list->id = $listId;
 
+		// Setup print interface variables
+		$printListAuthor = isset($_REQUEST['listAuthor']) ? filter_var($_REQUEST['listAuthor'], FILTER_VALIDATE_BOOLEAN) : false;
+		$printListDescription = isset($_REQUEST['listDescription']) ? filter_var($_REQUEST['listDescription'], FILTER_VALIDATE_BOOLEAN) : false;
+		$printEntryCovers = isset($_REQUEST['covers']) ? filter_var($_REQUEST['covers'], FILTER_VALIDATE_BOOLEAN) : false;
+		$printEntrySeries = isset($_REQUEST['series']) ? filter_var($_REQUEST['series'], FILTER_VALIDATE_BOOLEAN) : false;
+		$printEntryFormats = isset($_REQUEST['formats']) ? filter_var($_REQUEST['formats'], FILTER_VALIDATE_BOOLEAN) : false;
+		$printEntryDescription = isset($_REQUEST['description']) ? filter_var($_REQUEST['description'], FILTER_VALIDATE_BOOLEAN) : false;
+		$printEntryNotes = isset($_REQUEST['notes']) ? filter_var($_REQUEST['notes'], FILTER_VALIDATE_BOOLEAN) : false;
+		$printEntryHoldings = isset($_REQUEST['holdings']) ? filter_var($_REQUEST['holdings'], FILTER_VALIDATE_BOOLEAN) : false;
+		$printEntryRating = isset($_REQUEST['rating']) ? filter_var($_REQUEST['rating'], FILTER_VALIDATE_BOOLEAN) : false;
+		$printInterface = isset($_REQUEST['print']) ? filter_var($_REQUEST['print'], FILTER_VALIDATE_BOOLEAN) : false;
+		$interface->assign('printInterface', $printInterface);
+		$interface->assign('printListAuthor', $printListAuthor);
+		$interface->assign('printListDescription', $printListDescription);
+		$interface->assign('printEntryCovers', $printEntryCovers);
+		$interface->assign('printEntrySeries', $printEntrySeries);
+		$interface->assign('printEntryFormats', $printEntryFormats);
+		$interface->assign('printEntryDescription', $printEntryDescription);
+		$interface->assign('printEntryNotes', $printEntryNotes);
+		$interface->assign('printEntryHoldings', $printEntryHoldings);
+		$interface->assign('printEntryRating', $printEntryRating);
+
 		//If the list does not exist, create a new My Favorites List
 		if (!$list->find(true)) {
 			global $interface;
@@ -233,6 +255,7 @@ class MyAccount_MyList extends MyAccount {
 	private function buildListForDisplay(UserList $list, bool $allowEdit, string $sortName, int $pageSize) : void {
 		global $interface;
 
+		$printInterface = isset($_REQUEST['print']) ? filter_var($_REQUEST['print'], FILTER_VALIDATE_BOOLEAN) : false;
 		$queryParams = parse_url($_SERVER['REQUEST_URI'], PHP_URL_QUERY);
 		if ($queryParams == null) {
 			$queryParams = [];
@@ -289,6 +312,12 @@ class MyAccount_MyList extends MyAccount {
 		$endRecord = $page * $pageSize;
 		if ($endRecord > $totalRecords) {
 			$endRecord = $totalRecords;
+		}
+		if ($printInterface) {
+			// When printing, show all results on one page
+			$startRecord = 0;
+			$endRecord = $totalRecords;
+			$pageSize = $totalRecords;
 		}
 		$pageInfo = [
 			'resultTotal' => $totalRecords,

--- a/code/web/sys/UserLists/UserList.php
+++ b/code/web/sys/UserLists/UserList.php
@@ -400,6 +400,17 @@ class UserList extends DataObject {
 		return $this->_cleanDescription;
 	}
 
+	function getListAuthor(): ?string {
+		if ($this->user_id != null) {
+			$user = new User();
+			$user->id = $this->user_id;
+			if ($user->find(true)) {
+				return $user->getDisplayName();
+			}
+		}
+		return null;
+	}
+
 	/**
 	 * remove all resources within this list
 	 * @param bool $updateBrowseCategories


### PR DESCRIPTION
- added print interface option that uses an alternate layout template to reduce header/footer elements
- update print options button in My List to open a modal to prompt the user what elements they'd like to print: library name, library logo, list author, list description, list entry covers/series/formats/descriptions/notes/holdings/rating
- when using the print interface, always hide: Show Editions button, availability info, waitlist info, toolbars