### PR TITLE
DIS-1599:  Add health checks for db updates script

### DIFF
--- a/code/web/release_notes/25.12.00.MD
+++ b/code/web/release_notes/25.12.00.MD
@@ -17,6 +17,10 @@
 
 //lucas
 
+### Docker Updates
+- Removed requirement of setting LOCAL_USER_ID environment variable. (DIS-1596) (*LM*)
+- Avoid modifying host permissions by removing source code chown. (DIS-1596) (*LM*)
+
 ## This release includes code contributions from
 ### ByWater Solutions
 - Leo Stoyanov (LS)

--- a/code/web/release_notes/25.12.00.MD
+++ b/code/web/release_notes/25.12.00.MD
@@ -20,7 +20,7 @@
 ### Docker Updates
 - Removed requirement of setting LOCAL_USER_ID environment variable. (DIS-1596) (*LM*)
 - Avoid modifying host permissions by removing source code chown. (DIS-1596) (*LM*)
-
+- Added health checks to verify database connectivity and data population. (DIS-1599) (*LM*)
 ## This release includes code contributions from
 ### ByWater Solutions
 - Leo Stoyanov (LS)

--- a/docker/files/database/DatabaseHealth.php
+++ b/docker/files/database/DatabaseHealth.php
@@ -1,0 +1,29 @@
+<?php 
+
+function checkDatabaseConnection(PDO $pdo): bool {
+
+    if ($pdo === null) {
+        DockerLogger::error("Database connection is null");
+        return false;
+    }
+    
+    try {
+        $statement = 'SELECT 1;';
+        $stmt = $pdo->prepare($statement);
+        $stmt->execute();
+        return true;
+    } catch (PDOException $e) {
+        return false;
+    }
+}
+
+function isDatabaseInitialized(PDO $pdo): bool {
+    try {
+        $statement = 'SELECT libraryId FROM library LIMIT 1;';
+        $stmt = $pdo->prepare($statement);
+        $stmt->execute();
+        return true;
+    } catch (PDOException $e) {
+        return false;
+    }
+}

--- a/docker/files/scripts/entrypoint.sh
+++ b/docker/files/scripts/entrypoint.sh
@@ -9,49 +9,24 @@ USER_NAME="www-data"
 SOURCE_DIR="/usr/local/aspen-discovery"
 APACHE_LOG_DIR="/var/log/apache2"
 
-if [ -z "${LOCAL_USER_ID}" ]; then
-	log "LOCAL_USER_ID must be set!. Exiting..."
-	exit 1
+# Adjust user ID if needed
+if [[ -n "${LOCAL_USER_ID}" && "${LOCAL_USER_ID}" != "33" ]]; then
+	log "Setting UID for ${USER_NAME} to ${LOCAL_USER_ID}"
+	usermod -o -u "$LOCAL_USER_ID" "$USER_NAME"
 fi
 
+# Determine service to run
 if [ "$#" -eq 0 ]; then
-
-	log "Starting container with UID=${LOCAL_USER_ID}"
-
-	if [[ "${LOCAL_USER_ID}" != "33" ]]; then
-		log "Setting UID for ${USER_NAME} to ${LOCAL_USER_ID}"
-		usermod -o -u "$LOCAL_USER_ID" "$USER_NAME"
-	fi
-
-	if [[ -d "${SOURCE_DIR}" ]]; then
-		log "Fixing ownership on ${SOURCE_DIR}"
-		chown -R "$USER_NAME" ${SOURCE_DIR}
-	fi
 
 	exec "/start.sh"
 
-
 elif [ "$1" = 'apache' ]; then
 
-	# Adjust permissions if required
-	if [[ "${LOCAL_USER_ID}" != "33" ]]; then
-		log "Setting UID for ${USER_NAME} to ${LOCAL_USER_ID}"
-		usermod -o -u ${LOCAL_USER_ID} "$USER_NAME"
-
-		# Fix permissions due to UID change
-		chown -R ${USER_NAME} "${APACHE_LOG_DIR}"
-	fi
-	chown -R "$USER_NAME" "$SOURCE_DIR"
+	chown -R ${USER_NAME} "${APACHE_LOG_DIR}"
 	exec /apache.sh
 
 elif [ "$1" = 'cron' ]; then
 
-	# Adjust permissions if required
-	if [[ "${LOCAL_USER_ID}" != "33" ]]; then
-		log "Setting UID for ${USER_NAME} to ${LOCAL_USER_ID}"
-		usermod -o -u ${LOCAL_USER_ID} "$USER_NAME"
-	fi
-	chown -R ${USER_NAME} ${SOURCE_DIR}
 	exec /cron.sh
 
 else

--- a/docker/files/scripts/updateDatabase.php
+++ b/docker/files/scripts/updateDatabase.php
@@ -3,6 +3,8 @@
 require_once __DIR__ . '/../logger/DockerLogger.php';
 DockerLogger::init('BACKEND');
 
+require_once __DIR__ . '/../database/DatabaseHealth.php';
+
 // Set server name
 $_SERVER['SERVER_NAME'] = getenv('SITE_NAME');
 
@@ -123,6 +125,14 @@ function pruneCompletedUpdates($availableUpdates) {
 }
 
 function runPendingDatabaseUpdates() {
+
+	# Check database connection
+	global $aspen_db;
+	if (!checkDatabaseConnection($aspen_db) || !isDatabaseInitialized($aspen_db)) {
+		DockerLogger::error("Cannot connect to the database to run updates)");
+		exit(1);
+	}
+	
 	$pendingUpdates = getPendingDatabaseUpdates();
 	$updates = 0;
 	$failedUpdates = 0;
@@ -153,6 +163,8 @@ function runPendingDatabaseUpdates() {
 		];
 	}
 }
+
+# ================================================================================
 
 function prepareNightlyFullIndexing(): void {
 	require_once ROOT_DIR . '/sys/SystemVariables.php';


### PR DESCRIPTION
This patch adds health checks to corroborate : 
-  A healthy database connection has been established 
- If the database has been populated 
 before trying to run the updates during the initialization of the backend service