### PR TITLE
DIS-1345: Koha reserve fee message

### DIFF
--- a/code/web/Drivers/AbstractIlsDriver.php
+++ b/code/web/Drivers/AbstractIlsDriver.php
@@ -1079,4 +1079,8 @@ abstract class AbstractIlsDriver extends AbstractDriver {
 	public function getPatronHoldGroups($patronId): ?array {
 		return null;
 	}
+
+	public function hasHoldFeeMessage(): bool {
+		return false;
+	}
 }

--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -2016,6 +2016,9 @@ class Koha extends AbstractIlsDriver {
 		return $hold_result;
 	}
 
+	public function hasHoldFeeMessage(): bool {
+		return true;
+	}
 
 	/**
 	 * @param User $patron

--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -2885,6 +2885,18 @@ class Koha extends AbstractIlsDriver {
 			return $hold_result;
 		}
 
+		if (empty($_REQUEST['confirmedRenewal']) && $itemId) {
+			$feeMessage = $this->getPreRenewalFeeMessage($itemId);
+			if ($feeMessage) {
+				$result['success'] = false;
+				$result['message'] = $feeMessage;
+				$result['confirmRenewalFee'] = true;
+				$result['api']['title'] = translate(['text' => 'Confirm Renewal', 'isPublicFacing' => true]);
+				$result['api']['message'] = $feeMessage;
+				return $result;
+			}
+		}
+
 		/** @noinspection PhpBooleanCanBeSimplifiedInspection */
 		if (false && $this->getKohaVersion() >= 19.11) {
 			/** @noinspection PhpUnreachableStatementInspection */
@@ -3157,6 +3169,24 @@ class Koha extends AbstractIlsDriver {
 		return $result;
 	}
 
+	public function getPreRenewalFeeMessage(string $itemId): string|null {
+		$item = $this->getItemForRenewal($itemId);
+		if (!$item) {
+			return null;
+		}
+
+		$rawFee = $this->getRenewalFeeForItem($item['item_type_id'],$item['home_library_id']);
+		if (!$rawFee) {
+			return null;
+		}
+
+		return translate([
+			'text'           => 'You will be charged a renewal fee of %1%.',
+			'1'              => $this->formatFee($rawFee),
+			'isPublicFacing' => true,
+		]);
+	}
+
 	public function getRenewalFeeForItem(string $itemType, string $locationCode): float|null {
 		$rawRentalCharge = $this->getItemTypeRentalCharge($itemType);
 		if (!$rawRentalCharge || (float)$rawRentalCharge === 0.0) {
@@ -3205,7 +3235,7 @@ class Koha extends AbstractIlsDriver {
 		return null;
 	}
 
-	private function formatFee($rawFee): string|null {
+	private function formatFee(float $rawFee): string|null {
 		global $activeLanguage;
 		$currencyCode = 'USD';
 		$variables = new SystemVariables();

--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -3157,6 +3157,19 @@ class Koha extends AbstractIlsDriver {
 		return $result;
 	}
 
+	private function getRawCirculationRule(string $ruleName, array $context): string|null {
+		['itemTypeId' => $itemTypeId, 'locationId' => $locationId, 'patronCategoryId' => $patronCategoryId] = $context;
+
+		$endpoint = "/api/v1/circulation_rules?effective=true&item_type_id=$itemTypeId&library_id=$locationId&patron_category_id=$patronCategoryId&rules=$ruleName";
+		$response = $this->kohaApiUserAgent->get($endpoint, "koha.getCirculationRule.$ruleName");
+
+		if ($response && $response['code'] == 200) {
+			return $response['content'][0][$ruleName] ?? null;
+		}
+
+		return null;
+	}
+
 	/**
 	 * Get a list of fines for the user.
 	 * Code taken from C4::Account getcharges method

--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -2064,9 +2064,9 @@ class Koha extends AbstractIlsDriver {
 		/** @var File_MARC_Record 		- links to relavent item type information */
 		$marcRecordFile 				= $marcRecordDriver->getMarcRecord();
 		/** @var File_MARC_Data_Field 	- contains the item type id*/
-		$itemTypeField 					= $marcRecordFile->getField('942');
+		$itemTypeField 					= $marcRecordFile->getField('952');
 		
-		if ($itemTypeSubfield = $itemTypeField->getSubfield('c')) {
+		if ($itemTypeSubfield = $itemTypeField->getSubfield('y')) {
 			$itemTypeId = trim($itemTypeSubfield->getData());
 		}
 

--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -2032,6 +2032,18 @@ class Koha extends AbstractIlsDriver {
 		return  $chargeOnCollect ? "You will be charged a hold fee of $fee when you collect this item." : "You will be charged a hold fee of $fee for placing this hold." ;
 	}
 
+	private function formatFee($rawFee): string|null {
+		global $activeLanguage;
+		$currencyCode = 'USD';
+		$variables = new SystemVariables();
+		if ($variables->find(true)) {
+			$currencyCode = $variables->currencyCode;
+		}
+		$currencyFormatter = new NumberFormatter($activeLanguage->locale . '@currency=' . $currencyCode, NumberFormatter::CURRENCY);
+		return $currencyFormatter->formatCurrency($rawFee, $currencyCode);
+	}
+
+
 	private function getReserveFee(): string|null {
 
 		$patron = UserAccount::getActiveUserObj();

--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -2020,6 +2020,18 @@ class Koha extends AbstractIlsDriver {
 		return true;
 	}
 
+	public function getPreHoldSubmissionFeeMessage(): string|null {
+		if (!UserAccount::isLoggedIn()) {
+			return "You must be logged in to place holds.";
+		}
+		$chargeOnCollect = $this->getKohaSystemPreference('HoldFeeMode') == 'any_time_is_collected';
+		$fee = $this->getReserveFee();
+		if (!$fee || $fee == "0.000000"){
+			return null;
+		}
+		return  $chargeOnCollect ? "You will be charged a hold fee of $fee when you collect this item." : "You will be charged a hold fee of $fee for placing this hold." ;
+	}
+
 	private function getReserveFee(): string|null {
 
 		$patron = UserAccount::getActiveUserObj();

--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -3157,6 +3157,17 @@ class Koha extends AbstractIlsDriver {
 		return $result;
 	}
 
+	private function formatFee($rawFee): string|null {
+		global $activeLanguage;
+		$currencyCode = 'USD';
+		$variables = new SystemVariables();
+		if ($variables->find(true)) {
+			$currencyCode = $variables->currencyCode;
+		}
+		$currencyFormatter = new NumberFormatter($activeLanguage->locale . '@currency=' . $currencyCode, NumberFormatter::CURRENCY);
+		return $currencyFormatter->formatCurrency($rawFee, $currencyCode);
+	}
+
 	private function getRawCirculationRule(string $ruleName, array $context): string|null {
 		['itemTypeId' => $itemTypeId, 'locationId' => $locationId, 'patronCategoryId' => $patronCategoryId] = $context;
 

--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -3157,6 +3157,14 @@ class Koha extends AbstractIlsDriver {
 		return $result;
 	}
 
+	private function getItemForRenewal(string $itemId): array|null {
+		$response = $this->kohaApiUserAgent->get('/api/v1/items/' . (int)$itemId, 'koha.getItemForRenewal');
+		if ($response && $response['code'] == 200) {
+			return $response['content'];
+		}
+		return null;
+	}
+
 	private function formatFee($rawFee): string|null {
 		global $activeLanguage;
 		$currencyCode = 'USD';

--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -3157,6 +3157,32 @@ class Koha extends AbstractIlsDriver {
 		return $result;
 	}
 
+	public function getRenewalFeeForItem(string $itemType, string $locationCode): float|null {
+		$rawRentalCharge = $this->getItemTypeRentalCharge($itemType);
+		if (!$rawRentalCharge || (float)$rawRentalCharge === 0.0) {
+			return null;
+		}
+
+		$patron = UserAccount::getActiveUserObj();
+		$discount = $this->getRawCirculationRule('rentaldiscount', [
+			'patronCategoryId' => $patron->patronType,
+			'itemTypeId'       => $itemType,
+			'locationId'       => $locationCode,
+		]);
+		
+		return $this->calculateRenewalFeeForItem((float)$rawRentalCharge, $discount);
+	}
+
+	public function calculateRenewalFeeForItem(float $rentalCharge, float $discount): float|null {
+		if ($discount && $discount > 0) {
+			$rentalCharge = $rentalCharge * (1 - $discount / 100);
+		}
+		if ($rentalCharge === 0.0) {
+			return null;
+		}
+		return $rentalCharge;
+	}
+
 	private function getItemTypeRentalCharge(string $itemType): string|null {
 		$response = $this->kohaApiUserAgent->get('/api/v1/item_types', 'koha.getItemTypeRentalCharge');
 

--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -3157,6 +3157,20 @@ class Koha extends AbstractIlsDriver {
 		return $result;
 	}
 
+	private function getItemTypeRentalCharge(string $itemType): string|null {
+		$response = $this->kohaApiUserAgent->get('/api/v1/item_types', 'koha.getItemTypeRentalCharge');
+
+		if ($response && $response['code'] == 200) {
+			foreach ($response['content'] as $type) {
+				if ($type['item_type_id'] === $itemType) {
+					return $type['rentalcharge'] ?? null;
+				}
+			}
+		}
+
+		return null;
+	}
+
 	private function getItemForRenewal(string $itemId): array|null {
 		$response = $this->kohaApiUserAgent->get('/api/v1/items/' . (int)$itemId, 'koha.getItemForRenewal');
 		if ($response && $response['code'] == 200) {

--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -2851,7 +2851,8 @@ class Koha extends AbstractIlsDriver {
 			return $hold_result;
 		}
 
-		if (empty($_REQUEST['confirmedRenewal']) && $itemId) {
+		$homeLibrary = $patron->getHomeLibrary();
+		if (empty($_REQUEST['confirmedRenewal']) && $itemId && $homeLibrary && $homeLibrary->showCheckoutRenewalFeeMessage) {
 			$feeMessage = $this->getPreRenewalFeeMessage($itemId);
 			if ($feeMessage) {
 				$result['success'] = false;

--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -2024,12 +2024,12 @@ class Koha extends AbstractIlsDriver {
 		if (!UserAccount::isLoggedIn()) {
 			return "You must be logged in to place holds.";
 		}
-		$chargeOnCollect = $this->getKohaSystemPreference('HoldFeeMode') == 'any_time_is_collected';
-		$fee = $this->getReserveFee();
-		if (!$fee || $fee == "0.000000"){
+		$rawFee = $this->getRawReserveFee();
+		if (!$rawFee || $rawFee == "0.000000"){
 			return null;
 		}
-		return  $chargeOnCollect ? "You will be charged a hold fee of $fee when you collect this item." : "You will be charged a hold fee of $fee for placing this hold." ;
+		$fee = $this->formatFee($rawFee);
+		return  $this->getKohaSystemPreference('HoldFeeMode') == 'any_time_is_collected' ? "You will be charged a hold fee of $fee when you collect this item." : "You will be charged a hold fee of $fee for placing this hold." ;
 	}
 
 	private function formatFee($rawFee): string|null {
@@ -2043,8 +2043,7 @@ class Koha extends AbstractIlsDriver {
 		return $currencyFormatter->formatCurrency($rawFee, $currencyCode);
 	}
 
-
-	private function getReserveFee(): string|null {
+	private function getRawReserveFee(): string|null {
 
 		$patron = UserAccount::getActiveUserObj();
 		$this->initDatabaseConnection();

--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -2020,11 +2020,11 @@ class Koha extends AbstractIlsDriver {
 		return true;
 	}
 
-	public function getPreHoldSubmissionFeeMessage(): string|null {
+	public function getPreHoldSubmissionFeeMessage(MarcRecordDriver $marcRecordDriver): string|null {
 		if (!UserAccount::isLoggedIn()) {
 			return "You must be logged in to place holds.";
 		}
-		$rawFee = $this->getRawReserveFee();
+		$rawFee = $this->calculateHoldFeeForRecord($marcRecordDriver);
 		if (!$rawFee || $rawFee == "0.000000"){
 			return null;
 		}
@@ -2032,11 +2032,11 @@ class Koha extends AbstractIlsDriver {
 		return  $this->getKohaSystemPreference('HoldFeeMode') == 'any_time_is_collected' ? "You will be charged a hold fee of $fee when you collect this item." : "You will be charged a hold fee of $fee for placing this hold." ;
 	}
 		
-	public function getPostHoldSubmissionFeeMessage(): string|null {
+	public function getPostHoldSubmissionFeeMessage(MarcRecordDriver $marcRecordDriver): string|null {
 		if (!UserAccount::isLoggedIn()) {
 			return "You must be logged in to place holds.";
 		}
-		$rawFee = $this->getRawReserveFee();
+		$rawFee = $this->calculateHoldFeeForRecord($marcRecordDriver);
 		if (!$rawFee || $rawFee == "0.000000"){
 			return null;
 		}
@@ -2055,27 +2055,48 @@ class Koha extends AbstractIlsDriver {
 		return $currencyFormatter->formatCurrency($rawFee, $currencyCode);
 	}
 
-	private function getRawReserveFee(): string|null {
-
-		$patron = UserAccount::getActiveUserObj();
-		$this->initDatabaseConnection();
-
-		/** @noinspection SqlResolve */
-		$sql = "SELECT reservefee FROM borrowers LEFT JOIN categories ON borrowers.categorycode = categories.categorycode WHERE borrowernumber =" . mysqli_escape_string($this->dbConnection, $patron->unique_ils_id) . ";";
-		$results = mysqli_query($this->dbConnection, $sql);
-
-		if ($results === false) {
-			global $logger;
-			$logger->log("Error getting reserve fee " . mysqli_error($this->dbConnection), Logger::LOG_ERROR);
-			return false;
+	// Replicates the logic in Koha's _calculate_title_hold_fee() for bib-level holds
+	public function calculateHoldFeeForRecord(MarcRecordDriver $marcRecordDriver) {
+		/** @var Grouping_Item			- includes relevant location information */
+		$groupingItems 					= $marcRecordDriver->getRelatedRecord()->getItems();
+		/** @var User					- includes relevant user unique identifier and location information */
+		$patron 						= UserAccount::getActiveUserObj();
+		/** @var File_MARC_Record 		- links to relavent item type information */
+		$marcRecordFile 				= $marcRecordDriver->getMarcRecord();
+		/** @var File_MARC_Data_Field 	- contains the item type id*/
+		$itemTypeField 					= $marcRecordFile->getField('942');
+		
+		if ($itemTypeSubfield = $itemTypeField->getSubfield('c')) {
+			$itemTypeId = trim($itemTypeSubfield->getData());
 		}
-		while ($curRow = $results->fetch_assoc()) {
-			$reserveFee = $curRow['reservefee'];
+
+		$fees = [];
+
+		foreach ($groupingItems as $groupingItem) {
+			$fee = $this->getRawCirculationRule('hold_fee', [
+				'patronCategoryId' => $patron->patronType,
+				'itemTypeId' => $itemTypeId,
+				'locationId' => $groupingItem->locationCode
+			]);
+
+			array_push($fees, $fee);
 		}
-		$results->close();
-		return $reserveFee;
+
+		$sortingStrategy = $this->getKohaSystemPreference('TitleHoldFeeStrategy');
+
+    	if ( $sortingStrategy == 'highest' ) {
+    	    return max($fees);
+    	}
+		if ( $sortingStrategy == 'lowest' ) {
+    	    return min($fees);
+    	}
+		if ( $sortingStrategy == 'most_common' ) {
+			$feeCounts = array_count_values($fees);		
+			return arsort($feeCounts)[0];
+		}	
+    	
+    	return max($fees);
 	}
-
 
 	/**
 	 * @param User $patron

--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -2025,7 +2025,7 @@ class Koha extends AbstractIlsDriver {
 			return "You must be logged in to place holds.";
 		}
 		$rawFee = $this->calculateHoldFeeForRecord($marcRecordDriver);
-		if (!$rawFee || $rawFee == "0.000000"){
+		if (!$rawFee || $rawFee == 'unknown' || $rawFee == "0.000000"){
 			return null;
 		}
 		$fee = $this->formatFee($rawFee);
@@ -2037,7 +2037,7 @@ class Koha extends AbstractIlsDriver {
 			return "You must be logged in to place holds.";
 		}
 		$rawFee = $this->calculateHoldFeeForRecord($marcRecordDriver);
-		if (!$rawFee || $rawFee == "0.000000"){
+		if (!$rawFee || $rawFee == 'unknown' || $rawFee == "0.000000"){
 			return null;
 		}
 		$fee = $this->formatFee($rawFee);
@@ -2065,10 +2065,22 @@ class Koha extends AbstractIlsDriver {
 		$marcRecordFile 				= $marcRecordDriver->getMarcRecord();
 		/** @var File_MARC_Data_Field 	- contains the item type id*/
 		$itemTypeField 					= $marcRecordFile->getField('952');
-		
-		if ($itemTypeSubfield = $itemTypeField->getSubfield('y')) {
-			$itemTypeId = trim($itemTypeSubfield->getData());
+
+		if ($itemTypeField ==  false) {
+			global $logger;
+			$logger->log('No field 952 found on record with id: ' . $marcRecordDriver->getId(), Logger::LOG_ERROR);
+			return 'unknown';
 		}
+
+		$itemTypeSubfield = $itemTypeField->getSubfield('y');
+
+		if ($itemTypeSubfield ==  false) {
+			global $logger;
+			$logger->log('No subfield y found for field 952 on record with id: ' . $marcRecordDriver->getId(), Logger::LOG_ERROR);
+			return 'unknown';
+		}
+		
+		$itemTypeId = trim($itemTypeSubfield->getData());
 
 		$fees = [];
 

--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -2020,6 +2020,28 @@ class Koha extends AbstractIlsDriver {
 		return true;
 	}
 
+	private function getReserveFee(): string|null {
+
+		$patron = UserAccount::getActiveUserObj();
+		$this->initDatabaseConnection();
+
+		/** @noinspection SqlResolve */
+		$sql = "SELECT reservefee FROM borrowers LEFT JOIN categories ON borrowers.categorycode = categories.categorycode WHERE borrowernumber =" . mysqli_escape_string($this->dbConnection, $patron->unique_ils_id) . ";";
+		$results = mysqli_query($this->dbConnection, $sql);
+
+		if ($results === false) {
+			global $logger;
+			$logger->log("Error getting reserve fee " . mysqli_error($this->dbConnection), Logger::LOG_ERROR);
+			return false;
+		}
+		while ($curRow = $results->fetch_assoc()) {
+			$reserveFee = $curRow['reservefee'];
+		}
+		$results->close();
+		return $reserveFee;
+	}
+
+
 	/**
 	 * @param User $patron
 	 * @param string $recordId

--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -2017,7 +2017,8 @@ class Koha extends AbstractIlsDriver {
 	}
 
 	public function hasHoldFeeMessage(): bool {
-		return true;
+		global $library;
+		return !empty($library->showHoldFeeMessage);
 	}
 
 	public function getPreHoldSubmissionFeeMessage(MarcRecordDriver $marcRecordDriver): string|null {

--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -532,8 +532,6 @@ class Koha extends AbstractIlsDriver {
 		require_once ROOT_DIR . '/sys/Indexing/IlsRecord.php';
 		IlsRecord::preloadIlsRecords($this->getIndexingProfile()->name, $allBibNumbers);
 
-		$circControl = $this->getKohaSystemPreference('CircControl', 'PatronLibrary');
-		$activeLibrary = Library::getActiveLibrary();
 		foreach ($allRows as $curRow) {
 			$curCheckout = new Checkout();
 			$curCheckout->type = 'ils';
@@ -600,22 +598,7 @@ class Koha extends AbstractIlsDriver {
 
 			$patronType = $patron->patronType;
 			$itemType = $curRow['itype'];
-			if ($circControl == 'PatronLibrary') {
-				$circBranch = $patron->getHomeLocationCode();
-			} else if ($circControl == 'PickupLibrary') {
-				$circBranch = $curRow['branchcode'];
-				if ($activeLibrary) {
-					$locations = $activeLibrary->getLocations();
-					if (!empty($locations)) {
-						$firstLocation = reset($locations);
-						if ($firstLocation != null && !empty($firstLocation->code)) {
-							$circBranch = $firstLocation->code;
-						}
-					}
-				}
-			} else {
-				$circBranch = $curRow['branchcode'];
-			}
+			$circBranch = $this->getCircControlBranch($patron, $curRow['branchcode']);
 
 			$curCheckout->returnClaim = '';
 
@@ -2362,8 +2345,6 @@ class Koha extends AbstractIlsDriver {
 		require_once ROOT_DIR . '/sys/Indexing/IlsRecord.php';
 		IlsRecord::preloadIlsRecords($this->getIndexingProfile()->name, $allBibNumbers);
 
-		$circControl = $this->getKohaSystemPreference('CircControl', 'PatronLibrary');
-		$activeLibrary = Library::getActiveLibrary();
 		foreach ($allRows as $curRow) {
 			//Each row in the table represents a hold
 			$curHold = new Hold();
@@ -2444,22 +2425,7 @@ class Koha extends AbstractIlsDriver {
 				if($this->getKohaVersion() >= 22.11) {
 					$patronType = $patron->patronType;
 					$itemType = $curRow['itype'];
-					if ($circControl == 'PatronLibrary') {
-						$circBranch = $patron->getHomeLocationCode();
-					} else if ($circControl == 'PickupLibrary') {
-						$circBranch = $curRow['branchcode'];
-						if ($activeLibrary) {
-							$locations = $activeLibrary->getLocations();
-							if (!empty($locations)) {
-								$firstLocation = reset($locations);
-								if ($firstLocation != null && !empty($firstLocation->code)) {
-									$circBranch = $firstLocation->code;
-								}
-							}
-						}
-					} else {
-						$circBranch = $curRow['branchcode'];
-					}
+					$circBranch = $this->getCircControlBranch($patron, $curRow['branchcode']);
 					/** @noinspection SqlResolve */
 					$issuingRulesSql = "SELECT *  FROM circulation_rules where rule_name =  'waiting_hold_cancellation' AND (categorycode IN ('$patronType', '*') OR categorycode IS NULL) and (itemtype IN('$itemType', '*') OR itemtype is null) and (branchcode IN ('$circBranch', '*') OR branchcode IS NULL) order by branchcode desc, categorycode desc, itemtype desc limit 1";
 					$issuingRulesRS = mysqli_query($this->dbConnection, $issuingRulesSql);
@@ -3019,9 +2985,6 @@ class Koha extends AbstractIlsDriver {
 			$renewResponse = $this->getXMLWebServiceResponse($renewURL);
 			ExternalRequestLogEntry::logRequest('koha.renewCheckout', 'GET', $renewURL, $this->curlWrapper->getHeaders(), '', $this->curlWrapper->getResponseCode(), $renewResponse, []);
 
-			$circControl = $this->getKohaSystemPreference('CircControl', 'PatronLibrary');
-			$activeLibrary = Library::getActiveLibrary();
-
 			//Parse the result
 			if (isset($renewResponse->success) && ($renewResponse->success == 1)) {
 				$renewResults = mysqli_query($this->dbConnection, $renewSql);
@@ -3029,22 +2992,7 @@ class Koha extends AbstractIlsDriver {
 				while ($curRow = mysqli_fetch_assoc($renewResults)) {
 					$patronType = $patron->patronType;
 					$itemType = $curRow['itype'];
-					if ($circControl == 'PatronLibrary') {
-						$circBranch = $patron->getHomeLocationCode();
-					} else if ($circControl == 'PickupLibrary') {
-						$circBranch = $curRow['branchcode'];
-						if ($activeLibrary) {
-							$locations = $activeLibrary->getLocations();
-							if (!empty($locations)) {
-								$firstLocation = reset($locations);
-								if ($firstLocation != null && !empty($firstLocation->code)) {
-									$circBranch = $firstLocation->code;
-								}
-							}
-						}
-					} else {
-						$circBranch = $curRow['branchcode'];
-					}
+					$circBranch = $this->getCircControlBranch($patron, $curRow['branchcode']);
 					if ($this->getKohaVersion() >= 22.11) {
 						$renewCount = $curRow['renewals_count'];
 					} else {
@@ -3167,6 +3115,26 @@ class Koha extends AbstractIlsDriver {
 			}
 		}
 		return $result;
+	}
+
+	private function getCircControlBranch(User $patron, ?string $itemBranch): ?string {
+		$circControl = $this->getKohaSystemPreference('CircControl', 'PatronLibrary');
+		if ($circControl == 'PatronLibrary') {
+			return $patron->getHomeLocationCode();
+		}
+		if ($circControl == 'PickupLibrary') {
+			$activeLibrary = Library::getActiveLibrary();
+			if ($activeLibrary) {
+				$locations = $activeLibrary->getLocations();
+				if (!empty($locations)) {
+					$firstLocation = reset($locations);
+					if ($firstLocation != null && !empty($firstLocation->code)) {
+						return $firstLocation->code;
+					}
+				}
+			}
+		}
+		return $itemBranch;
 	}
 
 	public function getPreRenewalFeeMessage(string $itemId): string|null {

--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -2031,6 +2031,18 @@ class Koha extends AbstractIlsDriver {
 		$fee = $this->formatFee($rawFee);
 		return  $this->getKohaSystemPreference('HoldFeeMode') == 'any_time_is_collected' ? "You will be charged a hold fee of $fee when you collect this item." : "You will be charged a hold fee of $fee for placing this hold." ;
 	}
+		
+	public function getPostHoldSubmissionFeeMessage(): string|null {
+		if (!UserAccount::isLoggedIn()) {
+			return "You must be logged in to place holds.";
+		}
+		$rawFee = $this->getRawReserveFee();
+		if (!$rawFee || $rawFee == "0.000000"){
+			return null;
+		}
+		$fee = $this->formatFee($rawFee);
+		return  $this->getKohaSystemPreference('HoldFeeMode') == 'any_time_is_collected' ? "You will be charged a hold fee of $fee when you collect this item." : "You have been charged a hold fee of $fee for placing this hold." ;
+	}
 
 	private function formatFee($rawFee): string|null {
 		global $activeLanguage;

--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -3143,7 +3143,13 @@ class Koha extends AbstractIlsDriver {
 			return null;
 		}
 
-		$rawFee = $this->getRenewalFeeForItem($item['item_type_id'],$item['home_library_id']);
+		$branchField = $this->getKohaSystemPreference('HomeOrHoldingBranch', 'homebranch');
+		$itemBranch = $branchField === 'holdingbranch'
+			? ($item['holding_library_id'] ?? null)
+			: ($item['home_library_id'] ?? null);
+		$circBranch = $this->getCircControlBranch(UserAccount::getActiveUserObj(), $itemBranch);
+
+		$rawFee = $this->getRenewalFeeForItem($item['item_type_id'], $circBranch);
 		if (!$rawFee) {
 			return null;
 		}

--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -2021,38 +2021,28 @@ class Koha extends AbstractIlsDriver {
 	}
 
 	public function getPreHoldSubmissionFeeMessage(MarcRecordDriver $marcRecordDriver): string|null {
-		if (!UserAccount::isLoggedIn()) {
-			return "You must be logged in to place holds.";
-		}
-		$rawFee = $this->calculateHoldFeeForRecord($marcRecordDriver);
-		if (!$rawFee || $rawFee == 'unknown' || $rawFee == "0.000000"){
-			return null;
-		}
-		$fee = $this->formatFee($rawFee);
-		return  $this->getKohaSystemPreference('HoldFeeMode') == 'any_time_is_collected' ? "You will be charged a hold fee of $fee when you collect this item." : "You will be charged a hold fee of $fee for placing this hold." ;
-	}
-		
-	public function getPostHoldSubmissionFeeMessage(MarcRecordDriver $marcRecordDriver): string|null {
-		if (!UserAccount::isLoggedIn()) {
-			return "You must be logged in to place holds.";
-		}
-		$rawFee = $this->calculateHoldFeeForRecord($marcRecordDriver);
-		if (!$rawFee || $rawFee == 'unknown' || $rawFee == "0.000000"){
-			return null;
-		}
-		$fee = $this->formatFee($rawFee);
-		return  $this->getKohaSystemPreference('HoldFeeMode') == 'any_time_is_collected' ? "You will be charged a hold fee of $fee when you collect this item." : "You have been charged a hold fee of $fee for placing this hold." ;
+		return $this->getHoldFeeMessage($marcRecordDriver, false);
 	}
 
-	private function formatFee($rawFee): string|null {
-		global $activeLanguage;
-		$currencyCode = 'USD';
-		$variables = new SystemVariables();
-		if ($variables->find(true)) {
-			$currencyCode = $variables->currencyCode;
+	public function getPostHoldSubmissionFeeMessage(MarcRecordDriver $marcRecordDriver): string|null {
+		return $this->getHoldFeeMessage($marcRecordDriver, true);
+	}
+
+	private function getHoldFeeMessage(MarcRecordDriver $marcRecordDriver, bool $placed): string|null {
+		if (!UserAccount::isLoggedIn()) {
+			return "You must be logged in to place holds.";
 		}
-		$currencyFormatter = new NumberFormatter($activeLanguage->locale . '@currency=' . $currencyCode, NumberFormatter::CURRENCY);
-		return $currencyFormatter->formatCurrency($rawFee, $currencyCode);
+		$rawFee = $this->calculateHoldFeeForRecord($marcRecordDriver);
+		if (!$rawFee || $rawFee == 'unknown' || $rawFee == "0.000000") {
+			return null;
+		}
+		$fee = $this->formatFee($rawFee);
+		if ($this->getKohaSystemPreference('HoldFeeMode') == 'any_time_is_collected') {
+			return "You will be charged a hold fee of $fee when you collect this item.";
+		}
+		return $placed
+			? "You have been charged a hold fee of $fee for placing this hold."
+			: "You will be charged a hold fee of $fee for placing this hold.";
 	}
 
 	// Replicates the logic in Koha's _calculate_title_hold_fee() for bib-level holds

--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -2090,9 +2090,15 @@ class Koha extends AbstractIlsDriver {
 		if ( $sortingStrategy == 'lowest' ) {
     	    return min($fees);
     	}
+
+		// If more than one option share an equal number of occurrences, then pick the first one.
 		if ( $sortingStrategy == 'most_common' ) {
-			$feeCounts = array_count_values($fees);		
-			return arsort($feeCounts)[0];
+			$feeCounts = array_count_values($fees);
+			// Ensure it is sorted by fee (desc)
+			krsort($feeCounts);
+			// Sort by count (desc)
+			arsort($feeCounts);
+			return array_key_first($feeCounts);
 		}	
     	
     	return max($fees);

--- a/code/web/interface/themes/responsive/Record/hold-popup.tpl
+++ b/code/web/interface/themes/responsive/Record/hold-popup.tpl
@@ -77,6 +77,12 @@
 				</p>
 				{/if}
 
+				{if !empty($reserveFeeMessage)}
+					<p class="alert alert-warning">
+						{translate text=$reserveFeeMessage isPublicFacing=true}&nbsp;
+					</p>
+				{/if}
+
 				<div id="holdOptions">
 					{assign var="onlyOnePickupLocation" value=false}
 					{if count($pickupLocations) == 1}

--- a/code/web/interface/themes/responsive/Record/hold-success-popup.tpl
+++ b/code/web/interface/themes/responsive/Record/hold-success-popup.tpl
@@ -3,6 +3,11 @@
 	<div class="content">
 		{if !empty($success)}
 			<p class="alert alert-success">{$message}</p>
+			{if !empty($reserveFeeMessage)}
+				<p class="alert alert-warning">
+					{translate text=$reserveFeeMessage isPublicFacing=true}&nbsp;
+				</p>
+			{/if}
 			<div class="alert">
 					{translate text="Once the title arrives at your library you will receive a notification informing you that the title is ready for you." isPublicFacing=true}&nbsp;
 			</div>

--- a/code/web/release_notes/26.07.00.MD
+++ b/code/web/release_notes/26.07.00.MD
@@ -12,6 +12,9 @@
 // bryan
 
 // chloe
+### Koha Updates
+- Display the renewal fee (as set in Koha) both before checkout renewal.  ([DIS-2349](https://aspen-discovery.atlassian.net/browse/DIS-2349)) (*CZ*)
+- Ensure the renewal fee displayed accounts for the discount that applies per Koha's sys prefs and circulation rules.  ([DIS-2349](https://aspen-discovery.atlassian.net/browse/DIS-2349)) (*CZ*)
 
 // jacob
 

--- a/code/web/release_notes/26.07.00.MD
+++ b/code/web/release_notes/26.07.00.MD
@@ -15,6 +15,9 @@
 ### Koha Updates
 - Display the renewal fee (as set in Koha) both before checkout renewal.  ([DIS-2349](https://aspen-discovery.atlassian.net/browse/DIS-2349)) (*CZ*)
 - Ensure the renewal fee displayed accounts for the discount that applies per Koha's sys prefs and circulation rules.  ([DIS-2349](https://aspen-discovery.atlassian.net/browse/DIS-2349)) (*CZ*)
+- Display the hold fee (as set in Koha) both before and after a hold is placed.  ([DIS-1345](https://aspen-discovery.atlassian.net/browse/DIS-1345)) (*CZ*)
+- Ensure the hold fee accounts for the applicable Koha TitleHoldFeeStrategy.  ([DIS-1345](https://aspen-discovery.atlassian.net/browse/DIS-1345)) (*CZ*)
+
 
 // jacob
 

--- a/code/web/services/Record/AJAX.php
+++ b/code/web/services/Record/AJAX.php
@@ -2263,6 +2263,16 @@ class Record_AJAX extends JSON_Action {
 		$interface->assign('promptToFreezeHoldsImmediately', $user->promptToFreezeHoldsImmediately);
 		$interface->assign('onlyValidPickupLocation', $onlyValidPickupLocation ?? null);
 
+
+		/** @var Koha $catalogDriver */
+		$catalogDriver = $marcRecord->getCatalogDriver();
+		if ($catalogDriver->hasHoldFeeMessage()) {
+			$reserveFeeMessage = $catalogDriver->getPreHoldSubmissionFeeMessage();
+			if ($reserveFeeMessage) {
+				$interface->assign('reserveFeeMessage', $reserveFeeMessage);
+			}
+		}
+
 		$interface->assign('pickupLocations', $locations);
 		$interface->assign('pickupSublocations', $pickupSublocations);
 

--- a/code/web/services/Record/AJAX.php
+++ b/code/web/services/Record/AJAX.php
@@ -1336,7 +1336,8 @@ class Record_AJAX extends JSON_Action {
 					/** @var Koha $catalogDriver */
 					$catalogDriver = $user->getCatalogDriver();
 					if ($catalogDriver->hasHoldFeeMessage()) {
-						$reserveFeeMessage = $catalogDriver->getPostHoldSubmissionFeeMessage();
+						$marcRecord = RecordDriverFactory::initRecordDriverById($recordId);
+						$reserveFeeMessage = $catalogDriver->getPostHoldSubmissionFeeMessage($marcRecord);
 						if ($reserveFeeMessage) {
 							$interface->assign('reserveFeeMessage', $reserveFeeMessage);
 						}
@@ -2276,7 +2277,7 @@ class Record_AJAX extends JSON_Action {
 		/** @var Koha $catalogDriver */
 		$catalogDriver = $marcRecord->getCatalogDriver();
 		if ($catalogDriver->hasHoldFeeMessage()) {
-			$reserveFeeMessage = $catalogDriver->getPreHoldSubmissionFeeMessage();
+			$reserveFeeMessage = $catalogDriver->getPreHoldSubmissionFeeMessage($marcRecord);
 			if ($reserveFeeMessage) {
 				$interface->assign('reserveFeeMessage', $reserveFeeMessage);
 			}

--- a/code/web/services/Record/AJAX.php
+++ b/code/web/services/Record/AJAX.php
@@ -1333,6 +1333,15 @@ class Record_AJAX extends JSON_Action {
 						$interface->assign('whileYouWaitTitles', []);
 					}
 
+					/** @var Koha $catalogDriver */
+					$catalogDriver = $user->getCatalogDriver();
+					if ($catalogDriver->hasHoldFeeMessage()) {
+						$reserveFeeMessage = $catalogDriver->getPostHoldSubmissionFeeMessage();
+						if ($reserveFeeMessage) {
+							$interface->assign('reserveFeeMessage', $reserveFeeMessage);
+						}
+					}
+
 					$results = [
 						'success' => $return['success'],
 						'message' => $interface->fetch('Record/hold-success-popup.tpl'),

--- a/code/web/sys/DBMaintenance/version_updates/26.07.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/26.07.00.php
@@ -29,6 +29,14 @@ function getUpdates26_07_00(): array {
 		//galen
 
 		//chloe
+		'library_show_checkout_renewal_fee_message' => [
+			'title' => 'Add Show Checkout Renewal Fee Message to Library',
+			'description' => 'Adds a setting to control whether the checkout renewal fee message is shown to patrons',
+			'continueOnError' => false,
+			'sql' => [
+				'ALTER TABLE library ADD COLUMN showCheckoutRenewalFeeMessage TINYINT(1) DEFAULT 1',
+			]
+		], //library_show_checkout_renewal_fee_message
 
 		//pedro
 

--- a/code/web/sys/DBMaintenance/version_updates/26.07.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/26.07.00.php
@@ -42,7 +42,7 @@ function getUpdates26_07_00(): array {
 			'description' => 'Adds a setting to control whether the hold fee message is shown to patrons',
 			'continueOnError' => false,
 			'sql' => [
-				'ALTER TABLE library ADD COLUMN showHoldFeeMessage TINYINT(1) DEFAULT 0',
+				'ALTER TABLE library ADD COLUMN showHoldFeeMessage TINYINT(1) DEFAULT 1',
 			]
 		], //library_show_hold_fee_message
 	

--- a/code/web/sys/DBMaintenance/version_updates/26.07.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/26.07.00.php
@@ -37,7 +37,15 @@ function getUpdates26_07_00(): array {
 				'ALTER TABLE library ADD COLUMN showCheckoutRenewalFeeMessage TINYINT(1) DEFAULT 1',
 			]
 		], //library_show_checkout_renewal_fee_message
-
+		'library_show_hold_fee_message' => [
+			'title' => 'Add Show Hold Fee Message to Library',
+			'description' => 'Adds a setting to control whether the hold fee message is shown to patrons',
+			'continueOnError' => false,
+			'sql' => [
+				'ALTER TABLE library ADD COLUMN showHoldFeeMessage TINYINT(1) DEFAULT 0',
+			]
+		], //library_show_hold_fee_message
+	
 		//pedro
 
 		//mark j

--- a/code/web/sys/LibraryLocation/Library.php
+++ b/code/web/sys/LibraryLocation/Library.php
@@ -205,6 +205,7 @@ class Library extends DataObject {
 	public $showLogMeOutAfterPlacingHolds;
 	public $displayItemBarcode;
 	public $displayHoldsOnCheckout;
+	public $showCheckoutRenewalFeeMessage;
 	public /** @noinspection PhpUnused */
 		$displayCallNumberInCheckoutHistory;
 	public /** @noinspection PhpUnused */
@@ -2528,6 +2529,15 @@ class Library extends DataObject {
 								'hideInLists' => true,
 								'default' => '0',
 								'permissions' => ['Library ILS Connection'],
+							],
+							'showCheckoutRenewalFeeMessage' => [
+								'property' => 'showCheckoutRenewalFeeMessage',
+								'type' => 'checkbox',
+								'label' => 'Show Checkout Renewal Fee Message',
+								'description' => 'Whether or not to display a fee message to patrons before renewing checkouts. Requires ILS support.',
+								'note' => 'Applies to Koha Only.',
+								'hideInLists' => true,
+								'default' => 1,
 							],
 						],
 					],

--- a/code/web/sys/LibraryLocation/Library.php
+++ b/code/web/sys/LibraryLocation/Library.php
@@ -203,6 +203,7 @@ class Library extends DataObject {
 	public $showHoldCancelDate;
 	public $showHoldPosition;
 	public $showLogMeOutAfterPlacingHolds;
+	public $showHoldFeeMessage;
 	public $displayItemBarcode;
 	public $displayHoldsOnCheckout;
 	public $showCheckoutRenewalFeeMessage;
@@ -2536,6 +2537,15 @@ class Library extends DataObject {
 								'label' => 'Show Checkout Renewal Fee Message',
 								'description' => 'Whether or not to display a fee message to patrons before renewing checkouts. Requires ILS support.',
 								'note' => 'Applies to Koha Only.',
+								'hideInLists' => true,
+								'default' => 1,
+							],
+							'showHoldFeeMessage' => [
+								'property' => 'showHoldFeeMessage',
+								'type' => 'checkbox',
+								'label' => 'Show Hold Fee Message',
+								'description' => 'Whether or not to display a fee message to patrons when placing holds. Requires ILS support.',
+								'note' => 'Applies to Koha Only. Requires the hold_fee circulation rule',
 								'hideInLists' => true,
 								'default' => 1,
 							],


### PR DESCRIPTION
WIP for [DIS-1345](https://aspen-discovery.atlassian.net/browse/DIS-1345)

[DIS-1345]: https://aspen-discovery.atlassian.net/browse/DIS-1345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Note: the method generating the fee messages are separate (pre and post) despite being very similar as, in the future, they will be rewritten to query separate Koha API endpoints. In fact, the post submission may later become redundant and need to be deprecated. This version of the patch matches the current Koha main branch.


BLOCKED BY: Koha Bugzilla Bug 40817