### PR TITLE
DIS-1396: More Standardization of Original Cover URLs

### DIFF
--- a/code/web/interface/themes/responsive/Axis360/full-record.tpl
+++ b/code/web/interface/themes/responsive/Axis360/full-record.tpl
@@ -17,7 +17,7 @@
 			<div class="col-xs-4 col-sm-5 col-md-4 col-lg-3 text-center">
 				{if $disableCoverArt != 1}
 					<div id="recordCover" class="text-center row">
-						<a href="#" onclick="return AspenDiscovery.Axis360.getLargeCover('{$recordDriver->getUniqueID()}')"><img alt="{translate text='Book Cover' inAttribute=true isPublicFacing=true}" class="img-thumbnail {$coverStyle}" src="{$recordDriver->getBookcoverUrl('medium')}"></a>
+						<a href="#" onclick="return AspenDiscovery.Axis360.getLargeCover('{$recordDriver->getUniqueID()}')"><img alt="{translate text='Book Cover' inAttribute=true isPublicFacing=true}" class="img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" src="{$recordDriver->getBookcoverUrl('medium')}"></a>
 					</div>
 				{/if}
 				{if !empty($showRatings)}

--- a/code/web/interface/themes/responsive/EBSCO/researchStarter.tpl
+++ b/code/web/interface/themes/responsive/EBSCO/researchStarter.tpl
@@ -12,7 +12,7 @@
 			<div class="col-tn-12 col-xs-4 col-md-3 text-center">
 				{if !empty($image)}
 					<a href="{$link}" target="_blank" class="researchStarter-link"  aria-label="{$title} ({translate text='opens in new window' isPublicFacing=true})">
-					<img src="{$image}" class="researchStarter-image img-thumbnail {$coverStyle}" alt="{$title}">
+					<img src="{$image}" class="researchStarter-image img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" alt="{$title}">
 					</a>
 				{/if}
 			</div>

--- a/code/web/interface/themes/responsive/ExternalEContent/full-record.tpl
+++ b/code/web/interface/themes/responsive/ExternalEContent/full-record.tpl
@@ -17,7 +17,7 @@
 			<div class="col-xs-4 col-sm-5 col-md-4 col-lg-3 text-center">
 				{if $disableCoverArt != 1}
 					<div id="recordCover" class="text-center row">
-						<img alt="{translate text='Book Cover' isPublicFacing=true inAttribute=true}" class="img-thumbnail {$coverStyle}" src="{$recordDriver->getBookcoverUrl('medium')}">
+						<img alt="{translate text='Book Cover' isPublicFacing=true inAttribute=true}" class="img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" src="{$recordDriver->getBookcoverUrl('medium')}">
 					</div>
 				{/if}
 				{if !empty($showRatings)}

--- a/code/web/interface/themes/responsive/GroupedWork/full-record.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/full-record.tpl
@@ -20,7 +20,7 @@
 			<div class="col-xs-4 col-sm-5 col-md-4 col-lg-3 text-center">
 				{if $disableCoverArt != 1}
 					<div id="recordCover" class="text-center row">
-						<a href="#" onclick="return AspenDiscovery.GroupedWork.getLargeCover('{$recordDriver->getPermanentId()}')"><img alt="{translate text='Book Cover' isPublicFacing=true inAttribute=true}" class="img-thumbnail {$coverStyle}" src="{$recordDriver->getBookcoverUrl('medium')}"></a>
+						<a href="#" onclick="return AspenDiscovery.GroupedWork.getLargeCover('{$recordDriver->getPermanentId()}')"><img alt="{translate text='Book Cover' isPublicFacing=true inAttribute=true}" class="img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" src="{$recordDriver->getBookcoverUrl('medium')}"></a>
 					</div>
 				{/if}
 				{if !empty($showRatings)}

--- a/code/web/interface/themes/responsive/GroupedWork/previewRelatedCover.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/previewRelatedCover.tpl
@@ -6,7 +6,7 @@
 		<input type="hidden" name="method" value="setRelatedCover"/>
 		<div class="form-group">
 			<div id="recordCover" class="text-center row">
-				<img alt="{translate text='Book Cover' inAttribute=true isPublicFacing=true}" class="img-thumbnail {$coverStyle}" src="/bookcover.php?id={$recordId}&size=medium&type={$recordType}">
+				<img alt="{translate text='Book Cover' inAttribute=true isPublicFacing=true}" class="img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" src="/bookcover.php?id={$recordId}&size=medium&type={$recordType}">
 			</div>
 
 		</div>

--- a/code/web/interface/themes/responsive/GroupedWork/relatedRecords.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/relatedRecords.tpl
@@ -3,7 +3,7 @@
 		<div class="relatedRecord row striped-{cycle values="odd,even"} {if !empty($promptAlternateEdition) && $index===0} danger{/if}" style="padding:1px">
 			{if !empty($showEditionCovers) && $showEditionCovers == 1}
 				<div class="col-tn-2 col-md-2 col-lg-2">
-					<img src="{$relatedRecord->getBookcoverUrl('small')}" class="img-thumbnail {$coverStyle}" alt="{translate text='Book Cover' inAttribute=true isPublicFacing=true}">
+					<img src="{$relatedRecord->getBookcoverUrl('small')}" class="img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" alt="{translate text='Book Cover' inAttribute=true isPublicFacing=true}">
 				</div>
 			{/if}
 

--- a/code/web/interface/themes/responsive/GroupedWork/similarTitlesNovelist.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/similarTitlesNovelist.tpl
@@ -5,7 +5,7 @@
 			<div class="novelist-similar-item row">
 				<div class="coversColumn col-xs-3 col-sm-3 col-md-3 col-lg-2 text-center" aria-hidden="true" role="presentation">
 					{if isset($similarTitle.fullRecordLink)}
-						<a href='{$similarTitle.fullRecordLink}'><img src="{$similarTitle.smallCover}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}" class="listResultImage img-thumbnail {$coverStyle}"/></a>
+						<a href='{$similarTitle.fullRecordLink}'><img src="{$similarTitle.smallCover}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}"/></a>
 					{/if}
 				</div>
 				<div class="col-xs-9 col-lg-10">

