### PR TITLE
DIS-1160: Added Confirauble

### DIFF
--- a/code/web/interface/themes/responsive/DataObjectUtil/oneToMany.tpl
+++ b/code/web/interface/themes/responsive/DataObjectUtil/oneToMany.tpl
@@ -20,6 +20,11 @@
 			<tbody>
 			{foreach from=$propValue item=subObject}
 				{assign var=subObjectId value=$subObject->getPrimaryKeyValue()}
+				{* Get instance-specific structure once per object *}
+				{assign var=instanceStructure value=null}
+				{if method_exists($subObject, 'updateStructureForEditingObject')}
+					{assign var=instanceStructure value=$subObject->updateStructureForEditingObject($property.structure)}
+				{/if}
 				<tr id="{$propName}{$subObject->id}" class="{$propName}Row" data-id="{$subObject->id}">
 					<input type="hidden" id="{$propName}Id_{$subObject->id}" name="{$propName}Id[{$subObject->id}]" value="{$subObject->id}"/>
 					{if !empty($property.sortable)}
@@ -33,21 +38,30 @@
 							<td class="oneToManyCell" {if !empty($subProperty.relatedIls)}data-related-ils="~{implode subject=$subProperty.relatedIls glue='~'}~"{/if}>
 								{assign var=subPropName value=$subProperty.property}
 								{assign var=subPropValue value=$subObject->$subPropName}
+								{* Check for instance-specific readonly conditions *}
+								{assign var=instanceReadOnly value=false}
+								{assign var=instanceReadOnlyReason value=null}
+								{if !empty($instanceStructure[$subPropName].readOnly)}
+									{assign var=instanceReadOnly value=true}
+									{if !empty($instanceStructure[$subPropName].readOnlyReason)}
+										{assign var=instanceReadOnlyReason value=$instanceStructure[$subPropName].readOnlyReason}
+									{/if}
+								{/if}
 								{if $subProperty.type=='text' || $subProperty.type=='regularExpression' || $subProperty.type=='integer' || $subProperty.type=='html'}
-									<input type="text" name="{$propName}_{$subPropName}[{$subObject->id}]" value="{$subPropValue|escape}" class="form-control{if $subProperty.type=="integer"} integer{/if}{if !empty($subProperty.required)} required{/if}" {if !empty($subProperty.onchange)}onchange="{$subProperty.onchange}"{/if} {if !empty($subProperty.readOnly) || !empty($property.readOnly)} readonly{/if}{if !empty($subProperty.maxLength)} maxlength="{$subProperty.maxLength}"{/if} data-id="{$subObject->id}">
+								<input type="text" name="{$propName}_{$subPropName}[{$subObject->id}]" value="{$subPropValue|escape}" class="form-control{if $subProperty.type=="integer"} integer{/if}{if !empty($subProperty.required)} required{/if}" {if !empty($subProperty.onchange)}onchange="{$subProperty.onchange}"{/if} {if !empty($subProperty.readOnly) || !empty($property.readOnly) || $instanceReadOnly} readonly{if $instanceReadOnly && !empty($instanceReadOnlyReason)} title="{$instanceReadOnlyReason|escape}"{/if}{/if}{if !empty($subProperty.maxLength)} maxlength="{$subProperty.maxLength}"{/if}{if $subProperty.type=="integer" && !empty($subProperty.max)} max="{$subProperty.max}"{/if}{if $subProperty.type=="integer" && !empty($subProperty.min)} min="{$subProperty.min}"{/if} data-id="{$subObject->id}">
 								{elseif $subProperty.type=='date'}
-									<input type="date" name="{$propName}_{$subPropName}[{$subObject->id}]" value="{$subPropValue|escape}" class="form-control{if !empty($subProperty.required)} required{/if}"{if !empty($subProperty.readOnly) || !empty($property.readOnly)} readonly disabled{/if} data-id="{$subObject->id}">
+								<input type="date" name="{$propName}_{$subPropName}[{$subObject->id}]" value="{$subPropValue|escape}" class="form-control{if !empty($subProperty.required)} required{/if}"{if !empty($subProperty.readOnly) || !empty($property.readOnly) || $instanceReadOnly} readonly disabled{/if} data-id="{$subObject->id}">
 								{elseif $subProperty.type=='time'}
