### PR TITLE
DIS-1533: Handle Records with Missing Formats Gracefully

### DIFF
--- a/code/web/interface/themes/responsive/GroupedWork/multipleVariationManifestion.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/multipleVariationManifestion.tpl
@@ -2,7 +2,13 @@
 <div class="col-sm-12">
 	<div class="row">
 		<div class="col-sm-12 manifestation-format">
-			{translate text=$relatedManifestation->format isPublicFacing=true}
+			{if $relatedManifestation->hasInvalidFormat()}
+				<span class="text-warning" title="{translate text='Format information is missing for this item' inAttribute=true isPublicFacing=true}">
+					{translate text='Unknown Format' isPublicFacing=true}
+				</span>
+			{else}
+				{translate text=$relatedManifestation->format isPublicFacing=true}
+			{/if}
 		</div>
 	</div>
 	{foreach from=$relatedManifestation->getVariations() item=variation}

--- a/code/web/interface/themes/responsive/GroupedWork/singleVariationManifestion.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/singleVariationManifestion.tpl
@@ -4,7 +4,11 @@
 		{if $printInterface === false || ($printInterface === true && $printEntryFormats === true)}
 		<div class="col-tn-4 col-xs-4{if empty($viewingCombinedResults)} col-md-3{/if} manifestation-format">
 			<a class="btn btn-xs btn-primary btn-wrap" href="{$relatedManifestation->getUrl()}" {if $relatedManifestation->getNumRelatedRecords() > 1}onclick="return AspenDiscovery.ResultsList.showRelatedManifestations('{$workId|escapeCSS}','{$relatedManifestation->format|escapeCSS}','{$relatedManifestation->getFirstVariation()->databaseId|escapeCSS}');" aria-label="View Manifestations for {translate text=$relatedManifestation->format inAttribute=true isPublicFacing=true}"{else} aria-label="View {translate text=$relatedManifestation->format inAttribute=true}"{/if}>
-				{translate text=$relatedManifestation->format isPublicFacing=true}
+				{if $relatedManifestation->hasInvalidFormat()}
+					{translate text='Unknown Format' isPublicFacing=true}
+				{else}
+					{translate text=$relatedManifestation->format isPublicFacing=true}
+				{/if}
 			</a>
 			<br>
 			<a href="#" onclick="return AspenDiscovery.ResultsList.showRelatedManifestations('{$workId|escapeCSS}','{$relatedManifestation->format|escapeCSS}', '{$relatedManifestation->getFirstVariation()->databaseId|escapeCSS}');" aria-label="View Editions for {translate text=$relatedManifestation->format inAttribute=true}">

--- a/code/web/interface/themes/responsive/Record/full-record.tpl
+++ b/code/web/interface/themes/responsive/Record/full-record.tpl
@@ -20,7 +20,14 @@
 				{if $recordDriver->getFormats()}
 					<br>
 					<small>
-						({implode subject=$recordDriver->getFormats() glue=", " translate=true isPublicFacing=true})
+						{assign var=formats value=$recordDriver->getFormats()}
+						{assign var=hasEmptyFormat value=false}
+						{foreach from=$formats item=format}
+							{if empty($format)}
+								{assign var=hasEmptyFormat value=true}
+							{/if}
+						{/foreach}
+						({if $hasEmptyFormat}{translate text="Missing Format" isPublicFacing=true}{else}{implode subject=$formats glue=", " translate=true isPublicFacing=true}{/if})
 						{if $recordDriver->isClosedCaptioned()}
 							&nbsp;<i class="fas fa-closed-captioning"></i>
 						{/if}

--- a/code/web/release_notes/25.11.00.MD
+++ b/code/web/release_notes/25.11.00.MD
@@ -184,6 +184,7 @@
 - When "Use Original Cover URLs" is enabled, ensure cover images for grouped works in search results are standardized. (DIS-1396) (*LS*)
 - Added stack trace output (`%throwable`) to log4j pattern layouts for both console and file appenders in Java processes. (DIS-228) (*KH*, *LS*)
 - Corrected SQL operator precedence issue in DataObject soft-delete filtering. When permission queries use multiple OR conditions, the `deleted = 0` filter now correctly applies to all results by wrapping `OR` clauses in parentheses. (DIS-1496) (*LS*)
+- Records with incomplete format metadata now display "Missing Format" on record pages and "Unknown Format" in manifestation lists, instead displaying an error. (DIS-1533) (*LS*)
 
 //yanjun
 

--- a/code/web/sys/Grouping/Manifestation.php
+++ b/code/web/sys/Grouping/Manifestation.php
@@ -30,11 +30,11 @@ class Grouping_Manifestation {
 	function __construct(Grouping_Record|array $record) {
 		$this->_statusInformation = new Grouping_StatusInformation();
 		if (is_array($record)) {
-			$this->format = $record['format'];
-			$this->formatCategory = $record['formatCategory'];
+			$this->format = $record['format'] ?? '';
+			$this->formatCategory = $record['formatCategory'] ?? '';
 		} else {
-			$this->format = $record->format;
-			$this->formatCategory = $record->formatCategory;
+			$this->format = $record->format ?? '';
+			$this->formatCategory = $record->formatCategory ?? '';
 			$this->addRecord($record);
 		}
 	}
@@ -513,6 +513,16 @@ class Grouping_Manifestation {
 			'variations' => $variationsData
 		];
 		return json_encode($data);
+	}
+
+	/**
+	 * Check if this manifestation has invalid/missing format information.
+	 *
+	 * @return bool
+	 * @noinspection PhpUnused
+	 */
+	function hasInvalidFormat(): bool {
+		return empty($this->format) || empty($this->formatCategory);
 	}
 
 }


### PR DESCRIPTION
- Records with incomplete format metadata now display "Missing Format" on record pages and "Unknown Format" in manifestation lists, instead displaying an error.

Test Plan: Refer to the [Jira issue](https://aspen-discovery.atlassian.net/browse/DIS-1533).