### PR TITLE
DIS-1496: Fixed SQL Operator Precedence for Soft-Deleted Objects

### DIFF
--- a/code/web/release_notes/25.11.00.MD
+++ b/code/web/release_notes/25.11.00.MD
@@ -23,6 +23,9 @@
 ### Other Updates
 - Corrected the maximum character limit for the Label field of Custom Form Fields from 100 to 255 characters. (DIS-1490) (*LS*)
 
+### Other Updates
+- Corrected SQL operator precedence issue in DataObject soft-delete filtering. When permission queries use multiple OR conditions, the `deleted = 0` filter now correctly applies to all results by wrapping `OR` clauses in parentheses. (DIS-1496) (*LS*)
+
 //yanjun
 
 //imani

--- a/code/web/services/WebBuilder/AJAX.php
+++ b/code/web/services/WebBuilder/AJAX.php
@@ -135,7 +135,7 @@ class WebBuilder_AJAX extends JSON_Action {
 					$object->whereAdd("owningLibrary = -1", "OR");
 					$object->whereAdd("sharing = 2 OR sharing = 3", "OR");
 					if (Library::getLibraryList(true)){
-						$object->whereAdd("sharing = 1 AND sharedWithLibrary IN (" . implode(array_keys($libraryList)) . ")", "OR");
+						$object->whereAdd("sharing = 1 AND sharedWithLibrary IN (" . implode(",", array_keys($libraryList)) . ")", "OR");
 					}
 				}
 				$object->find();
@@ -160,7 +160,7 @@ class WebBuilder_AJAX extends JSON_Action {
 					$object->whereAdd("owningLibrary = -1", "OR");
 					$object->whereAdd("sharing = 2 OR sharing = 3", "OR");
 					if (Library::getLibraryList(true)){
-						$object->whereAdd("sharing = 1 AND sharedWithLibrary IN (" . implode(array_keys($libraryList)) . ")", "OR");
+						$object->whereAdd("sharing = 1 AND sharedWithLibrary IN (" . implode(",", array_keys($libraryList)) . ")", "OR");
 					}
 				}
 				$object->find();

--- a/code/web/services/WebBuilder/Images.php
+++ b/code/web/services/WebBuilder/Images.php
@@ -32,7 +32,7 @@ class WebBuilder_Images extends ObjectEditor {
 			$object->whereAdd("owningLibrary = -1", "OR");
 			$object->whereAdd("sharing = 2 OR sharing = 3", "OR");
 			if (Library::getLibraryList(true)){
-				$object->whereAdd("sharing = 1 AND sharedWithLibrary IN (" . implode(array_keys($libraryList)) . ")", "OR");
+				$object->whereAdd("sharing = 1 AND sharedWithLibrary IN (" . implode(",", array_keys($libraryList)) . ")", "OR");
 			}
 		}
 		$object->find();

--- a/code/web/services/WebBuilder/PDFs.php
+++ b/code/web/services/WebBuilder/PDFs.php
@@ -32,7 +32,7 @@ class WebBuilder_PDFs extends ObjectEditor {
 			$object->whereAdd("owningLibrary = -1", "OR");
 			$object->whereAdd("sharing = 2 OR sharing = 3", "OR");
 			if (Library::getLibraryList(true)){
-				$object->whereAdd("sharing = 1 AND sharedWithLibrary IN (" . implode(array_keys($libraryList)) . ")", "OR");
+				$object->whereAdd("sharing = 1 AND sharedWithLibrary IN (" . implode(",", array_keys($libraryList)) . ")", "OR");
 			}
 		}
 		$object->find();

--- a/code/web/sys/DB/DataObject.php
+++ b/code/web/sys/DB/DataObject.php
@@ -143,6 +143,11 @@ abstract class DataObject implements JsonSerializable {
 			$includeDeleted = property_exists($this, '_includeDeleted') ? $this->_includeDeleted : false;
 			$deletedPropIsSet = property_exists($this, 'deleted') && ($this->deleted !== null);
 			if (!$includeDeleted && !$deletedPropIsSet) {
+				// If there are existing OR conditions, wrap them in parentheses to ensure
+				// the deleted filter applies to all results (SQL operator precedence issue).
+				if (!empty($this->__where) && stripos($this->__where, ' OR ') !== false) {
+					$this->__where = '(' . $this->__where . ')';
+				}
 				$this->whereAdd($this->__table . '.deleted = 0');
 			}
 		}
@@ -670,6 +675,11 @@ abstract class DataObject implements JsonSerializable {
 			$includeDeleted = property_exists($this, '_includeDeleted') ? $this->_includeDeleted : false;
 			$deletedPropIsSet = property_exists($this, 'deleted') && ($this->deleted !== null);
 			if (!$includeDeleted && !$deletedPropIsSet) {
+				// If there are existing OR conditions, wrap them in parentheses to ensure
+				// the deleted filter applies to all results (SQL operator precedence issue).
+				if (!empty($this->__where) && stripos($this->__where, ' OR ') !== false) {
+					$this->__where = '(' . $this->__where . ')';
+				}
 				$this->whereAdd($this->__table . '.deleted = 0');
 			}
 		}


### PR DESCRIPTION
- Corrected SQL operator precedence issue in DataObject soft-delete filtering. When permission queries use multiple OR conditions, the `deleted = 0` filter now correctly applies to all results by wrapping `OR` clauses in parentheses.

Test Plan:
1. Log in to administrator account with "Administer Web Content for Home Library" permission.
2. Navigate to Admin > Web Builder > Images.
3. Delete an image scoped to your home library. Notice that the image displays in the admin list of Images.
4. Apply the patch and reload the page. Notice that the deleted image disappears from the list.

