### PR TITLE
DIS-1435: Add debugging support to worldpay

### DIFF
--- a/code/web/release_notes/25.11.00.MD
+++ b/code/web/release_notes/25.11.00.MD
@@ -22,6 +22,8 @@
 //chloe
 
 //lucas
+### E-Commerce Updates
+- Add the "Force debug log" checkbox to debug WorldPay payments transactions (DIS-1435) (*LM*)
 
 
 ## This release includes code contributions from

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -6323,6 +6323,10 @@ class MyAccount_AJAX extends JSON_Action {
 					$patron,
 				] = $result;
 			}
+		
+			// Log the WorldPay order creation request
+			require_once ROOT_DIR . '/sys/SystemLogging/ExternalRequestLogEntry.php';
+			ExternalRequestLogEntry::logRequest('fine_payment.createworldpayorder', 'GET', '/MyAccount/AJAX?method=createWorldPayOrder', [], json_encode($_REQUEST), '200', json_encode(['success' => true, 'paymentId' => $payment->id,'url' => $payment->url, 'transactionDate' => $payment->transactionDate, 'userId' => $payment->userId]), []);
 
 			return [
 				'success' => true,

--- a/code/web/services/WorldPay/Complete.php
+++ b/code/web/services/WorldPay/Complete.php
@@ -9,6 +9,15 @@ class WorldPay_Complete extends Action {
 		require_once ROOT_DIR . '/sys/Account/UserPayment.php';
 		$result = UserPayment::completeWorldPayPayment($_POST);
 
+		// Log the WorldPay response
+		require_once ROOT_DIR . '/sys/SystemLogging/ExternalRequestLogEntry.php';
+		$responseHeaders = [
+			'Content-type: application/json',
+			'Cache-Control: no-cache, must-revalidate',
+			'Expires: Mon, 26 Jul 1997 05:00:00 GMT'
+		];
+		ExternalRequestLogEntry::logRequest('fine_payment.worldpay_response', 'POST', $_SERVER['REQUEST_URI'], $responseHeaders, json_encode($_POST), '200', json_encode($result), []);
+
 		header('Content-type: application/json');
 		header('Cache-Control: no-cache, must-revalidate'); // HTTP/1.1
 		header('Expires: Mon, 26 Jul 1997 05:00:00 GMT'); // Date in the past

--- a/code/web/sys/DBMaintenance/version_updates/25.11.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.11.00.php
@@ -39,6 +39,13 @@ function getUpdates25_11_00(): array {
 		//James Staub - Nashville Public Library
 
 		//Lucas Montoya - Theke Solutions
+		'forceDebugLog' => [
+			'title' => 'Enable Forced Logging of Debugging Information for WorldPay Payments',
+			'description' => 'Enable to show debugging information about WorldPay payments regardless of whether the user IP is authorized or not',
+			'sql' => [
+				'ALTER TABLE worldpay_settings ADD COLUMN forceDebugLog TINYINT(1) DEFAULT 0',
+			]
+		], //enable_worldpay_debug_logging
 
 		//other
 

--- a/code/web/sys/ECommerce/WorldPaySetting.php
+++ b/code/web/sys/ECommerce/WorldPaySetting.php
@@ -11,6 +11,7 @@ class WorldPaySetting extends DataObject {
 	public $settleCode;
 	public $paymentSite;
 	public $useLineItems;
+	public $forceDebugLog;
 
 	private $_libraries;
 
@@ -61,6 +62,14 @@ class WorldPaySetting extends DataObject {
 				'type' => 'checkbox',
 				'label' => 'Send Line Items',
 				'description' => 'Whether or not to send Line Items to FIS',
+			],
+			'forceDebugLog' => [
+				'property' => 'forceDebugLog',
+				'type' => 'checkbox',
+				'label' => 'Force Debugging Logs',
+				'description' => 'Whether or not to allow users to get debugging information about payments either if the user IP is authorized or not',
+				'hideInLists' => false,
+				'default' => false,
 			],
 
 			'libraries' => [

--- a/code/web/sys/SystemLogging/ExternalRequestLogEntry.php
+++ b/code/web/sys/SystemLogging/ExternalRequestLogEntry.php
@@ -162,6 +162,7 @@ class ExternalRequestLogEntry extends DataObject {
 		$eCommerceOptions = [
 			[2,'payPalSettingId','PayPalSetting'],
 			[5,'proPaySettingId','ProPaySetting'],
+			[7,'worldPaySettingId','WorldPaySetting'],
 			[8,'aciSpeedpaySettingId','ACISpeedpaySetting'],
 			[9,'invoiceCloudSettingId','InvoiceCloudSetting'],
 			[11,'paypalPayflowSettingId','PayPalPayflowSetting'],


### PR DESCRIPTION
This patch allows the staff to debug payments transactions made to WorldPay
Test plan :
Login as a staff user with permissions to manage ecommerce payments settings
Set WorldPay configurations with valid credentials
Go to Greenhouse -> External Log Entry
Login with a user who has fines to pay (use an incognito window for testing)
Pay the fines
The staff user should be able to watch debugging information about movements related with the ecommerce