### PR TITLE
DIS-1531: Add manual clear cached values option

### DIFF
--- a/code/web/release_notes/25.11.00.MD
+++ b/code/web/release_notes/25.11.00.MD
@@ -188,6 +188,14 @@
 //yanjun
 ### Other Updates
 - Add a Clear Cached Values control under System Variables so admins can purge cached values manually. (DIS-1531) (*YL*)
+- Add Clear Cached Values Action to every upgrade. (DIS-1531) (*YL*)
+
+<div markdown="1" class="settings">
+
+#### New Settings
+- System Variables >  Clear Cached Values
+
+</div>
 
 //imani
 ## Community Engagement Updates

--- a/code/web/release_notes/25.11.00.MD
+++ b/code/web/release_notes/25.11.00.MD
@@ -186,6 +186,8 @@
 - Corrected SQL operator precedence issue in DataObject soft-delete filtering. When permission queries use multiple OR conditions, the `deleted = 0` filter now correctly applies to all results by wrapping `OR` clauses in parentheses. (DIS-1496) (*LS*)
 
 //yanjun
+### Other Updates
+- Add a Clear Cached Values control under System Variables so admins can purge cached values manually. (DIS-1531) (*YL*)
 
 //imani
 ## Community Engagement Updates

--- a/code/web/services/Admin/DBMaintenance.php
+++ b/code/web/services/Admin/DBMaintenance.php
@@ -34,6 +34,10 @@ class Admin_DBMaintenance extends Admin_Admin {
 			SystemVariables::forceNightlyIndex();
 
 			Theme::updateCssForAllThemes();
+
+			//Clear cached values after successful maintenance
+			require_once ROOT_DIR . '/sys/MemoryCache/CachedValue.php';
+			CachedValue::clearAllCachedValues();
 		}
 
 		//Check to see which updates have already been performed.

--- a/code/web/services/Admin/SystemVariables.php
+++ b/code/web/services/Admin/SystemVariables.php
@@ -72,4 +72,42 @@ class Admin_SystemVariables extends ObjectEditor {
 	function canView(): bool {
 		return UserAccount::userHasPermission('Administer System Variables');
 	}
+
+	function getAdditionalObjectActions($existingObject): array {
+		$objectActions = [];
+		if ($existingObject instanceof SystemVariables) {
+			$objectActions[] = [
+				'text' => 'Clear Cached Values',
+				'url' => '/Admin/SystemVariables?objectAction=clearCachedValues',
+			];
+		}
+		return $objectActions;
+	}
+
+	/** @noinspection PhpUnused */
+	function clearCachedValues(): void {
+		require_once ROOT_DIR . '/sys/MemoryCache/CachedValue.php';
+		$user = UserAccount::getActiveUserObj();
+		$success = CachedValue::clearAllCachedValues();
+
+		if ($user != null) {
+			if ($success) {
+				$user->updateMessage = translate([
+					'text' => 'Cached values were cleared successfully.',
+					'isAdminFacing' => true,
+				]);
+				$user->updateMessageIsError = 0;
+			} else {
+				$user->updateMessage = translate([
+					'text' => 'Cached values could not be cleared.',
+					'isAdminFacing' => true,
+				]);
+				$user->updateMessageIsError = 1;
+			}
+			$user->update();
+		}
+
+		header('Location: /Admin/SystemVariables');
+		exit();
+	}
 }

