### PR TITLE
DIS-1414: Update Solr Dockerfile

### DIFF
--- a/code/web/release_notes/25.10.00.MD
+++ b/code/web/release_notes/25.10.00.MD
@@ -221,6 +221,9 @@
 - Fix an error where Aspen doesn't honor the user preference "noPromptForUserReviews". (DIS-1250) (*LM*)
 ### Docker Updates
 - Split the backend service, add Php-fpm and MPM Event for Apache. (DIS-1226) (*LM*)
+- Fix an error where the solr.xml was copied to the incorrect directory. (DIS-1414) (*LM*)
+- Add a healthcheck for each solr core in the Solr Dockerfile. (DIS-1414) (*LM*)
+- Parameterize host and port in the Solr Dockerfile. (DIS-1414) (*LM*)
 
 
 ## This release includes code contributions from

--- a/docker/files/solr/Dockerfile
+++ b/docker/files/solr/Dockerfile
@@ -1,28 +1,55 @@
 FROM solr:8.11.2
+
+# Build arguments with defaults
+ARG SOLR_HOST=localhost
+ARG SOLR_PORT=8983
+
 USER root
 
-# Install dependencies
-RUN apt-get update \
-    && apt-get install -y  \
+# Install dependencies with error handling and cleanup
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
        sudo \
        vim \
-       sed \
-    && rm -rf /var/cache/apt/archives/* \
-    && rm -rf /var/lib/apt/lists/*
+       sed; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
-# Set where Solr will look for configsets
+# Set environment variables
 ENV SOLR_INSTALL_DIR=/opt/solr
 ENV SOLR_HOME=$SOLR_INSTALL_DIR/server/solr
+ENV SOLR_HOST=$SOLR_HOST
+ENV SOLR_PORT=$SOLR_PORT
 
-# Copy configset for each core
-COPY data_dir_setup/solr7/ ${SOLR_HOME}/configsets
-RUN chown -R ${SOLR_USER}:${SOLR_GROUP} ${SOLR_HOME}/configsets
+# Copy core directories to configsets
+COPY data_dir_setup/solr7/series ${SOLR_HOME}/configsets/series
+COPY data_dir_setup/solr7/genealogy ${SOLR_HOME}/configsets/genealogy
+COPY data_dir_setup/solr7/grouped_works_v2 ${SOLR_HOME}/configsets/grouped_works_v2
+COPY data_dir_setup/solr7/lists ${SOLR_HOME}/configsets/lists
+COPY data_dir_setup/solr7/course_reserves ${SOLR_HOME}/configsets/course_reserves
+COPY data_dir_setup/solr7/open_archives ${SOLR_HOME}/configsets/open_archives
+COPY data_dir_setup/solr7/website_pages ${SOLR_HOME}/configsets/website_pages
+COPY data_dir_setup/solr7/events ${SOLR_HOME}/configsets/events
 
-# Change the owner for /var/solr to 'solr'
-RUN chown -R solr:solr /var/solr
+# Copy solr.xml to SOLR_HOME
+COPY data_dir_setup/solr7/solr.xml ${SOLR_HOME}/solr.xml
+RUN set -eux; \
+    test -d "${SOLR_HOME}/configsets" || exit 1; \
+    chown -R ${SOLR_USER}:${SOLR_GROUP} ${SOLR_HOME}; \
+    chown -R ${SOLR_USER}:${SOLR_GROUP} /var/solr
 
-# Init as solr
+# Add health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+    CMD curl -f http://${SOLR_HOST}:${SOLR_PORT}/solr/series/admin/ping && \
+        curl -f http://${SOLR_HOST}:${SOLR_PORT}/solr/genealogy/admin/ping && \
+        curl -f http://${SOLR_HOST}:${SOLR_PORT}/solr/grouped_works_v2/admin/ping && \
+        curl -f http://${SOLR_HOST}:${SOLR_PORT}/solr/lists/admin/ping && \
+        curl -f http://${SOLR_HOST}:${SOLR_PORT}/solr/course_reserves/admin/ping && \
+        curl -f http://${SOLR_HOST}:${SOLR_PORT}/solr/open_archives/admin/ping && \
+        curl -f http://${SOLR_HOST}:${SOLR_PORT}/solr/website_pages/admin/ping && \
+        curl -f http://${SOLR_HOST}:${SOLR_PORT}/solr/events/admin/ping || exit 1
+
+# Switch to non-root user
 USER ${SOLR_USER}
-
-# Init in SolR home
 WORKDIR ${SOLR_HOME}


### PR DESCRIPTION
Currently, the Solr service is ending abruptly because of the solr.xml is copied in to $SOLR_HOME/configsets instead of $SOLR_HOME.

This development will fix that issue. Also, it will add a healthcheck to see if the cores are responding properly.

Finally, both host and port will be parameterized