-									<input type="time" name="{$propName}_{$subPropName}[{$subObject->id}]" value="{$subPropValue|escape}" class="form-control{if !empty($subProperty.required)} required{/if}"{if !empty($subProperty.readOnly) || !empty($property.readOnly)} readonly disabled{/if} data-id="{$subObject->id}">
+								<input type="time" name="{$propName}_{$subPropName}[{$subObject->id}]" value="{$subPropValue|escape}" class="form-control{if !empty($subProperty.required)} required{/if}"{if !empty($subProperty.readOnly) || !empty($property.readOnly) || $instanceReadOnly} readonly disabled{/if} data-id="{$subObject->id}">
 								{elseif $subProperty.type=='dynamic_label'}
-									<span id="{$propName}_{$subPropName}_{$subObject->id}" data-id="{$subObject->id}">{$subPropValue|escape}<span>
+								<span id="{$propName}_{$subPropName}_{$subObject->id}" data-id="{$subObject->id}">{$subPropValue|escape}<span>
 								{elseif $subProperty.type=='textarea' || $subProperty.type=='multilineRegularExpression'}
-									<textarea name="{$propName}_{$subPropName}[{$subObject->id}]" class="form-control{if !empty($subProperty.autoResizeTextArea)} auto-grow-textarea{/if}"{if !empty($subProperty.readOnly) || !empty($property.readOnly)} readonly{/if}{if !empty($subProperty.maxLength)} maxlength="{$subProperty.maxLength}"{/if} data-id="{$subObject->id}">{$subPropValue|escape}</textarea>
+									<textarea name="{$propName}_{$subPropName}[{$subObject->id}]" class="form-control{if !empty($subProperty.autoResizeTextArea)} auto-grow-textarea{/if}"{if !empty($subProperty.readOnly) || !empty($property.readOnly) || $instanceReadOnly} readonly{/if}{if !empty($subProperty.maxLength)} maxlength="{$subProperty.maxLength}"{/if} data-id="{$subObject->id}">{$subPropValue|escape}</textarea>
 								{elseif $subProperty.type=='checkbox'}
-									{if !empty($subProperty.readOnly) || !empty($property.readOnly)}
+									{if !empty($subProperty.readOnly) || !empty($property.readOnly) || $instanceReadOnly}
 										{if $subPropValue == 1}{translate text='Yes' isAdminFacing=true}{else}{translate text='No' isAdminFacing=true}{/if}
 									{/if}
-									<input type='checkbox' name='{$propName}_{$subPropName}[{$subObject->id}]' {if $subPropValue == 1}checked='checked'{/if} {if !empty($subProperty.readOnly) || !empty($property.readOnly)} style="display: none"{/if} data-id="{$subObject->id}" {if !empty($subProperty.onchange)}onchange="{$subProperty.onchange}"{/if}/>
+									<input type='checkbox' name='{$propName}_{$subPropName}[{$subObject->id}]' {if $subPropValue == 1}checked='checked'{/if} {if !empty($subProperty.readOnly) || !empty($property.readOnly) || $instanceReadOnly} style="display: none"{/if} data-id="{$subObject->id}" {if !empty($subProperty.onchange)}onchange="{$subProperty.onchange}"{/if}/>
 								{elseif $subProperty.type=='multiSelect'}
 									<span id="{$propName}_{$subPropName}_{$subObject->id}" data-id="{$subObject->id}">
 										{if is_array($subPropValue) && count($subPropValue) > 0}
@@ -72,7 +86,7 @@
 									<span>
 								{else}
 									{if $subObject->canActiveUserChangeSelection()}