--- a/code/web/interface/themes/responsive/GroupedWork/whileYouWait.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/whileYouWait.tpl
@@ -6,7 +6,7 @@
 		{foreach from=$whileYouWaitTitles item=whileYouWaitTitle}
 			<div class="col-tn-12 col-sm-4 text-center">
 				<a href="{$whileYouWaitTitle.url}">
-					<img src="{$whileYouWaitTitle.coverUrl}" class="listResultImage img-thumbnail {$coverStyle}" alt="{$whileYouWaitTitle.title|escape}">
+					<img src="{$whileYouWaitTitle.coverUrl}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" alt="{$whileYouWaitTitle.title|escape}">
 				</a>
 				{if !empty($showRatings)}
 					<div class="browse-rating rater" data-average_rating="{$whileYouWaitTitle.ratingData.average}" data-id="{$whileYouWaitTitle.id}">

--- a/code/web/interface/themes/responsive/GroupedWork/youMightAlsoLike.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/youMightAlsoLike.tpl
@@ -8,7 +8,7 @@
 				<div class="row">
 					<div class="col-tn-12">
 						<a href="{$title->getLinkUrl()}">
-							<img src="{$title->getBookcoverUrl('medium')}" class="listResultImage img-thumbnail {$coverStyle}" alt="{$title->getTitle()|escape}">
+							<img src="{$title->getBookcoverUrl('medium')}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" alt="{$title->getTitle()|escape}">
 						</a>
 					</div>
 				</div>

--- a/code/web/interface/themes/responsive/Hoopla/full-record.tpl
+++ b/code/web/interface/themes/responsive/Hoopla/full-record.tpl
@@ -18,7 +18,7 @@
 			<div class="col-xs-4 col-sm-5 col-md-4 col-lg-3 text-center">
 				{if $disableCoverArt != 1}
 					<div id="recordCover" class="text-center row">
-						<a href="#" onclick="return AspenDiscovery.Hoopla.getLargeCover('{$recordDriver->getUniqueID()}')"><img alt="{translate text='Book Cover' isPublicFacing=true inAttribute=true}" class="img-thumbnail {$coverStyle}" src="{$recordDriver->getBookcoverUrl('medium')}"></a>
+						<a href="#" onclick="return AspenDiscovery.Hoopla.getLargeCover('{$recordDriver->getUniqueID()}')"><img alt="{translate text='Book Cover' isPublicFacing=true inAttribute=true}" class="img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" src="{$recordDriver->getBookcoverUrl('medium')}"></a>
 					</div>
 				{/if}
 				{if !empty($showRatings)}

--- a/code/web/interface/themes/responsive/MaterialsRequest/request-form-fields.tpl
+++ b/code/web/interface/themes/responsive/MaterialsRequest/request-form-fields.tpl
@@ -372,7 +372,7 @@
 			<div class="row">
 				<div class="col-sm-3">
 					<div id="existingTitleForRequestCover">
-						<div class="text-center row"><a href="" target="_blank"><img alt="Book Cover" class="img-thumbnail floating" src="/bookcover.php?id=cca5af54-2d1b-e8fe-f93e-789dcbfdfe59-eng&amp;size=medium&amp;type=grouped_work&amp;category=eBook"></a></div>
+						<div class="text-center row"><a href="" target="_blank"><img alt="Book Cover" class="img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} floating" src="/bookcover.php?id=cca5af54-2d1b-e8fe-f93e-789dcbfdfe59-eng&amp;size=medium&amp;type=grouped_work&amp;category=eBook"></a></div>
 					</div>
 				</div>
 				<div class="col-sm-9">

--- a/code/web/interface/themes/responsive/MyAccount/axis360CheckedOutTitle.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/axis360CheckedOutTitle.tpl
@@ -16,10 +16,10 @@
 							{if $record->getCoverUrl()}
 								{if $record->recordId && $record->getLinkUrl()}
 									<a href="{$record->getLinkUrl()}" id="descriptionTrigger{$record->recordId|escape:"url"}" aria-hidden="true">
-										<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+										<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 									</a>
 								{else} {* Cover Image but no Record-View link *}
-									<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}" aria-hidden="true">
+									<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}" aria-hidden="true">
 								{/if}
 							{/if}
 						{/if}

--- a/code/web/interface/themes/responsive/MyAccount/axis360Hold.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/axis360Hold.tpl
@@ -11,10 +11,10 @@
 					{if $record->getCoverUrl()}
 						{if $record->recordId && $record->getLinkUrl()}
 							<a href="{$record->getLinkUrl()}" id="descriptionTrigger{$record->recordId|escape:"url"}" aria-hidden="true">
-								<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+								<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 							</a>
 						{else} {* Cover Image but no Record-View link *}
-							<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}" aria-hidden="true">
+							<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}" aria-hidden="true">
 						{/if}
 					{/if}
 				</div>

--- a/code/web/interface/themes/responsive/MyAccount/cloudLibraryCheckedOutTitle.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/cloudLibraryCheckedOutTitle.tpl
@@ -16,10 +16,10 @@
 							{if $record->getCoverUrl()}
 								{if $record->recordId && $record->getLinkUrl()}
 									<a href="{$record->getLinkUrl()}" id="descriptionTrigger{$record->recordId|escape:"url"}" aria-hidden="true">
-										<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+										<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 									</a>
 								{else} {* Cover Image but no Record-View link *}
-									<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}" aria-hidden="true">
+									<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}" aria-hidden="true">
 								{/if}
 							{/if}
 						{/if}

--- a/code/web/interface/themes/responsive/MyAccount/cloudLibraryHold.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/cloudLibraryHold.tpl
@@ -11,10 +11,10 @@
 					{if $record->getCoverUrl()}
 						{if $record->sourceId && $record->getLinkUrl()}
 							<a href="{$record->getLinkUrl()}" id="descriptionTrigger{$record->sourceId|escape:"url"}" aria-hidden="true">
-								<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+								<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 							</a>
 						{else} {* Cover Image but no Record-View link *}
-							<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}" aria-hidden="true">
+							<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}" aria-hidden="true">
 						{/if}
 					{/if}
 				</div>

