### PR TITLE
DIS-1643: Aligned Koha Messaging Settings Phone Column for TalkingTech (Itiva)

### DIFF
--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -6490,6 +6490,7 @@ class Koha extends AbstractIlsDriver {
 		$systemPreferencesSql = "SELECT * FROM systempreferences where variable = 'SMSSendDriver' OR variable ='TalkingTechItivaPhoneNotification' OR variable ='PhoneNotification'";
 		$systemPreferencesRS = mysqli_query($this->dbConnection, $systemPreferencesSql);
 		$enablePhoneMessaging = false;
+		$phoneMessagingType = 'phone';
 		while ($systemPreference = $systemPreferencesRS->fetch_assoc()) {
 			if ($systemPreference['variable'] == 'SMSSendDriver') {
 				$interface->assign('enableSmsMessaging', !empty($systemPreference['value']));
@@ -6505,9 +6506,13 @@ class Koha extends AbstractIlsDriver {
 				$interface->assign('smsProviders', $smsProviders);
 			} elseif ($systemPreference['variable'] == 'TalkingTechItivaPhoneNotification' || $systemPreference['variable'] == 'PhoneNotification') {
 				$enablePhoneMessaging |= !empty($systemPreference['value']);
+				if (!empty($systemPreference['value'])) {
+					$phoneMessagingType = ($systemPreference['variable'] == 'TalkingTechItivaPhoneNotification') ? 'itiva' : 'phone';
+				}
 			}
 		}
 		$systemPreferencesRS->close();
+		$interface->assign('phoneMessagingType', $phoneMessagingType);
 		$interface->assign('enablePhoneMessaging', $enablePhoneMessaging);
 
 		/** @noinspection SqlResolve */
@@ -6580,6 +6585,7 @@ class Koha extends AbstractIlsDriver {
 		$systemPreferencesRS->close();
 
 		$messageAttributes = [];
+		$phoneCapableMessageAttributes = [];
 		$messageAttributesSql = "SELECT * FROM message_attributes";
 		$messageAttributesRS = mysqli_query($this->dbConnection, $messageAttributesSql);
 		while ($messageType = $messageAttributesRS->fetch_assoc()) {
@@ -6597,6 +6603,10 @@ class Koha extends AbstractIlsDriver {
 				"Patron_Expiry" => 'Patron Expiry',
 				default => $messageType['message_name'],
 			};
+			// Koha TalkingTech only allow phone for specific notices.
+			if (in_array($messageType['message_name'], ['Advance_Notice', 'Hold_Filled', 'Hold_Reminder'])) {
+				$phoneCapableMessageAttributes[$messageType['message_attribute_id']] = true;
+			}
 			$messageAttributes[] = $messageType;
 		}
 		$messageAttributesRS->close();
@@ -6647,10 +6657,21 @@ class Koha extends AbstractIlsDriver {
 				$messagingSettings[$messageType]['daysInAdvance'] = $userMessagingSetting['days_in_advance'];
 			}
 			if ($userMessagingSetting['message_transport_type'] != null) {
-				$messagingSettings[$messageType]['selectedTransports'][$userMessagingSetting['message_transport_type']] = $userMessagingSetting['message_transport_type'];
+				$transportType = $userMessagingSetting['message_transport_type'];
+				$messagingSettings[$messageType]['selectedTransports'][$transportType] = $transportType;
 			}
 		}
 		$userMessagingSettingsRS->close();
+
+		// Only show phone/Itiva options for message types Koha allows.
+		if ($phoneMessagingType == 'itiva') {
+			foreach ($messagingSettings as $messageAttributeId => &$messagingSetting) {
+				if (!array_key_exists($messageAttributeId, $phoneCapableMessageAttributes)) {
+					unset($messagingSetting['allowableTransports'][$phoneMessagingType], $messagingSetting['selectedTransports'][$phoneMessagingType]);
+				}
+			}
+			unset($messagingSetting);
+		}
 		$interface->assign('messagingSettings', $messagingSettings);
 
 		$validNoticeDays = [];

--- a/code/web/interface/themes/responsive/MyAccount/kohaMessagingSettings.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/kohaMessagingSettings.tpl
@@ -82,11 +82,11 @@
 					{/if}
 					{if !empty($enablePhoneMessaging)}
 						<td>
-						{if !empty($messagingSettings.$messageTypeId) && !empty($messagingSettings.$messageTypeId.allowableTransports.phone)}
+						{if !empty($messagingSettings.$messageTypeId) && !empty($messagingSettings.$messageTypeId.allowableTransports.$phoneMessagingType)}
 							{if !empty($canSave)}
-								<input type="checkbox" id="phone{$messageTypeId}" name="{$messageTypeId}[]" value="phone" aria-label="Receive Phone Call for {$messageType.label}" onclick="$('#none{$messageTypeId}').attr('checked', false); return AspenDiscovery.Account.toggleKohaDigestCheckbox()" {if !empty($messagingSettings.$messageTypeId) && !empty($messagingSettings.$messageTypeId.selectedTransports.phone)}checked="checked"{/if}>
+								<input type="checkbox" id="phone{$messageTypeId}" name="{$messageTypeId}[]" value="{$phoneMessagingType}" aria-label="Receive Phone Call for {$messageType.label}" onclick="$('#none{$messageTypeId}').attr('checked', false); return AspenDiscovery.Account.toggleKohaDigestCheckbox()" {if !empty($messagingSettings.$messageTypeId) && !empty($messagingSettings.$messageTypeId.selectedTransports.$phoneMessagingType)}checked="checked"{/if}>
 							{else}
-								{if $messagingSettings.$messageTypeId.selectedTransports.phone} {translate text='Yes' isPublicFacing=true}{else} {translate text='No' isPublicFacing=true}{/if}
+								{if $messagingSettings.$messageTypeId.selectedTransports.$phoneMessagingType} {translate text='Yes' isPublicFacing=true}{else} {translate text='No' isPublicFacing=true}{/if}
 							{/if}
 						{else}
 							-

--- a/code/web/release_notes/25.12.00.MD
+++ b/code/web/release_notes/25.12.00.MD
@@ -48,6 +48,9 @@
 // kodi
 
 // leo
+### Koha Updates
+- Fixed Messaging Settings to honor the TalkingTech (itiva) phone transport and hide phone checkboxes on non-itiva-capable notices, matching Koha OPAC. (DIS-1643) (*LS*)
+
 ### Other Updates
 - Fixed an issue where the Aspen Admin Local Administrator settings could not be edited because the Email Address field was read-only but also required. (DIS-1627) (*LS*)
 


### PR DESCRIPTION
- Fixed Messaging Settings to honor the TalkingTech (itiva) phone transport and hide phone checkboxes on non-itiva-capable notices, matching Koha OPAC.

Test Plan:
1. Enable the `TalkingTechItivaPhoneNotification` system preference in Koha.
2. Go to edit a patron account and notice that phone column checkboxes display for Advance Notice, Hold Filled, and Hold Reminder.
3. Log in or masquerade as the same patron account in Aspen and go to Messaging Settings. Notice that all phone column checkboxes incorrectly display.
4. Apply the patch and reload the page. Notice that only the appropriate checkboxes display.

