### PR TITLE
DIS-325: Improved Keyboard Focus for Browse Categories

### DIFF
--- a/code/web/interface/themes/responsive/css/browse-categories.less
+++ b/code/web/interface/themes/responsive/css/browse-categories.less
@@ -81,7 +81,9 @@
   div {
     cursor: pointer;
     &:focus {
-      outline: none; // hide outlining of clicked category
+      outline: 2px solid #3174af;
+      outline-offset: -2px;
+      box-shadow: 0 0 0 2px rgba(26, 115, 232, 0.4);
     }
     &:hover {
       text-decoration: underline; // emulate link behavior
@@ -90,9 +92,16 @@
     margin-left: auto;
     margin-right: auto;
   }
+
   &.selected {
-    border: 2px solid @selectedCategoryBorderColor;
-    font-size: @browse-category-font-size; // decreased size of increase, set relative to base font size  plb 9-17-2014
+    border: 3px solid @selectedCategoryBorderColor;
+    font-size: @browse-category-font-size;
+
+    div:focus {
+      outline: 2px solid #3174af;
+      outline-offset: -2px;
+      box-shadow: 0 0 0 2px rgba(26, 115, 232, 0.4);
+    }
   }
 }
 

--- a/code/web/interface/themes/responsive/css/main.css
+++ b/code/web/interface/themes/responsive/css/main.css
@@ -9402,14 +9402,21 @@ a.placard-link {
   margin-right: auto;
 }
 .browse-category div:focus {
-  outline: none;
+  outline: 2px solid #3174af;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px rgba(26, 115, 232, 0.4);
 }
 .browse-category div:hover {
   text-decoration: underline;
 }
 .browse-category.selected {
-  border: 2px solid #3497d1;
+  border: 3px solid #3497d1;
   font-size: 20px;
+}
+.browse-category.selected div:focus {
+  outline: 2px solid #3174af;
+  outline-offset: -2px;
+  box-shadow: 0 0 0 2px rgba(26, 115, 232, 0.4);
 }
 #selected-browse-label {
   background-color: #fff;

--- a/code/web/interface/themes/responsive/js/aspen/browse.js
+++ b/code/web/interface/themes/responsive/js/aspen/browse.js
@@ -74,6 +74,14 @@ AspenDiscovery.Browse = (function(){
 				AspenDiscovery.Browse.changeBrowseCategory(categoryId);
 			});
 
+			// Handle keyboard navigation (tabbing) to scroll carousel.
+			browseCategoryCarousel.on('focus', 'li div', function(){
+				var $item = $(this).closest('li');
+				if ($('#browse-category-picker .jcarousel-control-prev').css('display') !== 'none') {
+					$("#browse-category-carousel").jcarousel('scroll', $item, true);
+				}
+			});
+
 			if ($('#browse-category-picker .jcarousel-control-prev').css('display') !== 'none') {
 				// only enable if the carousel features are being used.
 				// as of now, basalt & vail are not. plb 12-1-2014

--- a/code/web/release_notes/25.11.00.MD
+++ b/code/web/release_notes/25.11.00.MD
@@ -116,6 +116,8 @@
 - Promote search result titles to semantic `h2` headings and ensure a hidden page-level `h1`. (DIS-1445) (*LS*)
 - Refresh the visually hidden helper and convert the clear-search control into a properly labeled button. (DIS-1445) (*LS*)
 - Announce the Notes accordion section as a level-two heading while retaining its existing look. (DIS-1445) (*LS*)
+- Added visible focus indicators when tabbing through browse categories. (DIS-325) (*LE*, *LS*)
+- Resolved issue where using keyboard navigation to move through browse categories caused the carousel to jump to the end; carousel now smoothly scrolls to bring the focused category into view. (DIS-325) (*LS*)
 
 ### Administrations Updates
 - Allowed the soft-deletion of Themes and their restoration through the Object Restorations interface. (DIS-1463) (*LS*, *MDN*)
@@ -202,6 +204,7 @@
 - Leo Stoyanov (LS)
 - Yanjun Li (YL)
 - Imani Thomas (IT)
+- Laura Escamilla (LE)
 
 ### Grove For Libraries
 - Mark Noble (MDN)


### PR DESCRIPTION
- Added visible focus indicators when tabbing through browse categories.
- Resolved issue where using keyboard navigation to move through browse categories caused the carousel to jump to the end; carousel now smoothly scrolls to bring the focused category into view.