### PR TITLE
DIS-1341: Fixed List Entry Buttons Misalignment When No Description Exists

### DIFF
--- a/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/listEntry.tpl
@@ -65,7 +65,9 @@
 				</div>
 			{/if}
 
-			{include file="GroupedWork/allManifestations.tpl" isSearchResults=true}
+			<div class="row">
+				{include file="GroupedWork/allManifestations.tpl" isSearchResults=true}
+			</div>
 
 			{* Description Section *}
 			{if !empty($summDescription) && $printInterface === false}
@@ -85,7 +87,6 @@
 					</div>
 				</div>
 			{/if}
-
 
 			{if $printInterface === false}
 			<div class="resultActions row">

--- a/code/web/release_notes/25.09.00.MD
+++ b/code/web/release_notes/25.09.00.MD
@@ -251,6 +251,7 @@
 - Fixed undefined array key "subSection" on some Usage Graphs pages. (DIS-1234) (*LS*)
 - Increase the max length of the display name column in Locations. (DIS-1186) (*AB*)
 - Ensure Text Block translations can access the list of valid languages if run from cron. (DIS-1314) (*MDN*)
+- Fixed positioning of action buttons in list entries when titles lack summary descriptions. (DIS-1341) (*LS*)
 
 ## This release includes code contributions from
 ### ByWater Solutions


### PR DESCRIPTION
- Fixed positioning of action buttons in list entries when titles lack summary descriptions.

Test Plan:
1. Navigate to a list with an entry that has no description. Notice that the action buttons are inline with the record manifestation(s).
2. Apply the patch and reload the page. Notice that the buttons correctly display below the manifestation(s).