### PR TITLE
DIS-1490: Increased Label Max Length for Custom Form Fields

### DIFF
--- a/code/web/release_notes/25.11.00.MD
+++ b/code/web/release_notes/25.11.00.MD
@@ -12,6 +12,8 @@
 //myranda
 
 //leo
+### Other Updates
+- Corrected the maximum character limit for the Label field of Custom Form Fields from 100 to 255 characters. (DIS-1490) (*LS*)
 
 //yanjun
 

--- a/code/web/sys/WebBuilder/CustomFormField.php
+++ b/code/web/sys/WebBuilder/CustomFormField.php
@@ -74,8 +74,7 @@ class CustomFormField extends DataObject {
 				'type' => 'text',
 				'label' => 'Label',
 				'description' => 'A label for the field',
-				'size' => '40',
-				'maxLength' => 100,
+				'maxLength' => 255,
 				'required' => true,
 			],
 			'fieldType' => [


### PR DESCRIPTION
- Corrected the maximum character limit for the Label field of Custom Form Fields from 100 to 255 characters.

Test Plan:
1. Create a Custom Form.
2. Create a form field and try to input more than 100 characters in the Label field. Notice that the maximum number of characters you could input is 100.
3. Apply the patch and reload the page. Notice that you can enter up to 255 characters.

