### PR TITLE
DIS-1415: Fixed Sytem Messages Not Displaying Due to Library System Messages

### DIFF
--- a/code/web/index.php
+++ b/code/web/index.php
@@ -803,7 +803,7 @@ if (!$isAJAX) {
 			$librarySystemMessage->setPreFormattedMessage($library->systemMessage);
 			$systemMessages[] = $librarySystemMessage;
 		}
-		$systemMessages += SystemMessage::getActiveSystemMessages();
+		$systemMessages = array_merge($systemMessages, SystemMessage::getActiveSystemMessages());
 
 		$interface->assign('systemMessages', $systemMessages);
 	} catch (Exception $e) {

--- a/code/web/release_notes/25.10.00.MD
+++ b/code/web/release_notes/25.10.00.MD
@@ -189,6 +189,7 @@
 - Fixed an issue where uploaded images, in particular the Logo within the Theme settings, were unproportionally enlarged. (DIS-1374) (*LS*)
 - Improved `oneToMany.tpl` to support per-instance readonly field conditions and automatic max/min constraint application for integer fields, allowing individual items to have different readonly states with dynamic tooltips populated through `readOnlyReason` attributes across form element types. (DIS-1160) (*LS*)
 - Fixed an issue where Themes settings would be cross contaminated during updates to CSS for all Themes. (DIS-1377) (*LS*)
+- Resolved an issue where System Messages may not display for libraries using the Legacy System Message in Library System settings. (DIS-1415) (*LS*)
 
 //yanjun
 ### Hoopla Updates


### PR DESCRIPTION
- Fixed an issue where System Messages may not display for libraries using the Legacy System Message in Library System settings.