### PR TITLE
DIS-1599: Add health checks for database updates

### DIFF
--- a/code/web/release_notes/25.12.00.MD
+++ b/code/web/release_notes/25.12.00.MD
@@ -131,6 +131,7 @@
 ### Docker Updates
 - Removed requirement of setting LOCAL_USER_ID environment variable. (DIS-1596) (*LM*)
 - Avoid modifying host permissions by removing source code chown. (DIS-1596) (*LM*)
+- Added health checks to verify database connectivity and data population. (DIS-1599) (*LM*)
 
 // James Staub
 ### Other Updates
@@ -139,7 +140,6 @@
 // Galen Charlton
 ### Cover Images Updates
 - Add support for ChiliFresh as a cover image source. ([DIS-1602](https://aspen-discovery.atlassian.net/browse/DIS-1602)) (*GMC*)
-
 
 //tomas
 ### Indexing Updates

--- a/docker/files/database/DatabaseHealth.php
+++ b/docker/files/database/DatabaseHealth.php
@@ -1,0 +1,29 @@
+<?php 
+
+function checkDatabaseConnection(PDO $pdo): bool {
+
+	if ($pdo === null) {
+		DockerLogger::error("Database connection is null");
+		return false;
+	}
+	
+	try {
+		$statement = 'SELECT 1;';
+		$stmt = $pdo->prepare($statement);
+		$stmt->execute();
+		return true;
+	} catch (PDOException $e) {
+		return false;
+	}
+}
+
+function isDatabaseInitialized(PDO $pdo): bool {
+	try {
+		$statement = 'SELECT libraryId FROM library LIMIT 1;';
+		$stmt = $pdo->prepare($statement);
+		$stmt->execute();
+		return true;
+	} catch (PDOException $e) {
+		return false;
+	}
+}

--- a/docker/files/scripts/updateDatabase.php
+++ b/docker/files/scripts/updateDatabase.php
@@ -3,6 +3,8 @@
 require_once __DIR__ . '/../logger/DockerLogger.php';
 DockerLogger::init('BACKEND');
 
+require_once __DIR__ . '/../database/DatabaseHealth.php';
+
 // Set server name
 $_SERVER['SERVER_NAME'] = getenv('SITE_NAME');
 
@@ -123,6 +125,14 @@ function pruneCompletedUpdates($availableUpdates) {
 }
 
 function runPendingDatabaseUpdates() {
+
+	# Check database connection
+	global $aspen_db;
+	if (!checkDatabaseConnection($aspen_db) || !isDatabaseInitialized($aspen_db)) {
+		DockerLogger::error("Cannot connect to the database to run updates)");
+		exit(1);
+	}
+	
 	$pendingUpdates = getPendingDatabaseUpdates();
 	$updates = 0;
 	$failedUpdates = 0;
@@ -153,6 +163,8 @@ function runPendingDatabaseUpdates() {
 		];
 	}
 }
+
+# ================================================================================
 
 function prepareNightlyFullIndexing(): void {
 	require_once ROOT_DIR . '/sys/SystemVariables.php';


### PR DESCRIPTION
This patch implements health check for database connectivity and data injection and they are applied to the updateDatabase.php script during the initialization via Docker.

The health checks allows Aspen performs a secure exit rather than generate an uncontrolled error.