### PR TITLE
DIS-1301: Fixed Search URL for Accessible Browse Categories

### DIFF
--- a/code/web/interface/themes/responsive/Search/home.tpl
+++ b/code/web/interface/themes/responsive/Search/home.tpl
@@ -9,7 +9,7 @@
 
 			<div class="browse-category-feed-item" id="browse-category-{$browseCategory.textId}" role="article">
 				<div class="browse-category-group-heading">
-					<a id="browse-search-link-{$browseCategory.textId}" href="{if $browseCategory.searchUrl}{$browseCategory.searchUrl}{/if}" title="View all results for {translate text=$browseCategory.label isPublicFacing=true}"> <h2 id="tablist-browse-category-{$browseCategory.textId}"><i class="fas fa-search" role="presentation"></i> {translate text=$browseCategory.label isPublicFacing=true}</h2></a>
+					{if $browseCategory.searchUrl && $browseCategory.searchUrl != '#'}<a id="browse-search-link-{$browseCategory.textId}" href="{$browseCategory.searchUrl}" title="View all results for {translate text=$browseCategory.label isPublicFacing=true}">{/if}<h2 id="tablist-browse-category-{$browseCategory.textId}"><i class="fas fa-search" role="presentation"></i> {translate text=$browseCategory.label isPublicFacing=true}</h2>{if $browseCategory.searchUrl && $browseCategory.searchUrl != '#'}</a>{/if}
 					{if !empty($isLoggedIn)}
 						<button id="browse-dismiss-{$browseCategory.textId}" class="btn btn-default browse-dismiss" onclick="AspenDiscovery.Account.dismissBrowseCategory(null, '{$browseCategory.textId}')" title="{translate text='Hide Category %1%' 1={$browseCategory.label} inAttribute=true isPublicFacing=true}">
 							<i class="fas fa-times" role="presentation"></i> {translate text='Hide' isPublicFacing=true}

--- a/code/web/interface/themes/responsive/Search/home.tpl
+++ b/code/web/interface/themes/responsive/Search/home.tpl
@@ -9,7 +9,7 @@
 
 			<div class="browse-category-feed-item" id="browse-category-{$browseCategory.textId}" role="article">
 				<div class="browse-category-group-heading">
-					{if $browseCategory.searchUrl && $browseCategory.searchUrl != '#'}<a id="browse-search-link-{$browseCategory.textId}" href="{$browseCategory.searchUrl}" title="View all results for {translate text=$browseCategory.label isPublicFacing=true}">{/if}<h2 id="tablist-browse-category-{$browseCategory.textId}"><i class="fas fa-search" role="presentation"></i> {translate text=$browseCategory.label isPublicFacing=true}</h2>{if $browseCategory.searchUrl && $browseCategory.searchUrl != '#'}</a>{/if}
+					{if !empty($browseCategory.searchUrl)}<a id="browse-search-link-{$browseCategory.textId}" href="{$browseCategory.searchUrl}" title="View all results for {translate text=$browseCategory.label isPublicFacing=true}">{/if}<h2 id="tablist-browse-category-{$browseCategory.textId}"><i class="fas fa-search" role="presentation"></i> {translate text=$browseCategory.label isPublicFacing=true}</h2>{if !empty($browseCategory.searchUrl)}</a>{/if}
 					{if !empty($isLoggedIn)}
 						<button id="browse-dismiss-{$browseCategory.textId}" class="btn btn-default browse-dismiss" onclick="AspenDiscovery.Account.dismissBrowseCategory(null, '{$browseCategory.textId}')" title="{translate text='Hide Category %1%' 1={$browseCategory.label} inAttribute=true isPublicFacing=true}">
 							<i class="fas fa-times" role="presentation"></i> {translate text='Hide' isPublicFacing=true}

