### PR TITLE
DIS-1255: Added Sorting by Frozen Holds

### DIFF
--- a/code/web/release_notes/25.09.00.MD
+++ b/code/web/release_notes/25.09.00.MD
@@ -134,6 +134,9 @@
 ### Evergreen Updates
 - Fixed an issue where the initial reading history import could stall if a bad response code or response message was received from Evergreen. (DIS-1222) (*LS*)
 
+### Holds Updates
+- Add the option to sort pending, frozen holds by "Reactivation Date". (DIS-1225) (*LS*)
+
 ### Indexing Updates
 - Added sortMissingLast attribute to local availability fields to prevent unscoped items from appearing at top of date-sorted results. (DIS-1259)
 

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -4084,6 +4084,9 @@ class MyAccount_AJAX extends JSON_Action {
 				if ($library->showHoldCancelDate) {
 					$unavailableHoldSortOptions['cancelDate'] = 'Hold Cancellation Date';
 				}
+				if ($user->suspendRequiresReactivationDate()) {
+					$unavailableHoldSortOptions['reactivate'] = 'Reactivation Date';
+				}
 
 				$availableHoldSortOptions = [
 					'title' => 'Title',


### PR DESCRIPTION
- Add the option to sort pending, frozen holds by "Reactivation Date".

Test Plan:
1. Log into a patron account.
2. Freeze a couple of Pending Holds.
3. Sort them by "Reactivation Date". Notice that frozen holds that will be reactivated with the earliest reactivation dates are at the top.