--- a/code/web/interface/themes/responsive/MyAccount/curbsidePickupsHoldsReady.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/curbsidePickupsHoldsReady.tpl
@@ -9,12 +9,12 @@
 						{if !empty($record->getLinkUrl())}
 							<a href="{$record->getLinkUrl()}" id="descriptionTrigger{$record->recordId|escape:"url"}" aria-hidden="true">
 								<img src="{$record->getCoverUrl()}"
-									 class="listResultImage img-thumbnail img-responsive {$coverStyle}"
+									 class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} img-responsive {$coverStyle}"
 									 alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 							</a>
 						{else} {* Cover Image but no Record-View link *}
 							<img src="{$record->getCoverUrl()}"
-								 class="listResultImage img-thumbnail img-responsive {$coverStyle}"
+								 class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} img-responsive {$coverStyle}"
 								 alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}"
 								 aria-hidden="true">
 						{/if}

--- a/code/web/interface/themes/responsive/MyAccount/hooplaCheckedOutTitle.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/hooplaCheckedOutTitle.tpl
@@ -14,10 +14,10 @@
 							{if $record->getCoverUrl()}
 								{if $record->recordId && $record->getLinkUrl()}
 									<a href="{$record->getLinkUrl()}" id="descriptionTrigger{$record->recordId|escape:"url"}" aria-hidden="true">
-										<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+										<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 									</a>
 								{else} {* Cover Image but no Record-View link *}
-									<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}" aria-hidden="true">
+									<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}" aria-hidden="true">
 								{/if}
 							{/if}
 						{/if}

--- a/code/web/interface/themes/responsive/MyAccount/hooplaHold.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/hooplaHold.tpl
@@ -10,10 +10,10 @@
                     {if $record->getCoverUrl()}
                         {if $record->recordId && $record->getLinkUrl()}
                             <a href="{$record->getLinkUrl()}" id="descriptionTrigger{$record->recordId|escape:"url"}" aria-hidden="true">
-                                <img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+                                <img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
                             </a>
                         {else}
-                            <img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}" aria-hidden="true">
+                            <img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}" aria-hidden="true">
                         {/if}
                     {/if}
                 </div>

--- a/code/web/interface/themes/responsive/MyAccount/ilsCheckedOutTitle.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/ilsCheckedOutTitle.tpl
@@ -16,10 +16,10 @@
 							{if $record->getCoverUrl()}
 								{if $record->recordId && !empty($record->getLinkUrl())}
 									<a href="{$record->getLinkUrl()}" id="descriptionTrigger{$record->recordId|escape:"url"}" aria-hidden="true">
-										<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+										<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 									</a>
 								{else} {* Cover Image but no Record-View link *}
-									<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}" aria-hidden="true">
+									<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}" aria-hidden="true">
 								{/if}
 							{/if}
 						{/if}

--- a/code/web/interface/themes/responsive/MyAccount/ilsHold.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/ilsHold.tpl
@@ -18,12 +18,12 @@
 							<a href="{$record->getLinkUrl()}" id="descriptionTrigger{$record->recordId|escape:"url"}"
 							   aria-hidden="true">
 								<img src="{$record->getCoverUrl()}"
-									 class="listResultImage img-thumbnail img-responsive {$coverStyle}"
+									 class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} img-responsive {$coverStyle}"
 									 alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 							</a>
 						{else} {* Cover Image but no Record-View link *}
 							<img src="{$record->getCoverUrl()}"
-								 class="listResultImage img-thumbnail img-responsive {$coverStyle}"
+								 class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} img-responsive {$coverStyle}"
 								 alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}"
 								 aria-hidden="true">
 						{/if}

--- a/code/web/interface/themes/responsive/MyAccount/lists.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/lists.tpl
@@ -55,7 +55,7 @@
 				{if $showCovers == true}
 				<div class="coversColumn col-xs-3 col-sm-3 col-md-3 col-lg-2 text-center" aria-hidden="true" role="presentation">
 						<a href="/MyAccount/MyList/{$list->id}" class="alignleft listResultImage">
-							<img src="/bookcover.php?type=list&amp;id={$list->id}&amp;size=medium" class="listResultImage img-thumbnail {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+							<img src="/bookcover.php?type=list&amp;id={$list->id}&amp;size=medium" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 						</a>
 				</div>
 				{/if}

--- a/code/web/interface/themes/responsive/MyAccount/overdriveCheckedOutTitle.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/overdriveCheckedOutTitle.tpl
@@ -14,10 +14,10 @@
 							{if $record->getCoverUrl()}
 								{if $record->recordId && $record->getLinkUrl()}
 									<a href="{$record->getLinkUrl()}" id="descriptionTrigger{$record->recordId|escape:"url"}" aria-hidden="true">
-										<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+										<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 									</a>
 								{else} {* Cover Image but no Record-View link *}
-									<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}" aria-hidden="true">
+									<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}" aria-hidden="true">
 								{/if}
 							{/if}
 						{/if}

--- a/code/web/interface/themes/responsive/MyAccount/overdriveHold.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/overdriveHold.tpl
@@ -11,10 +11,10 @@
 					{if $record->getCoverUrl()}
 						{if $record->recordId && $record->getLinkUrl()}
 							<a href="{$record->getLinkUrl()}" id="descriptionTrigger{$record->recordId|escape:"url"}" aria-hidden="true">
-								<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+								<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 							</a>
 						{else} {* Cover Image but no Record-View link *}
-							<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}" aria-hidden="true">
+							<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}" aria-hidden="true">
 						{/if}
 					{/if}
 				</div>

--- a/code/web/interface/themes/responsive/MyAccount/palaceProjectCheckedOutTitle.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/palaceProjectCheckedOutTitle.tpl
@@ -14,10 +14,10 @@
 							{if $record->getCoverUrl()}
 								{if $record->recordId && $record->getLinkUrl()}
 									<a href="{$record->getLinkUrl()}" id="descriptionTrigger{$record->recordId|escapeCSS}" aria-hidden="true">
-										<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+										<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 									</a>
 								{else} {* Cover Image but no Record-View link *}
-									<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}" aria-hidden="true">
+									<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}" aria-hidden="true">
 								{/if}
 							{/if}
 						{/if}

