### PR TITLE
DIS-1513: Fixed Failing Sierra Self Registration Due to Invalid JSON

### DIFF
--- a/code/web/Drivers/Sierra.php
+++ b/code/web/Drivers/Sierra.php
@@ -2120,7 +2120,7 @@ class Sierra extends Millennium {
 			if ($selfRegistrationForm->selfRegUseAgency) {
 				$params['fixedFields']['158'] = [
 					'label' => 'Patron Agency',
-					'value' => $selfRegistrationForm->selfRegAgency
+					'value' => (string)$selfRegistrationForm->selfRegAgency
 				];
 			}
 			if ($selfRegistrationForm->addSelfRegNote) {

--- a/code/web/release_notes/25.11.00.MD
+++ b/code/web/release_notes/25.11.00.MD
@@ -62,6 +62,9 @@
 //myranda
 
 //leo
+### Sierra Updates
+- Resolved an issue where patrons could not self register if the library had Patron Self Agency enabled. (DIS-1513) (*LS*)
+
 ### Symphony Updates
 - Allowed staff to place holds on patrons' Material Requests available on the "Requests Needing Holds" page without having to masquerade as the patron. (DIS-1477) (*LS*)
 


### PR DESCRIPTION
- Resolved an issue where patrons could not self register if the library had Patron Self Agency enabled.

Test Plan:
1. Register for a library card. Notice an error displays reading, “Unknown Error while registering your account”.
2. Apply the patch and repeat step 1. Notice that the registration is successful. 