### PR TITLE
DIS-1464 Replace depreciated commands in upgrade script

### DIFF
--- a/code/web/release_notes/25.11.00.MD
+++ b/code/web/release_notes/25.11.00.MD
@@ -23,6 +23,7 @@
 
 //lucas
 
+//bryan
 - Replace depreciated commands in update script. (DIS-1464) (*BNJ*)
 
 ## This release includes code contributions from
@@ -37,6 +38,9 @@
 - Katherine Perdue (KP)
 - Kodi Lein (KL)
 - Myranda Fuentes (MAF)
+
+### Nashville Public Library
+- Bryan Jones (BNJ)
 
 ### Open Fifth
 - Alexander Blanchard (AB)

--- a/code/web/release_notes/25.11.00.MD
+++ b/code/web/release_notes/25.11.00.MD
@@ -23,6 +23,7 @@
 
 //lucas
 
+- Replace depreciated commands in update script. (DIS-1464) (*BNJ*)
 
 ## This release includes code contributions from
 ### ByWater Solutions

--- a/install/upgrade.sh
+++ b/install/upgrade.sh
@@ -13,10 +13,10 @@ fi
 
 echo "Starting upgrade of $1 to version $2"
 
-service crond stop
+systemctl stop crond 
 pkill -9 java
 
-yum -y update
+dnf -y update
 
 cd /usr/local/aspen-discovery
 git pull origin $2
@@ -41,7 +41,7 @@ read waitOver
 cd /usr/local/aspen-discovery/data_dir_setup
 /usr/local/aspen-discovery/data_dir_setup/update_solr_files.sh $1
 
-service mysqld restart
+systemctl restart mariadb 
 sleep 10
 apachectl graceful
 sleep 5
@@ -49,7 +49,7 @@ sleep 5
 cd /usr/local/aspen-discovery
 git gc
 
-service crond start
+systemctl start crond
 
 echo "Upgrade completed."
 


### PR DESCRIPTION
- Replaced `service` with `systemctl` and fix syntax

- Replaced `yum` with `dnf`

- Replaced `mysqld` with `mariadb`