### PR TITLE
DIS-1396: Added Missing Use Original Covers CSS

### DIFF
--- a/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/result.tpl
@@ -12,7 +12,7 @@
 						<div class="listResultImage img-thumbnail {$coverStyle}">
 							<a href="{$summUrl}" tabindex="-1">
 								{if !empty($isNew)}<span class="list-cover-badge">{translate text="New!" isPublicFacing=true}</span> {/if}
-								<img src="{$bookCoverUrlMedium}" alt="{$summTitle|removeTrailingPunctuation|escapeCSS}" title="{$summTitle|removeTrailingPunctuation|escapeCSS}">
+								<img src="{$bookCoverUrlMedium}" class="{if $useOriginalCoverUrls}use-original-covers{/if}" alt="{$summTitle|removeTrailingPunctuation|escapeCSS}" title="{$summTitle|removeTrailingPunctuation|escapeCSS}">
 							</a>
 						</div>
 					{/if}

--- a/code/web/release_notes/25.11.00.MD
+++ b/code/web/release_notes/25.11.00.MD
@@ -77,6 +77,7 @@
 - Do not trigger property change effects for inconsequential changes. (DIS-1498) (*MDN*)
 - Code cleanup related to searches. (DIS-1474) (*MDN*)
 - Correctly load active library and location based on entered hosting information. (DIS-1529) (*MDN*)
+- When "Use Original Cover URLs" is enabled, ensure cover images for grouped works in search results are standardized. (DIS-1396) (*LS*)
 
 //kirstien
 ### API Updates

--- a/code/web/release_notes/25.11.00.MD
+++ b/code/web/release_notes/25.11.00.MD
@@ -77,7 +77,6 @@
 - Do not trigger property change effects for inconsequential changes. (DIS-1498) (*MDN*)
 - Code cleanup related to searches. (DIS-1474) (*MDN*)
 - Correctly load active library and location based on entered hosting information. (DIS-1529) (*MDN*)
-- When "Use Original Cover URLs" is enabled, ensure cover images for grouped works in search results are standardized. (DIS-1396) (*LS*)
 
 //kirstien
 ### API Updates
@@ -155,6 +154,7 @@
 - Restored the selection checkboxes on the Local Administrators list so Batch Delete works as expected. (DIS-1460) (*LS*)
 - Fixed error preventing creating a Location because `getCloudLibraryScope()` returned the incorrect type. (DIS-1504) (*LS*)
 - Fixed CSV export functionality for API Usage Graphs. (DIS-1519) (*LS*)
+- When "Use Original Cover URLs" is enabled, ensure cover images for grouped works in search results are standardized. (DIS-1396) (*LS*)
 
 //yanjun
 


### PR DESCRIPTION
- When "Use Original Cover URLs" is enabled, ensure cover images for grouped works in search results are standardized.