### PR TITLE
DIS-1653: Add spellcheckMaxCollationTries to system_variables

### DIFF
--- a/code/web/release_notes/25.12.00.MD
+++ b/code/web/release_notes/25.12.00.MD
@@ -145,6 +145,10 @@
 ### Indexing Updates
 - Add SolrCloud support by using the Schema API instead of downloading the schema file. (DIS-1569) (*TC*)
 
+#### New Settings
+- System Administration > System Variables > Spellcheck Max Collation Tries (DIS-1653) (*TC*)
+  - New setting to limit the number of tries for spellcheck collation to improve performance on large datasets.
+
 ## This release includes code contributions from
 ### ByWater Solutions
 - Leo Stoyanov (LS)

--- a/code/web/sys/DBMaintenance/version_updates/25.12.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.12.00.php
@@ -101,7 +101,17 @@ function getUpdates25_12_00(): array {
 				genericArtCode TINYTEXT
 				) ENGINE = InnoDB",
 			]
-		]
+		],
+
+		// Tomas Cohen Arazi - Theke Solutions
+		'configurable_solr_spellcheck_collation' => [
+			'title' => 'SolR - Spellcheck Collation max tries',
+			'description' => 'Make SolR spellcheck.maxCollationTries configurable',
+			'sql' => [
+				"ALTER TABLE system_variables ADD COLUMN spellcheckMaxCollationTries int(11) DEFAULT 25 AFTER solrQueryTimeout;"
+			],
+		],
+
 		//other
 
 	];

--- a/code/web/sys/SolrConnector/Solr.php
+++ b/code/web/sys/SolrConnector/Solr.php
@@ -1332,6 +1332,10 @@ abstract class Solr {
 
 		// Enable Spell Checking
 		if ($spell != '') {
+			require_once ROOT_DIR . '/sys/SystemVariables.php';
+			$systemVariables = SystemVariables::getSystemVariables();
+			$maxCollationTries = ($systemVariables && $systemVariables->spellcheckMaxCollationTries > 0) ? $systemVariables->spellcheckMaxCollationTries : 25;
+
 			$options['spellcheck'] = 'true';
 			$options['spellcheck.q'] = $spell;
 //			if ($dictionary != null) {
@@ -1347,7 +1351,7 @@ abstract class Solr {
 			$options['spellcheck.collateParam.mm'] = '100%';
 			$options['spellcheck.maxCollations'] = 5;
 			$options['spellcheck.collateExtendedResults'] = 'true';
-			$options['spellcheck.maxCollationTries'] = 25;
+			$options['spellcheck.maxCollationTries'] = $maxCollationTries;
 			$options['spellcheck.accuracy'] = .5;
 		}
 

--- a/code/web/sys/SystemVariables.php
+++ b/code/web/sys/SystemVariables.php
@@ -32,6 +32,7 @@ class SystemVariables extends DataObject {
 	public $libraryToUseForPayments;
 	public $solrConnectTimeout;
 	public $solrQueryTimeout;
+	public $spellcheckMaxCollationTries;
 	public $catalogStatus;
 	public $offlineMessage;
 	public $appScheme;
@@ -302,6 +303,16 @@ class SystemVariables extends DataObject {
 				'required' => true,
 				'default' => 10,
 				'min' => 1,
+			],
+			'spellcheckMaxCollationTries' => [
+				'property' => 'spellcheckMaxCollationTries',
+				'type' => 'integer',
+				'label' => 'Spellcheck Max Collation Tries',
+				'description' => 'Maximum number of collation attempts for spellcheck queries (lower values improve performance)',
+				'required' => true,
+				'default' => 25,
+				'min' => 1,
+				'max' => 50,
 			],
 			'catalogStatus' => [
 				'property' => 'catalogStatus',


### PR DESCRIPTION
This patch adds a new configuration entry for SolR's `spellcheck.maxCollationTries`.

The setting is hardcoded to the value of `25` right now. This patch makes it configurable and also default to `25` to avoid any behavior change as-is.

To test:
0. Have a running Aspen dev environment
1. Apply this patch
2. Perform the maintenance update
3. Open the SolR logs. In my env I would do:

```shell
   $ docker logs -f aspen-dev-box-solr-1 | grep spellcheck.maxCollationTries
```

4. Perform any search on your dev Aspen instance
=> SUCCESS: The logs show spellcheck.maxCollationTries=25 is passed i.e. no behavior change
5. Edit System Administration > System Variables > Spellcheck Max Collation Tries to any value. For example: 5
6. Repeat 4
=> SUCCESS: spellcheck.maxCollationTries=5 is in the logs
7. Sign off this patch :-D