--- a/code/web/interface/themes/responsive/MyAccount/palaceProjectHold.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/palaceProjectHold.tpl
@@ -10,10 +10,10 @@
 				{if $record->getCoverUrl()}
 					{if $record->recordId && $record->getLinkUrl()}
 						<a href="{$record->getLinkUrl()}" id="descriptionTrigger{$record->recordId||escapeCSS}" aria-hidden="true">
-							<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+							<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 						</a>
 					{else}  Cover Image but no Record-View link
-						<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}" aria-hidden="true">
+						<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}" aria-hidden="true">
 					{/if}
 				{/if}
 			</div>

--- a/code/web/interface/themes/responsive/MyAccount/readingHistoryEntry.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/readingHistoryEntry.tpl
@@ -5,10 +5,10 @@
 			{if !empty($record.coverUrl)}
 				{if !empty($record.recordId) && $record.linkUrl}
 					<a href="{$record.linkUrl}" id="descriptionTrigger{$record.recordId|escape:"url"}" aria-hidden="true">
-						<img src="{$record.coverUrl}" class="listResultImage img-thumbnail img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+						<img src="{$record.coverUrl}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 					</a>
 				{else} {* Cover Image but no Record-View link *}
-					<img src="{$record.coverUrl}" class="listResultImage img-thumbnail img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}" aria-hidden="true">
+					<img src="{$record.coverUrl}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}" aria-hidden="true">
 				{/if}
 			{/if}
 		</div>

--- a/code/web/interface/themes/responsive/MyAccount/vdxRequest.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/vdxRequest.tpl
@@ -11,10 +11,10 @@
 				{if !empty($record->getCoverUrl())}
 					{if !empty($record->getLinkUrl())}
 						<a href="{$record->getLinkUrl()}" id="descriptionTrigger{$record->recordId|escape:"url"}" aria-hidden="true">
-							<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+							<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 						</a>
 					{else} {* Cover Image but no Record-View link *}
-						<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}" aria-hidden="true">
+						<img src="{$record->getCoverUrl()}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}" aria-hidden="true">
 					{/if}
 				{/if}
 

--- a/code/web/interface/themes/responsive/OverDrive/full-record.tpl
+++ b/code/web/interface/themes/responsive/OverDrive/full-record.tpl
@@ -17,7 +17,7 @@
 			<div class="col-xs-4 col-sm-5 col-md-4 col-lg-3 text-center">
 				{if $disableCoverArt != 1}
 					<div id="recordCover" class="text-center row">
-						<a href="#" onclick="return AspenDiscovery.OverDrive.getLargeCover('{$recordDriver->getUniqueID()}')"><img alt="{translate text='Book Cover' isPublicFacing=true inAttribute=true}" class="img-thumbnail {$coverStyle}" src="{$recordDriver->getBookcoverUrl('medium')}"></a>
+						<a href="#" onclick="return AspenDiscovery.OverDrive.getLargeCover('{$recordDriver->getUniqueID()}')"><img alt="{translate text='Book Cover' isPublicFacing=true inAttribute=true}" class="img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" src="{$recordDriver->getBookcoverUrl('medium')}"></a>
 					</div>
 				{/if}
 				{if !empty($showRatings)}

--- a/code/web/interface/themes/responsive/PalaceProject/full-record.tpl
+++ b/code/web/interface/themes/responsive/PalaceProject/full-record.tpl
@@ -17,7 +17,7 @@
 			<div class="col-xs-4 col-sm-5 col-md-4 col-lg-3 text-center">
 				{if $disableCoverArt != 1}
 					<div id="recordCover" class="text-center row">
-						<a href="#" onclick="return AspenDiscovery.PalaceProject.getLargeCover('{$recordDriver->getUniqueID()}')"><img alt="{translate text='Book Cover' inAttribute=true isPublicFacing=true}" class="img-thumbnail {$coverStyle}" src="{$recordDriver->getBookcoverUrl('medium')}"></a>
+						<a href="#" onclick="return AspenDiscovery.PalaceProject.getLargeCover('{$recordDriver->getUniqueID()}')"><img alt="{translate text='Book Cover' inAttribute=true isPublicFacing=true}" class="img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" src="{$recordDriver->getBookcoverUrl('medium')}"></a>
 					</div>
 				{/if}
 				{if !empty($showRatings)}

--- a/code/web/interface/themes/responsive/Record/full-record.tpl
+++ b/code/web/interface/themes/responsive/Record/full-record.tpl
@@ -32,7 +32,7 @@
 				<div class="col-xs-4 col-sm-5 col-md-4 col-lg-3 text-center">
 					{if $disableCoverArt != 1}
 						<div id="recordCover" class="text-center row">
-							<img alt="{translate text='Book Cover' isPublicFacing=true inAttribute=true}" class="img-thumbnail {$coverStyle}" src="{$recordDriver->getBookcoverUrl('medium')}">
+							<img alt="{translate text='Book Cover' isPublicFacing=true inAttribute=true}" class="img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" src="{$recordDriver->getBookcoverUrl('medium')}">
 						</div>
 					{/if}
 					{if !empty($showRatings)}

--- a/code/web/interface/themes/responsive/Record/hold-popup.tpl
+++ b/code/web/interface/themes/responsive/Record/hold-popup.tpl
@@ -212,7 +212,7 @@
 															<input type="radio" name="editionOption" id="editionOption{$edition->databaseId}" value="{$edition->id}" {if $smarty.foreach.editions.index == 0}checked{/if}> {translate text="Select This Edition" isPublicFacing=true}
 														</div>
 														<div class="edition-cover">
-															<img src="{$relatedRecord->getBookcoverUrl('small')}" class="img-thumbnail {$coverStyle}" alt="{translate text='Book Cover' inAttribute=true isPublicFacing=true}">
+															<img src="{$relatedRecord->getBookcoverUrl('small')}" class="img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" alt="{translate text='Book Cover' inAttribute=true isPublicFacing=true}">
 														</div>
 														<div class="edition-data">
 															{$edition->publicationDate}. {$edition->publisher}. {$edition->physical}.<br/>

