### PR TITLE
DIS-1590: Update existing Events when information in the Event Type is made non-customizable

### DIFF
--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -9911,6 +9911,8 @@ AspenDiscovery.EContent = (function(){
 
 AspenDiscovery.Events = (function(){
 	return {
+		saveEventsObjCallback: function() {},
+
 		trackUsage: function (id) {
 			var ajaxUrl = Globals.path + "/Events/JSON?method=trackUsage&id=" + id;
 			$.getJSON(ajaxUrl);
@@ -10579,6 +10581,66 @@ AspenDiscovery.Events = (function(){
 					win.print();
 				};
 			}
+		},
+		checkEventsForType: function (submitForm) {
+			var titleCustomizable = $("#titleCustomizable").is(':checked');
+			var descriptionCustomizable = $("#descriptionCustomizable").is(':checked');
+			var coverCustomizable = $("#coverCustomizable").is(':checked');
+			var eventLengthCustomizable = $("#lengthCustomizable").is(':checked');
+
+			var url = Globals.path + "/Events/AJAX";
+			var params = {
+				'method': 'checkEventsForType',
+				titleCustomizable: titleCustomizable,
+				descriptionCustomizable: descriptionCustomizable,
+				coverCustomizable: coverCustomizable,
+				eventLengthCustomizable: eventLengthCustomizable,
+				objectId: $("#id").val()
+			};
+
+			$.getJSON(url, params,function(data){
+				if (data.success){
+					if (data.noEventsOfType === true){
+						submitForm();
+					} else{
+						AspenDiscovery.Events.saveEventsObjCallback = submitForm;
+						AspenDiscovery.showMessageWithButtons(data.title, data.modalBody, data.modalButtons, '', '', false, '', true);
+					}
+				}else{
+					AspenDiscovery.showMessage('Sorry', data.message);
+				}
+			})
+		},
+		saveEventsForType: function(doFullSave){
+			var titleCustomizable = $("#titleCustomizable").is(':checked');
+			var descriptionCustomizable = $("#descriptionCustomizable").is(':checked');
+			var coverCustomizable = $("#coverCustomizable").is(':checked');
+			var eventLengthCustomizable = $("#lengthCustomizable").is(':checked');
+
+			var eventLengthHoursToMinutes = $("#eventLength_hours").val() * 60;
+			var eventLengthMinutes = $("#eventLength_minutes").val();
+			var eventLength = parseInt(eventLengthHoursToMinutes) + parseInt(eventLengthMinutes);
+
+			var params = {
+				objectId: $("#id").val(),
+				title: $("#title").val(),
+				description: $("#description").val(),
+				cover: $("#importFile-label-cover").val(),
+				eventLength: eventLength,
+				titleCustomizable: titleCustomizable,
+				descriptionCustomizable: descriptionCustomizable,
+				coverCustomizable: coverCustomizable,
+				eventLengthCustomizable: eventLengthCustomizable,
+				doFullSave: doFullSave
+			};
+			var url = Globals.path + '/Events/AJAX?method=saveEventsForType';
+			$.getJSON(url, params,function(data){
+				if (data.success === true){
+					AspenDiscovery.Events.saveEventsObjCallback();
+				}else{
+					AspenDiscovery.showMessage('Sorry', data.message);
+				}
+			});
 		}
 	};
 }(AspenDiscovery.Events || {}));

--- a/code/web/interface/themes/responsive/js/aspen/events.js
+++ b/code/web/interface/themes/responsive/js/aspen/events.js
@@ -1,5 +1,7 @@
 AspenDiscovery.Events = (function(){
 	return {
+		saveEventsObjCallback: function() {},
+
 		trackUsage: function (id) {
 			var ajaxUrl = Globals.path + "/Events/JSON?method=trackUsage&id=" + id;
 			$.getJSON(ajaxUrl);
@@ -668,6 +670,66 @@ AspenDiscovery.Events = (function(){
 					win.print();
 				};
 			}
+		},
+		checkEventsForType: function (submitForm) {
+			var titleCustomizable = $("#titleCustomizable").is(':checked');
+			var descriptionCustomizable = $("#descriptionCustomizable").is(':checked');
+			var coverCustomizable = $("#coverCustomizable").is(':checked');
+			var eventLengthCustomizable = $("#lengthCustomizable").is(':checked');
+
+			var url = Globals.path + "/Events/AJAX";
+			var params = {
+				'method': 'checkEventsForType',
+				titleCustomizable: titleCustomizable,
+				descriptionCustomizable: descriptionCustomizable,
+				coverCustomizable: coverCustomizable,
+				eventLengthCustomizable: eventLengthCustomizable,
+				objectId: $("#id").val()
+			};
+
+			$.getJSON(url, params,function(data){
+				if (data.success){
+					if (data.noEventsOfType === true){
+						submitForm();
+					} else{
+						AspenDiscovery.Events.saveEventsObjCallback = submitForm;
+						AspenDiscovery.showMessageWithButtons(data.title, data.modalBody, data.modalButtons, '', '', false, '', true);
+					}
+				}else{
+					AspenDiscovery.showMessage('Sorry', data.message);
+				}
+			})
+		},
+		saveEventsForType: function(doFullSave){
+			var titleCustomizable = $("#titleCustomizable").is(':checked');
+			var descriptionCustomizable = $("#descriptionCustomizable").is(':checked');
+			var coverCustomizable = $("#coverCustomizable").is(':checked');
+			var eventLengthCustomizable = $("#lengthCustomizable").is(':checked');
+
+			var eventLengthHoursToMinutes = $("#eventLength_hours").val() * 60;
+			var eventLengthMinutes = $("#eventLength_minutes").val();
+			var eventLength = parseInt(eventLengthHoursToMinutes) + parseInt(eventLengthMinutes);
+
+			var params = {
+				objectId: $("#id").val(),
+				title: $("#title").val(),
+				description: $("#description").val(),
+				cover: $("#importFile-label-cover").val(),
+				eventLength: eventLength,
+				titleCustomizable: titleCustomizable,
+				descriptionCustomizable: descriptionCustomizable,
+				coverCustomizable: coverCustomizable,
+				eventLengthCustomizable: eventLengthCustomizable,
+				doFullSave: doFullSave
+			};
+			var url = Globals.path + '/Events/AJAX?method=saveEventsForType';
+			$.getJSON(url, params,function(data){
+				if (data.success === true){
+					AspenDiscovery.Events.saveEventsObjCallback();
+				}else{
+					AspenDiscovery.showMessage('Sorry', data.message);
+				}
+			});
 		}
 	};
 }(AspenDiscovery.Events || {}));

--- a/code/web/release_notes/25.12.00.MD
+++ b/code/web/release_notes/25.12.00.MD
@@ -46,6 +46,8 @@
 // kirstien
 
 // kodi
+### Aspen Events Updates
+- Add functionality to prompt user about updating existing events of an event type when customization settings are updated for that event type. (DIS-1590) (*KL*)
 
 // leo
 ### Other Updates

--- a/code/web/services/Events/AJAX.php
+++ b/code/web/services/Events/AJAX.php
@@ -417,5 +417,89 @@ class Events_AJAX extends JSON_Action {
 				]) . "</button>",
 		];
 	}
