### PR TITLE
DIS-1504: Fixed Error Creating a New Location

### DIFF
--- a/code/web/release_notes/25.11.00.MD
+++ b/code/web/release_notes/25.11.00.MD
@@ -68,6 +68,7 @@
 ### Other Updates
 - Corrected the maximum character limit for the Label field of Custom Form Fields from 100 to 255 characters. (DIS-1490) (*LS*)
 - Restored the selection checkboxes on the Local Administrators list so Batch Delete works as expected. (DIS-1460) (*LS*)
+- Fixed error preventing creating a Location because `getCloudLibraryScope()` returned the incorrect type. (DIS-1504) (*LS*)
 
 //yanjun
 

--- a/code/web/sys/LibraryLocation/Location.php
+++ b/code/web/sys/LibraryLocation/Location.php
@@ -2158,18 +2158,21 @@ class Location extends DataObject {
 	}
 
 	public function getCloudLibraryScope(): int {
-		if ($this->_cloudLibraryScope === null && $this->locationId) {
-			require_once ROOT_DIR . '/sys/CloudLibrary/LocationCloudLibraryScope.php';
-			$locationCloudLibraryScope = new LocationCloudLibraryScope();
-			$locationCloudLibraryScope->locationId = $this->locationId;
-			if ($locationCloudLibraryScope->find(true)) {
-				require_once ROOT_DIR . '/sys/CloudLibrary/CloudLibraryScope.php';
-				$cloudLibraryScope = new CloudLibraryScope();
-				$cloudLibraryScope->id = $locationCloudLibraryScope->scopeId;
-				if ($cloudLibraryScope->find(true)) {
-					$this->_cloudLibraryScope = $cloudLibraryScope->id;
+		if ($this->_cloudLibraryScope === null) {
+			if ($this->locationId) {
+				require_once ROOT_DIR . '/sys/CloudLibrary/LocationCloudLibraryScope.php';
+				$locationCloudLibraryScope = new LocationCloudLibraryScope();
+				$locationCloudLibraryScope->locationId = $this->locationId;
+				if ($locationCloudLibraryScope->find(true)) {
+					require_once ROOT_DIR . '/sys/CloudLibrary/CloudLibraryScope.php';
+					$cloudLibraryScope = new CloudLibraryScope();
+					$cloudLibraryScope->id = $locationCloudLibraryScope->scopeId;
+					if ($cloudLibraryScope->find(true)) {
+						$this->_cloudLibraryScope = $cloudLibraryScope->id;
+					}
 				}
 			}
+
 			// If still not set, default to '-1', which corresponds to 'none'.
 			if ($this->_cloudLibraryScope === null) {
 				$this->_cloudLibraryScope = -1;


### PR DESCRIPTION
- Fixed error preventing creating a Location because `getCloudLibraryScope()` returned the incorrect type.

Test Plan:
1. Create a new Location in the admin interface and save it. Notice that an error displays.
2. Apply the patch and repeat step 1. Notice that the Location is successfully created.