--- a/code/web/interface/themes/responsive/RecordDrivers/CourseReserve/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/CourseReserve/listEntry.tpl
@@ -10,7 +10,7 @@
 			<div class="col-xs-3 col-sm-3 col-md-3 col-lg-2 text-center">
 				{if $disableCoverArt != 1}
 					<a href="/MyAccount/MyList/{$summShortId}" class="alignleft listResultImage">
-						<img src="{$bookCoverUrl}" class="listResultImage img-thumbnail {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+						<img src="{$bookCoverUrl}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 					</a>
 				{/if}
 			</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/CourseReserve/result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/CourseReserve/result.tpl
@@ -4,7 +4,7 @@
 		<div class="coversColumn col-xs-3 col-sm-3 col-md-3 col-lg-2 text-center" aria-hidden="true" role="presentation">
 			{if $disableCoverArt != 1}
 				<a href="/CourseReserves/{$summShortId}" class="alignleft listResultImage" tabindex="-1">
-					<img src="{$bookCoverUrl}" class="listResultImage img-thumbnail {$coverStyle}" alt="{$summTitle|removeTrailingPunctuation|highlight|escapeCSS|truncate:180:"..."}">
+					<img src="{$bookCoverUrl}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" alt="{$summTitle|removeTrailingPunctuation|highlight|escapeCSS|truncate:180:"..."}">
 				</a>
 			{/if}
 		</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/EBSCO/combinedResult.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/EBSCO/combinedResult.tpl
@@ -4,7 +4,7 @@
 		<div class="coversColumn col-xs-3 text-center">
 			{if $disableCoverArt != 1}
 				<a href="{$summUrl}" aria-hidden="true">
-					<img src="{$bookCoverUrl}" class="listResultImage img-thumbnail {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+					<img src="{$bookCoverUrl}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 				</a>
 			{/if}
 		</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/EBSCO/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/EBSCO/listEntry.tpl
@@ -10,7 +10,7 @@
 			<div class="col-xs-3 col-sm-3 col-md-3 col-lg-2 text-center">
 				{if $disableCoverArt != 1 && !empty($bookCoverUrlMedium)}
 					<a href="{$summUrl}" onclick="AspenDiscovery.EBSCO.trackEdsUsage('{$summId}')" target="_blank" aria-hidden="true">
-						<img src="{$bookCoverUrlMedium}" class="listResultImage img-thumbnail {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+						<img src="{$bookCoverUrlMedium}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 					</a>
 				{/if}
 			</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/EBSCO/result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/EBSCO/result.tpl
@@ -5,9 +5,9 @@
 			{if $disableCoverArt != 1 && !empty($bookCoverUrlMedium)}
 				<a href="{$summUrl}" onclick="AspenDiscovery.EBSCO.trackEdsUsage('{$summId}')" target="_blank" aria-hidden="true">
 					{if !empty($libKeyCoverImageUrl) && !$retracted}
-						<img src="{$libKeyCoverImageUrl}" class="listResultImage img-thumbnail {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+						<img src="{$libKeyCoverImageUrl}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 					{else}
-						<img src="{$bookCoverUrlMedium}" class="listResultImage img-thumbnail {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+						<img src="{$bookCoverUrlMedium}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 					{/if}
 				</a>
 			{/if}

--- a/code/web/interface/themes/responsive/RecordDrivers/EBSCOhost/combinedResult.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/EBSCOhost/combinedResult.tpl
@@ -4,7 +4,7 @@
 		<div class="coversColumn col-xs-3 text-center">
 			{if $disableCoverArt != 1}
 				<a href="{$summUrl}" aria-hidden="true">
-					<img src="{$bookCoverUrl}" class="listResultImage img-thumbnail {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+					<img src="{$bookCoverUrl}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 				</a>
 			{/if}
 		</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/EBSCOhost/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/EBSCOhost/listEntry.tpl
@@ -10,7 +10,7 @@
 			<div class="col-xs-3 col-sm-3 col-md-3 col-lg-2 text-center">
 				{if $disableCoverArt != 1 && !empty($bookCoverUrlMedium)}
 					<a href="{$summUrl}" target="_blank" aria-hidden="true">
-						<img src="{$bookCoverUrlMedium}" class="listResultImage img-thumbnail {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+						<img src="{$bookCoverUrlMedium}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 					</a>
 				{/if}
 			</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/EBSCOhost/result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/EBSCOhost/result.tpl
@@ -5,9 +5,9 @@
 			{if $disableCoverArt != 1 && !empty($bookCoverUrlMedium)}
 				<a href="{$summUrl}" onclick="AspenDiscovery.EBSCO.trackEdsUsage('{$summId}')" target="_blank" aria-hidden="true">
 					{if !empty($libKeyCoverImageUrl) && !$retracted}
-						<img src="{$libKeyCoverImageUrl}" class="listResultImage img-thumbnail {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+						<img src="{$libKeyCoverImageUrl}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 					{else}
-						<img src="{$bookCoverUrlMedium}" class="listResultImage img-thumbnail {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+						<img src="{$bookCoverUrlMedium}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 					{/if}
 				</a>
 			{/if}

--- a/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/combinedResult.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/combinedResult.tpl
@@ -10,7 +10,7 @@
 				<div class="coversColumn col-xs-3 text-center">
 					{if $disableCoverArt != 1}
 						<a href="{$summUrl}" aria-hidden="true">
-							<img src="{$bookCoverUrl}" class="listResultImage img-thumbnail {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+							<img src="{$bookCoverUrl}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 						</a>
 					{/if}
 				</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/courseReserveEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/courseReserveEntry.tpl
@@ -4,7 +4,7 @@
 		{if !empty($showCovers)}
 			<div class="col-xs-3 col-sm-3 col-md-3 col-lg-2 text-center">
 				<a href="{$summUrl}" aria-hidden="true">
