### PR TITLE
DIS-1442: Add primary ISBN and primary UPC to getListTitles

### DIFF
--- a/code/web/RecordDrivers/GroupedWorkDriver.php
+++ b/code/web/RecordDrivers/GroupedWorkDriver.php
@@ -1550,6 +1550,8 @@ class GroupedWorkDriver extends IndexRecordDriver {
 			'ratingData' => $this->getRatingData(),
 			'format' => $this->getFormats(),
 			'language' => $this->getLanguage(),
+			'primary_isbn' => $this->getPrimaryIsbn(),
+			'primary_upc' => $this->getPrimaryUPC(),
 		];
 	}
 
@@ -1684,6 +1686,14 @@ class GroupedWorkDriver extends IndexRecordDriver {
 	public function getPrimaryIsbn() {
 		if (isset($this->fields['primary_isbn'])) {
 			return $this->fields['primary_isbn'];
+		} else {
+			return null;
+		}
+	}
+
+	public function getPrimaryUPC() {
+		if (isset($this->fields['primary_upc'])) {
+			return $this->fields['primary_upc'];
 		} else {
 			return null;
 		}

--- a/code/web/release_notes/25.11.00.MD
+++ b/code/web/release_notes/25.11.00.MD
@@ -52,6 +52,9 @@
 - Code cleanup related to searches. (DIS-1474) (*MDN*)
 
 //kirstien
+### API Updates
+- In List API, getListTitles will now return the primary ISBN and primary UPC values for a grouped work. (DIS-1442) (*KK*)
+
 ### Layout Updates
 - In the header menu if a link has a submenu, add a down arrow to indicate that. (DIS-1431) (*KK*)
 

--- a/code/web/services/API/ListAPI.php
+++ b/code/web/services/API/ListAPI.php
@@ -624,6 +624,8 @@ class ListAPI extends AbstractAPI {
 							'ratingData' => $title['ratingData'],
 							'format' => $title['format'],
 							'language' => $title['language'],
+							'primary_isbn' => $title['primary_isbn'],
+							'primary_upc' => $title['primary_upc'],
 						];
 					}
 				} else if (!$isLida) { //if not LiDA look at all the things
@@ -646,6 +648,8 @@ class ListAPI extends AbstractAPI {
 						'ratingData' => $title['ratingData'],
 						'format' => $title['format'],
 						'language' => $title['language'],
+						'primary_isbn' => $title['primary_isbn'],
+						'primary_upc' => $title['primary_upc'],
 					];
 				}
 			}


### PR DESCRIPTION
- Created getPrimaryUPC function for Grouped Work Driver to return primary_upc value
- Added calls to getPrimaryISBN and getPrimaryUPC in getSummaryInformation in Grouped Work Driver
- Added references to these new keys in  _getUserListTitles in List API to return them in getListTitles