### PR TITLE
DIS-1290: Fixed Inconsistent "Available Here" Logic Causes Incorrect Availability Display

### DIFF
--- a/code/web/release_notes/25.09.00.MD
+++ b/code/web/release_notes/25.09.00.MD
@@ -171,6 +171,7 @@
 ### Searching Updates
 - Fixed "facet does not exist" error for Web Resource facet popups. (DIS-1193) (*LS*)
 - Fixed an issue where navigation links "Previous" and "Next" would not display on grouped works beyond the first page of search results. (DIS-1268) (*LS*)
+- Resolved inconsistent availability display where items incorrectly showed as "It's Here" for patrons who were not at the library's physical location. (DIS-1290) (*LS*)
 
 ### Server Setup Updates
 - Fixed subdomain detection to properly handle multi-level subdomains by extracting all possible subdomain combinations for more flexible library/location matching. (DIS-1217) (*LS, MDN*)

--- a/code/web/sys/Grouping/Record.php
+++ b/code/web/sys/Grouping/Record.php
@@ -191,8 +191,12 @@ class Grouping_Record {
 				if ($item->locallyOwned) {
 					$this->_statusInformation->setIsLocallyOwned(true);
 					$this->_statusInformation->addLocalCopies($item->numCopies);
-					if ($item->available) {
-						$this->_statusInformation->setAvailableHere(true);
+					if ($item->available && !$item->isEContent) {
+						global $locationSingleton;
+						$physicalLocation = $locationSingleton->getPhysicalLocation();
+						if (!empty($physicalLocation)) {
+							$this->_statusInformation->setAvailableHere(true);
+						}
 					}
 				}
 				if ($item->libraryOwned) {


### PR DESCRIPTION
- Resolved inconsistent availability display where items incorrectly showed as "It's Here" for patrons who were not at the library's physical location.

Test Plan:
1. Enable “Show It's Here” for your Library System of choice.
2. Navigate to its catalog for a Location.
3. Search the catalog and notice the “It’s Here” statuses even though your IP address does not match the location’s IP Address.
4. Apply the patch and notice that the status changes. 
5. Add your IP address to the IP Addresses settings and select the location. Notice that the “It’s Here” status displays on grouped works.