### PR TITLE
DIS-1519: Fixed Exporting API Usage Graphs Data

### DIFF
--- a/code/web/release_notes/25.11.00.MD
+++ b/code/web/release_notes/25.11.00.MD
@@ -76,6 +76,7 @@
 - Corrected the maximum character limit for the Label field of Custom Form Fields from 100 to 255 characters. (DIS-1490) (*LS*)
 - Restored the selection checkboxes on the Local Administrators list so Batch Delete works as expected. (DIS-1460) (*LS*)
 - Fixed error preventing creating a Location because `getCloudLibraryScope()` returned the incorrect type. (DIS-1504) (*LS*)
+- Fixed CSV export functionality for API Usage Graphs. (DIS-1519) (*LS*)
 
 //yanjun
 

--- a/code/web/services/API/AJAX.php
+++ b/code/web/services/API/AJAX.php
@@ -2,9 +2,10 @@
 require_once ROOT_DIR . '/JSON_Action.php';
 
 class API_AJAX extends JSON_Action {
-	public function exportUsageData() {
+	/** @noinspection PhpUnused */
+	public function exportUsageData(): void {
 		require_once ROOT_DIR . '/services/API/UsageGraphs.php';
 		$aspenUsageGraph = new API_UsageGraphs();
-		$aspenUsageGraph->buildCSV();
+		$aspenUsageGraph->buildCSV('API');
 	}
 }


### PR DESCRIPTION
- Fixed CSV export functionality for API Usage Graphs.

Test Plan:
1. Navigate to the Aspen Discovery API Usage Dashboard in the admin interface.
2. Navigate to any Usage Graph.
3. Click “Export to CSV” at the bottom of the page. Notice the error that display on the screen.
4. Apply the patch.
5. Repeat step 3 and notice that a CSV file downloads.

