### PR TITLE
DIS-790 Limit available pickup locations

### DIFF
--- a/code/web/release_notes/25.09.01.MD
+++ b/code/web/release_notes/25.09.01.MD
@@ -1,4 +1,7 @@
 ## Aspen Discovery Updates
+### Hold Updates
+- Correct showing message that a patron's preferred pickup location is invalid when "Allow Patrons to Update Their Preferred Pickup Location" is disabled. (DIS-790) (*MDN*)
+
 ### Other Updates
 - Fix an issue where system messages and placards when viewing a location were shown incorrectly. (DIS-1224) (*MDN*)
 - Fix an issue saving object history for properties with very long names. (DIS-1348) (*MDN*)

--- a/code/web/services/Record/AJAX.php
+++ b/code/web/services/Record/AJAX.php
@@ -1884,62 +1884,52 @@ class Record_AJAX extends Action {
 			}
 		}
 
+		//Check to see if the patron's preferred pickup location and sublocation (if applicable) are valid.
+		// do this regardless of if "allow remembering pickup location" is on since we use the check for other messages
+		$preferredPickupLocationIsValid = false;
+		$preferredPickupLocation = null;
+		$preferredPickupSublocationIsValid = false;
+		foreach ($locations as $location) {
+			if (is_object($location) && ($location->locationId == $user->pickupLocationId)) {
+				$preferredPickupLocationIsValid = true;
+				$preferredPickupLocation = $location;
+				break;
+			}
+		}
+
+		$preferredPickupSublocationIsValid = true;
+		if ($preferredPickupLocationIsValid) {
+			//The preferred location is valid, check to see if sublocations are in use and if so if the preferred pickup area is valid
+			$preferredSublocationsAtPreferredLocation = $preferredPickupLocation->getPickupSublocations($user);
+			if (count($preferredSublocationsAtPreferredLocation) > 1) {
+				$preferredPickupSublocationIsValid = false;
+				require_once ROOT_DIR . '/sys/LibraryLocation/Sublocation.php';
+				require_once ROOT_DIR . '/sys/LibraryLocation/SublocationPatronType.php';
+				$patronType = $user->getPTypeObj();
+				$sublocationLookup = new Sublocation();
+				$sublocationLookup->id = $user->pickupSublocationId;
+				$sublocationLookup->isValidHoldPickupAreaILS = 1;
+				$sublocationLookup->isValidHoldPickupAreaAspen = 1;
+				if ($sublocationLookup->find(true)) {
+					$sublocationPType = new SublocationPatronType();
+					$sublocationPType->patronTypeId = $patronType->id;
+					$sublocationPType->sublocationId = $sublocationLookup->id;
+					if ($sublocationPType->find(true)) {
+						$preferredPickupSublocationIsValid = true;
+					}
+				}
+			}
+		}
+
 		global $library;
 		//Check to see if we can bypass the holds popup and just place the hold
 		if (!$multipleAccountPickupLocations && !$promptForHoldNotifications && $library->allowRememberPickupLocation) {
 			//If the patron's preferred pickup location is not valid, then force them to pick a new location
-			$preferredPickupLocationIsValid = false;
-			$preferredPickupLocation = null;
-			$preferredPickupSublocationIsValid = false;
-			foreach ($locations as $location) {
-				if (is_object($location) && ($location->locationId == $user->pickupLocationId)) {
-					$preferredPickupLocationIsValid = true;
-					$preferredPickupLocation = $location;
-					break;
-				}
-			}
-
-			$preferredPickupSublocationIsValid = true;
-			if ($preferredPickupLocationIsValid) {
-				//The preferred location is valid, check to see if sublocations are in use and if so if the preferred pickup area is valid
-				$preferredSublocationsAtPreferredLocation = $preferredPickupLocation->getPickupSublocations($user);
-				if (count($preferredSublocationsAtPreferredLocation) > 1) {
-					$preferredPickupSublocationIsValid = false;
-					require_once ROOT_DIR . '/sys/LibraryLocation/Sublocation.php';
-					require_once ROOT_DIR . '/sys/LibraryLocation/SublocationPatronType.php';
-					$patronType = $user->getPTypeObj();
-					$sublocationLookup = new Sublocation();
-					$sublocationLookup->id = $user->pickupSublocationId;
-					$sublocationLookup->isValidHoldPickupAreaILS = 1;
-					$sublocationLookup->isValidHoldPickupAreaAspen = 1;
-					if ($sublocationLookup->find(true)) {
-						$sublocationPType = new SublocationPatronType();
-						$sublocationPType->patronTypeId = $patronType->id;
-						$sublocationPType->sublocationId = $sublocationLookup->id;
-						if ($sublocationPType->find(true)) {
-							$preferredPickupSublocationIsValid = true;
-						}
-					}
-				}
-			}
-
 			if ($preferredPickupLocationIsValid && $preferredPickupSublocationIsValid) {
 				$rememberHoldPickupLocation = $user->rememberHoldPickupLocation;
 			} else {
 				$rememberHoldPickupLocation = false;
-				$locationKeys = array_keys($locations);
-				if (!$preferredPickupLocationIsValid && count($locations) == 2 && !empty($locations[$locationKeys[1]])) {
-					$onlyValidPickupLocation = $locations[$locationKeys[1]]->code;
-					$interface->assign('pickupLocationInvalidMessage', translate([
-						'text' => 'Your preferred pickup location is not available for this item, as it is restricted by item location rules. The item must be picked up at the following location.',
-						'isPublicFacing' => true,
-					]));
-				} elseif (!$preferredPickupLocationIsValid) {
-					$interface->assign('pickupLocationInvalidMessage', translate([
-						'text' => 'Your preferred pickup location is not available for this item, as it is restricted by item location rules. Please select a pickup location.',
-						'isPublicFacing' => true,
-					]));
-				} elseif (!$preferredPickupSublocationIsValid) {
+				if (!$preferredPickupSublocationIsValid) {
 					if ($user->pickupSublocationId > 0) {
 						$interface->assign('pickupLocationInvalidMessage', translate([
 							'text' => 'Your preferred pickup area is not available for your patron type. Please select a pickup location.',
@@ -1964,6 +1954,21 @@ class Record_AJAX extends Action {
 			// If the Library System does not allow remembering pickup location (i.e., !$library->allowRememberPickupLocation),
 			// then no need to display a message because the patron cannot choose a preferred pickup location anyway.
 		}
+
+		$locationKeys = array_keys($locations);
+		if (!$preferredPickupLocationIsValid && count($locations) == 2 && !empty($locations[$locationKeys[1]])) {
+			$onlyValidPickupLocation = $locations[$locationKeys[1]]->code;
+			$interface->assign('pickupLocationInvalidMessage', translate([
+				'text' => 'Your preferred pickup location is not available for this item, as it is restricted by item location rules. The item must be picked up at the following location.',
+				'isPublicFacing' => true,
+			]));
+		} elseif (!$preferredPickupLocationIsValid) {
+			$interface->assign('pickupLocationInvalidMessage', translate([
+				'text' => 'Your preferred pickup location is not available for this item, as it is restricted by item location rules. Please select a pickup location.',
+				'isPublicFacing' => true,
+			]));
+		}
+
 		$interface->assign('rememberHoldPickupLocation', $rememberHoldPickupLocation);
 		$interface->assign('onlyValidPickupLocation', $onlyValidPickupLocation ?? null);
 


### PR DESCRIPTION
- Correct showing message that a patron's preferred pickup location is invalid when "Allow Patrons to Update Their Preferred Pickup Location" is disabled.