### PR TITLE
DIS-1477: Allowed Staff to Place Symphony Holds on Requested Materials

### DIFF
--- a/code/web/Drivers/SirsiDynixROA.php
+++ b/code/web/Drivers/SirsiDynixROA.php
@@ -1400,13 +1400,21 @@ class SirsiDynixROA extends HorizonAPI {
 	 * @access  public
 	 */
 	function placeSirsiHold(User $patron, string $recordId, ?string $itemId, ?string $volume = null, ?string $pickupBranch = null, string $type = 'request', ?string $cancelIfNotFilledByDate = null, bool $forceVolumeHold = false, bool $useBooksByMail = false) : array {
-		//Get the session token for the user
 		$staffSessionToken = $this->getStaffSessionToken();
 		$sessionToken = $this->getSessionToken($patron);
-		if (!$staffSessionToken) {
+
+		// If the patron's session token is unavailable, check if staff can place holds on their behalf.
+		// This handles the Materials Requests case where staff is NOT masquerading.
+		if (empty($sessionToken) && !empty($staffSessionToken)) {
+			if (!UserAccount::isUserMasquerading() && UserAccount::userHasPermission('Place Holds For Materials Requests')) {
+				$sessionToken = $staffSessionToken;
+			}
+		}
+
+		if (empty($sessionToken)) {
 			$result['success'] = false;
 			$result['message'] = translate([
-				'text' => "Sorry, it does not look like you are logged in currently.  Please login and try again",
+				'text' => "Sorry, it does not look like you are logged in currently. Please log in and try again.",
 				'isPublicFacing' => true,
 			]);
 
@@ -1415,7 +1423,7 @@ class SirsiDynixROA extends HorizonAPI {
 				'isPublicFacing' => true,
 			]);
 			$result['api']['message'] = translate([
-				'text' => 'Sorry, it does not look like you are logged in currently.  Please login and try again',
+				'text' => 'Sorry, it does not look like you are logged in currently. Please log in and try again.',
 				'isPublicFacing' => true,
 			]);
 			return $result;

--- a/code/web/release_notes/25.11.00.MD
+++ b/code/web/release_notes/25.11.00.MD
@@ -13,7 +13,7 @@
 
 //leo
 ### Symphony Updates
-- Allow staff to place holds on patrons' Material Requests available on the "Requests Needing Holds" page without having to masquerade as the patron. (DIS-1477) (*LS*)
+- Allowed staff to place holds on patrons' Material Requests available on the "Requests Needing Holds" page without having to masquerade as the patron. (DIS-1477) (*LS*)
 
 //yanjun
 

--- a/code/web/release_notes/25.11.00.MD
+++ b/code/web/release_notes/25.11.00.MD
@@ -12,6 +12,8 @@
 //myranda
 
 //leo
+### Symphony Updates
+- Allow staff to place holds on patrons' Material Requests available on the "Requests Needing Holds" page without having to masquerade as the patron. (DIS-1477) (*LS*)
 
 //yanjun
 


### PR DESCRIPTION
- Allowed staff to place holds on patrons' Material Requests available on the "Requests Needing Holds" page without having to masquerade as the patron.

Test Plan:
1. Log in as a staff account connected to the ILS.
2. Place a hold on the “Requests Needing Holds” page from a patron account unrelated to the currently logged-in account. Notice the displayed error that the hold failed.
3. Apply the patch.
4. Repeat step 2 and notice that the hold succeeds.