### PR TITLE
DIS-1540: Consider Not For Loan Statuses Before Checked Out Statuses for Koha

### DIFF
--- a/code/reindexer/src/org/aspen_discovery/reindexer/KohaRecordProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/KohaRecordProcessor.java
@@ -196,10 +196,10 @@ class KohaRecordProcessor extends IlsRecordProcessor {
 		status = getStatusFromSubfield(itemField, '4', "Damaged");
 		if (status != null) return new ItemStatus(status, ItemStatus.FROM_STATUS_FIELD, this, recordIdentifier);
 
-		status = getStatusFromSubfield(itemField, 'q', "Checked Out");
+		status = getStatusFromSubfield(itemField, '7', "Library Use Only"); // Not for Loan
 		if (status != null) return new ItemStatus(status, ItemStatus.FROM_STATUS_FIELD, this, recordIdentifier);
 
-		status = getStatusFromSubfield(itemField, '7', "Library Use Only"); //not for loan
+		status = getStatusFromSubfield(itemField, 'q', "Checked Out");
 		if (status != null) return new ItemStatus(status, ItemStatus.FROM_STATUS_FIELD, this, recordIdentifier);
 
 		status = getStatusFromSubfield(itemField, 'k', null);

--- a/code/web/release_notes/25.11.00.MD
+++ b/code/web/release_notes/25.11.00.MD
@@ -177,6 +177,7 @@
 
 ### Koha Updates
 - Hide the "Patron Expiry" row under Messaging Settings if "Enforce patron account expiry notice" is enabled for that Patron Category in Koha. ([DIS-1443](https://aspen-discovery.atlassian.net/browse/DIS-1443)) (*LS*)
+- Modified indexing to consider "Not for Loan" statuses in subfield 7 before "Checked Out" statuses in subfield q for MARC records. (DIS-1540) (*LS*)
 
 ### Material Requests Updates
 - Materials requests are now automatically removed from the "Requests Needing Holds" list when their status is changed to a status where "Check for Holds?" is set to "No." (DIS-1461) (*LS*)


### PR DESCRIPTION
- Modified indexing to consider "Not for Loan" statuses in subfield 7 before "Checked Out" statuses in subfield q for MARC records.

Test Plan:
1. Find a record with that is both checked out and suppressed with a “Not for Loan” status in Aspen. Notice that “Checked Out” displays as its status.
2. Apply the patch and reindex it. Notice that “Not for Loan,” or some variation, displays as its status.

