### PR TITLE
DIS-1448: Allow libraries to limit the display of native events from other libraries

### DIFF
--- a/code/events_indexer/src/com/turning_leaf_technologies/events/AspenEventsIndexer.java
+++ b/code/events_indexer/src/com/turning_leaf_technologies/events/AspenEventsIndexer.java
@@ -29,9 +29,10 @@ public class AspenEventsIndexer {
 	private final EventsIndexerLogEntry logEntry;
 	private final HashMap<Long, AspenEvent> eventInstances = new HashMap<>();
 	private final HashSet<String> librariesToShowFor = new HashSet<>();
+	private final HashMap<Long, String> librariesToShowSeparatelyFor = new HashMap<>();
 	private final static CRC32 checksumCalculator = new CRC32();
 	private final String coverPath;
-
+	private int eventsSearchSetting;
 	private final List<String> idsToDelete = new ArrayList<>();
 
 	private final ConcurrentUpdateHttp2SolrClient solrUpdateServer;
@@ -74,11 +75,32 @@ public class AspenEventsIndexer {
 				logEntry.incNumEvents(eventCountRS.getInt("COUNT(*)"));
 			}
 
-			PreparedStatement getLibraryScopesStmt = aspenConn.prepareStatement("SELECT subdomain from library inner join library_events_setting on library.libraryId = library_events_setting.libraryId WHERE settingSource = 'aspenEvents' AND settingId = ?");
+			//retrieve the scoping setting for the indexing setting
+			PreparedStatement getLibraryScopeSettingStmt = aspenConn.prepareStatement("SELECT * from events_indexing_settings WHERE id = ?");
+			getLibraryScopeSettingStmt.setLong(1, settingsId);
+			ResultSet getLibraryScopeSettingRS = getLibraryScopeSettingStmt.executeQuery();
+			if (getLibraryScopeSettingRS.next()) {
+				this.eventsSearchSetting = getLibraryScopeSettingRS.getInt("eventsSearchSetting");
+			}
+
+			PreparedStatement getLibraryScopesStmt = aspenConn.prepareStatement("SELECT library.libraryId, subdomain from library inner join library_events_setting on library.libraryId = library_events_setting.libraryId WHERE settingSource = 'aspenEvents' AND settingId = ?");
 			getLibraryScopesStmt.setLong(1, settingsId);
 			ResultSet getLibraryScopesRS = getLibraryScopesStmt.executeQuery();
-			while (getLibraryScopesRS.next()){
-				librariesToShowFor.add(getLibraryScopesRS.getString("subdomain").toLowerCase());
+			if (eventsSearchSetting != 3) {
+				while (getLibraryScopesRS.next()){
+					librariesToShowFor.add(getLibraryScopesRS.getString("subdomain").toLowerCase());
+				}
+			} else { //libraries on single setting want their own individual scopes
+				while (getLibraryScopesRS.next()){
+					librariesToShowSeparatelyFor.put(getLibraryScopesRS.getLong("libraryId"), getLibraryScopesRS.getString("subdomain").toLowerCase());
+				}
+			}
+
+			//add subdomains who want to show events from all libraries
+			PreparedStatement getLibrariesToShowAllForStmt = aspenConn.prepareStatement("SELECT l.subdomain FROM library AS l INNER JOIN library_events_setting AS les ON l.libraryId = les.libraryId INNER JOIN events_indexing_settings AS eis ON les.settingId = eis.id WHERE les.settingSource = 'aspenEvents' AND eis.eventsSearchSetting = 0");
+			ResultSet getLibrariesToShowAllForRS = getLibrariesToShowAllForStmt.executeQuery();
+			while (getLibrariesToShowAllForRS.next()) {
+				librariesToShowFor.add(getLibrariesToShowAllForRS.getString("subdomain").toLowerCase());
 			}
 
 			PreparedStatement eventsStmt;
@@ -242,8 +264,14 @@ public class AspenEventsIndexer {
 
 				solrDocument.addField("description", eventInfo.getDescription());
 
+				if (eventsSearchSetting == 3) {
+					librariesToShowFor.add(librariesToShowSeparatelyFor.get(eventInfo.getLocationId()));
+				}
+
 				// Libraries scopes
 				solrDocument.addField("library_scopes", librariesToShowFor);
+
+				librariesToShowFor.remove(librariesToShowSeparatelyFor.get(eventInfo.getLocationId()));
 
 				solrDocument.addField("boost", boost);
 				solrUpdateServer.add(solrDocument);

--- a/code/web/release_notes/25.11.00.MD
+++ b/code/web/release_notes/25.11.00.MD
@@ -72,6 +72,15 @@
 //katherine
 
 //kodi
+### Aspen Native Events Updates
+- Added a new setting for libraries to specify how they want to scope events for libraries on a single setting (DIS-1448) (*KL*)
+
+<div markdown="1" class="settings">
+
+#### New Settings
+- Events > Aspen Events Settings > Events Search Scope
+
+</div>
 
 //myranda
 

--- a/code/web/sys/DBMaintenance/version_updates/25.11.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.11.00.php
@@ -43,6 +43,13 @@ function getUpdates25_11_00(): array {
 		//kirstien - Grove
 
 		//kodi - Grove
+		'events_search_setting' => [
+			'title' => 'Events Search Setting',
+			'description' => 'Add column to events_indexing_settings for search scope settings.',
+			'sql' => [
+				'ALTER TABLE events_indexing_settings ADD COLUMN eventsSearchSetting INT DEFAULT 1'
+			]
+		],
 
 		// Myranda - Grove
 

--- a/code/web/sys/Events/EventsIndexingSetting.php
+++ b/code/web/sys/Events/EventsIndexingSetting.php
@@ -58,6 +58,19 @@ class EventsIndexingSetting extends DataObject {
 				'label' => 'Last Update Of Changed Events',
 				'readOnly' => 1,
 			],
+			'eventsSearchSetting' => [
+				'property' => 'eventsSearchSetting',
+				'type' => 'enum',
+				'label' => 'Events Search Scope',
+				'description' => 'The search scope for events.',
+				'values' => [
+					'0' => 'All events for all libraries',
+					'1' => 'All events at any selected library',
+					'2' => 'Events for the selected library only',
+				],
+				'default' => '1',
+				'hideInLists' => true,
+			],
 			'libraries' => [
 				'property' => 'libraries',
 				'type' => 'multiSelect',


### PR DESCRIPTION
- Adds new setting to native events indexing setting "eventsSearchSetting" to define search scope for libraries on this setting 
- Adds new logic to events indexer to determine which scopes should be included for an event

Updated release notes

Tested on my local instance of Aspen
Needs additional testing to check scoping works correctly