### PR TITLE
DIS-1275 Allow Messages to be displayed after Self Check

### DIFF
--- a/code/web/CatalogConnection.php
+++ b/code/web/CatalogConnection.php
@@ -1895,7 +1895,7 @@ class CatalogConnection {
 		}
 	}
 
-	public function checkoutBySip(User $patron, $barcode, $currentLocationId): array {
+	public function checkoutBySip(User $patron, string $barcode, $currentLocationId): array {
 		return $this->driver->checkoutBySip($patron, $barcode, $currentLocationId);
 	}
 
@@ -1905,6 +1905,18 @@ class CatalogConnection {
 
 	public function checkoutByAPI(User $patron, $barcode, Location $currentLocation): array {
 		return $this->driver->checkoutByAPI($patron, $barcode, $currentLocation);
+	}
+
+	public function hasAPICheckin() : bool {
+		return $this->driver->hasAPICheckin();
+	}
+
+	public function checkInByAPI(User $patron, string $barcode, Location $currentLocation): array {
+		return $this->driver->checkInByAPI($patron, $barcode, $currentLocation);
+	}
+
+	public function checkInBySip(User $patron, string $barcode, Location $currentLocation): array {
+		return $this->driver->checkInBySip($patron, $barcode, $currentLocation);
 	}
 
 	public function allowUpdatesOfPreferredName(User $patron): bool {

--- a/code/web/Drivers/AbstractIlsDriver.php
+++ b/code/web/Drivers/AbstractIlsDriver.php
@@ -825,7 +825,7 @@ abstract class AbstractIlsDriver extends AbstractDriver {
 		return false;
 	}
 
-	public function checkoutBySip(User $patron, $barcode, $currentLocationId) {
+	public function checkoutBySip(User $patron, string $barcode, $currentLocationId) : array {
 		$checkout_result = [];
 		$success = false;
 		$title = translate([
@@ -941,13 +941,33 @@ abstract class AbstractIlsDriver extends AbstractDriver {
 		return [
 			'success' => false,
 			'message' => 'This functionality has not been implemented for this ILS',
+			'api' => [
+				'title' => translate([
+					'text' => 'Error',
+					'isPublicFacing' => true,
+				]),
+				'message' => translate([
+					'text' => 'This functionality has not been implemented for this ILS',
+					'isPublicFacing' => true,
+				]),
+			],
 		];
 	}
 
-	public function checkInBySIP(User $patron, $barcode, Location $currentLocation): array {
+	public function checkInBySIP(User $patron, string $barcode, Location $currentLocation): array {
 		return [
 			'success' => false,
 			'message' => 'This functionality has not been implemented for this ILS',
+			'api' => [
+				'title' => translate([
+					'text' => 'Error',
+					'isPublicFacing' => true,
+				]),
+				'message' => translate([
+					'text' => 'This functionality has not been implemented for this ILS',
+					'isPublicFacing' => true,
+				]),
+			],
 		];
 	}
 

--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -8728,6 +8728,9 @@ class Koha extends AbstractIlsDriver {
 							'title' => $title,
 							'due' => $response->due_date ?? null,
 							'barcode' => $barcode,
+							'itemId' => $recordId,
+							'owningLocationCode' => $holdingBranch,
+							'checkoutLocationCode' => $checkoutLocation
 						];
 
 						$patron->clearCachedAccountSummaryForSource($this->getIndexingProfile()->name);

--- a/code/web/interface/themes/responsive/ILS/selfCheckTester.tpl
+++ b/code/web/interface/themes/responsive/ILS/selfCheckTester.tpl
@@ -8,6 +8,10 @@
 					<div><strong>{$checkoutResult.title}</strong></div>
 					<div>{$checkoutResult.message}</div>
 
+					{if !empty($checkoutResult.completionMessage)}
+						<div>{$checkoutResult.completionMessage}</div>
+					{/if}
+
 					{if !empty($checkoutResult.itemData)}
 						<div>Title: {$checkoutResult.itemData.title}</div>
 						<div>Due: {$checkoutResult.itemData.due}</div>

--- a/code/web/release_notes/25.09.00.MD
+++ b/code/web/release_notes/25.09.00.MD
@@ -2,10 +2,13 @@
 
 // mark
 ### Administration Updates
-- Reorganize Grouped Work Display Options to list options alphabetically and collapse sections by default for easier navigation. (DIS-1251)
+- Reorganize Grouped Work Display Options to list options alphabetically and collapse sections by default for easier navigation. (DIS-1251) (*MDN*)
+
+### API Updates
+- Return completion message at the end of successful Scan and Go operations. (DIS-1275) (*MDN*) 
 
 ### Grouped Work Updates
-- Add a new option to control the Format Display Style for Grouped Works. (DIS-1251)
+- Add a new option to control the Format Display Style for Grouped Works. (DIS-1251) (*MDN*)
   - When the new option is enabled, the display of formats for a Grouped Work will change to a horizontal swiper rather than a vertical list.
 - When setting display info, do not prompt for series information if the series module is enabled. (DIS-1116) (*MDN*)
 
@@ -53,6 +56,16 @@
 
 ### Record Display Updates
 - Show ISBN Qualifier (subfield q) in addition to ISBN within full record view. (DIS-1246) (*MDN*)
+
+### Scan and Go Updates
+- Allow Self Check Messages to be configured for display after titles have been checked out from LiDA. Anyone with permission to administer Self Check Settings can update these. (DIS-1275) (*MDN*)
+
+<div markdown="1" class="settings">
+
+#### New Settings
+- Aspen LiDA > Self Check Completion Messages
+
+</div>
 
 ### Symphony Updates
 - Properly load fines during the scan and go process to ensure checks for maximum fine thresholds work. (DIS-1117) (*MDN*)
@@ -246,8 +259,7 @@
 ## Special Documentation thanks to
 - Myranda Fuentes (Grove)
 - Tricia Andrews (Metropolitan Library System)
-- Will Skora (Cleveland Public Library)
-- Jeff Godin (Traverse Area District Library)
+- Kris Becker (Jackson County Library System)
 
 ## This release includes sponsored developments from
 - 

--- a/code/web/services/API/UserAPI.php
+++ b/code/web/services/API/UserAPI.php
@@ -6178,7 +6178,8 @@ class UserAPI extends AbstractAPI {
 								'success' => $result['success'],
 								'title' => $result['api']['title'],
 								'message' => $result['api']['message'],
-								'itemData' => $result['itemData']
+								'itemData' => $result['itemData'],
+								'completionMessage' => $result['completionMessage'] ?? '',
 							];
 						} else {
 							return [
@@ -6266,7 +6267,7 @@ class UserAPI extends AbstractAPI {
 								'success' => $result['success'],
 								'title' => $result['api']['title'],
 								'message' => $result['api']['message'],
-								'itemData' => $result['itemData']
+								'itemData' => $result['itemData'] ?? []
 							];
 						} else {
 							return [

--- a/code/web/services/AspenLiDA/SelfCheckCompletionMessages.php
+++ b/code/web/services/AspenLiDA/SelfCheckCompletionMessages.php
@@ -1,0 +1,69 @@
+<?php
+require_once ROOT_DIR . '/Action.php';
+require_once ROOT_DIR . '/services/Admin/ObjectEditor.php';
+require_once ROOT_DIR . '/sys/AspenLiDA/SelfCheckCompletionMessage.php';
+
+class AspenLiDA_SelfCheckCompletionMessages extends ObjectEditor {
+	function getObjectType(): string {
+		return 'SelfCheckCompletionMessage';
+	}
+
+	function getModule(): string {
+		return "AspenLiDA";
+	}
+
+	function getToolName(): string {
+		return 'SelfCheckCompletionMessages';
+	}
+
+	function getPageTitle(): string {
+		return 'Self Check Completion Messages';
+	}
+
+	function getAllObjects($page, $recordsPerPage): array {
+		$list = [];
+
+		$object = new SelfCheckCompletionMessage();
+		$object->orderBy($this->getSort());
+		$this->applyFilters($object);
+		$object->limit(($page - 1) * $recordsPerPage, $recordsPerPage);
+		$object->find();
+		while ($object->fetch()) {
+			$list[$object->id] = clone $object;
+		}
+
+		return $list;
+	}
+
+	function getDefaultSort(): string {
+		return 'id asc';
+	}
+
+	function getObjectStructure($context = ''): array {
+		return SelfCheckCompletionMessage::getObjectStructure($context);
+	}
+
+	function getPrimaryKeyColumn(): string {
+		return 'id';
+	}
+
+	function getIdKeyColumn(): string {
+		return 'id';
+	}
+
+	function getBreadcrumbs(): array {
+		$breadcrumbs = [];
+		$breadcrumbs[] = new Breadcrumb('/Admin/Home', 'Administration Home');
+		$breadcrumbs[] = new Breadcrumb('/Admin/Home#aspen_lida', 'Aspen LiDA');
+		$breadcrumbs[] = new Breadcrumb('/AspenLiDA/SelfCheckCompletionMessages', 'Self Check Completion Messages');
+		return $breadcrumbs;
+	}
+
+	function getActiveAdminSection(): string {
+		return 'aspen_lida';
+	}
+
+	function canView(): bool {
+		return UserAccount::userHasPermission('Administer Aspen LiDA Self-Check Settings');
+	}
+}

--- a/code/web/services/ILS/SelfCheckTester.php
+++ b/code/web/services/ILS/SelfCheckTester.php
@@ -4,7 +4,7 @@ require_once ROOT_DIR . '/Action.php';
 require_once ROOT_DIR . '/services/Admin/Admin.php';
 
 class ILS_SelfCheckTester extends Admin_Admin {
-	function launch() {
+	function launch() : void {
 		global $interface;
 		if (isset($_REQUEST['submitCheckout']) || isset($_REQUEST['submitCheckin'])) {
 			require_once ROOT_DIR . "/services/API/UserAPI.php";

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -4809,6 +4809,7 @@ class User extends DataObject {
 				$sections['aspen_lida']->addAction(new AdminAction('Branded App Settings', 'Define settings for branded versions of Aspen LiDA.', '/AspenLiDA/BrandedAppSettings'), 'Administer Aspen LiDA Settings');
 			}
 			$sections['aspen_lida']->addAction(new AdminAction('Self-Check Settings', 'Define settings for self-check in Aspen LiDA.', '/AspenLiDA/SelfCheckSettings'), 'Administer Aspen LiDA Self-Check Settings');
+			$sections['aspen_lida']->addAction(new AdminAction('Self-Check Completion Messages', 'Define messages to show when self-check checkouts are completed in Aspen LiDA.', '/AspenLiDA/SelfCheckCompletionMessages'), 'Administer Aspen LiDA Self-Check Settings');
 		}
 		if (array_key_exists('Series', $enabledModules)) {
 			$sections['series'] = new AdminSection("Series Search");
@@ -5846,7 +5847,7 @@ class User extends DataObject {
 		return 0;
 	}
 
-	function checkoutItem($barcode, Location $currentLocation): array {
+	function checkoutItem(string $barcode, Location $currentLocation): array {
 		if ($this->getCatalogDriver()->hasAPICheckout()) {
 			$result = $this->getCatalogDriver()->checkoutByAPI($this, $barcode, $currentLocation);
 		} else {
@@ -5854,6 +5855,39 @@ class User extends DataObject {
 		}
 
 		if ($result['success']) {
+			$format = '';
+			//Get the item for the barcode
+			/** @var SearchObject_AbstractGroupedWorkSearcher $searcher */
+			$searcher = SearchObjectFactory::initSearchObject();
+			$groupedWorkForBarcode = $searcher->getRecordByBarcode($barcode);
+			if ($groupedWorkForBarcode != null) {
+				require_once ROOT_DIR . '/RecordDrivers/GroupedWorkDriver.php';
+				$groupedWorkDriver = new GroupedWorkDriver($groupedWorkForBarcode);
+				// Get all the related records, use for covers since we don't need actions
+				foreach ($groupedWorkDriver->getRelatedRecords(true) as $record) {
+					foreach ($record->getItems() as $item) {
+						if ($item->itemId == $result['itemData']['itemId']) {
+							$format = $record->getFormat();
+							break;
+						}
+					}
+				}
+			}
+
+			//Determine if we need to show a message
+			require_once ROOT_DIR . '/sys/AspenLIDA/SelfCheckCompletionMessage.php';
+			$selfCheckCompletionMessage = new SelfCheckCompletionMessage();
+			$escapedFormat = $selfCheckCompletionMessage->escape($format);
+			$escapedOwningLocationCode = $result['itemData']['owningLocationCode'];
+			$escapedCheckoutLocationCode = $result['itemData']['checkoutLocationCode'];
+			$selfCheckCompletionMessage->whereAdd("$escapedFormat REGEXP formats");
+			$selfCheckCompletionMessage->whereAdd("$escapedOwningLocationCode REGEXP owningLocations");
+			$selfCheckCompletionMessage->whereAdd("$escapedCheckoutLocationCode REGEXP checkoutLocations");
+			$result['completionMessage'] = '';
+			if ($selfCheckCompletionMessage->find(true)) {
+				$result['completionMessage'] = $selfCheckCompletionMessage->getTextBlockTranslation('completionMessage', $this->interfaceLanguage);
+			}
+
 			$this->forceReloadOfCheckouts();
 		}
 		$this->clearCache();
@@ -5868,7 +5902,7 @@ class User extends DataObject {
 		if ($this->getCatalogDriver()->hasAPICheckin()) {
 			$result = $this->getCatalogDriver()->checkInByAPI($this, $barcode, $currentLocation);
 		} else {
-			$result = $this->getCatalogDriver()->checkInBySip($this, $barcode, $currentLocation->code);
+			$result = $this->getCatalogDriver()->checkInBySip($this, $barcode, $currentLocation);
 		}
 
 		if ($result['success']) {

--- a/code/web/sys/AspenLiDA/SelfCheckCompletionMessage.php
+++ b/code/web/sys/AspenLiDA/SelfCheckCompletionMessage.php
@@ -1,0 +1,81 @@
+<?php /** @noinspection PhpMissingFieldTypeInspection */
+
+class SelfCheckCompletionMessage extends DataObject {
+	public $__table = 'self_check_completion_message';
+	public $id;
+	public $formats;
+	public $owningLocations;
+	public $checkoutLocations;
+	public $_completionMessage;
+
+	static $_objectStructure = [];
+	static function getObjectStructure(string $context = ''): array {
+		if (isset(self::$_objectStructure[$context]) && self::$_objectStructure[$context] !== null) {
+			return self::$_objectStructure[$context];
+		}
+		$structure = [
+			'id' => [
+				'property' => 'id',
+				'type' => 'label',
+				'label' => 'Id',
+				'description' => 'The unique id within the database',
+			],
+			'formats' => [
+				'property' => 'formats',
+				'type' => 'regularExpression',
+				'label' => 'Formats to show message for (Regex)',
+				'description' => 'A regular expression for the formats to show this message for, leave blank or use .* to include everything',
+				'maxLength' => '500',
+				'required' => false,
+				'default' => '.*',
+			],
+			'owningLocations' => [
+				'property' => 'owningLocations',
+				'type' => 'regularExpression',
+				'label' => 'Owning Locations to show message for (Regex)',
+				'description' => 'A regular expression for the owning locations to show this message for, leave blank or use .* to include everything',
+				'maxLength' => '500',
+				'required' => false,
+				'default' => '.*',
+			],
+			'checkoutLocations' => [
+				'property' => 'checkoutLocations',
+				'type' => 'regularExpression',
+				'label' => 'Checkout Locations to show message for (Regex)',
+				'description' => 'A regular expression for the checkout locations to show this message for, leave blank or use .* to include everything',
+				'maxLength' => '500',
+				'required' => false,
+				'default' => '.*',
+			],
+			'completionMessage' => [
+				'property' => 'completionMessage',
+				'type' => 'translatablePlainTextBlock',
+				'label' => 'Completion Message',
+				'description' => 'The message to show after the checkout is completed',
+				'readOnly' => false,
+				'required' => true,
+				'maxLength' => 500,
+				'hideInLists' => true,
+			],
+		];
+
+		self::$_objectStructure[$context] = $structure;
+		return self::$_objectStructure[$context];
+	}
+
+	public function insert(string $context = '') : int|bool {
+		$ret = parent::insert();
+		if ($ret !== FALSE) {
+			$this->saveTextBlockTranslations('completionMessage');
+		}
+		return $ret;
+	}
+
+	public function update(string $context = '') : int|bool {
+		$ret = parent::update();
+		if ($ret !== FALSE) {
+			$this->saveTextBlockTranslations('completionMessage');
+		}
+		return $ret;
+	}
+}

--- a/code/web/sys/DBMaintenance/version_updates/25.09.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.09.00.php
@@ -1,7 +1,7 @@
 <?php
 
+/** @noinspection PhpUnused */
 function getUpdates25_09_00(): array {
-	$curTime = time();
 	return [
 		/*'name' => [
 			 'title' => '',
@@ -65,6 +65,19 @@ function getUpdates25_09_00(): array {
 				'ALTER TABLE grouped_work_display_settings ADD COLUMN formatDisplayStyle INT DEFAULT 1'
 			]
 		], //add_grouped_work_display_format_display
+		'add_self_check_completion_message' => [
+			'title' => 'Add Self Check Completion Message',
+			'description' => 'Add configuration table for self check completion messages',
+			'continueOnError' => false,
+			'sql' => [
+				'CREATE TABLE self_check_completion_message (
+					id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+					formats VARCHAR(500),
+					owningLocations VARCHAR(500),
+					checkoutLocations VARCHAR(500)
+				) ENGINE INNODB',
+			]
+		], //add_self_check_completion_message
 
 		//katherine - Grove
 

--- a/code/web/sys/SearchObject/AbstractGroupedWorkSearcher.php
+++ b/code/web/sys/SearchObject/AbstractGroupedWorkSearcher.php
@@ -797,12 +797,15 @@ abstract class SearchObject_AbstractGroupedWorkSearcher extends SearchObject_Sol
 	 * Retrieves a document specified by the item barcode.
 	 *
 	 * @param string $barcode A barcode of an item in the document to retrieve from Solr
-	 * @access  public
-	 * @return  string              The requested resource
+	 * @return  ?array               The requested resource
 	 * @throws  AspenError
 	 */
-	function getRecordByBarcode($barcode) {
-		return $this->indexEngine->getRecordByBarcode($barcode);
+	function getRecordByBarcode(string $barcode) : ?array {
+		if ($this->indexEngine instanceof GroupedWorksSolrConnector || $this->indexEngine instanceof GroupedWorksSolrConnector2) {
+			return $this->indexEngine->getRecordByBarcode($barcode);
+		}else{
+			return null;
+		}
 	}
 
 	/**

--- a/code/web/sys/SearchObject/GroupedWorkSearcher2.php
+++ b/code/web/sys/SearchObject/GroupedWorkSearcher2.php
@@ -1026,11 +1026,10 @@ class SearchObject_GroupedWorkSearcher2 extends SearchObject_AbstractGroupedWork
 	 * Retrieves a document specified by the item barcode.
 	 *
 	 * @param string $barcode A barcode of an item in the document to retrieve from Solr
-	 * @access  public
-	 * @return  string              The requested resource
+	 * @return  ?array               The requested resource
 	 * @throws  AspenError
 	 */
-	function getRecordByBarcode($barcode) {
+	function getRecordByBarcode(string $barcode) : ?array  {
 		$recordData = $this->indexEngine->getRecordByBarcode($barcode);
 		if ($recordData != null) {
 			$recordData = $this->cleanScopedFieldsForRecord($recordData);

--- a/code/web/sys/SolrConnector/GroupedWorksSolrConnector.php
+++ b/code/web/sys/SolrConnector/GroupedWorksSolrConnector.php
@@ -15,11 +15,7 @@ class GroupedWorksSolrConnector extends Solr {
 		return ROOT_DIR . '/../../sites/default/conf/groupedWorksSearchSpecs.yaml';
 	}
 
-	function getRecordByBarcode($barcode) {
-		if ($this->debug) {
-			echo "<pre>Get Record by Barcode: $barcode</pre>\n";
-		}
-
+	function getRecordByBarcode($barcode) : ?array {
 		// Query String Parameters
 		$options = [
 			'q' => "barcode:\"$barcode\"",
@@ -30,11 +26,7 @@ class GroupedWorksSolrConnector extends Solr {
 			AspenError::raiseError($result);
 		}
 
-		if (isset($result['response']['docs'][0])) {
-			return $result['response']['docs'][0];
-		} else {
-			return null;
-		}
+		return $result['response']['docs'][0] ?? null;
 	}
 
 	function getRecordByIsbn($isbns, $fieldsToReturn = null) {

--- a/code/web/sys/SolrConnector/GroupedWorksSolrConnector2.php
+++ b/code/web/sys/SolrConnector/GroupedWorksSolrConnector2.php
@@ -23,11 +23,7 @@ class GroupedWorksSolrConnector2 extends Solr {
 
 	}
 
-	function getRecordByBarcode($barcode) {
-		if ($this->debug) {
-			echo "<pre>Get Record by Barcode: $barcode</pre>\n";
-		}
-
+	function getRecordByBarcode($barcode) : ?array {
 		// Query String Parameters
 		$options = [
 			'q' => "barcode:\"$barcode\"",
@@ -38,11 +34,7 @@ class GroupedWorksSolrConnector2 extends Solr {
 			AspenError::raiseError($result);
 		}
 
-		if (isset($result['response']['docs'][0])) {
-			return $result['response']['docs'][0];
-		} else {
-			return null;
-		}
+		return $result['response']['docs'][0] ?? null;
 	}
 
 	function getRecordByIsbn($isbns, $fieldsToReturn = null) {

--- a/code/web/sys/SolrConnector/Solr.php
+++ b/code/web/sys/SolrConnector/Solr.php
@@ -652,7 +652,7 @@ abstract class Solr {
 	 * @param Library $searchLibrary
 	 * @return array
 	 */
-	public function getBoostFactors(/** @noinspection PhpUnusedParameterInspection */ $searchLibrary, $searchTerm, $searchLocation, $searchIndex) {
+	public function getBoostFactors(/** @noinspection PhpUnusedParameterInspection */ $searchLibrary, $searchLocation, $searchTerm, $searchIndex) {
 		return [];
 	}
 


### PR DESCRIPTION
- Allow Self Check Messages to be configured for display after titles have been checked out from LiDA. Anyone with permission to administer Self Check Settings can update these.
- Return completion message at the end of successful Scan and Go operations.