### PR TITLE
DIS-922: Fixed Password Validation for Non-Mandatory Password During Koha Self-Reg

### DIFF
--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -4578,7 +4578,6 @@ class Koha extends AbstractIlsDriver {
 						'maxLength' => $pinValidationRules['maxLength'],
 						'onlyDigitsAllowed' => $pinValidationRules['onlyDigitsAllowed'],
 						'showConfirm' => false,
-						'required' => true,
 						'showDescription' => true,
 						'autocomplete' => false,
 					],
@@ -4591,7 +4590,6 @@ class Koha extends AbstractIlsDriver {
 						'maxLength' => $pinValidationRules['maxLength'],
 						'onlyDigitsAllowed' => $pinValidationRules['onlyDigitsAllowed'],
 						'showConfirm' => false,
-						'required' => true,
 						'showDescription' => false,
 						'autocomplete' => false,
 					],
@@ -4756,7 +4754,20 @@ class Koha extends AbstractIlsDriver {
 		global $library;
 		$result = ['success' => false,];
 
-		if (isset($_REQUEST['borrower_password'])) {
+		// Check if password is mandatory before attempting validation.
+		$this->initDatabaseConnection();
+		$sql = "SELECT value FROM systempreferences WHERE variable = 'PatronSelfRegistrationBorrowerMandatoryField';";
+		$results = mysqli_query($this->dbConnection, $sql);
+		$mandatoryFieldsValue = '';
+		if ($curRow = $results->fetch_assoc()) {
+			$mandatoryFieldsValue = $curRow['value'];
+		}
+		$results->close();
+		$requiredFields = explode('|', $mandatoryFieldsValue);
+		$requiredFields = array_flip($requiredFields);
+		$passwordIsRequired = array_key_exists('password', $requiredFields);
+
+		if (isset($_REQUEST['borrower_password']) && $passwordIsRequired) {
 			$password = $_REQUEST['borrower_password'];
 			$pinValidationRules = $this->getPasswordPinValidationRules();
 

--- a/code/web/release_notes/25.10.00.MD
+++ b/code/web/release_notes/25.10.00.MD
@@ -91,6 +91,7 @@
 
 ### Koha Updates
 - Fixed an issue where a password reset via Aspen to Koha would succeed, but an error message would display instead. (DIS-1383) (*LS*)
+- Fixed an issue where password validation would be performed during self registration even though the field was not mandatory. (DIS-922) (*LS*)
 
 //yanjun
 ### Hoopla Updates


### PR DESCRIPTION
- Fixed an issue where password validation would be performed during self registration even though the field was not required.