### PR TITLE
DIS-1693:  Allow updating settings via environment variables

### DIFF
--- a/code/web/release_notes/26.01.00.MD
+++ b/code/web/release_notes/26.01.00.MD
@@ -20,6 +20,8 @@
 //mark j
 
 //lucas
+### Docker Updates
+- Added support for updating settings from the configuration files (.ini) by using environment variables. (DIS-1693) (*LM*)
 
 //tomas
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,51 +1,122 @@
-### 1) Install Docker & Docker-Compose
+# Aspen Discovery - Docker
 
-Only these components are necessary before proceeding with the installation of Aspen:
+## Quick Start
 
-* Docker ([install instructions](https://docs.docker.com/engine/install/))
-* Docker Compose ([install instructions](https://docs.docker.com/compose/install/#install-compose-on-linux-systems))
-
-### 2) Prepare host
-
-This example deployment will persist the data on a directory structure inside
-the directory pointed by `$ASPEN_DATA_DIR`. You will need to adjust it for a production
-deployment.
-
-```
-echo "export ASPEN_INSTANCE=aspen" >> ~/.bashrc
-echo "export ASPEN_DATA_DIR=~/aspen-repos/${ASPEN_INSTANCE}" >> ~/.bashrc
-source ~/.bashrc
-```
-#### 2.1) Create the directories
-
-```
-mkdir -p ${ASPEN_DATA_DIR}/database \
-         ${ASPEN_DATA_DIR}/conf \
-         ${ASPEN_DATA_DIR}/data \
-         ${ASPEN_DATA_DIR}/logs
+```bash
+git clone https://github.com/Aspen-Discovery/aspen-discovery.git
+cd aspen-discovery/docker
+cp files/env/default.env .env
+docker compose up -d
 ```
 
-### 3.0) Copy docker-compose.yml and .env
-
-```
-curl -O ${ASPEN_DATA_DIR}/docker-compose.yml https://raw.githubusercontent.com/Aspen-Discovery/aspen-discovery/24.08.00/docker/docker-compose.yml
-curl -O ${ASPEN_DATA_DIR}/.env https://raw.githubusercontent.com/Aspen-Discovery/aspen-discovery/24.08.00/docker/env/default.env
-```
- 
-### 4) Create and start containers
-
-We go to the directory where the docker-compose.yml is located and execute :
-
-```
-docker compose -p aspen up -d
+Wait for initialization to complete:
+```bash
+docker compose logs -f backend
+# Look for: "Starting PHP-FPM in foreground mode..."
 ```
 
-You need to wait until "Aspen is ready to use!" message is displayed
-(Check 'docker logs -f aspen_backend' )
-### 5) Check Aspen instance is up
+Access Aspen at http://localhost:85 (default credentials: `aspen_admin` / `secretPass123`)
 
-On the browser :
+## Environment Variables
 
-```
-$URL:80
+### Site Settings
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SITE_NAME` | `aspen` | Site identifier |
+| `URL` | `http://localhost:85` | Public URL |
+| `TITLE` | `Aspen Discovery` | Library title |
+| `LIBRARY` | `Test Library` | Library name |
+| `TIMEZONE` | `America/Argentina/Cordoba` | PHP timezone |
+| `ASPEN_ADMIN_PASSWORD` | `secretPass123` | Admin password |
+| `SUPPORTING_COMPANY` | `ByWater Solutions` | Support company name |
+
+### Database
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DATABASE_HOST` | `db` | MariaDB hostname |
+| `DATABASE_PORT` | `3306` | MariaDB port |
+| `DATABASE_NAME` | `aspen` | Database name |
+| `DATABASE_USER` | `aspenusr` | Database user |
+| `DATABASE_PASSWORD` | `aspenpasswd` | Database password |
+| `DATABASE_ROOT_PASSWORD` | `password` | MariaDB root password |
+
+### Services
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SOLR_HOST` | `solr` | Solr hostname |
+| `SOLR_PORT` | `8983` | Solr port |
+| `PHP_FPM_HOST` | `backend` | PHP-FPM hostname |
+| `PHP_FPM_PORT` | `9000` | PHP-FPM port |
+
+### Koha Integration (Optional)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ENABLE_KOHA` | `no` | Enable Koha integration (`yes`/`no`) |
+| `KOHA_OPAC_URL` | - | Koha OPAC URL |
+| `KOHA_STAFF_URL` | - | Koha staff client URL |
+| `KOHA_DATABASE_HOST` | - | Koha database host |
+| `KOHA_DATABASE_NAME` | - | Koha database name |
+| `KOHA_DATABASE_USER` | - | Koha database user |
+| `KOHA_DATABASE_PASSWORD` | - | Koha database password |
+| `KOHA_DATABASE_PORT` | - | Koha database port |
+| `KOHA_CLIENT_ID` | - | Koha API client ID |
+| `KOHA_CLIENT_SECRET` | - | Koha API client secret |
+
+### Docker Images
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BACKEND_IMAGE_TAG` | `aspendiscovery/aspen:latest` | Backend image |
+| `SOLR_IMAGE_TAG` | `aspendiscovery/solr:latest` | Solr image |
+| `MARIADB_IMAGE` | `mariadb:10.5` | MariaDB image |
+
+## Updating Configuration
+
+Environment variables are synced to configuration files on every container start. To apply changes:
+
+1. Edit your `.env` file
+2. Recreate containers:
+   ```bash
+   docker compose up -d --force-recreate
+   ```
+
+**Supported variables for runtime updates:**
+- `DATABASE_HOST`, `DATABASE_PORT`, `DATABASE_NAME`, `DATABASE_USER`, `DATABASE_PASSWORD`
+- `TIMEZONE`, `URL`, `TITLE`, `LIBRARY`
+- `SOLR_HOST`, `SOLR_PORT`
+
+**Note:** Changing database credentials requires the MariaDB user to already exist. MariaDB only creates users on first initialization.
+
+## Services & Ports
+
+| Service | Port | Description |
+|---------|------|-------------|
+| apache | 85 | Web interface |
+| solr | 8983 | Search engine admin |
+| backend | - | PHP-FPM (internal) |
+| cron | - | Background tasks (internal) |
+| db | 3306 | MariaDB (internal) |
+
+## Common Commands
+
+```bash
+# View logs
+docker compose logs -f backend
+
+# Shell access
+docker compose exec backend bash
+
+# Stop services
+docker compose down
+
+# Apply configuration changes
+docker compose up -d --force-recreate
+
+# Full reset (delete all data)
+docker compose down -v
+rm -rf data/
 ```

--- a/docker/files/env/default.env
+++ b/docker/files/env/default.env
@@ -5,11 +5,11 @@
 # ASPEN SETTINGS
 # =============================================================================
 LOCAL_USER_ID=1000
-SITE_NAME=aspen.localhost
+SITE_NAME=aspen
 SUPPORTING_COMPANY=ByWater Solutions
-LIBRARY=Test library
-TITLE=Test library (title)
-URL=http://aspen.localhost
+LIBRARY=Test Library
+TITLE=Aspen Discovery
+URL=http://localhost:85
 SOLR_HOST=solr
 SOLR_PORT=8983
 PHP_FPM_HOST=backend

--- a/docker/files/scripts/start.sh
+++ b/docker/files/scripts/start.sh
@@ -98,7 +98,7 @@ done
 
 # Run pending database updates
 log "Running pending database updates..."
-php updateDatabase.php
+php updateDatabase.php "$SITE_NAME"
 
 sudo -u www-data php /usr/local/aspen-discovery/docker/files/cron/checkBackgroundProcessesDocker.php $SITE_NAME >/proc/1/fd/1 2>/proc/1/fd/2
 

--- a/docker/files/scripts/start.sh
+++ b/docker/files/scripts/start.sh
@@ -39,6 +39,12 @@ if [ ! -f "$confSiteFile" ] ; then
 	fi
 fi
 
+# Sync environment variables to config files (runs every start)
+log "Syncing environment variables to config..."
+if ! php syncEnvToConfig.php ; then
+	log "WARNING: Environment sync failed, using existing config"
+fi
+
 # Initialize Aspen database
 log "Initializing database";
 if ! php initDatabase.php ; then

--- a/docker/files/scripts/syncEnvToConfig.php
+++ b/docker/files/scripts/syncEnvToConfig.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * Sync environment variables to existing config files.
+ * Only updates values for env vars that are explicitly set.
+ * Preserves all other configuration.
+ *
+ * Runs on every container start to apply env var changes.
+ */
+
+require_once __DIR__ . '/../logger/DockerLogger.php';
+DockerLogger::init('BACKEND');
+
+$siteName = getenv('SITE_NAME');
+if (!$siteName) {
+	DockerLogger::error("SITE_NAME environment variable is required");
+	exit(1);
+}
+
+$configDir = "/usr/local/aspen-discovery/sites/{$siteName}/conf";
+
+if (!is_dir($configDir)) {
+	DockerLogger::info("Config directory not found, skipping env sync: {$configDir}");
+	exit(0);
+}
+
+// Map env vars to ini file locations: [envVar => [file, section, key]]
+$envMapping = [
+	// Database (config.pwd.ini)
+	'DATABASE_HOST'     => ['config.pwd.ini', 'Database', 'database_aspen_host'],
+	'DATABASE_PORT'     => ['config.pwd.ini', 'Database', 'database_aspen_dbport'],
+	'DATABASE_NAME'     => ['config.pwd.ini', 'Database', 'database_aspen_dbname'],
+	'DATABASE_USER'     => ['config.pwd.ini', 'Database', 'database_user'],
+	'DATABASE_PASSWORD' => ['config.pwd.ini', 'Database', 'database_password'],
+
+	// Site (config.ini)
+	'TIMEZONE'          => ['config.ini', 'Site', 'timezone'],
+	'URL'               => ['config.ini', 'Site', 'url'],
+	'TITLE'             => ['config.ini', 'Site', 'title'],
+	'LIBRARY'           => ['config.ini', 'Site', 'libraryName'],
+
+	// Solr (config.ini)
+	'SOLR_HOST'         => ['config.ini', 'Index', 'solrHost'],
+	'SOLR_PORT'         => ['config.ini', 'Index', 'solrPort'],
+
+	// System (config.ini)
+	'DEBUG'             => ['config.ini', 'System', 'debug'],
+];
+
+// Group changes by file
+$fileChanges = [];
+$changedEnvVars = [];
+
+foreach ($envMapping as $envVar => [$file, $section, $key]) {
+	$value = getenv($envVar);
+	if ($value !== false && $value !== '') {
+		$fileChanges[$file][$section][$key] = $value;
+		$changedEnvVars[] = $envVar;
+	}
+}
+
+if (empty($fileChanges)) {
+	DockerLogger::info("No environment variables to sync");
+	exit(0);
+}
+
+DockerLogger::info("Syncing environment variables: " . implode(', ', $changedEnvVars));
+
+// Apply changes to each file
+foreach ($fileChanges as $file => $sections) {
+	$filePath = "{$configDir}/{$file}";
+	if (!file_exists($filePath)) {
+		DockerLogger::warn("Config file not found: {$filePath}");
+		continue;
+	}
+
+	$updated = updateIniFile($filePath, $sections);
+	if ($updated) {
+		DockerLogger::info("Updated {$file}");
+	}
+}
+
+// Rebuild database_dsn if any DB component changed
+if (isset($fileChanges['config.pwd.ini']['Database'])) {
+	rebuildDsn($configDir);
+	DockerLogger::info("Rebuilt database_dsn");
+}
+
+DockerLogger::info("Environment sync complete");
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/**
+ * Update specific values in an INI file while preserving all other content.
+ *
+ * @param string $filePath Path to the INI file
+ * @param array $changes Array of [section => [key => value]] to update
+ * @return bool True if file was modified
+ */
+function updateIniFile(string $filePath, array $changes): bool {
+	$lines = file($filePath, FILE_IGNORE_NEW_LINES);
+	$currentSection = null;
+	$modified = false;
+
+	foreach ($lines as $i => $line) {
+		$trimmed = trim($line);
+
+		// Track current section
+		if (preg_match('/^\[(.+)\]$/', $trimmed, $m)) {
+			$currentSection = $m[1];
+			continue;
+		}
+
+		// Skip comments and empty lines
+		if ($trimmed === '' || (isset($trimmed[0]) && $trimmed[0] === ';')) {
+			continue;
+		}
+
+		// Check if this line should be updated
+		if ($currentSection && isset($changes[$currentSection])) {
+			foreach ($changes[$currentSection] as $key => $newValue) {
+				// Match key at start of line (handles various spacing)
+				if (preg_match('/^' . preg_quote($key, '/') . '\s*=/', $trimmed)) {
+					// Determine if value needs quotes
+					$needsQuotes = strpos($newValue, ' ') !== false || strpos($newValue, '{') !== false || strpos($newValue, '}') !== false || strpos($newValue, ';') !== false;
+					$formatted = $needsQuotes ? "\"{$newValue}\"" : $newValue;
+
+					// Preserve original indentation
+					$indent = '';
+					if (preg_match('/^(\s*)/', $line, $indentMatch)) {
+						$indent = $indentMatch[1];
+					}
+
+					$lines[$i] = "{$indent}{$key} = {$formatted}";
+					$modified = true;
+					unset($changes[$currentSection][$key]);
+				}
+			}
+		}
+	}
+
+	if ($modified) {
+		file_put_contents($filePath, implode("\n", $lines) . "\n");
+	}
+
+	return $modified;
+}
+
+/**
+ * Rebuild the database_dsn value from environment variables.
+ * Falls back to INI file values or defaults if env vars not set.
+ *
+ * @param string $configDir Path to the config directory
+ */
+function rebuildDsn(string $configDir): void {
+	$pwdFile = "{$configDir}/config.pwd.ini";
+
+	if (!file_exists($pwdFile)) {
+		return;
+	}
+
+	$config = parse_ini_file($pwdFile, true);
+
+	// Prefer env vars, then INI file, then defaults
+	$host = getenv('DATABASE_HOST') ?: ($config['Database']['database_aspen_host'] ?? 'localhost');
+	$port = getenv('DATABASE_PORT') ?: ($config['Database']['database_aspen_dbport'] ?? '3306');
+	$name = getenv('DATABASE_NAME') ?: ($config['Database']['database_aspen_dbname'] ?? 'aspen');
+
+	$dsn = "mysql:host={$host};port={$port};dbname={$name}";
+
+	// Update dsn in file
+	updateIniFile($pwdFile, ['Database' => ['database_dsn' => $dsn]]);
+}

--- a/docker/files/scripts/updateDatabase.php
+++ b/docker/files/scripts/updateDatabase.php
@@ -5,9 +5,6 @@ DockerLogger::init('BACKEND');
 
 require_once __DIR__ . '/../database/DatabaseHealth.php';
 
-// Set server name
-$_SERVER['SERVER_NAME'] = getenv('SITE_NAME');
-
 require_once __DIR__ . '/../../../code/web/bootstrap.php';
 require_once __DIR__ . '/../../../code/web/bootstrap_aspen.php';
 


### PR DESCRIPTION
The current setup doesn't allow changing settings in the .ini files (like DATABASE_HOST, DATABASE_PORT, TIMEZONE, SOLR_HOST) except by doing a fresh start, since the initialization doesn't regenerate configurations once they exist.

  This patch allows updating .ini file settings by simply changing environment variables and recreating the container (docker compose up -d --force-recreate or docker stack deploy). A new syncEnvToConfig.php script runs on every container start and syncs environment variable values to the corresponding .ini file settings, preserving all other configuration
  values.

  Supported environment variables:

DATABASE_HOST, DATABASE_PORT, DATABASE_NAME, DATABASE_USER, DATABASE_PASSWORD

TIMEZONE, URL, TITLE, LIBRARY

SOLR_HOST, SOLR_PORT

  Note: Changing database credentials requires the MariaDB user to already exist. MariaDB only creates users on first initialization when the data directory is empty.