--- a/code/web/sys/DBMaintenance/version_updates/25.11.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.11.00.php
@@ -98,6 +98,13 @@ function getUpdates25_11_00(): array {
 		// Myranda - Grove
 
 		//Yanjun Li - ByWater
+		'addSystemVariableClearCachedValues' => [
+			'title' => 'Add System Variable to clear Cached Values table',
+			'description' => 'Add a system variable to clear cached values.',
+			'sql' => [
+				'ALTER TABLE system_variables ADD COLUMN clearCachedValues TINYINT(1) NOT NULL DEFAULT 0;',
+			]
+		], //addSystemVariableClearCachedValues
 
 		// Leo Stoyanov - BWS
 		'record_grouping_overrides' => [

--- a/code/web/sys/DBMaintenance/version_updates/25.11.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.11.00.php
@@ -98,13 +98,6 @@ function getUpdates25_11_00(): array {
 		// Myranda - Grove
 
 		//Yanjun Li - ByWater
-		'addSystemVariableClearCachedValues' => [
-			'title' => 'Add System Variable to clear Cached Values table',
-			'description' => 'Add a system variable to clear cached values.',
-			'sql' => [
-				'ALTER TABLE system_variables ADD COLUMN clearCachedValues TINYINT(1) NOT NULL DEFAULT 0;',
-			]
-		], //addSystemVariableClearCachedValues
 
 		// Leo Stoyanov - BWS
 		'record_grouping_overrides' => [

--- a/code/web/sys/MemoryCache/CachedValue.php
+++ b/code/web/sys/MemoryCache/CachedValue.php
@@ -8,4 +8,16 @@ class CachedValue extends DataObject {
 	public $valueType;
 	public $value;
 	public $expirationTime;
+
+	public static function clearAllCachedValues(): bool {
+		try {
+			$cachedValue = new CachedValue();
+			$cachedValue->deleteAll();
+			return true;
+		} catch (Exception $e) {
+			global $logger;
+			$logger->log('Unable to clear cached_values: ' . $e->getMessage(), Logger::LOG_ERROR);
+			return false;
+		}
+	}
 }

--- a/code/web/sys/SystemVariables.php
+++ b/code/web/sys/SystemVariables.php
@@ -49,6 +49,7 @@ class SystemVariables extends DataObject {
 	public $removeTheWordSeriesFromEndOfSeries;
 	public $disable_user_agent_logging;
 	public $logFrequentCrons;
+	public $clearCachedValues;
 
 
 	static $_objectStructure = [];
@@ -396,6 +397,13 @@ class SystemVariables extends DataObject {
 				'note' => 'Frequent jobs include: ' . implode(', ', $frequentJobs) . '.',
 				'default' => false,
 			],
+			'clearCachedValues' => [
+				'property' => 'clearCachedValues',
+				'type' => 'checkbox',
+				'label' => 'Clear Cached Values',
+				'description' => 'Clear all entries from the cached_values table.',
+				'default' => false,
+			]
 		];
 
 		if (!UserAccount::getActiveUserObj()->isAspenAdminUser()) {
@@ -471,6 +479,19 @@ class SystemVariables extends DataObject {
 	}
 
 	public function update(string $context = '') : int|bool {
+		$cleanupSuccess = null;
+		if (!empty($this->clearCachedValues)) {
+			require_once ROOT_DIR . '/sys/MemoryCache/CachedValue.php';
+			$cachedValue = new CachedValue();
+			try {
+				$cachedValue->deleteAll();
+				$cleanupSuccess = true;
+			} catch (Exception $e) {
+				$cleanupSuccess = false;
+			}
+			$this->clearCachedValues = 0;
+		}
+
 		if ($this->trackIpAddresses == 0) {
 			//Delete all previously stored usage stats.
 			$usageByIP = new UsageByIPAddress();
@@ -483,6 +504,28 @@ class SystemVariables extends DataObject {
 			$userAgent = new UserAgent();
 			$userAgent->delete(true);
 		}
-		return parent::update($context);
+		$updateResult = parent::update($context);
+
+		if ($cleanupSuccess !== null) {
+			$user = UserAccount::getActiveUserObj();
+			if ($user != null) {
+				if ($cleanupSuccess) {
+					$user->updateMessage = translate([
+						'text' => 'Cached values were cleared successfully.',
+						'isAdminFacing' => true,
+					]);
+					$user->updateMessageIsError = 0;
+				} else {
+					$user->updateMessage = translate([
+						'text' => 'Cached values could not be cleared.',
+						'isAdminFacing' => true,
+					]);
+					$user->updateMessageIsError = 1;
+				}
+				$user->update();
+			}
+		}
+
+		return $updateResult;
 	}
 }

--- a/code/web/sys/SystemVariables.php
+++ b/code/web/sys/SystemVariables.php
@@ -49,7 +49,6 @@ class SystemVariables extends DataObject {
 	public $removeTheWordSeriesFromEndOfSeries;
 	public $disable_user_agent_logging;
 	public $logFrequentCrons;
-	public $clearCachedValues;
 
 
 	static $_objectStructure = [];
@@ -397,13 +396,6 @@ class SystemVariables extends DataObject {
 				'note' => 'Frequent jobs include: ' . implode(', ', $frequentJobs) . '.',
 				'default' => false,
 			],
-			'clearCachedValues' => [
-				'property' => 'clearCachedValues',
-				'type' => 'checkbox',
-				'label' => 'Clear Cached Values',
-				'description' => 'Clear all entries from the cached_values table.',
-				'default' => false,
-			]
 		];
 
 		if (!UserAccount::getActiveUserObj()->isAspenAdminUser()) {
@@ -479,19 +471,6 @@ class SystemVariables extends DataObject {
 	}
 
 	public function update(string $context = '') : int|bool {
-		$cleanupSuccess = null;
-		if (!empty($this->clearCachedValues)) {
-			require_once ROOT_DIR . '/sys/MemoryCache/CachedValue.php';
-			$cachedValue = new CachedValue();
-			try {
-				$cachedValue->deleteAll();
-				$cleanupSuccess = true;
-			} catch (Exception $e) {
-				$cleanupSuccess = false;
-			}
-			$this->clearCachedValues = 0;
-		}
-
 		if ($this->trackIpAddresses == 0) {
 			//Delete all previously stored usage stats.
 			$usageByIP = new UsageByIPAddress();
@@ -504,28 +483,6 @@ class SystemVariables extends DataObject {
 			$userAgent = new UserAgent();
 			$userAgent->delete(true);
 		}
-		$updateResult = parent::update($context);
-
-		if ($cleanupSuccess !== null) {
-			$user = UserAccount::getActiveUserObj();
-			if ($user != null) {
-				if ($cleanupSuccess) {
-					$user->updateMessage = translate([
-						'text' => 'Cached values were cleared successfully.',
-						'isAdminFacing' => true,
-					]);
-					$user->updateMessageIsError = 0;
-				} else {
-					$user->updateMessage = translate([
-						'text' => 'Cached values could not be cleared.',
-						'isAdminFacing' => true,
-					]);
-					$user->updateMessageIsError = 1;
-				}
-				$user->update();
-			}
-		}
-
-		return $updateResult;
+		return parent::update($context);
 	}
 }


### PR DESCRIPTION
Add a “Clear Cached Values” checkbox in System Variables so Admins can manually purge the cached_values table. Admins can see a success or error message after they check the box and save the page. 

This idea came from when an Evergreen server was updated, Aspen needed to clear the cached values, especially for IDL entries. Giving library admins a checkbox on the interface lets them handle the cleanup without waiting for support companies to respond. And the same control can potentially help with other cases when cached values need a quick purge. 

To test:
1. Log in as an admin with access to System Variables
2. Check DB and see cached_values table is not empty 
3. Go to System Variables > Check Clear Cached Values
4. Click “Save Changes and Stay Here” or “Save Changes and Return”, and see the success or error message 
5. Check the cached_values table again and confirm whether entries are cleaned or not