### PR TITLE
DIS-1400: Allowed Translation Terms from LiDA to be Automatically Created in Aspen Discovery via API Calls

### DIFF
--- a/code/web/release_notes/25.10.00.MD
+++ b/code/web/release_notes/25.10.00.MD
@@ -5,6 +5,7 @@
 
 ### API Updates
 - Remove unused AnodeAPI. (DIS-1372) (*MDN*)
+- Fixed an issue where new translation terms from LiDA would not automatically populate in the Translations interface via translation API calls. (DIS-1400) (*LS*)
 
 ### Grouped Work Display Updates
 - In new horizontal format display, show local copies only when showing copies for a format. (DIS-1366) (*MDN*)

--- a/code/web/services/API/SystemAPI.php
+++ b/code/web/services/API/SystemAPI.php
@@ -712,7 +712,7 @@ class SystemAPI extends AbstractAPI {
 		];
 		/** @var Translator $translator */ global $translator;
 		foreach ($terms as $term) {
-			$translatedTerm = $translator->translate($term, $term, [], true, true);
+			$translatedTerm = $translator->translate($term, $term, [], true, true, false, false, false, false, false, true);
 			$translatedTerm = html_entity_decode($translatedTerm);
 			$translatedTerm = strip_tags($translatedTerm);
 			$response[$_REQUEST['language']][$term] = trim($translatedTerm);
@@ -778,7 +778,7 @@ class SystemAPI extends AbstractAPI {
 		}
 
 		/** @var Translator $translator */ global $translator;
-		$translatedTerm = $translator->translate($term, $term, $values, true, true);
+		$translatedTerm = $translator->translate($term, $term, $values, true, true, false, false, false, false, false, true);
 		$translatedTerm = html_entity_decode($translatedTerm);
 		$translatedTerm = strip_tags($translatedTerm);
 		return [
@@ -814,10 +814,11 @@ class SystemAPI extends AbstractAPI {
 				}
 
 				$logger->log("Preparing to translate " . count($terms['terms']), Logger::LOG_DEBUG);
+				$logger->log("Terms: " . print_r($terms['terms'], true), Logger::LOG_DEBUG);
 				$translatedTerms = [];
 				/** @var Translator $translator */ global $translator;
 				foreach ($terms['terms'] as $key => $term) {
-					$translatedTerm = $translator->translate($term, $term, [], true, true);
+					$translatedTerm = $translator->translate($term, $term, [], true, true, false, false, false, false, false, true);
 					$translatedTerm = html_entity_decode($translatedTerm);
 					$translatedTerm = strip_tags($translatedTerm);
 					$translatedTerms[$key] = trim($translatedTerm);

--- a/code/web/services/API/SystemAPI.php
+++ b/code/web/services/API/SystemAPI.php
@@ -814,7 +814,6 @@ class SystemAPI extends AbstractAPI {
 				}
 
 				$logger->log("Preparing to translate " . count($terms['terms']), Logger::LOG_DEBUG);
-				$logger->log("Terms: " . print_r($terms['terms'], true), Logger::LOG_DEBUG);
 				$translatedTerms = [];
 				/** @var Translator $translator */ global $translator;
 				foreach ($terms['terms'] as $key => $term) {

--- a/code/web/sys/Translation/Translator.php
+++ b/code/web/sys/Translation/Translator.php
@@ -103,18 +103,8 @@ class Translator {
 					$defaultTextChanged = false;
 					// Write term records to DB in translation mode or when called from API.
 					if ($allowTermCreation) {
-						if ($phrase == 'Are you sure you want to delete this list? The list will be soft-deleted and can be restored within 30 days.') {
-							global $logger;
-							$logger->log("Term to be inserted!", Logger::LOG_ERROR);
-						}
 						if (!$translationTerm->find(true)) {
-							if ($phrase == 'Are you sure you want to delete this list? The list will be soft-deleted and can be restored within 30 days.') {
-								global $logger;
-								$logger->log("Term does not exist yet!", Logger::LOG_ERROR);
-							}
 							$translationTerm->defaultText = $defaultText;
-							//Insert the translation term
-
 							$translationTerm->samplePageUrl = mb_strimwidth($_SERVER['REQUEST_URI'], 0, 255);
 							$translationTerm->isPublicFacing = $isPublicFacing;
 							$translationTerm->isAdminFacing = $isAdminFacing;
@@ -124,8 +114,7 @@ class Translator {
 							try {
 								if ($translationTerm->insert() !== false) {
 									$termTooLong = false;
-									//Send this to the Community Content Server as well
-
+									// Send this to the Community Content Server as well.
 									require_once ROOT_DIR . '/sys/SystemVariables.php';
 									$systemVariables = SystemVariables::getSystemVariables();
 									if ($systemVariables && !empty($systemVariables->communityContentUrl)) {

--- a/code/web/sys/Translation/Translator.php
+++ b/code/web/sys/Translation/Translator.php
@@ -72,13 +72,14 @@ class Translator {
 	 * @param bool $isAdminEnteredData Whether this is data an administrator entered (System message, etc).
 	 * @param bool $translateParameters Whether parameters should be translated.
 	 * @param bool $escape Whether the translation should be escaped before rendering.
+	 * @param bool $fromAPI Whether the translation is being requested from an API call, typically from LiDA.
 	 * @return string The translated phrase.
 	 */
 	function translate(
 		?string $phrase, string $defaultText = '', array $replacementValues = [],
 		bool $inAttribute = false, bool $isPublicFacing = false, bool $isAdminFacing = false,
 		bool $isMetadata = false, bool $isAdminEnteredData = false,
-		bool $translateParameters = false, bool $escape = false
+		bool $translateParameters = false, bool $escape = false, bool $fromAPI = false
 	): string {
 
 		if ($phrase === '' || is_numeric($phrase)) {
@@ -90,6 +91,7 @@ class Translator {
 
 		global $activeLanguage;
 		$translationMode = $this->translationModeActive() && !$inAttribute && (UserAccount::userHasPermission('Translate Aspen'));
+		$allowTermCreation = $translationMode || $fromAPI;
 		try {
 			if (!empty($activeLanguage)) {
 				$translationKey = $activeLanguage->id . '_' . ($translationMode ? 1 : 0) . '_' . $phrase;
@@ -99,9 +101,17 @@ class Translator {
 					$translationTerm = new TranslationTerm();
 					$translationTerm->term = $phrase;
 					$defaultTextChanged = false;
-					// Only write term records to DB in translation mode; otherwise, just load existing term.
-					if ($translationMode) {
+					// Write term records to DB in translation mode or when called from API.
+					if ($allowTermCreation) {
+						if ($phrase == 'Are you sure you want to delete this list? The list will be soft-deleted and can be restored within 30 days.') {
+							global $logger;
+							$logger->log("Term to be inserted!", Logger::LOG_ERROR);
+						}
 						if (!$translationTerm->find(true)) {
+							if ($phrase == 'Are you sure you want to delete this list? The list will be soft-deleted and can be restored within 30 days.') {
+								global $logger;
+								$logger->log("Term does not exist yet!", Logger::LOG_ERROR);
+							}
 							$translationTerm->defaultText = $defaultText;
 							//Insert the translation term
 
@@ -185,33 +195,36 @@ class Translator {
 						}
 					}
 					else {
-						// Non-translation mode: check DB override first, then .ini defaults.
-						if (empty($this->words)) {
-							$this->loadTranslationsFromIniFile();
-						}
-						$dbTranslation = $this->loadDbOverride($phrase);
-						if ($dbTranslation !== null) {
-							$returnString = $dbTranslation;
-						} elseif (isset($this->words[$phrase])) {
-							$returnString = $this->words[$phrase];
-						} elseif (!empty($defaultText)) {
-							$returnString = $defaultText;
-						} else {
-							$returnString = $phrase;
-						}
-						if (count($replacementValues) > 0) {
-							foreach ($replacementValues as $index => $replacementValue) {
-								if ($translateParameters) {
-									$replacementValue = $this->translate($replacementValue, '', [], true, $isPublicFacing, $isAdminFacing, $isMetadata, $isAdminEnteredData, $translateParameters);
-								}
-								$returnString = str_replace('%' . $index . '%', $replacementValue, $returnString);
+						// Non-translation mode: try to load the term if it exists.
+						if (!$translationTerm->find(true)) {
+							// Term doesn't exist - check DB override first, then .ini defaults.
+							if (empty($this->words)) {
+								$this->loadTranslationsFromIniFile();
 							}
+							$dbTranslation = $this->loadDbOverride($phrase);
+							if ($dbTranslation !== null) {
+								$returnString = $dbTranslation;
+							} elseif (isset($this->words[$phrase])) {
+								$returnString = $this->words[$phrase];
+							} elseif (!empty($defaultText)) {
+								$returnString = $defaultText;
+							} else {
+								$returnString = $phrase;
+							}
+							if (count($replacementValues) > 0) {
+								foreach ($replacementValues as $index => $replacementValue) {
+									if ($translateParameters) {
+										$replacementValue = $this->translate($replacementValue, '', [], true, $isPublicFacing, $isAdminFacing, $isMetadata, $isAdminEnteredData, $translateParameters, false, $fromAPI);
+									}
+									$returnString = str_replace('%' . $index . '%', $replacementValue, $returnString);
+								}
+							}
+							if ($escape) {
+								$returnString = htmlentities($returnString);
+							}
+							$this->cachedTranslations[$translationKey] = $returnString;
+							return $returnString;
 						}
-						if ($escape) {
-							$returnString = htmlentities($returnString);
-						}
-						$this->cachedTranslations[$translationKey] = $returnString;
-						return $returnString;
 					}
 
 					if ($activeLanguage->code == 'pig') {
@@ -244,11 +257,15 @@ class Translator {
 							}
 
 							$translation->translation = $defaultTranslation;
-							if ($translationMode) {
-								$ret = $translation->update();
+							if ($allowTermCreation) {
+								if ($translation->id) {
+									$ret = $translation->update();
+								} else {
+									$ret = $translation->insert();
+								}
 								if (!$ret) {
 									global $logger;
-									$logger->log("Could not update translation", Logger::LOG_ERROR);
+									$logger->log("Could not save translation for term ID " . $translationTerm->id, Logger::LOG_ERROR);
 								}
 							}
 						} elseif ($defaultTextChanged) {


### PR DESCRIPTION
- Fixed an issue where new translation terms from LiDA would not automatically populate in the Translations interface via translation API calls.

Test Plan:
1. Add a new translation term to `defaults.json`.
   - `opt_out_soft_deletion` will work because it is new.
2. Launch the LiDA application for your library.
3. Notice that the translation term is not present in the Translation interface of Aspen Discovery when you search for it.
4. Apply the patch and relaunch LiDA. Notice that the translation displays in the Translations interface.