### PR TITLE
DIS-1657: Fixed BotChecker 'isBot' Error When User Agent Tracking Is Disabled

### DIFF
--- a/code/web/release_notes/25.12.00.MD
+++ b/code/web/release_notes/25.12.00.MD
@@ -113,6 +113,7 @@
 - Added a "View Calendar" button to the Calendar Display Settings page for easy navigation to the calendar page. (DIS-1629) (*LS*)
 - Included ISBN and UPC data in the CSV export of search results. (DIS-1379) (*LS*)
 - Increased the HTTP stream timeout when updating suggesters in Solr. (DIS-1592) (*LS*)
+- Fixed PHP warning "Attempt to read property 'isBot' on string" that occurred on every page request when the "Disable User Agent Tracking" was enabled. (DIS-1657) (*LS*)
 
 // imani
 

--- a/code/web/sys/BotChecker.php
+++ b/code/web/sys/BotChecker.php
@@ -15,7 +15,7 @@ class BotChecker {
 			global $memCache;
 			global $configArray;
 			global $userAgent;
-			if (!empty($userAgent) && is_object($userAgent) && isset($userAgent->isBot)) {
+			if ($userAgent?->isBot !== null) {
 				return $userAgent->isBot;
 			}
 			if (isset($_SERVER['HTTP_USER_AGENT'])) {

--- a/code/web/sys/BotChecker.php
+++ b/code/web/sys/BotChecker.php
@@ -15,7 +15,7 @@ class BotChecker {
 			global $memCache;
 			global $configArray;
 			global $userAgent;
-			if (!empty($userAgent)) {
+			if (!empty($userAgent) && is_object($userAgent) && isset($userAgent->isBot)) {
 				return $userAgent->isBot;
 			}
 			if (isset($_SERVER['HTTP_USER_AGENT'])) {


### PR DESCRIPTION
- Fixed PHP warning "Attempt to read property 'isBot' on string" that occurred on every page request when the "Disable User Agent Tracking" was enabled.

Test Plan:
1. Enable “Disable User Agent Tracking” under System Variables in the admin interface.
2. Perform any action to access a modal and notice an AJAX error display.
3. Apply the patch and repeat step 2 to see no errors.

