### PR TITLE
DIS-1569 Use the Schema API instead of downloading the schema file

### DIFF
--- a/code/web/release_notes/25.12.00.MD
+++ b/code/web/release_notes/25.12.00.MD
@@ -141,6 +141,10 @@
 - Add support for ChiliFresh as a cover image source. ([DIS-1602](https://aspen-discovery.atlassian.net/browse/DIS-1602)) (*GMC*)
 
 
+//tomas
+### Indexing Updates
+- Add SolrCloud support by using the Schema API instead of downloading the schema file. (DIS-1569) (*TC*)
+
 ## This release includes code contributions from
 ### ByWater Solutions
 - Leo Stoyanov (LS)
@@ -164,6 +168,7 @@
 
 ### Theke Solutions
 - Lucas Montoya (LM)
+- Tomas Cohen Arazi (TC)
 
 ## Special Testing thanks to
 - 

--- a/code/web/sys/SolrConnector/Solr.php
+++ b/code/web/sys/SolrConnector/Solr.php
@@ -139,9 +139,9 @@ abstract class Solr {
 		if (empty($index)) {
 			global $library;
 			if ($library) {
-				$index = 'grouped_works';
+				$index = 'grouped_works_v2';
 			} else {
-				$index = isset($configArray['Index']['default_core']) ? $configArray['Index']['default_core'] : "grouped_works";
+				$index = isset($configArray['Index']['default_core']) ? $configArray['Index']['default_core'] : "grouped_works_v2";
 			}
 
 			$this->index = $index;

--- a/code/web/sys/SolrConnector/Solr.php
+++ b/code/web/sys/SolrConnector/Solr.php
@@ -151,7 +151,8 @@ abstract class Solr {
 
 		$timer->logTime("Load search specs");
 
-		$this->host = $host . '/' . $index;
+		$this->baseUrl = $host;  // e.g., http://solr:8084/solr
+		$this->host = $host . '/' . $index;  // Keep for backward compatibility
 
 		// If we're still processing then solr is online
 		$this->client = new CurlWrapper();
@@ -2103,25 +2104,31 @@ abstract class Solr {
 			//There are very large performance gains for caching this in memory since we need to do a remote call and file parse
 			$fields = $memCache->get("schema_fields_$key");
 			if (!$fields || isset($_REQUEST['reload'])) {
-				$schemaUrl = $this->host . '/admin/file?file=schema.xml&contentType=text/xml;charset=utf-8';
-				$schema = @simplexml_load_file($schemaUrl);
-				if ($schema == null) {
+				$schemaApiUrl = $this->baseUrl . '/' . $this->index . '/schema/fields';
+				$schemaJson = @file_get_contents($schemaApiUrl);
+				$schemaData = $schemaJson ? json_decode($schemaJson, true) : null;
+				if ($schemaData === null) {
 					AspenError::raiseError("Solr is not currently running");
 				}
 				$fields = [];
-				foreach ($schema->fields->field as $field) {
-					//print_r($field);
-					if ($field['stored'] == 'true' || $field['indexed'] == 'true') {
-						$fields[] = (string)$field['name'];
+				foreach ($schemaData['fields'] as $field) {
+					if (($field['stored'] ?? false) || ($field['indexed'] ?? false)) {
+						$fields[] = $field['name'];
 					}
 				}
 				if ($solrScope) {
-					foreach ($schema->fields->dynamicField as $field) {
-						if ($field['name'] != 'custom_facet_*') {
-							$fields[] = substr((string)$field['name'], 0, -1) . $solrScope;
-						}else{
-							for ($i = 1; $i <= 4; $i++) {
-								$fields[] = substr((string)$field['name'], 0, -1) . $i;
+					// Get dynamic fields from Schema API
+					$dynamicFieldsUrl = $this->baseUrl . '/' . $this->index . '/schema/dynamicfields';
+					$dynamicJson = @file_get_contents($dynamicFieldsUrl);
+					$dynamicData = $dynamicJson ? json_decode($dynamicJson, true) : null;
+					if ($dynamicData && isset($dynamicData['dynamicFields'])) {
+						foreach ($dynamicData['dynamicFields'] as $field) {
+							if ($field['name'] != 'custom_facet_*') {
+								$fields[] = substr($field['name'], 0, -1) . $solrScope;
+							} else {
+								for ($i = 1; $i <= 4; $i++) {
+									$fields[] = substr($field['name'], 0, -1) . $i;
+								}
 							}
 						}
 					}


### PR DESCRIPTION
- Use /schema/fields instead of /admin/file?file=schema.xml
- Compatible with modern Solr versions and SolrCloud
- Maintains same error handling for offline Solr detection

Test Plan:
1. SolrCloud: Deploy cluster, verify schema fields load in admin interface
2. Single Node: Test catalog browsing and search functionality
3. Error Handling: Stop Solr, verify 'Solr is not currently running' error
4. Cache: Test ?reload=1 parameter refreshes schema from API
5. Manual: curl http://localhost:8983/solr/schema/fields | jq '.fields[0]'