### PR TITLE
DIS-1323: Update USPS URL

### DIFF
--- a/code/web/release_notes/25.10.00.MD
+++ b/code/web/release_notes/25.10.00.MD
@@ -17,6 +17,8 @@
 //leo
 
 //yanjun
+### Other Updates
+- Fix an issue where USPS address vaidation could fail by updating the USPS API URL to "https://apis.usps.com". (DIS-1323) (*YL*)
 
 //imani
 

--- a/code/web/sys/Utils/SystemUtils.php
+++ b/code/web/sys/Utils/SystemUtils.php
@@ -90,7 +90,7 @@ class SystemUtils {
 	}
 
 	static function validateAddress($streetAddress, $city, $state, $zip): bool {
-		$baseUrl = 'https://api.usps.com';
+		$baseUrl = 'https://apis.usps.com';
 		require_once ROOT_DIR . '/sys/CurlWrapper.php';
 
 		//GET OAUTH TOKEN


### PR DESCRIPTION
Some libraries with valid credentials on the old USPS developer site couldn’t use the address validation function on the self-reg form,  see error `The address you entered does not appear to be valid `even when entering the valid address

USPS has moved its website from [Old site: developer.usps.com](http://developer.usps.com/) to [New site: developers.usps.com (added "s" after "developer")](http://developers.usps.com/) , the new developer API portal: https://www.usps.com/business/web-tools-apis/. We should updatet the USPS API URL from api.usps.com to apis.usps.com according to this USPS Github https://github.com/USPS/api-examples?tab=readme-ov-file

To Test: 
1. Libraries with valid credentials on the old USPS developer site see the error `The address you entered does not appear to be valid` even when entering the valid address
2. Try on postman with https://api.usps.com/oauth2/v3/token, get 200 OK response with `access_token`
3. Try on postman with https://api.usps.com/addresses/v3/address? with the `access_token` as the Authorization, see 401 response. 
4. Libraries log in to old site and delete the valid credentials and couldn’t create a new credential 
5. Libraries log in to new site and delete the old valid credentials, and be able to create a new credential
6. Repeat step 2, get 401 with error `invalid_client`
7. Repeat step 6 with URL https://apis.usps.com/oauth2/v3/token and get 200 OK response with `access_token` 
8. Repeat step 3 and get 200 OK response.
9. Enter the new credentials on Aspen, see the error as step 1 
10. Apply the patch 
11. Repeat step 1 and see no error 