### PR TITLE
DIS-1696: fix infinite loop during initial reading history import from Evergreen

### DIFF
--- a/code/web/Drivers/Evergreen.php
+++ b/code/web/Drivers/Evergreen.php
@@ -1088,6 +1088,11 @@ class Evergreen extends AbstractIlsDriver {
 					$hasMoreHistory = false;
 					break;
 				}
+			} else {
+				global $logger;
+				$logger->log("Failed to authenticate patron when getting their Evergreen reading history for $patron->ils_barcode.", Logger::LOG_ERROR);
+				$hasMoreHistory = false;
+				break;
 			}
 		}
 

--- a/code/web/release_notes/26.01.00.MD
+++ b/code/web/release_notes/26.01.00.MD
@@ -12,6 +12,8 @@
 //imani
 
 //galen
+### Evergreen Updates
+- Fix an infinite loop during initial reading history import from Evergreen if patron authentication fails ([DIS-1696](https://aspen-discovery.atlassian.net/browse/DIS-1696)) (**GMC**)
 
 //alexander
 


### PR DESCRIPTION
In particular, this fixes an infinite loop if the patron cannot be authenticated to Evergreen, either because of some transitory system glitch or (a bit more likely) because the patron's credentials as stored in Aspen are out of date.

Test plan would be something like this, given an Aspen system connected to an Evergreen system:

- Log in as a patron to Aspen and request an import of reading history
- Change the patron's password in Evergreen
- Run the loadInitialReadingHistory.php cronjob
- Note that the the job runs indefinitely, so it will need to be cancelled
- Apply the patch, reset the reading history import request if needed be, and try the cronjob again
- This time it should get past the test patron.