### PR TITLE
DIS-1134 - Fixes for showing Series Data within List Results

### DIFF
--- a/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/listEntry.tpl
@@ -46,14 +46,59 @@
 				</div>
 			{/if}
 
-			{if (!empty($summSeries) && !empty($summSeries.seriesTitle)) && ($printInterface === false || ($printInterface === true && $printEntrySeries === true))}
+			{if !empty($showSeries) && (!empty($summSeries) && !empty($summSeries.seriesTitle)) && ($printInterface === false || ($printInterface === true && $printEntrySeries === true))}
 				{* If the series has an ISBN, use it to make the class unique to this series *}
-				<div class="series{$summISBN} row">
-					<div class="result-label col-xs-3">{translate text="Series" isPublicFacing=true} </div>
-					<div class="result-value col-xs-9">
-						<a href="/GroupedWork/{$summId}/Series">{$summSeries.seriesTitle}</a>{if !empty($summSeries.volume)}<strong> {translate text="volume %1%" 1=$summSeries.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}
+				{assign var=indexedSeries value=$recordDriver->getIndexedSeries()}
+				{if ($summSeries && empty($summSeries.allHidden)) || ($indexedSeries && empty($summSeries.fromSeriesIndex))}
+					<div class="series{$summISBN} row">
+						<div class="result-label col-sm-3">{translate text="Series" isPublicFacing=true} </div>
+						<div class="result-value col-sm-9">
+							{if !empty($summSeries)}
+								{if !empty($summSeries.fromNovelist)}
+									<a href="/GroupedWork/{$summId}/Series">{$summSeries.seriesTitle}</a>{if !empty($summSeries.volume)} <strong>{translate text=volume isPublicFacing=true} {$summSeries.volume|format_float_with_min_decimals}</strong>{/if}<br>
+								{elseif !empty($summSeries.fromSeriesIndex)}
+									{if !$summSeries.hidden}
+										<a href="/Series/{$summSeries.seriesId}">{$summSeries.seriesTitle}</a>{if !empty($summSeries.volume)}<strong> {translate text="volume %1%" 1=$summSeries.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}<br>
+									{/if}
+									{if !empty($summSeries.additionalSeries)}
+										{assign var=numSeriesShown value=1}
+										{foreach from=$summSeries.additionalSeries item=additional}
+											{if !$additional.hidden}
+												{assign var=numSeriesShown value=$numSeriesShown+1}
+												{if $numSeriesShown == 4}
+													<a onclick="$('#moreSeries_{$summId}').show();$('#moreSeriesLink_{$summId}').hide();" id="moreSeriesLink_{$summId}">{translate text='More Series...' isPublicFacing=true}</a>
+													<div id="moreSeries_{$summId}" style="display:none">
+												{/if}
+												<a href="/Series/{$additional.seriesId}">{$additional.seriesTitle}</a>{if !empty($additional.volume)}<strong> {translate text="volume %1%" 1=$additional.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}<br>
+											{/if}
+										{/foreach}
+										{if $numSeriesShown >= 4}
+											</div>
+										{/if}
+									{/if}
+								{elseif !empty($summSeries.seriesTitle)}
+									<a href="/Search/Results?searchIndex=Series&lookfor={$summSeries.seriesTitle}&sort=year+asc%2Ctitle+asc">{$summSeries.seriesTitle}</a>{if !empty($summSeries.volume)}<strong> {translate text="volume %1%" 1=$summSeries.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}<br>
+								{/if}
+							{/if}
+							{if !empty($indexedSeries) && empty($summSeries.fromSeriesIndex)}
+								{assign var=numSeriesShown value=0}
+								{foreach from=$indexedSeries item=seriesItem name=loop}
+									{if !isset($summSeries.seriesTitle) || ((strpos(strtolower($seriesItem.seriesTitle), strtolower($summSeries.seriesTitle)) === false) && (strpos(strtolower($summSeries.seriesTitle), strtolower($seriesItem.seriesTitle)) === false))}
+										{assign var=numSeriesShown value=$numSeriesShown+1}
+										{if $numSeriesShown == 4}
+											<a onclick="$('#moreSeries_{$summId}').show();$('#moreSeriesLink_{$summId}').hide();" id="moreSeriesLink_{$summId}">{translate text='More Series...' isPublicFacing=true}</a>
+											<div id="moreSeries_{$summId}" style="display:none">
+										{/if}
+										<a href="/Search/Results?searchIndex=Series&lookfor=%22{$seriesItem.seriesTitle|escape:"url"}%22&sort=year+asc%2Ctitle+asc">{$seriesItem.seriesTitle|escape}</a>{if !empty($seriesItem.volume)}<strong> {translate text="volume %1%" 1=$seriesItem.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}<br>
+									{/if}
+								{/foreach}
+								{if $numSeriesShown >= 4}
+									</div>
+								{/if}
+							{/if}
+						</div>
 					</div>
