### PR TITLE
Dis 1501: Improve the Solr image creation stage for core persistence.

### DIFF
--- a/code/web/release_notes/25.11.00.MD
+++ b/code/web/release_notes/25.11.00.MD
@@ -70,6 +70,9 @@
 ### E-Commerce Updates
 - Add the "Force debug log" checkbox to debug WorldPay payments transactions (DIS-1435) (*LM*)
 
+### Docker Updates
+- Modify the way Solr cores are installed to avoid hiding new changes in the image. (DIS-1501) (*LM*)
+
 //bryan
 - Replace depreciated commands in update script. (DIS-1464) (*BNJ*)
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -84,8 +84,47 @@ services:
       - "${SOLR_PORT}:${SOLR_PORT:-8983}"
     volumes:
       - solr:/var/solr
-      - solr:/opt/solr/server/solr
     networks:
       - net-aspen
     depends_on:
       - backend
+    entrypoint:
+    - /bin/bash
+    - '-c'
+    - |
+      init-var-solr
+      # Series core
+      precreate-core series /opt/solr/server/solr/configsets/series
+      cp -r /opt/solr/server/solr/configsets/series/* series
+
+      # Genealogy core
+      precreate-core genealogy /opt/solr/server/solr/configsets/genealogy
+      cp -r /opt/solr/server/solr/configsets/genealogy/* genealogy
+
+      # Grouped Works v2 core
+      precreate-core grouped_works_v2 /opt/solr/server/solr/configsets/grouped_works_v2
+      cp -r /opt/solr/server/solr/configsets/grouped_works_v2/* grouped_works_v2
+
+      # Lists core
+      precreate-core lists /opt/solr/server/solr/configsets/lists
+      cp -r /opt/solr/server/solr/configsets/lists/* lists
+
+      # Course Reserves core
+      precreate-core course_reserves /opt/solr/server/solr/configsets/course_reserves
+      cp -r /opt/solr/server/solr/configsets/course_reserves/* course_reserves
+
+      # Open Archives core
+      precreate-core open_archives /opt/solr/server/solr/configsets/open_archives
+      cp -r /opt/solr/server/solr/configsets/open_archives/* open_archives
+
+      # Website Pages core
+      precreate-core website_pages /opt/solr/server/solr/configsets/website_pages
+      cp -r /opt/solr/server/solr/configsets/website_pages/* website_pages
+
+      # Events core
+      precreate-core events /opt/solr/server/solr/configsets/events
+      cp -r /opt/solr/server/solr/configsets/events/* events
+
+
+      chown -R solr:solr /var/solr
+      runuser -u solr -- solr-foreground

--- a/docker/files/env/default.env
+++ b/docker/files/env/default.env
@@ -1,4 +1,9 @@
-# Aspen settings
+# Aspen Discovery Default Environment Configuration
+# Copy this file to your deployment directory as .env and customize as needed
+
+# =============================================================================
+# ASPEN SETTINGS
+# =============================================================================
 LOCAL_USER_ID=1000
 SITE_NAME=aspen.localhost
 SUPPORTING_COMPANY=ByWater Solutions
@@ -11,7 +16,9 @@ PHP_FPM_HOST=backend
 PHP_FPM_PORT=9000
 ASPEN_ADMIN_PASSWORD=secretPass123
 
-# DB settings
+# =============================================================================
+# DATABASE SETTINGS
+# =============================================================================
 DATABASE_HOST=db
 DATABASE_PORT=3306
 DATABASE_NAME=aspen
@@ -21,7 +28,9 @@ DATABASE_ROOT_USER=root
 DATABASE_ROOT_PASSWORD=password
 TIMEZONE=America/Argentina/Cordoba
 
-# Koha integration ("yes" to enable)
+# =============================================================================
+# KOHA INTEGRATION ("yes" to enable)
+# =============================================================================
 ENABLE_KOHA=no
 KOHA_OPAC_URL=
 KOHA_STAFF_URL=
@@ -34,13 +43,17 @@ KOHA_DATABASE_TIMEZONE=
 KOHA_CLIENT_ID=
 KOHA_CLIENT_SECRET=
 
-# Docker images to use
+# =============================================================================
+# DOCKER IMAGES
+# =============================================================================
 BACKEND_IMAGE_TAG=
 SOLR_IMAGE_TAG=
 TUNNEL_IMAGE_TAG=
 MARIADB_IMAGE=
 
-# Koha MySQL tunnel
+# =============================================================================
+# KOHA MYSQL TUNNEL (if needed for remote Koha connection)
+# =============================================================================
 TUNNEL_LOCAL_PORT=
 TUNNEL_REMOTE_HOST=
 TUNNEL_REMOTE_PORT=

--- a/docker/files/solr/Dockerfile
+++ b/docker/files/solr/Dockerfile
@@ -18,38 +18,40 @@ RUN set -eux; \
 
 # Set environment variables
 ENV SOLR_INSTALL_DIR=/opt/solr
-ENV SOLR_HOME=$SOLR_INSTALL_DIR/server/solr
+ENV SOLR_HOME=/var/solr/data
 ENV SOLR_HOST=$SOLR_HOST
 ENV SOLR_PORT=$SOLR_PORT
+ENV SOLR_OPTS="-Dsolr.config.lib.enabled=true" \
+    SERIES_CONFIGSET_PATH=/opt/solr/server/solr/configsets/series/conf \
+    GENEALOGY_CONFIGSET_PATH=/opt/solr/server/solr/configsets/genealogy/conf \
+    GROUPED_WORK_V2_CONFIGSET_PATH=/opt/solr/server/solr/configsets/grouped_works_v2/conf \
+    LISTS_CONFIGSET_PATH=/opt/solr/server/solr/configsets/lists/conf \
+    COURSE_RESERVES_CONFIGSET_PATH=/opt/solr/server/solr/configsets/course_reserves/conf \
+    OPEN_ARCHIVES_CONFIGSET_PATH=/opt/solr/server/solr/configsets/open_archives/conf \
+    WEBSITE_PAGES_CONFIGSET_PATH=/opt/solr/server/solr/configsets/website_pages/conf \
+    EVENTS_CONFIGSET_PATH=/opt/solr/server/solr/configsets/events/conf
 
-# Copy core directories to configsets
-COPY data_dir_setup/solr7/series ${SOLR_HOME}/configsets/series
-COPY data_dir_setup/solr7/genealogy ${SOLR_HOME}/configsets/genealogy
-COPY data_dir_setup/solr7/grouped_works_v2 ${SOLR_HOME}/configsets/grouped_works_v2
-COPY data_dir_setup/solr7/lists ${SOLR_HOME}/configsets/lists
-COPY data_dir_setup/solr7/course_reserves ${SOLR_HOME}/configsets/course_reserves
-COPY data_dir_setup/solr7/open_archives ${SOLR_HOME}/configsets/open_archives
-COPY data_dir_setup/solr7/website_pages ${SOLR_HOME}/configsets/website_pages
-COPY data_dir_setup/solr7/events ${SOLR_HOME}/configsets/events
+# Create configset directories
+RUN mkdir -p $SERIES_CONFIGSET_PATH && \
+    mkdir -p $GENEALOGY_CONFIGSET_PATH && \
+    mkdir -p $GROUPED_WORK_V2_CONFIGSET_PATH && \
+    mkdir -p $LISTS_CONFIGSET_PATH && \
+    mkdir -p $COURSE_RESERVES_CONFIGSET_PATH && \
+    mkdir -p $OPEN_ARCHIVES_CONFIGSET_PATH && \
+    mkdir -p $WEBSITE_PAGES_CONFIGSET_PATH && \
+    mkdir -p $EVENTS_CONFIGSET_PATH
+
+# Copy core configuration to configsets
+COPY data_dir_setup/solr7/series/conf ${SERIES_CONFIGSET_PATH}
+COPY data_dir_setup/solr7/genealogy/conf ${GENEALOGY_CONFIGSET_PATH}
+COPY data_dir_setup/solr7/grouped_works_v2/conf ${GROUPED_WORK_V2_CONFIGSET_PATH}
+COPY data_dir_setup/solr7/lists/conf ${LISTS_CONFIGSET_PATH}
+COPY data_dir_setup/solr7/course_reserves/conf ${COURSE_RESERVES_CONFIGSET_PATH}
+COPY data_dir_setup/solr7/open_archives/conf ${OPEN_ARCHIVES_CONFIGSET_PATH}
+COPY data_dir_setup/solr7/website_pages/conf ${WEBSITE_PAGES_CONFIGSET_PATH}
+COPY data_dir_setup/solr7/events/conf ${EVENTS_CONFIGSET_PATH}
 
 # Copy solr.xml to SOLR_HOME
 COPY data_dir_setup/solr7/solr.xml ${SOLR_HOME}/solr.xml
 RUN set -eux; \
-    test -d "${SOLR_HOME}/configsets" || exit 1; \
-    chown -R ${SOLR_USER}:${SOLR_GROUP} ${SOLR_HOME}; \
-    chown -R ${SOLR_USER}:${SOLR_GROUP} /var/solr
-
-# Add health check
-HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
-    CMD curl -f http://${SOLR_HOST}:${SOLR_PORT}/solr/series/admin/ping && \
-        curl -f http://${SOLR_HOST}:${SOLR_PORT}/solr/genealogy/admin/ping && \
-        curl -f http://${SOLR_HOST}:${SOLR_PORT}/solr/grouped_works_v2/admin/ping && \
-        curl -f http://${SOLR_HOST}:${SOLR_PORT}/solr/lists/admin/ping && \
-        curl -f http://${SOLR_HOST}:${SOLR_PORT}/solr/course_reserves/admin/ping && \
-        curl -f http://${SOLR_HOST}:${SOLR_PORT}/solr/open_archives/admin/ping && \
-        curl -f http://${SOLR_HOST}:${SOLR_PORT}/solr/website_pages/admin/ping && \
-        curl -f http://${SOLR_HOST}:${SOLR_PORT}/solr/events/admin/ping || exit 1
-
-# Switch to non-root user
-USER ${SOLR_USER}
-WORKDIR ${SOLR_HOME}
+    chown -R ${SOLR_USER}:${SOLR_GROUP} ${SOLR_HOME}


### PR DESCRIPTION
Currently, Solr cores are copied directly to the opt directory, which is volatile by design.

The problem is that new changes made to the Solr image will be hidden if a user persists the data  within that directory. 

This patch solves the issue by copying the cores data (into the opt directory) in the build step and setting the SOLR_HOME variable in “/var/solr/data”. Then, using Solr commands, the entrypoint pre-creates the cores in SOLR_HOME and copies the cores data into the new core-directory avoiding new changes in the image are hidden 