### PR TITLE
DIS-1658: Fixed Format Facets with Parentheses Returning No Search Results

### DIFF
--- a/code/web/release_notes/25.12.00.MD
+++ b/code/web/release_notes/25.12.00.MD
@@ -103,6 +103,10 @@
 ### Self Registration Updates
 - In Library Systems settings, "Self Registration Form Message" and "Self Registration Success Message" now use translatable text blocks so messaging can be customized per language. (DIS-1581) (*LS*)
 
+### Searching Updates
+- Fixed an issue where Format facets containing parentheses would return no search results when selected. (DIS-1658) (*LS*)
+  - This means that the Format field in the Format Map can contain parentheses now.
+
 ### Side Load Updates
 - Added logs to indicate when side loaded records contain invalid 856 indicators. (DIS-1593) (*LS*)
 

--- a/code/web/sys/SearchObject/GroupedWorkSearcher2.php
+++ b/code/web/sys/SearchObject/GroupedWorkSearcher2.php
@@ -291,7 +291,7 @@ class SearchObject_GroupedWorkSearcher2 extends SearchObject_AbstractGroupedWork
 					$escapedFormatCategory = str_replace([' ', '(', ')'], ['_', '\\(', '\\)'], $selectedFormatCategoryValue);
 					foreach ($selectedFormatValues as $selectedFormatValue) {
 						$escapedFormat = str_replace([' ', '(', ')'], ['_', '\\(', '\\)'], $selectedFormatValue);
-						$allEditionFilters[] = "edition_info:$solrScope#{$escapedFormatCategory}#{$escapedFormat}#{$this->selectedAvailabilityToggleValue}#{$escapedAvailableAt}#";
+						$allEditionFilters[] = "edition_info:$solrScope#$escapedFormatCategory#$escapedFormat#$this->selectedAvailabilityToggleValue#$escapedAvailableAt#";
 					}
 				}
 			}

--- a/code/web/sys/SearchObject/GroupedWorkSearcher2.php
+++ b/code/web/sys/SearchObject/GroupedWorkSearcher2.php
@@ -286,11 +286,12 @@ class SearchObject_GroupedWorkSearcher2 extends SearchObject_AbstractGroupedWork
 		$allEditionFilters = [];
 		if (!$this->indexEngine->editionLimitersAreDisabled()) {
 			foreach ($selectedAvailableAtValues as $selectedAvailableAtValue) {
-				$selectedAvailableAtValue = str_replace('(', '\(', $selectedAvailableAtValue);
-				$selectedAvailableAtValue = str_replace(')', '\)', $selectedAvailableAtValue);
+				$escapedAvailableAt = str_replace([' ', '(', ')'], ['_', '\\(', '\\)'], $selectedAvailableAtValue);
 				foreach ($selectedFormatCategoryValues as $selectedFormatCategoryValue) {
+					$escapedFormatCategory = str_replace([' ', '(', ')'], ['_', '\\(', '\\)'], $selectedFormatCategoryValue);
 					foreach ($selectedFormatValues as $selectedFormatValue) {
-						$allEditionFilters[] = str_replace(' ', '_', "edition_info:$solrScope#$selectedFormatCategoryValue#$selectedFormatValue#$this->selectedAvailabilityToggleValue#$selectedAvailableAtValue#");
+						$escapedFormat = str_replace([' ', '(', ')'], ['_', '\\(', '\\)'], $selectedFormatValue);
+						$allEditionFilters[] = "edition_info:$solrScope#{$escapedFormatCategory}#{$escapedFormat}#{$this->selectedAvailabilityToggleValue}#{$escapedAvailableAt}#";
 					}
 				}
 			}


### PR DESCRIPTION
- Fixed an issue where Format facets containing parentheses would return no search results when selected.
  - This means that the Format field in the Format Map can contain parentheses now.

Test Plan:
1. Create a format mapping with a Format value that contains parentheses.
2. Reindex records with that format and filter for them using the Format facet.
3. Notice that no results are returned for that filtered facet.
4. Apply the patch and reload the page. Notice results display.