-					<img src="{$bookCoverUrlMedium}" class="listResultImage img-thumbnail{* img-responsive*} {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+					<img src="{$bookCoverUrlMedium}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if}{* img-responsive*} {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 				</a>
 				{if !empty($showRatings)}
 					{include file="GroupedWork/title-rating.tpl" id=$summId ratingData=$summRating showNotInterested=false}

--- a/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/listEntry.tpl
@@ -9,7 +9,7 @@
 		{if (!empty($showCovers) && $printInterface === false) || ($printInterface === true && $printEntryCovers === true)}
 			<div class="col-xs-3 col-sm-3 col-md-3 col-lg-2 text-center">
 				<a href="{$summUrl}" aria-hidden="true">
-					<img src="{$bookCoverUrlMedium}" class="listResultImage img-thumbnail{* img-responsive*} {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+					<img src="{$bookCoverUrlMedium}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if}{* img-responsive*} {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 				</a>
 				{if (!empty($showRatings) && $printInterface === false) || ($printInterface === true && $printEntryRating === true)}
 					{include file="GroupedWork/title-rating.tpl" id=$summId ratingData=$summRating showNotInterested=false}

--- a/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/seriesEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/seriesEntry.tpl
@@ -4,7 +4,7 @@
 			{if !empty($showCovers)}
 				<div class="col-xs-3 col-sm-3 col-md-3 col-lg-2 text-center">
 					<a href="{$summUrl}" aria-hidden="true">
-						<img src="{$bookCoverUrlMedium}" class="listResultImage img-thumbnail{* img-responsive*} {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+						<img src="{$bookCoverUrlMedium}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if}{* img-responsive*} {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 					</a>
 				</div>
 			{/if}

--- a/code/web/interface/themes/responsive/RecordDrivers/Index/combinedResult.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Index/combinedResult.tpl
@@ -10,7 +10,7 @@
 				<div class="coversColumn col-xs-3 text-center">
 					{if $disableCoverArt != 1}
 						<a href="{$summUrl}" aria-hidden="true">
-							<img src="{$bookCoverUrl}" class="listResultImage img-thumbnail {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+							<img src="{$bookCoverUrl}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 						</a>
 					{/if}
 				</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/List/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/List/listEntry.tpl
@@ -10,7 +10,7 @@
 			<div class="col-xs-3 col-sm-3 col-md-3 col-lg-2 text-center">
 				{if $disableCoverArt != 1}
 					<a href="/MyAccount/MyList/{$summShortId}" class="alignleft listResultImage">
-						<img src="{$bookCoverUrl}" class="listResultImage img-thumbnail {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+						<img src="{$bookCoverUrl}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 					</a>
 				{/if}
 			</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/List/result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/List/result.tpl
@@ -4,7 +4,7 @@
 		<div class="coversColumn col-xs-3 col-sm-3 col-md-3 col-lg-2 text-center" aria-hidden="true" role="presentation">
 			{if $disableCoverArt != 1}
 				<a href="/MyAccount/MyList/{$summShortId}" class="alignleft listResultImage" tabindex="-1">
-					<img src="{$bookCoverUrl}" class="listResultImage img-thumbnail {$coverStyle}" alt="{$summTitle|removeTrailingPunctuation|highlight|escapeCSS|truncate:180:"..."}">
+					<img src="{$bookCoverUrl}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" alt="{$summTitle|removeTrailingPunctuation|highlight|escapeCSS|truncate:180:"..."}">
 				</a>
 			{/if}
 		</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/OpenArchives/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/OpenArchives/listEntry.tpl
@@ -10,7 +10,7 @@
 			<div class="col-xs-3 col-sm-3 col-md-3 col-lg-2 text-center">
 				{if $disableCoverArt != 1}
 					<a href="{$openArchiveUrl}" class="alignleft listResultImage" onclick="AspenDiscovery.OpenArchives.trackUsage('{$id}')" target="_blank" aria-hidden="true">
-						<img src="{$bookCoverUrl}" class="listResultImage img-thumbnail {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+						<img src="{$bookCoverUrl}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 					</a>
 				{/if}
 			</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/OpenArchives/result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/OpenArchives/result.tpl
@@ -4,7 +4,7 @@
 		<div class="coversColumn col-xs-3 col-sm-3 col-md-3 col-lg-2 text-center" aria-hidden="true" role="presentation">
 			{if $disableCoverArt != 1}
 				<a href="{$openArchiveUrl}" class="alignleft listResultImage" onclick="AspenDiscovery.OpenArchives.trackUsage('{$id}')" target="_blank" tabindex="-1">
-					<img src="{$bookCoverUrl}" class="listResultImage img-thumbnail {$coverStyle}" alt="{$title|removeTrailingPunctuation|highlight|truncate:180:"..."}">
+					<img src="{$bookCoverUrl}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" alt="{$title|removeTrailingPunctuation|highlight|truncate:180:"..."}">
 				</a>
 			{/if}
 		</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/Series/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Series/listEntry.tpl
@@ -11,7 +11,7 @@
 				{if $disableCoverArt != 1}
 					<a href="/MyAccount/MyList/{$summShortId}" class="alignleft listResultImage">
 						{if !empty($isNew)}<span class="list-cover-badge">{translate text="New!" isPublicFacing=true}</span> {/if}
-						<img src="{$bookCoverUrl}" class="listResultImage img-thumbnail {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+						<img src="{$bookCoverUrl}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 					</a>
 				{/if}
 			</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/Series/result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Series/result.tpl
@@ -6,7 +6,7 @@
 				<a href="/Series/{$summShortId}" class="alignleft listResultImage" tabindex="-1">
 					<div class="listResultImage border">
 						{if !empty($isNew)}<span class="list-cover-badge">{translate text="New!" isPublicFacing=true}</span> {/if}
-						<img src="{$bookCoverUrl}" class="img-thumbnail {$coverStyle}" alt="{$summTitle|removeTrailingPunctuation|highlight|escapeCSS|truncate:180:"..."}">
+						<img src="{$bookCoverUrl}" class="img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" alt="{$summTitle|removeTrailingPunctuation|highlight|escapeCSS|truncate:180:"..."}">
 					</div>
 				</a>
 			{/if}

--- a/code/web/interface/themes/responsive/RecordDrivers/Summon/combinedResult.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Summon/combinedResult.tpl
@@ -4,7 +4,7 @@
 		<div class="coversColumn col-xs-3 text-center">
 			{if $disableCoverArt != 1}
 				<a href="{$summUrl}" aria-hidden="true">
-					<img src="{$bookCoverUrl}" class="listResultImage img-thumbnail {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+					<img src="{$bookCoverUrl}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 				</a>
 			{/if}
 		</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/Summon/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Summon/listEntry.tpl
@@ -10,7 +10,7 @@
 				<div class="col-xs-3 col-sm-3 col-md-3 col-lg-2 text-center">
 					{if $disableCoverArt != 1 && !empty($bookCoverUrlMedium)}
 						<a href="{$summUrl}" target="_blank" aria-hidden="true">
-							<img src="{$bookCoverUrlMedium}" class="listResultImage img-thumbnail {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+							<img src="{$bookCoverUrlMedium}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 						</a>
 					{/if}
 				</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/Summon/result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Summon/result.tpl
@@ -4,7 +4,7 @@
 		<div class="coversColumn col-xs-3 col-sm-3{if empty($viewingCombinedResults)} col-md-3 col-lg-2{/if} text-center" aria-hidden="true" role="presentation">
 			{if $disableCoverArt != 1 && !empty($bookCoverUrlMedium)}
 				<a href="{$summUrl}" onclick="AspenDiscovery.Summon.trackSummonUsage('{$summId}')" target="_blank" aria-hidden="true">
-					<img src="{$bookCoverUrlMedium}" class="listResultImage img-thumbnail {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+					<img src="{$bookCoverUrlMedium}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 				</a>
 			{/if}
 		</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/Talpa/result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Talpa/result.tpl
@@ -11,7 +11,7 @@
 			{if !empty($showCovers)}
 				<div class="coversColumn col-xs-3 col-sm-3{if !empty($viewingCombinedResults)} col-md-3 col-lg-2{/if} text-center" aria-hidden="true" role="presentation">
 					{if $disableCoverArt != 1}
-						<div class="listResultImage img-thumbnail {$coverStyle}">
+						<div class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}">
 							<a href="{$summUrl}" tabindex="-1">
 								{if !empty($isNew)}<span class="list-cover-badge">{translate text="New!" isPublicFacing=true}</span> {/if}
 								<img src="{$bookCoverUrlMedium}" alt="{$summTitle|removeTrailingPunctuation|escapeCSS|truncate:25:'...'}" title="{$summTitle|removeTrailingPunctuation|escapeCSS}">

