### PR TITLE
DIS-1344: Align "Reveal Password" Label With "Login Form Password Label" Field

### DIFF
--- a/code/web/interface/themes/responsive/MyAccount/addAccountLink.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/addAccountLink.tpl
@@ -18,7 +18,7 @@
 			<div class='col-xs-12 col-sm-offset-4 col-sm-8'>
 				<label for="showPwd" class="checkbox">
 					<input type="checkbox" id="showPwd" name="showPwd" onclick="return AspenDiscovery.pwdToText('password')"/>
-					{translate text="Reveal Password" isPublicFacing=true}
+					{translate text="Reveal %1%" 1=$passwordLabel isPublicFacing=true}
 				</label>
 			</div>
 		</div>

--- a/code/web/interface/themes/responsive/MyAccount/ajax-login.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/ajax-login.tpl
@@ -75,7 +75,7 @@
 			<div class="col-xs-12 col-sm-offset-4 col-sm-8">
 				<label for="showPwd" class="checkbox">
 					<input type="checkbox" id="showPwd" name="showPwd" onclick="return AspenDiscovery.pwdToText('password')">
-					{translate text="Reveal Password" isPublicFacing=true}
+					{translate text="Reveal %1%" 1=$passwordLabel isPublicFacing=true}
 				</label>
 
 				{if empty($isOpac)}

--- a/code/web/interface/themes/responsive/MyAccount/login-staff.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/login-staff.tpl
@@ -86,7 +86,7 @@
 						<div class="col-xs-12 col-sm-offset-4 col-sm-8">
 							<label for="showPwd" class="checkbox">
 								<input type="checkbox" id="showPwd" name="showPwd" onclick="return AspenDiscovery.pwdToText('password')">
-								{translate text="Reveal Password" isPublicFacing=true}
+								{translate text="Reveal %1%" 1=$passwordLabel isPublicFacing=true}
 							</label>
 
 							{if !$canLoginSSO}

--- a/code/web/interface/themes/responsive/MyAccount/login.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/login.tpl
@@ -86,7 +86,7 @@
 						<div class="col-xs-12 col-sm-offset-4 col-sm-8">
 							<label for="showPwd" class="checkbox">
 								<input type="checkbox" id="showPwd" name="showPwd" onclick="return AspenDiscovery.pwdToText('password')">
-								{translate text="Reveal Password" isPublicFacing=true}
+								{translate text="Reveal %1%" 1=$passwordLabel isPublicFacing=true}
 							</label>
 
 							{if empty($inLibrary) && empty($isOpac) && empty($isStandalonePage)}

--- a/code/web/release_notes/25.10.00.MD
+++ b/code/web/release_notes/25.10.00.MD
@@ -18,6 +18,8 @@
 //myranda
 
 //leo
+### Account Updates
+- Align the "Reveal Password" label on pages and modals with the "Login Form Password Label" field. (DIS-1344) (*LS*)
 
 //yanjun
 

--- a/code/web/release_notes/25.10.00.MD
+++ b/code/web/release_notes/25.10.00.MD
@@ -19,7 +19,7 @@
 
 //leo
 ### Account Updates
-- Align the "Reveal Password" label on pages and modals with the "Login Form Password Label" field. (DIS-1344) (*LS*)
+- Aligned the "Reveal Password" label on pages and modals with the "Login Form Password Label" field. (DIS-1344) (*LS*)
 
 //yanjun
 


### PR DESCRIPTION
- Aligned the "Reveal Password" label on pages and modals with the "Login Form Password Label" field.

Test Plan: 
1. Navigate to any pages and modals that contain the “Reveal Password” checkbox label. Notice that is does not match the chosen password label. 
2. Apply the patch and notice that they now match the chosen password label.