-										<select name='{$propName}_{$subPropName}[{$subObject->id}]' id='{$propName}{$subPropName}_{$subObject->id}' class='form-control {if !empty($subProperty.required)} required{/if}' {if !empty($subProperty.onchange)}onchange="{$subProperty.onchange}"{/if} {if !empty($subProperty.readOnly) || !empty($property.readOnly)} readonly disabled{/if} data-id="{$subObject->id}">
+										<select name='{$propName}_{$subPropName}[{$subObject->id}]' id='{$propName}{$subPropName}_{$subObject->id}' class='form-control {if !empty($subProperty.required)} required{/if}' {if !empty($subProperty.onchange)}onchange="{$subProperty.onchange}"{/if} {if !empty($subProperty.readOnly) || !empty($property.readOnly) || $instanceReadOnly} readonly disabled{/if} data-id="{$subObject->id}">
 											{foreach from=$subProperty.values item=propertyName key=propertyValue}
 												<option value='{$propertyValue}' {if $subPropValue == $propertyValue}selected='selected'{/if}>{if !empty($subProperty.translateValues)}{translate text=$propertyName|escape inAttribute=true isPublicFacing=$subProperty.isPublicFacing isAdminFacing=$subProperty.isAdminFacing }{else}{$propertyName|escape}{/if}</option>
 											{/foreach}
@@ -100,7 +114,7 @@
 										{assign var=subPropName value=$subProperty.property}
 										{assign var=subPropValue value=$subObject->$subPropName}
 										{foreach from=$subProperty.values item=propertyName}
-											<input name='{$propName}_{$subPropName}[{$subObject->id}][]' type="checkbox" value='{$propertyName}' {if is_array($subPropValue) && in_array($propertyName, $subPropValue)}checked='checked'{/if}{if !empty($subProperty.readOnly) || !empty($property.readOnly)} readonly disabled{/if}>
+											<input name='{$propName}_{$subPropName}[{$subObject->id}][]' type="checkbox" value='{$propertyName}' {if is_array($subPropValue) && in_array($propertyName, $subPropValue)}checked='checked'{/if}{if !empty($subProperty.readOnly) || !empty($property.readOnly) || $instanceReadOnly} readonly disabled{/if}>
 											{$propertyName|escape}
 											<br>
 										{/foreach}
@@ -231,6 +245,8 @@
 									"value='{if !empty($subProperty.default)}{$subProperty.default}{/if}' " +
 									"class='form-control{if $subProperty.type=="integer"} integer{/if}{if !empty($subProperty.required)} required{/if}'" +
 									'{if !empty($subProperty.maxLength)} maxlength="{$subProperty.maxLength}"{/if}' +
+									'{if $subProperty.type=="integer" && !empty($subProperty.max)} max="{$subProperty.max}"{/if}' +
+									'{if $subProperty.type=="integer" && !empty($subProperty.min)} min="{$subProperty.min}"{/if}' +
 									" data-id='" + numAdditional{$propName}
 								+ "'>";
 							{/if}

--- a/code/web/release_notes/25.10.00.MD
+++ b/code/web/release_notes/25.10.00.MD
@@ -61,6 +61,16 @@
 //myranda
 
 //leo
+### Grouped Work Facets Updates
+- Added "Num Total Facets" option to set how many facets display when patrons click "More..." to expand facet groups while searching. (DIS-1160) (*LS*)
+    - The Available At, Format, and Branch (i.e., Owning Location) facets continue to be dynamically calculated rather than configurable.
+    - Renamed "Num Entries" column label to "Num Default Entries" to clarify its purpose.
+
+#### New Settings
+- Catalog/Grouped Works > Grouped Work Facets > "Num Total Entries" column under the Facets table
+
+### Other Updates
+- Improved `oneToMany.tpl` to support per-instance readonly field conditions and automatic max/min constraint application for integer fields, allowing individual items to have different readonly states with dynamic tooltips populated through `readOnlyReason` attributes across form element types. (DIS-1160) (*LS*)
 
 //yanjun
 ### Other Updates