--- a/code/web/interface/themes/responsive/RecordDrivers/WebPage/result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/WebPage/result.tpl
@@ -4,7 +4,7 @@
 		<div class="coversColumn col-xs-3 col-sm-3 col-md-3 col-lg-2 text-center" aria-hidden="true" role="presentation">
 			{if $disableCoverArt != 1}
 				<a href="{$pageUrl}" class="alignleft listResultImage" onclick="AspenDiscovery.Websites.trackUsage('{$id}')" tabindex="-1">
-					<img src="{$bookCoverUrl}" class="listResultImage img-thumbnail {$coverStyle}" alt="{$title|removeTrailingPunctuation|highlight|truncate:180:"..."}">
+					<img src="{$bookCoverUrl}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" alt="{$title|removeTrailingPunctuation|highlight|truncate:180:"..."}">
 				</a>
 			{/if}
 		</div>

--- a/code/web/interface/themes/responsive/Search/dplaCombinedResults.tpl
+++ b/code/web/interface/themes/responsive/Search/dplaCombinedResults.tpl
@@ -8,7 +8,7 @@
 							{if $disableCoverArt != 1}
 								{if !empty($result.object)}
 									<a href="{$result.link}">
-										<img src="{$result.object}" class="listResultImage img-thumbnail {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+										<img src="{$result.object}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 									</a>
 								{/if}
 							{/if}

--- a/code/web/interface/themes/responsive/Search/dplaResults.tpl
+++ b/code/web/interface/themes/responsive/Search/dplaResults.tpl
@@ -9,7 +9,7 @@
 					<div class="col-xs-2">
 						{if !empty($result.object)}
 							<a href="{$result.link}" aria-hidden="true">
-								<img src="{$result.object}" class="listResultImage img-thumbnail img-responsive {$coverStyle}" alt="{$result.title}{if !empty($result.publisher)} {translate text="from" isPublicFacing=true} {$result.publisher}{/if}"/>
+								<img src="{$result.object}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} img-responsive {$coverStyle}" alt="{$result.title}{if !empty($result.publisher)} {translate text="from" isPublicFacing=true} {$result.publisher}{/if}"/>
 							</a>
 						{/if}
 					</div>

--- a/code/web/interface/themes/responsive/Series/placeholderListEntry.tpl
+++ b/code/web/interface/themes/responsive/Series/placeholderListEntry.tpl
@@ -10,7 +10,7 @@
 				<div class="col-xs-3 col-sm-3 col-md-3 col-lg-2 text-center">
 					{if $disableCoverArt != 1 && !empty($bookCoverUrl)}
 						<div>
-							<img src="{$bookCoverUrl}" class="listResultImage img-thumbnail {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+							<img src="{$bookCoverUrl}" class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 						</div>
 					{/if}
 				</div>

--- a/code/web/interface/themes/responsive/Series/seriesMembers.tpl
+++ b/code/web/interface/themes/responsive/Series/seriesMembers.tpl
@@ -8,7 +8,7 @@
 					<h1 id="listTitle">{$series->displayName|escape:"html"}</h1>
 					<div class="row">
 						<div class="col-xs-3 col-sm-3 col-md-3 col-lg-2 text-center">
-							<img class="listResultImage img-thumbnail {$coverStyle}" src='{$cover}' alt='{translate text='Series Cover' inAttribute=true isPublicFacing=true}'/>
+							<img class="listResultImage img-thumbnail{if $useOriginalCoverUrls} use-original-covers{/if} {$coverStyle}" src='{$cover}' alt='{translate text='Series Cover' inAttribute=true isPublicFacing=true}'/>
 						</div>
 						<div class="col-xs-9 col-sm-9 col-md-9 col-lg-10">
 							{if !empty($authors)}

--- a/code/web/interface/themes/responsive/css/bootstrap/less/scaffolding.less
+++ b/code/web/interface/themes/responsive/css/bootstrap/less/scaffolding.less
@@ -94,6 +94,13 @@ img {
     padding: 0;
     margin: 0 0 1.5em;
   }
