### PR TITLE
DIS-1342: Fix primary setting check in HooplaDriver.getHolds()

### DIFF
--- a/code/web/Drivers/HooplaDriver.php
+++ b/code/web/Drivers/HooplaDriver.php
@@ -837,7 +837,7 @@ class HooplaDriver extends AbstractEContentDriver {
 		];
 		$patronHomeLibrary = $patron->getHomeLibrary();
 		$primaryHooplaSetting = $patronHomeLibrary->getPrimaryHooplaSetting();
-		if ($this->isHooplaVersion2() && !$primaryHooplaSetting != null) {
+		if ($this->isHooplaVersion2() && $primaryHooplaSetting != null) {
 			$flexEnabled = $primaryHooplaSetting->hooplaFlexEnabled;
 		} else {
 			$flexEnabled = $this ->hooplaFlexEnabled;


### PR DESCRIPTION
Fix primary setting check in HooplaDriver.getHolds(), so holds can display correctly in titles on holds 