### PR TITLE
DIS-1542 delete list return check

### DIFF
--- a/code/web/release_notes/25.11.00.MD
+++ b/code/web/release_notes/25.11.00.MD
@@ -229,6 +229,9 @@
 ### Sierra Updates
 - Fix mapping of workPhone and phone for Sierra which had been swapped. (DIS-1489) (*IT*)
 
+### API Updates
+- Fix deleteList in ListAPI returning list deleted successfully when database issues prevents deletion (DIS-1542) (*IT*)
+
 //alexander
 ### Other
 - Added the option of using the address to display the location on Google Maps. (DIS-1338) (*AB*)

--- a/code/web/services/API/ListAPI.php
+++ b/code/web/services/API/ListAPI.php
@@ -1325,12 +1325,32 @@ class ListAPI extends AbstractAPI {
 				$userCanEdit = $user->canEditList($list);
 				if ($userCanEdit) {
 					$optOutOfSoftDeletion = !empty($_REQUEST['optOutOfSoftDeletion']) && filter_var($_REQUEST['optOutOfSoftDeletion'], FILTER_VALIDATE_BOOLEAN);
-					$list->delete(false, $optOutOfSoftDeletion);
-					return [
-						'success' => true,
-						'title' => translate(['text' => 'Success', 'isPublicFacing' => true]),
-						'message' => translate(['text' => 'List deleted successfully', 'isPublicFacing' => true]),
-					];
+					$result = $list->delete(false, $optOutOfSoftDeletion);
+					if($result === 1) //we successfully modified our list
+					{
+						return [
+							'success' => true,
+							'title' => translate(['text' => 'Success', 'isPublicFacing' => true]),
+							'message' => translate(['text' => 'List deleted successfully', 'isPublicFacing' => true]),
+						];
+					}
+					else if($result === true) // true is returned from DataObject if no changes were detected
+					{
+						// this branch shouldn't happen because if we found the list we should have changes to update but better to be safe.
+						// in an ideal world we shoiuld only need the first section.
+						return [
+							'success' => false,
+							'title' => translate(['text' => 'Error', 'isPublicFacing' => true]),
+							'message' => translate(['text' => 'We attempted to delete your list but it looks like no changes occurred', 'isPublicFacing' => true]),
+						];
+					} else { // some kind of DB error happened and we almost certainly did not successfully delete the list.
+						return [
+							'success' => false,
+							'title' => translate(['text' => 'Error', 'isPublicFacing' => true]),
+							'result' => $result,
+							'message' => translate(['text' => $list->getLastError(), 'isPublicFacing' => true]),
+						];
+					}
 				} else {
 					return [
 						'success' => false,

--- a/code/web/services/API/ListAPI.php
+++ b/code/web/services/API/ListAPI.php
@@ -1344,11 +1344,13 @@ class ListAPI extends AbstractAPI {
 							'message' => translate(['text' => 'We attempted to delete your list but it looks like no changes occurred', 'isPublicFacing' => true]),
 						];
 					} else { // some kind of DB error happened and we almost certainly did not successfully delete the list.
+						global $logger;
+						$logger->log($list->getLastError(), Logger::LOG_ERROR); //log the error since we don't want to risk exposing it to end users.
 						return [
 							'success' => false,
 							'title' => translate(['text' => 'Error', 'isPublicFacing' => true]),
 							'result' => $result,
-							'message' => translate(['text' => $list->getLastError(), 'isPublicFacing' => true]),
+							'message' => translate(['text' => 'A Database error occurred attempting to delete your list.', 'isPublicFacing' => true]),
 						];
 					}
 				} else {


### PR DESCRIPTION
to test:
* create a list for a user
* In postman or your favorite API testing tool make a request to /API/ListAPI?method=deleteList with the id of your list, and the username and password of your user added
* if the deletion is successful you should get the normal list deleted successfully message.
* if there are any issues, like for example you don't have an active user since you just hit the api directly without a session from logging in, when the delete fails you should get a message saying such instead of a false positive saying a delete was successfull when it wasn't.