-				</div>
+				{/if}
 			{/if}
 
 			{if (!empty($listEntryNotes) && $printInterface === false) || (!empty($listEntryNotes) && $printInterface === true && $printEntryNotes === true)}
@@ -89,10 +134,10 @@
 			{/if}
 
 			{if $printInterface === false}
-			<div class="resultActions row">
-				{include file='GroupedWork/result-tools-horizontal.tpl' ratingData=$summRating recordUrl=$summUrl showMoreInfo=true showNotInterested=false}
-			</div>
-            {/if}
+				<div class="resultActions row">
+					{include file='GroupedWork/result-tools-horizontal.tpl' ratingData=$summRating recordUrl=$summUrl showMoreInfo=true showNotInterested=false}
+				</div>
+			{/if}
 		</div>
 
 		{if !empty($listEditAllowed) && $printInterface === false}

--- a/code/web/release_notes/25.11.00.MD
+++ b/code/web/release_notes/25.11.00.MD
@@ -18,6 +18,10 @@
 ### Library Setting Updates
 - Hide library settings based on whether they apply to the active ILS. (DIS-1514) (*MDN*)
 
+### List Updates
+- Show or hide series data based on Grouped Work Display Settings for consistency with Search Results. (DIS-1334) (*MDN*)
+- Ensure that series display for Grouped Works on lists is consistent with search results. (DIS-1334) (*MDN*)
+
 ### Polaris Updates
 - Improve Indexing Performance. (DIS-1487) (*MDN*)
   - Load all items that have been updated or deleted before looking up bibs to update based on items. 

--- a/code/web/sys/Grouping/GroupedWorkDisplaySetting.php
+++ b/code/web/sys/Grouping/GroupedWorkDisplaySetting.php
@@ -704,7 +704,7 @@ class GroupedWorkDisplaySetting extends DataObject {
 					'showInSearchResultsMainDetails' => [
 						'property' => 'showInSearchResultsMainDetails',
 						'type' => 'multiSelect',
-						'label' => 'Optional details to show for a record in search results : ',
+						'label' => 'Optional details to show for a record in search results',
 						'description' => 'Selected details will be shown in the main details section of a record on a search results page.',
 						'listStyle' => 'checkboxSimple',
 						'values' => self::$searchResultsMainDetailsOptions,

--- a/code/web/sys/UserLists/UserList.php
+++ b/code/web/sys/UserLists/UserList.php
@@ -743,6 +743,13 @@ class UserList extends DataObject {
 			$filteredListEntries = $listEntryInfo['listEntries'];
 		//}
 
+		global $library;
+		global $interface;
+		$groupedWorkDisplaySettings = $library->getGroupedWorkDisplaySettings();
+		foreach ($groupedWorkDisplaySettings->showInSearchResultsMainDetails as $detailOption) {
+			$interface->assign($detailOption, true);
+		}
+
 		$filteredIdsBySource = [];
 		foreach ($filteredListEntries as $listItemEntry) {
 			if (!array_key_exists($listItemEntry['source'], $filteredIdsBySource)) {


### PR DESCRIPTION
- Show or hide series data based on Grouped Work Display Settings for consistency with Search Results.
- Ensure that series display for Grouped Works on lists is consistent with search results.