### PR TITLE
DIS-1654: Fixed Advanced Search Submitting Default Availability Toggle Filter Causing "global" to Appear in Results

### DIFF
--- a/code/web/interface/themes/responsive/Search/advanced.tpl
+++ b/code/web/interface/themes/responsive/Search/advanced.tpl
@@ -103,7 +103,7 @@
 					{* addGroup() returns the variable nextGroupNumber so the return false is necessary *}
 					<input type="submit" name="submit" value="{translate text="Find" inAttribute=true isPublicFacing=true inAttribute=true}" class="btn btn-primary pull-right">
 					<br><br>
-					{if $facetList || $showPublicationDate}
+					{if $facetList}
 						<div class="accordion">
 							<div {*id="facet-accordion"*} class="panel panel-default">
 								<div class="panel-heading">

--- a/code/web/release_notes/25.12.00.MD
+++ b/code/web/release_notes/25.12.00.MD
@@ -113,6 +113,8 @@
 - Added a "View Calendar" button to the Calendar Display Settings page for easy navigation to the calendar page. (DIS-1629) (*LS*)
 - Included ISBN and UPC data in the CSV export of search results. (DIS-1379) (*LS*)
 - Increased the HTTP stream timeout when updating suggesters in Solr. (DIS-1592) (*LS*)
+- Fixed issue where Advanced Search results included lists and events containing the word "global" when no specific availability filter was selected. (DIS-1654) (*LS*)
+- Fixed template warning for undefined `$showPublicationDate` variable on Advanced Search page. (DIS-1654) (*LS*)
 
 // imani
 

--- a/code/web/services/Search/AdvancedBase.php
+++ b/code/web/services/Search/AdvancedBase.php
@@ -160,6 +160,7 @@ abstract class Search_AdvancedBase extends Action {
 				}
 				if (!$valueSelected) {
 					$currentList[$availabilityToggleValue]['selected'] = true;
+					$currentList[$availabilityToggleValue]['filter'] = '';
 				}
 			}
 


### PR DESCRIPTION
- Fixed issue where Advanced Search results included lists and events containing the word "global" when no specific availability filter was selected.
- Fixed template warning for undefined `$showPublicationDate` variable on Advanced Search page.

Test Plan:
1. Navigate to the Advanced Search page.
2. Type in an author’s name, select the “Author” search index, and click “Find”.
3. Notice that the URL contains availability_toggle%3A%22global%22, and in the results, there may be an Explore More carousel containing unrelated lists and events that refer to something “global”.
4. Apply the patch and repeat steps 1-2. Notice that the parameter is gone from the URL, and there is no Explore More carousel regarding “global” content.

