### PR TITLE
Dis 1387 incorrect links for oa records and cover detection

### DIFF
--- a/code/oai_indexer/src/com/turning_leaf_technologies/oai/OaiIndexerMain.java
+++ b/code/oai_indexer/src/com/turning_leaf_technologies/oai/OaiIndexerMain.java
@@ -575,7 +575,7 @@ public class OaiIndexerMain {
 									case "dc:identifier":
 									case "mods:identifier":
 										String textContentLower = textContent.toLowerCase();
-										if (textContentLower.startsWith("http") && !textContentLower.endsWith(".jpg") && !textContentLower.endsWith(".mp3") && !textContentLower.endsWith(".pdf")) {
+										if (textContentLower.startsWith("http") && !textContentLower.contains(".jpg") && !textContentLower.contains(".png") && !textContentLower.contains(".mp3") && !textContentLower.contains(".pdf")) {
 											if (solrRecord.getIdentifier() == null || !solrRecord.getIdentifier().startsWith("http")) {
 												solrRecord.setIdentifier(textContent);
 											} else {

--- a/code/web/release_notes/25.10.00.MD
+++ b/code/web/release_notes/25.10.00.MD
@@ -61,6 +61,10 @@
 //myranda
 
 //leo
+### Digital Archives Updates
+- Fixed Open Archives indexer to prevent image URLs (JPG, PNG, MP3, PDF) from being selected as record identifiers when they appear anywhere in the URL path. (DIS-1387) (*LS*)
+- Fixed Open Archives cover images not displaying when URLs contain HTML entities. (DIS-1387) (*LS*)
+- Added support for Omeka installation thumbnail extraction with new regex pattern for `<img class="full"...>` elements. (DIS-1387) (*LS*)
 
 //yanjun
 ### Other Updates

--- a/code/web/sys/Covers/BookCoverProcessor.php
+++ b/code/web/sys/Covers/BookCoverProcessor.php
@@ -1469,7 +1469,7 @@ class BookCoverProcessor {
 		}
 	}
 
-	private function getOpenArchivesCover($id) {
+	private function getOpenArchivesCover($id): bool {
 		//The thumbnail is not saved in the metadata.  To get the URL we need to fetch the page
 		//and then get the thumbnail from the og:image element
 		require_once ROOT_DIR . '/sys/OpenArchives/OpenArchivesRecord.php';
@@ -1489,61 +1489,71 @@ class BookCoverProcessor {
 			$curlWrapper->close_curl();
 			$matches = [];
 			if (preg_match('~<meta property="og:image" content="(.*?)" />~', $pageContents, $matches)) {
-				$bookcoverUrl = $matches[1];
-				if ($this->processImageURL('open_archives', $bookcoverUrl, true)){
+				$bookcoverUrl = html_entity_decode($matches[1]);
+				if ($this->processImageURL('open_archives', $bookcoverUrl)){
 					return true;
 				}
 			}
 			if (preg_match('~<img src="(.*?)" border="0" alt="Thumbnail image">~', $pageContents, $matches)) {
-				$bookcoverUrl = $matches[1];
-				if (strpos($bookcoverUrl, 'http') !== 0) {
+				$bookcoverUrl = html_entity_decode($matches[1]);
+				if (!str_starts_with($bookcoverUrl, 'http')) {
 					$urlComponents = parse_url($url);
 					$bookcoverUrl = $urlComponents['scheme'] . '://' . $urlComponents['host'] . $bookcoverUrl;
 				}
-				if ($this->processImageURL('open_archives', $bookcoverUrl, true)){
+				if ($this->processImageURL('open_archives', $bookcoverUrl)){
 					return true;
 				}
 			}
-			if (preg_match('~<div id="item-images">.*<img src="(.*?)".*>~', $pageContents, $matches)) {
-				$bookcoverUrl = $matches[1];
-				if (strpos($bookcoverUrl, 'http') !== 0) {
+			if (preg_match('~<div id="item-images">.*<img src="(.*?)".*>~s', $pageContents, $matches)) {
+				$bookcoverUrl = html_entity_decode($matches[1]);
+				if (!str_starts_with($bookcoverUrl, 'http')) {
 					$urlComponents = parse_url($url);
 					$bookcoverUrl = $urlComponents['scheme'] . '://' . $urlComponents['host'] . $bookcoverUrl;
 				}
-				if ($this->processImageURL('open_archives', $bookcoverUrl, true)){
+				if ($this->processImageURL('open_archives', $bookcoverUrl)){
+					return true;
+				}
+			}
+			if (preg_match('~<img class="full".*?src="(.*?)".*>~s', $pageContents, $matches)) {
+				$bookcoverUrl = html_entity_decode($matches[1]);
+				if (!str_starts_with($bookcoverUrl, 'http')) {
+					$urlComponents = parse_url($url);
+					$bookcoverUrl = $urlComponents['scheme'] . '://' . $urlComponents['host'] . $bookcoverUrl;
+				}
+				if ($this->processImageURL('open_archives', $bookcoverUrl)){
 					return true;
 				}
 			}
 			if (preg_match('/\\\\"thumbnailUri\\\\":\\\\"(.*?)\\\\"/', $pageContents, $matches)) {
 				$bookcoverUrl = $matches[1];
-				if (strpos($bookcoverUrl, 'http') !== 0) {
+				if (!str_starts_with($bookcoverUrl, 'http')) {
 					$urlComponents = parse_url($url);
 					$bookcoverUrl = $urlComponents['scheme'] . '://' . $urlComponents['host'] . '/digital' . $bookcoverUrl;
 				}
 				$bookcoverUrl = str_replace('\/', '/', $bookcoverUrl);
-				if ($this->processImageURL('open_archives', $bookcoverUrl, true)){
+				if ($this->processImageURL('open_archives', $bookcoverUrl)){
 					return true;
 				}
 			}
 			if (preg_match('~<img class=".*?img-preview-large.*?".*?src="(.*?)".*>~', $pageContents, $matches)) {
 				$bookcoverUrl = $matches[1];
-				if (strpos($bookcoverUrl, 'http') !== 0) {
+				if (!str_starts_with($bookcoverUrl, 'http')) {
 					$urlComponents = parse_url($url);
 					$bookcoverUrl = $urlComponents['scheme'] . '://' . $urlComponents['host'] . $bookcoverUrl;
 				}
 				$bookcoverUrl = str_replace('\/', '/', $bookcoverUrl);
-				if ($this->processImageURL('open_archives', $bookcoverUrl, true)){
+				if ($this->processImageURL('open_archives', $bookcoverUrl)){
 					return true;
 				}
 			}
 			if (preg_match('~<img class=".*?img-thumbnail.*?".*?src="(.*?)".*>~', $pageContents, $matches)) {
 				$bookcoverUrl = $matches[1];
-				if (strpos($bookcoverUrl, 'http') !== 0) {
+				if (!str_starts_with($bookcoverUrl, 'http')) {
 					$urlComponents = parse_url($url);
 					$bookcoverUrl = $urlComponents['scheme'] . '://' . $urlComponents['host'] . $bookcoverUrl;
 				}
 				$bookcoverUrl = str_replace('\/', '/', $bookcoverUrl);
-				if ($this->processImageURL('open_archives', $bookcoverUrl, true)){
+				if ($this->processImageURL('open_archives', $bookcoverUrl)){
 					return true;
 				}
 			}
@@ -1558,7 +1568,7 @@ class BookCoverProcessor {
 					foreach ($expressions as $expression) {
 						if (!empty($expression) && preg_match('~' . $expression . '~i', $pageContents, $matches)) {
 							$bookcoverUrl = str_replace('&amp;', '&', $matches[1]);
-							if ($this->processImageURL('open_archives', $bookcoverUrl, true)) {
+							if ($this->processImageURL('open_archives', $bookcoverUrl)) {
 								return true;
 							}
 						}


### PR DESCRIPTION
- Fixed Open Archives indexer to prevent image URLs (JPG, PNG, MP3, PDF) from being selected as record identifiers when they appear anywhere in the URL path.
- Fixed Open Archives cover images not displaying when URLs contain HTML entities.
- Added support for Omeka installation thumbnail extraction with new regex pattern for `<img class="full"...>` elements.

Test Plan: Difficult to test, but ensure that OAI records continue to index properly with the correct redirect links and cover images.