### PR TITLE
DIS-1403: Show renewals remaining in addition to total renewals

### DIFF
--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -8284,6 +8284,10 @@ class Koha extends AbstractIlsDriver {
 		return true;
 	}
 
+	public function showRenewalsRemaining(): bool {
+		return true;
+	}
+
 	public function showHoldPlacedDate(): bool {
 		return true;
 	}

--- a/code/web/Drivers/Polaris.php
+++ b/code/web/Drivers/Polaris.php
@@ -3154,6 +3154,10 @@ class Polaris extends AbstractIlsDriver {
 		return true;
 	}
 
+	public function showRenewalsRemaining(): bool {
+		return true;
+	}
+
 	private function getCarrierList(): array {
 		$staffUserInfo = $this->getStaffUserInfo();
 		$polarisUrl = "/PAPIService/REST/protected/v1/1033/100/1/{$staffUserInfo['accessToken']}/sysadmin/mobilephonecarriers";

--- a/code/web/release_notes/25.10.00.MD
+++ b/code/web/release_notes/25.10.00.MD
@@ -88,6 +88,8 @@
 - Add print options for calendar to toggle display of event end-times and descriptions. (DIS-1343) (*KP*)
 
 //kodi
+### Account Updates
+- Show renewals remaining for checkouts for Polaris and Koha (DIS-1403) (*KL*)
 
 //myranda
 ### Theme Updates


### PR DESCRIPTION
Small changes in both Koha.php and Polaris.php to show renewals remaining for checked out items
Update release notes

Requires additional testing