--- a/code/web/sys/DBMaintenance/version_updates/25.10.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.10.00.php
@@ -44,6 +44,14 @@ function getUpdates25_10_00(): array {
 		//Yanjun Li - ByWater
 
 		// Leo Stoyanov - BWS
+		'add_num_total_entries_to_show_in_more_to_grouped_work_facet' => [
+			'title' => 'Add Total Num Entries To Show In More To Grouped Work Facet',
+			'description' => 'Add configurable field to control how many facet values show in the "More..." popup/expansion.',
+			'continueOnError' => false,
+			'sql' => [
+				'ALTER TABLE grouped_work_facet ADD COLUMN numTotalEntriesToShowInMore INT(11) NOT NULL DEFAULT 30',
+			]
+		], // add_num_total_entries_to_show_in_more_to_grouped_work_facet
 
 		//alexander - Open Fifth
 

--- a/code/web/sys/Grouping/GroupedWorkFacet.php
+++ b/code/web/sys/Grouping/GroupedWorkFacet.php
@@ -4,9 +4,11 @@ class GroupedWorkFacet extends FacetSetting {
 	public $__table = 'grouped_work_facet';
 	public $facetGroupId;
 
+
 	public function getNumericColumnNames(): array {
 		$numericColumns = parent::getNumericColumnNames();
 		$numericColumns[] = 'facetGroupId';
+		$numericColumns[] = 'numTotalEntriesToShowInMore';
 		return $numericColumns;
 	}
 
@@ -180,13 +182,48 @@ class GroupedWorkFacet extends FacetSetting {
 			'numEntriesToShowByDefault' => [
 				'property' => 'numEntriesToShowByDefault',
 				'type' => 'integer',
-				'label' => 'Num Entries',
-				'description' => 'The number of values to show by default.',
+				'label' => 'Num Default Entries',
+				'description' => 'The number of facets to display under a facet group by default.',
 				'default' => '5',
+			],
+			'numTotalEntriesToShowInMore' => [
+				'property' => 'numTotalEntriesToShowInMore',
+				'type' => 'integer',
+				'label' => 'Num Total Entries',
+				'description' => 'The number of values to show in the displayed after clicking &quot;More...&quot;. This setting is ignored for Format, Available At, and Owning Location facets, which use calculated limits.',
+				'default' => '30',
+				'max' => 100,
+				'min' => 1,
 			],
 		];
 
 		self::$_objectStructure[$context] = $structure;
 		return self::$_objectStructure[$context];
+	}
+
+	public static function calculateDynamicFacetLimit(string $facetName): int {
+		if ($facetName == 'format') {
+			require_once ROOT_DIR . '/sys/Indexing/IndexedFormat.php';
+			$indexedFormat = new IndexedFormat();
+			return $indexedFormat->count();
+		} elseif ($facetName == 'available_at' || $facetName == 'owning_location') {
+			require_once ROOT_DIR . '/sys/LibraryLocation/Location.php';
+			require_once ROOT_DIR . '/sys/Indexing/SideLoad.php';
+			$location = new Location();
+			$numLocations = $location->count();
+			$sideload = new SideLoad();
+			return $numLocations + $sideload->count() + 10;
+		}
+		return 0;
+	}
+
+	public function updateStructureForEditingObject($structure): array {
+		$dynamicLimitFacets = ['format', 'available_at', 'owning_location'];
+		if (isset($structure['numTotalEntriesToShowInMore']) && in_array($this->facetName, $dynamicLimitFacets)) {
+			$structure['numTotalEntriesToShowInMore']['readOnly'] = true;
+			$structure['numTotalEntriesToShowInMore']['readOnlyReason'] = 'This value is automatically calculated based on the number of ' . ($this->facetName == 'format' ? 'indexed formats' : 'locations and sideloads') . ' in the system.';
+			$this->numTotalEntriesToShowInMore = self::calculateDynamicFacetLimit($this->facetName);
+		}
+		return $structure;
 	}
 }

