### PR TITLE
DIS-1297: Ensure Locally Owned and Available Items Show as Available at Search Location

### DIFF
--- a/code/web/release_notes/25.10.00.MD
+++ b/code/web/release_notes/25.10.00.MD
@@ -18,6 +18,8 @@
 //myranda
 
 //leo
+### Holds Updates
+- Corrected an issue where a locally owned and available item at a search location would incorrectly display as "Checked Out/Available Elsewhere". (DIS-1297) (*LS*)
 
 //yanjun
 

--- a/code/web/sys/Grouping/Record.php
+++ b/code/web/sys/Grouping/Record.php
@@ -191,11 +191,14 @@ class Grouping_Record {
 				if ($item->locallyOwned) {
 					$this->_statusInformation->setIsLocallyOwned(true);
 					$this->_statusInformation->addLocalCopies($item->numCopies);
-					if ($item->available && !$item->isEContent) {
-						global $locationSingleton;
-						$physicalLocation = $locationSingleton->getPhysicalLocation();
-						if (!empty($physicalLocation)) {
-							$this->_statusInformation->setAvailableHere(true);
+					if ($item->available) {
+						$this->_statusInformation->setAvailableLocally(true);
+						if (!$item->isEContent) {
+							global $locationSingleton;
+							$physicalLocation = $locationSingleton->getPhysicalLocation();
+							if (!empty($physicalLocation)) {
+								$this->_statusInformation->setAvailableHere(true);
+							}
 						}
 					}
 				}


### PR DESCRIPTION
- Corrected an issue where a locally owned and available item at a search location would incorrectly display as "Checked Out/Available Elsewhere".