--- a/code/web/release_notes/25.10.00.MD
+++ b/code/web/release_notes/25.10.00.MD
@@ -121,6 +121,9 @@
 ### Collection Spotlights Updates
 - Collection Spotlights settings action buttons are now standardized at the top of settings pages to align with other admin interfaces. (DIS-1340) (*LS*)
 
+### Browse Categories Updates
+- With "Use Accessible Layout" enabled for a Theme, browse categories on the home page now generate proper search URLs instead of placeholder links. (DIS-1301) (*LS*)
+
 ### Cover Images Updates
 - Added Bengali script support for the generation of default covers. (DIS-1355) (*LS*)
 - When "Use Original Cover URLs" is enabled, standardized cover images dimensions, prevented relatively small images from displaying, and modified how they are stored. (DIS-1396) (*LS*)

--- a/code/web/services/Browse/AJAX.php
+++ b/code/web/services/Browse/AJAX.php
@@ -776,7 +776,7 @@ class Browse_AJAX extends Action {
 		return $browseMode;
 	}
 
-	private $textId;
+	public $textId;
 
 	/**
 	 * @param null $textId Optional Id to set the object's textId to

--- a/code/web/services/Search/Home.php
+++ b/code/web/services/Search/Home.php
@@ -214,10 +214,15 @@ class Search_Home extends Action {
 				if ($browseCategory->isValidForDisplay()) {
 					$textId = $browseCategory->textId;
 					$subCatResult = $searchAPI->getSubCategories($textId);
+					require_once ROOT_DIR . '/services/Browse/AJAX.php';
+					$browseAJAX = new Browse_AJAX();
+					$browseAJAX->textId = $textId;
+					$categoryResults = $browseAJAX->getBrowseCategoryResults();
+					$searchUrl = $categoryResults['searchUrl'] ?? '#';
 					$browseCategories[] = [
 						'textId' => $textId,
 						'label' => $browseCategory->label,
-						'searchUrl' => '#',
+						'searchUrl' => $searchUrl,
 						'hasSubcategories' => !empty($subCatResult['subCategories']),
 					];
 				}

--- a/code/web/services/Search/Home.php
+++ b/code/web/services/Search/Home.php
@@ -214,16 +214,17 @@ class Search_Home extends Action {
 				if ($browseCategory->isValidForDisplay()) {
 					$textId = $browseCategory->textId;
 					$subCatResult = $searchAPI->getSubCategories($textId);
-					require_once ROOT_DIR . '/services/Browse/AJAX.php';
-					$browseAJAX = new Browse_AJAX();
-					$browseAJAX->textId = $textId;
-					$categoryResults = $browseAJAX->getBrowseCategoryResults();
-					$searchUrl = $categoryResults['searchUrl'] ?? '#';
+					$hasSubcategories = !empty($subCatResult['subCategories']);
+					$subcategoryCount = $hasSubcategories ? count($subCatResult['subCategories']) : 0;
+					// Only set searchUrl to '#' for categories without subcategories or with exactly one subcategory
+					// because it will become the only search URL.
+					// For parent categories with multiple subcategories, set empty string to prevent dead-end links.
+					$searchUrl = (!$hasSubcategories || $subcategoryCount == 1) ? '#' : '';
 					$browseCategories[] = [
 						'textId' => $textId,
 						'label' => $browseCategory->label,
 						'searchUrl' => $searchUrl,
-						'hasSubcategories' => !empty($subCatResult['subCategories']),
+						'hasSubcategories' => $hasSubcategories,
 					];
 				}
 			}


### PR DESCRIPTION
- With "Use Accessible Layout" enabled for a Theme, browse categories on the home page now generate proper search URLs instead of placeholder links.

Test Plan:
1. Enable Accessible Layout in the Themes settings for a catalog.
2. Navigate to the home page to view browse categories.
3. Click on the main browse category search link that has subcategories. Notice that it does not navigate you anywhere.
4. Apply the patch, reload the page, and click the same search link. Notice that it navigates you to the appropriate results.