### PR TITLE
DIS-1299: Fixed Default Covers Without Authors Not Generating

### DIFF
--- a/code/web/release_notes/25.09.00.MD
+++ b/code/web/release_notes/25.09.00.MD
@@ -38,6 +38,7 @@
 
 ### Cover Images Updates
 - Added Ethiopic script support for the generation of default covers. (DIS-1284) (*LS*)
+- Fixed an issue where records without authors would have missing default covers (e.g., Open Archives Collections). (DIS-1299) (*LS*)
 
 ### Events Updates
 - Fixed issue where changes to some fields were not being saved to the database. (DIS-1220) (*LS*)

--- a/code/web/sys/Covers/DefaultCoverImageBuilder.php
+++ b/code/web/sys/Covers/DefaultCoverImageBuilder.php
@@ -99,8 +99,8 @@ class DefaultCoverImageBuilder {
 		}
 	}
 
-	public function getCover($title, $author, $filename, $image = null): void {
-		$script = $this->detectScript($title . $author);
+	public function getCover($title, ?string $author, $filename, $image = null): void {
+		$script = $this->detectScript($title . ($author ?? ''));
 		$this->selectFontForScript($script);
 
 		$this->setForegroundAndBackgroundColors($title, $author);
@@ -118,7 +118,7 @@ class DefaultCoverImageBuilder {
 		imagefilledrectangle($imageCanvas, 0, 0, $this->imageWidth, $this->topMargin, $backgroundColor);
 
 		$artworkHeight = $this->drawArtwork($imageCanvas, $backgroundColor, $foregroundColor, $title);
-		if ($script === 'arabic') {
+		if ($script === 'arabic' && $author !== null) {
 			$author = $this->transliterateToArabic($author);
 		}
 		$this->drawText($imageCanvas, $title, $author, $artworkHeight);
@@ -164,7 +164,7 @@ class DefaultCoverImageBuilder {
 		}
 	}
 
-	private function drawText(GdImage|bool $imageCanvas, string $title, string $author, float $artworkHeight): void {
+	private function drawText(GdImage|bool $imageCanvas, string $title, ?string $author, float $artworkHeight): void {
 		$textColor = imagecolorallocate($imageCanvas, 50, 50, 50);
 		$title_font_size = $this->imageWidth * 0.07;
 		$x = 10;
@@ -187,7 +187,7 @@ class DefaultCoverImageBuilder {
 
 		$author_font_size = $this->imageWidth * 0.055;
 		$width = $this->imageWidth - (2 * $this->imageHeight * $this->topMargin / 100);
-		$author = StringUtils::trimStringToLengthAtWordBoundary($author, 40, true);
+		$author = $author ? StringUtils::trimStringToLengthAtWordBoundary($author, 40, true) : '';
 		[$authorHeight, $authorLines] = wrapTextForDisplay($this->authorFont, $author, $author_font_size, $author_font_size * .1, $width);
 
 		// Ensure author does not overlap artwork section.


### PR DESCRIPTION
- Fixed an issue where records without authors would have missing default covers (e.g., Open Archives Collections).

Test Plan:
1. Navigate to the Open Archives Collection search. Notice that covers may be missing if the record has no author.
2. Apply the patch and reload the page. Notice that the covers generate.