### PR TITLE
DIS-1558 Reset location cache between fetches

### DIFF
--- a/code/web/release_notes/25.11.00.MD
+++ b/code/web/release_notes/25.11.00.MD
@@ -250,6 +250,7 @@
 ### Other Updates
 - Add a Clear Cached Values button under System Variables so admins can purge cached values manually. (DIS-1531) (*YL*)
 - Add Clear Cached Values Action to every upgrade. (DIS-1531) (*YL*)
+- Fix getLibraries returning wrong location lists in System API. Cached locations reset between libraries. (DIS-1558) (*YL*)
 
 //imani
 ## Community Engagement Updates

--- a/code/web/sys/LibraryLocation/Library.php
+++ b/code/web/sys/LibraryLocation/Library.php
@@ -5891,7 +5891,7 @@ class Library extends DataObject {
 		return $this->_materialsRequestFormats;
 	}
 
-	private $_locations = null;
+	protected $_locations = null;
 	/**
 	 * @return Location[]
 	 */


### PR DESCRIPTION
Found a bug when making a request to SystemAPI?method=getLibraries , different libraries had the same locations. This is because in the Library.php > getLocations(), $_locations is private and never gets reset. So libraries reuse the first library’s cached locations. 

To Test:
1. Call SystemAPI?method=getLibraries 
2. See results, different library objects have the same locations
3. Apply PR
4. Make the call again and see that different library objects have their own locations. 