+
+  &.use-original-covers {
+    max-width: 180px;
+    max-height: 225px;
+    width: auto;
+    height: auto;
+  }
 }
 
 // Perfect circle

--- a/code/web/interface/themes/responsive/css/bootstrap/less/scaffolding.less
+++ b/code/web/interface/themes/responsive/css/bootstrap/less/scaffolding.less
@@ -103,6 +103,53 @@ img {
   }
 }
 
+.listEntry .use-original-covers,
+.result .use-original-covers {
+  max-width: 120px;
+  max-height: 180px;
+}
+// Show Editions view
+.relatedRecord .use-original-covers {
+  max-width: 90px;
+  max-height: 135px;
+}
+
+@media (min-width: @screen-sm-min) and (max-width: @screen-sm-max) {
+  .listEntry .use-original-covers,
+  .result .use-original-covers {
+    max-width: 100px;
+    max-height: 150px;
+  }
+  .relatedRecord .use-original-covers {
+    max-width: 80px;
+    max-height: 120px;
+  }
+}
+
+@media (min-width: @screen-md-min) and (max-width: @screen-md-max) {
+  .listEntry .use-original-covers,
+  .result .use-original-covers {
+    max-width: 105px;
+    max-height: 165px;
+  }
+  .relatedRecord .use-original-covers {
+    max-width: 85px;
+    max-height: 128px;
+  }
+}
+
+@media (max-width: @screen-xs-max) {
+  .listEntry .use-original-covers,
+  .result .use-original-covers {
+    max-width: 80px;
+    max-height: 120px;
+  }
+  .relatedRecord .use-original-covers {
+    max-width: 70px;
+    max-height: 105px;
+  }
+}
+
 // Perfect circle
 .img-circle {
   border-radius: 50%; // set radius in percents

--- a/code/web/interface/themes/responsive/css/main.css
+++ b/code/web/interface/themes/responsive/css/main.css
@@ -324,6 +324,12 @@ img {
   padding: 0;
   margin: 0 0 1.5em;
 }
+.img-thumbnail.use-original-covers {
+  max-width: 180px;
+  max-height: 225px;
+  width: auto;
+  height: auto;
+}
 .img-circle {
   border-radius: 50%;
 }
@@ -9657,6 +9663,12 @@ a.browse-thumbnail.active {
   border-width: 0;
   padding: 0;
   margin: 0 0 1.5em;
+}
+.browse-list img.use-original-covers {
+  max-width: 180px;
+  max-height: 225px;
+  width: auto;
+  height: auto;
 }
 .browse-list img.use-original-covers {
   max-width: 80px;

--- a/code/web/interface/themes/responsive/css/main.css
+++ b/code/web/interface/themes/responsive/css/main.css
@@ -330,6 +330,48 @@ img {
   width: auto;
   height: auto;
 }
+.listEntry .use-original-covers,
+.result .use-original-covers {
+  max-width: 120px;
+  max-height: 180px;
+}
+.relatedRecord .use-original-covers {
+  max-width: 90px;
+  max-height: 135px;
+}
+@media (min-width: 768px) and (max-width: 991px) {
+  .listEntry .use-original-covers,
+  .result .use-original-covers {
+    max-width: 100px;
+    max-height: 150px;
+  }
+  .relatedRecord .use-original-covers {
+    max-width: 80px;
+    max-height: 120px;
+  }
+}
+@media (min-width: 992px) and (max-width: 1199px) {
+  .listEntry .use-original-covers,
+  .result .use-original-covers {
+    max-width: 105px;
+    max-height: 165px;
+  }
+  .relatedRecord .use-original-covers {
+    max-width: 85px;
+    max-height: 128px;
+  }
+}
+@media (max-width: 767px) {
+  .listEntry .use-original-covers,
+  .result .use-original-covers {
+    max-width: 80px;
+    max-height: 120px;
+  }
+  .relatedRecord .use-original-covers {
+    max-width: 70px;
+    max-height: 105px;
+  }
+}
 .img-circle {
   border-radius: 50%;
 }

--- a/code/web/release_notes/25.10.00.MD
+++ b/code/web/release_notes/25.10.00.MD
@@ -44,7 +44,7 @@
 
 ### Cover Images Updates
 - Added Bengali script support for the generation of default covers. (DIS-1355) (*LS*)
-- When "Use Original Cover URLs" is enabled, standardized cover images dimensions, prevented relatively small images from displaying, and modified how they are stored. (DIS-1396) (*LS*)
+- When "Use Original Cover URLs" is enabled, standardized cover images dimensions and prevented relatively small images from displaying and too large images displaying on certain pages. (DIS-1396) (*LS*)
 
 ### Cron Updates
 - Add logging to the cron to update saved searching. (DIS-1409) (*MDN*)

--- a/code/web/sys/Covers/BookCoverProcessor.php
+++ b/code/web/sys/Covers/BookCoverProcessor.php
@@ -50,9 +50,9 @@ class BookCoverProcessor {
 			}
 		}
 
-		if ($this->checkForEarlyRedirect()) {
-			return true;
-		}
+//		if ($this->checkForEarlyRedirect()) {
+//			return true;
+//		}
 
 		if($this->bookCoverInfo->imageSource == 'upload') {
 			if($this->getUploadedRecordCover($this->id)) {

--- a/code/web/sys/Covers/BookCoverProcessor.php
+++ b/code/web/sys/Covers/BookCoverProcessor.php
@@ -50,9 +50,9 @@ class BookCoverProcessor {
 			}
 		}
 
-//		if ($this->checkForEarlyRedirect()) {
-//			return true;
-//		}
+		if ($this->checkForEarlyRedirect()) {
+			return true;
+		}
 
 		if($this->bookCoverInfo->imageSource == 'upload') {
 			if($this->getUploadedRecordCover($this->id)) {


### PR DESCRIPTION
- Added use-original-covers class to relevant template files and add additional CSS to `scaffolding.less` to handle covers outside of browse categories.
- Added more use-original-covers CSS for lists (e.g., User Lists and Reading History) and for "Show Editions" view.