### PR TITLE
DIS-1627: Made Aspen Admin Local Administrator Email Not Required

### DIFF
--- a/code/web/release_notes/25.12.00.MD
+++ b/code/web/release_notes/25.12.00.MD
@@ -34,6 +34,8 @@
 // kodi
 
 // leo
+### Other Updates
+- Fixed an issue where the Aspen Admin Local Administrator settings could not be edited because the Email Address field was read-only but also required. (DIS-1627) (*LS*)
 
 // imani
 

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -6412,6 +6412,7 @@ class User extends DataObject {
 			$structure['firstname']['readOnly'] = true;
 			$structure['lastname']['readOnly'] = true;
 			$structure['email']['readOnly'] = true;
+			$structure['email']['required'] = false;
 			unset($structure['additionalAdministrationLocations']);
 		}
 


### PR DESCRIPTION
- Fixed an issue where the Aspen Admin Local Administrator settings could not be edited because the Email Address field was read-only but also required.

Test Plan:
1. Navigate to the Aspen Admin Local Administrator setting in the admin interface.
2. Make a change and try to save the setting. Notice that it does not let you because the Email Address field is required but read-only.
3. Apply the patch and repeat step 2 to see it save.

