### PR TITLE
DIS-1522 label templates

### DIFF
--- a/code/web/release_notes/25.12.00.MD
+++ b/code/web/release_notes/25.12.00.MD
@@ -1,0 +1,44 @@
+## Aspen Discovery Updates
+// mark
+
+// kirstien
+
+// kodi
+
+// leo
+
+// imani
+
+// yanjun
+
+//alexander
+
+//chloe
+
+//lucas
+
+## This release includes code contributions from
+### ByWater Solutions
+- Leo Stoyanov (LS)
+- Yanjun Li (YL)
+- Imani Thomas (IT)
+
+### Grove For Libraries
+- Mark Noble (MDN)
+- Kirstien Kroeger (KK)
+- Kodi Lein (KL)
+
+### Open Fifth
+- Alexander Blanchard (AB)
+
+### Theke Solutions
+- Lucas Montoya (LM)
+
+## Special Testing thanks to
+- 
+
+## Special Documentation thanks to
+- 
+
+## This release includes sponsored developments from
+- 

--- a/code/web/sys/DBMaintenance/version_updates/25.12.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.12.00.php
@@ -1,0 +1,38 @@
+<?php
+
+/** @noinspection PhpUnused */
+function getUpdates25_12_00(): array {
+	return [
+		/*'name' => [
+			 'title' => '',
+			 'description' => '',
+			 'continueOnError' => false,
+			 'sql' => [
+				 ''
+			 ]
+		 ], //name*/
+
+		//mark - Grove
+
+		//kirstien - Grove
+
+		//kodi - Grove
+
+		// Myranda - Grove
+
+		//Yanjun Li - ByWater
+
+		// Leo Stoyanov - BWS
+
+		//alexander - Open Fifth
+
+		//chloe - Open Fifth
+
+		//James Staub - Nashville Public Library
+
+		//Lucas Montoya - Theke Solutions
+
+		//other
+		
+	];
+}

--- a/code/web/version.json
+++ b/code/web/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "25.11.00",
-  "stage": "beta 1"
+  "version": "25.12.00",
+  "stage": "alpha"
 }


### PR DESCRIPTION
No functional changes here, just adding comments to templates to identify which files rendered which markup while inspecting the markup on any given page. 

To test:
Go to any url in aspen with ?debug=true appended to the url (or &debug=true if you already have query parameters in the url)
You should see comments in the code indicating the start and end of templates including files and paths.