### PR TITLE
DIS-1510: Fixed Sierra Pickup Location Filtering to Fall Back to Default Logic When API Returns Incomplete Data

### DIFF
--- a/code/web/Drivers/Sierra.php
+++ b/code/web/Drivers/Sierra.php
@@ -509,6 +509,7 @@ class Sierra extends Millennium {
 			return [
 				'success' => false,
 				'message' => 'Missing record or patron; unable to retrieve valid pickup locations',
+				'useDefaultLocationFiltering' => true,
 			];
 		}
 		$patronId = $patron->unique_ils_id;
@@ -535,10 +536,11 @@ class Sierra extends Millennium {
 		} else {
 			$message = 'Unable to retrieve valid pickup locations from Sierra. ';
 			$message .= $pickupLocationsResponse->name ?? '';
-			$message .= $pickupLocationsResponse->description ? ': ' . $pickupLocationsResponse->description : '';
+			$message .= !empty($pickupLocationsResponse->description) ? ': ' . $pickupLocationsResponse->description : '';
 			return [
 				'success' => false,
 				'message' => $message,
+				'useDefaultLocationFiltering' => true,
 			];
 		}
 	}

--- a/code/web/release_notes/25.11.00.MD
+++ b/code/web/release_notes/25.11.00.MD
@@ -62,6 +62,9 @@
 //myranda
 
 //leo
+### Sierra Updates
+- Fixed an issue where patrons were unable to place holds on certain items because the Sierra API returned incomplete data. (DIS-1510) (*LS*)
+
 ### Symphony Updates
 - Allowed staff to place holds on patrons' Material Requests available on the "Requests Needing Holds" page without having to masquerade as the patron. (DIS-1477) (*LS*)
 

--- a/code/web/services/API/UserAPI.php
+++ b/code/web/services/API/UserAPI.php
@@ -2295,14 +2295,14 @@ class UserAPI extends AbstractAPI {
 							$validLocationCodesFromILS = $getPickupLocationsFromILS['locationCodes'];
 							$pickupLocations = array_filter($pickupLocations, function ($location) use ($validLocationCodesFromILS) {
 								foreach ($validLocationCodesFromILS as $validCode) {
-									if (strpos($validCode, $location['locationCode']) === 0) {
+									if (str_starts_with($validCode, $location['locationCode'])) {
 										return true;
 									}
 								}
 								return false;
 							});
 							$pickupLocations = array_values($pickupLocations);
-						} else {
+						} elseif (empty($getPickupLocationsFromILS['useDefaultLocationFiltering'])) {
 							$pickupLocations = [];
 						}
 					}

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -2072,13 +2072,13 @@ class MyAccount_AJAX extends JSON_Action {
 								return true;
 							}
 							foreach ($validLocationCodesFromILS as $validCode) {
-								if (strpos($validCode, $location->code) === 0) {
+								if (str_starts_with($validCode, $location->code)) {
 									return true;
 								}
 							}
 							return false;
 						});
-					} else {
+					} elseif (empty($getPickupLocationsFromILS['useDefaultLocationFiltering'])) {
 						$pickupBranches = [];
 					}
 				}

--- a/code/web/services/Record/AJAX.php
+++ b/code/web/services/Record/AJAX.php
@@ -1964,13 +1964,13 @@ class Record_AJAX extends Action {
 						return true;
 					}
 					foreach ($validLocationCodesFromILS as $validCode) {
-						if (strpos($validCode, $location->code) === 0) {
+						if (str_starts_with($validCode, $location->code)) {
 							return true;
 						}
 					}
 					return false;
 				});
-			} else {
+			} elseif (empty($getPickupLocationsFromILS['useDefaultLocationFiltering'])) {
 				$locations = [];
 			}
 		}


### PR DESCRIPTION
- Fixed an issue where patrons were unable to place holds on certain items because the Sierra API returned incomplete data.