### PR TITLE
DIS-1396: Honor Width of Column for Original Covers

### DIFF
--- a/code/web/interface/themes/responsive/css/browse-categories.less
+++ b/code/web/interface/themes/responsive/css/browse-categories.less
@@ -281,9 +281,9 @@
     width:100%;
     min-height: 100px;
     &.use-original-covers {
+      width: 100%;
       max-width: 180px;
       max-height: 225px;
-      width: auto;
       height: auto;
     }
     &.floating {

--- a/code/web/interface/themes/responsive/css/main.css
+++ b/code/web/interface/themes/responsive/css/main.css
@@ -9677,9 +9677,9 @@ a.browse-thumbnail.active {
   min-height: 100px;
 }
 .browse-thumbnail img.use-original-covers {
+  width: 100%;
   max-width: 180px;
   max-height: 225px;
-  width: auto;
   height: auto;
 }
 .browse-thumbnail img.floating {

--- a/code/web/release_notes/25.11.00.MD
+++ b/code/web/release_notes/25.11.00.MD
@@ -244,6 +244,7 @@
 - Fixed CSV export functionality for API Usage Graphs. (DIS-1519) (*LS*)
 - Fixed an issue where read-only timestamp properties would be cleared when a form re-saved. (DIS-1503) (*LS*)
 - When "Use Original Cover URLs" is enabled, ensure cover images for grouped works in search results are standardized. (DIS-1396) (*LS*)
+  - Prevent browse-category and cover-search tiles from overflowing by letting oversized covers wrap naturally within the restricted layout width.
 - Added stack trace output (`%throwable`) to log4j pattern layouts for both console and file appenders in Java processes. (DIS-228) (*KH*, *LS*)
 - Corrected SQL operator precedence issue in DataObject soft-delete filtering. When permission queries use multiple OR conditions, the `deleted = 0` filter now correctly applies to all results by wrapping `OR` clauses in parentheses. (DIS-1496) (*LS*)
 - Records with incomplete format metadata now display "Missing Format" on record pages and "Unknown Format" in manifestation lists, instead displaying an error. (DIS-1533) (*LS*)


### PR DESCRIPTION
- Prevent browse-category and cover-search tiles from overflowing by letting oversized covers wrap naturally within the restricted layout width.