--- a/code/web/sys/LibraryLocation/FacetSetting.php
+++ b/code/web/sys/LibraryLocation/FacetSetting.php
@@ -2,16 +2,17 @@
 
 abstract class FacetSetting extends DataObject {
 	public $__displayNameColumn = 'displayName';
-	public $id;                      //int(25)
-	public $displayName;                    //varchar(255)
+	public $id;
+	public $displayName;
 	public $displayNamePlural;
 	public $facetName;
 	public $weight;
-	public $numEntriesToShowByDefault; //
-	public $showAsDropDown;   //True or false
+	public $numEntriesToShowByDefault;
+	public $numTotalEntriesToShowInMore;
+	public $showAsDropDown;
 	public $multiSelect;
 	public $canLock;
-	public $sortMode;         //alphabetically = alphabetically, num_results = by number of results
+	public $sortMode;
 	public $showAboveResults;
 	public $showInResults;
 	public $showInAdvancedSearch;

--- a/code/web/sys/SearchObject/GroupedWorkSearcher2.php
+++ b/code/web/sys/SearchObject/GroupedWorkSearcher2.php
@@ -364,15 +364,10 @@ class SearchObject_GroupedWorkSearcher2 extends SearchObject_AbstractGroupedWork
 			$this->facetOptions["f.rating_facet.facet.method"] = 'enum';
 			$this->facetOptions["f.format_category.facet.method"] = 'enum';
 			$this->facetOptions["f.format.facet.method"] = 'enum';
-			//Limit the number of formats returned to the total number we have indexed so all can show.
-			require_once ROOT_DIR . "/sys/Indexing/IndexedFormat.php";
-			$indexedFormat = new IndexedFormat();
-			$numFormats = $indexedFormat->count();
-			$location = new Location();
-			$numLocations = $location->count();
-			$sideload = new Sideload();
-			$numLocations = $numLocations + $sideload->count() + 10;
-			$this->facetOptions["f.format.facet.limit"] = $numFormats;
+			$this->setPerFacetLimits();
+			require_once ROOT_DIR . '/sys/Grouping/GroupedWorkFacet.php';
+			$this->facetOptions["f.format.facet.limit"] = GroupedWorkFacet::calculateDynamicFacetLimit('format');
+			$numLocations = GroupedWorkFacet::calculateDynamicFacetLimit('available_at');
 			$this->facetOptions["f.available_at.facet.limit"] = $numLocations;
 			$this->facetOptions["f.owning_location.facet.limit"] = $numLocations;
 			$this->facetOptions["f.availability_toggle.facet.method"] = 'enum';
@@ -1059,5 +1054,27 @@ class SearchObject_GroupedWorkSearcher2 extends SearchObject_AbstractGroupedWork
 		require_once ROOT_DIR . '/RecordDrivers/GroupedWorkDriver.php';
 		$record = $this->cleanScopedFieldsForRecord($record);
 		return new GroupedWorkDriver($record);
+	}
+
+	/**
+	 * Set individual facet limits based on numTotalEntriesToShowInMore configuration.
+	 */
+	private function setPerFacetLimits(): void {
+		$searchLibrary = Library::getActiveLibrary();
+		global $locationSingleton;
+		$searchLocation = $locationSingleton->getActiveLocation();
+
+		if ($searchLocation != null) {
+			$facets = $searchLocation->getGroupedWorkDisplaySettings()->getFacets();
+		} else {
+			$facets = $searchLibrary->getGroupedWorkDisplaySettings()->getFacets();
+		}
+
+		foreach ($facets as $facet) {
+			if (!empty($facet->numTotalEntriesToShowInMore)) {
+				$facetName = $this->getScopedFieldName($facet->getFacetName($this->searchVersion));
+				$this->facetOptions["f.{$facetName}.facet.limit"] = $facet->numTotalEntriesToShowInMore;
+			}
+		}
 	}
 }


### PR DESCRIPTION
### Grouped Work Facets Updates
- Added "Num Total Facets" option to set how many facets display when patrons click "More..." to expand facet groups while searching.
    - The Available At, Format, and Branch (i.e., Owning Location) facets continue to be dynamically calculated rather than configurable.
    - Renamed "Num Entries" column label to "Num Default Entries" to clarify its purpose.

#### New Settings
- Catalog/Grouped Works > Grouped Work Facets > "Num Total Entries" column under the Facets table

### Other Updates
- Improved `oneToMany.tpl` to support per-instance readonly field conditions and automatic max/min constraint application for integer fields, allowing individual items to have different readonly states with dynamic tooltips populated through `readOnlyReason` attributes across form element types.

Test Plan:
1. Apply the patch.
2. Navigate to Catalog/Grouped Works > Grouped Work Facets > "Num Total Entries" column under the Facets table.
3. Enter various numbers for each row, where allowed.
4. Search the catalog and browse through the facet groups' settings you modified to confirm total facet counts after clicking "More...".