### PR TITLE
DIS-1596:  Remove requirement of setting LOCAL_USER_ID environment variable

### DIFF
--- a/code/web/release_notes/25.12.00.MD
+++ b/code/web/release_notes/25.12.00.MD
@@ -118,6 +118,9 @@
 
 
 //lucas
+### Docker Updates
+- Removed requirement of setting LOCAL_USER_ID environment variable. (DIS-1596) (*LM*)
+- Avoid modifying host permissions by removing source code chown. (DIS-1596) (*LM*)
 
 // James Staub
 ### Other Updates
@@ -126,6 +129,7 @@
 // Galen Charlton
 ### Cover Images Updates
 - Add support for ChiliFresh as a cover image source. ([DIS-1602](https://aspen-discovery.atlassian.net/browse/DIS-1602)) (*GMC*)
+
 
 ## This release includes code contributions from
 ### ByWater Solutions

--- a/docker/files/scripts/entrypoint.sh
+++ b/docker/files/scripts/entrypoint.sh
@@ -9,49 +9,24 @@ USER_NAME="www-data"
 SOURCE_DIR="/usr/local/aspen-discovery"
 APACHE_LOG_DIR="/var/log/apache2"
 
-if [ -z "${LOCAL_USER_ID}" ]; then
-	log "LOCAL_USER_ID must be set!. Exiting..."
-	exit 1
+# Adjust user ID if needed
+if [[ -n "${LOCAL_USER_ID}" && "${LOCAL_USER_ID}" != "33" ]]; then
+	log "Setting UID for ${USER_NAME} to ${LOCAL_USER_ID}"
+	usermod -o -u "$LOCAL_USER_ID" "$USER_NAME"
 fi
 
+# Determine service to run
 if [ "$#" -eq 0 ]; then
-
-	log "Starting container with UID=${LOCAL_USER_ID}"
-
-	if [[ "${LOCAL_USER_ID}" != "33" ]]; then
-		log "Setting UID for ${USER_NAME} to ${LOCAL_USER_ID}"
-		usermod -o -u "$LOCAL_USER_ID" "$USER_NAME"
-	fi
-
-	if [[ -d "${SOURCE_DIR}" ]]; then
-		log "Fixing ownership on ${SOURCE_DIR}"
-		chown -R "$USER_NAME" ${SOURCE_DIR}
-	fi
 
 	exec "/start.sh"
 
-
 elif [ "$1" = 'apache' ]; then
 
-	# Adjust permissions if required
-	if [[ "${LOCAL_USER_ID}" != "33" ]]; then
-		log "Setting UID for ${USER_NAME} to ${LOCAL_USER_ID}"
-		usermod -o -u ${LOCAL_USER_ID} "$USER_NAME"
-
-		# Fix permissions due to UID change
-		chown -R ${USER_NAME} "${APACHE_LOG_DIR}"
-	fi
-	chown -R "$USER_NAME" "$SOURCE_DIR"
+	chown -R ${USER_NAME} "${APACHE_LOG_DIR}"
 	exec /apache.sh
 
 elif [ "$1" = 'cron' ]; then
 
-	# Adjust permissions if required
-	if [[ "${LOCAL_USER_ID}" != "33" ]]; then
-		log "Setting UID for ${USER_NAME} to ${LOCAL_USER_ID}"
-		usermod -o -u ${LOCAL_USER_ID} "$USER_NAME"
-	fi
-	chown -R ${USER_NAME} ${SOURCE_DIR}
 	exec /cron.sh
 
 else


### PR DESCRIPTION
In the context of containers, this type of variable should not be mandatory and should have an alternative value instead of closing.
Also, following Docker good practices, it shouldn’t modify permissions of anything of the host side since it could be a risk in terms of security.

This patch removes the mandatority of setting the LOCAL_USER_ID environment variable and removes a chown command which modifies host permissions.


