### PR TITLE
DIS-1152: Get Unsuppressed Volume Data for All Variations

### DIFF
--- a/code/web/release_notes/25.09.00.MD
+++ b/code/web/release_notes/25.09.00.MD
@@ -68,6 +68,7 @@
 
 ### Holds Updates
 - If Sierra loan rules for a particular record limit hold pickups to specific locations, only show those locations as options in Aspen. (DIS-790) (*KP*)
+- Fixed an issue where only volumes for the related record would display as options for holds; all variations are now considered. (DIS-1152) (*LS*)
 
 ### Hoopla Updates
 - Update Hoopla Setting tooltips for API Username and API Password fields to clarify these values are typically provided by an Aspen support vendor (DIS-295) (*MAF*)

--- a/code/web/services/Record/AJAX.php
+++ b/code/web/services/Record/AJAX.php
@@ -756,12 +756,18 @@ class Record_AJAX extends Action {
 				];
 			}
 
-			// Get a list of volumes with unsuppressed items for the record.
+			// Get a list of volumes with unsuppressed items for the record's variations.
 			$volumeData = [];
-			$unsuppressedVolumeData = $relatedRecord->getUnsuppressedVolumeData();
-			foreach ($unsuppressedVolumeData as $volumeInfo) {
-				$volumeData[$volumeInfo->volumeId] = clone($volumeInfo);
-				$volumeData[$volumeInfo->volumeId]->setHasLocalItems(false);
+			foreach ($relatedRecord->recordVariations as $variation) {
+				foreach ($variation->getRecords() as $record) {
+					$unsuppressedVolumeData = $record->getUnsuppressedVolumeData();
+					foreach ($unsuppressedVolumeData as $volumeInfo) {
+						if (!isset($volumeData[$volumeInfo->volumeId])) {
+							$volumeData[$volumeInfo->volumeId] = clone($volumeInfo);
+							$volumeData[$volumeInfo->volumeId]->setHasLocalItems(false);
+						}
+					}
+				}
 			}
 
 			$numItemsWithVolumes = 0;


### PR DESCRIPTION
- Fixed an issue where only volumes for the related record would display as options for holds; all variations are now considered.