+	/** @noinspection PhpUnused */
+	function checkEventsForType() {
+		$titleCustomizable = (isset($_REQUEST['titleCustomizable']) && $_REQUEST['titleCustomizable'] == 'true') ? 1 : 0;
+		$descriptionCustomizable = (isset($_REQUEST['descriptionCustomizable']) && $_REQUEST['descriptionCustomizable'] == 'true') ? 1 : 0;
+		$coverCustomizable = (isset($_REQUEST['coverCustomizable']) && $_REQUEST['coverCustomizable'] == 'true') ? 1 : 0;
+		$eventLengthCustomizable = (isset($_REQUEST['eventLengthCustomizable']) && $_REQUEST['eventLengthCustomizable'] == 'true') ? 1 : 0;
+
+		//If everything is customizable no need to prompt user
+		$booleanSum = $titleCustomizable + $descriptionCustomizable + $coverCustomizable + $eventLengthCustomizable;
+
+		if (!empty($_REQUEST['objectId']) && is_numeric($_REQUEST['objectId']) && $booleanSum != 4) {
+			require_once ROOT_DIR . '/sys/Events/Event.php';
+			$eventOfType = new Event();
+			$eventOfType->eventTypeId = $_REQUEST['objectId'];
+			if ($eventOfType->find(true)) {
+				$result = [
+					'success' => true,
+					'title' => translate([
+						'text' => 'Update All Events of This Type?',
+						'isAdminFacing' => true,
+					]),
+					'modalBody' => translate([
+						'text' => 'If customization settings have been changed, there may be events of this type with different customization settings, would you like to update them?',
+						'isAdminFacing' => true,
+					]),
+					'modalButtons' => "<button class='tool btn btn-primary modal-btn' onclick='return AspenDiscovery.Events.saveEventsForType(true)'>Yes</button><button class='tool btn btn-primary modal-btn' onclick='return AspenDiscovery.Events.saveEventsForType(false)'>No</button>",
+				];
+			} else {
+				$result = [
+					'success' => true,
+					'noEventsOfType' => true,
+				];
+			}
+		} else {
+			$result = [
+				'success' => true,
+				'noEventsOfType' => true,
+			];
+		}
+
+		return $result;
+
+	}
+
+	/** @noinspection PhpUnused */
+	function saveEventsForType() {
+		$result = [
+			'success' => true,
+		];
+		$titleCustomizable = (isset($_REQUEST['titleCustomizable']) && $_REQUEST['titleCustomizable'] == 'true') ? 1 : 0;
+		$descriptionCustomizable = (isset($_REQUEST['descriptionCustomizable']) && $_REQUEST['descriptionCustomizable'] == 'true') ? 1 : 0;
+		$coverCustomizable = (isset($_REQUEST['coverCustomizable']) && $_REQUEST['coverCustomizable'] == 'true') ? 1 : 0;
+		$eventLengthCustomizable = (isset($_REQUEST['eventLengthCustomizable']) && $_REQUEST['eventLengthCustomizable'] == 'true') ? 1 : 0;
+
+		//If everything is customizable no need to update events with default data for the event type
+		$booleanSum = $titleCustomizable + $descriptionCustomizable + $coverCustomizable + $eventLengthCustomizable;
+
+		if ($_REQUEST['doFullSave'] == "true" && ($booleanSum != 4)) {
+			//Update all Events of this Event Type
+			require_once ROOT_DIR . '/sys/Events/Event.php';
+			$eventOfType = new Event();
+			$eventOfType->eventTypeId = $_REQUEST['objectId'];
+			$eventOfType->find();
+			while ($eventOfType->fetch()) {
+				if (!$titleCustomizable) {
+					$eventOfType->title = $_REQUEST['title'];
+				}
+				if (!$descriptionCustomizable) {
+					$eventOfType->description = $_REQUEST['description'];
+				}
+				if (!$coverCustomizable) {
+					$eventOfType->cover = $_REQUEST['cover'];
+				}
+				if (!$eventLengthCustomizable) {
+					$eventOfType->eventLength = $_REQUEST['eventLength'];
+				}
+				$eventOfType->update('',false);
+				$result = [
+					'success' => true,
+				];
+			}
+		}
+		return $result;
+	}
 
 }

--- a/code/web/services/Events/EventTypes.php
+++ b/code/web/services/Events/EventTypes.php
@@ -54,6 +54,10 @@ class Events_EventTypes extends ObjectEditor {
 		return 'https://help.aspendiscovery.org/help/catalog/events';
 	}
 
+	function getOnSubmissionJS(): string {
+		return 'AspenDiscovery.Events.checkEventsForType(submitForm)';
+	}
+
 	function getBreadcrumbs(): array {
 		$breadcrumbs = [];
 		$breadcrumbs[] = new Breadcrumb('/Admin/Home', 'Administration Home');


### PR DESCRIPTION
Add functionality to prompt user about updating existing events of an event type when customization settings are updated for that event type

Update release notes

Tested on my local instance of Aspen