### PR TITLE
DIS-1287: Fixed Saved Searches Timestamps

### DIFF
--- a/code/web/release_notes/25.09.00.MD
+++ b/code/web/release_notes/25.09.00.MD
@@ -147,6 +147,7 @@
 ### Searching Updates
 - Fixed "facet does not exist" error for Web Resource facet popups. (DIS-1193) (*LS*)
 - Fixed an issue where navigation links "Previous" and "Next" would not display on grouped works beyond the first page of search results. (DIS-1268) (*LS*)
+- Corrected search history timestamps to display the current date instead of future dates. (DIS-1287) (*LS*)
 
 ### Server Setup Updates
 - Fixed subdomain detection to properly handle multi-level subdomains by extracting all possible subdomain combinations for more flexible library/location matching. (DIS-1217) (*LS, MDN*)

--- a/code/web/sys/SearchObject/BaseSearcher.php
+++ b/code/web/sys/SearchObject/BaseSearcher.php
@@ -1828,10 +1828,7 @@ abstract class SearchObject_BaseSearcher {
 	 * @var string $searchSource
 	 */
 	public function init($searchSource = null) {
-		// Start the timer
-		$mtime = explode(' ', microtime());
-		$this->initTime = $mtime[1] . $mtime[0];
-
+		$this->initTime = time();
 		$this->searchSource = $searchSource;
 		return true;
 	}


### PR DESCRIPTION
- Corrected search history timestamps to display the current date instead of future dates.

Test Plan:
1. Perform a search in the catalog.
2. Save the search.
3. Navigate to Search History. Observe the incorrect timestamp for the saved search.
4. Apply the patch and repeat steps 1-3. Notice that the timestamp is correct.