### PR TITLE
DIS-1712: Events with no time requirements

### DIFF
--- a/code/events_indexer/src/com/turning_leaf_technologies/events/AspenEvent.java
+++ b/code/events_indexer/src/com/turning_leaf_technologies/events/AspenEvent.java
@@ -31,6 +31,7 @@ class AspenEvent {
 	private final long sublocationId;
 	private final Boolean status;
 	private final Boolean nonPublic;
+	private final Boolean hideTimestamps;
 	private final ArrayList<EventField> fields = new ArrayList<EventField>();
 
 	AspenEvent(ResultSet existingEventsRS) throws SQLException{
@@ -50,6 +51,7 @@ class AspenEvent {
 		this.sublocationId = existingEventsRS.getLong("sublocationId");
 		this.status = existingEventsRS.getBoolean("status");
 		this.nonPublic = existingEventsRS.getBoolean("private");
+		this.hideTimestamps = existingEventsRS.getBoolean("hideTimestamps");
 	}
 
 	void addField(String name, String value, String[] allowableValues, int type, int facet) {
@@ -137,6 +139,21 @@ class AspenEvent {
 			return "private";
 		} else {
 			return "public";
+		}
+	}
+
+	public Boolean getHideTimestamps() {
+		return hideTimestamps;
+	}
+
+	public Date getHideTimestampsStart(EventsIndexerLogEntry logEntry) {
+		try {
+			LocalDateTime date = LocalDateTime.parse(startDate + " " + "00:00:00", dtf);
+			ZoneOffset eventZoneOffset = zoneId.getRules().getOffset(date);
+			return Date.from(date.toInstant(eventZoneOffset));
+		} catch (DateTimeParseException e) {
+			logEntry.incErrors("Error parsing date with hidden timestamp from " + startDate, e);
+			return null;
 		}
 	}
 
@@ -230,7 +247,7 @@ class AspenEvent {
 		}
 
 		public String getValue() {
-			if (allowableValues.length > 0 && StringUtils.isNumeric(value)) {
+			if (allowableValues.length > 0 && StringUtils.isNumeric(value) && !value.isEmpty()) {
 				try {
 					return allowableValues[Integer.parseInt(value)].trim();
 				}catch (ArrayIndexOutOfBoundsException e) {

--- a/code/events_indexer/src/com/turning_leaf_technologies/events/AspenEventsIndexer.java
+++ b/code/events_indexer/src/com/turning_leaf_technologies/events/AspenEventsIndexer.java
@@ -12,6 +12,9 @@ import java.io.IOException;
 import java.sql.*;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.*;
 import java.util.Date;
 import java.util.zip.CRC32;
@@ -103,9 +106,9 @@ public class AspenEventsIndexer {
 			PreparedStatement deleteEventsStmt;
 			if (runFullUpdate) {
 				// Get event instance and event info
-				eventsStmt = aspenConn.prepareStatement("SELECT ei.*, e.title, e.description, e.eventTypeId, e.locationId, l.displayName, sl.name AS sublocationName, sl2.name AS sublocationOverride, e.sublocationId, e.cover, e.private FROM event_instance AS ei LEFT JOIN event as e ON e.id = ei.eventID LEFT JOIN location AS l ON e.locationId = l.locationId LEFT JOIN sublocation AS sl on e.sublocationId = sl.id LEFT JOIN sublocation AS sl2 ON ei.sublocationId = sl2.id WHERE ei.date < ? AND ei.deleted = 0;");
+				eventsStmt = aspenConn.prepareStatement("SELECT ei.*, e.title, e.description, e.eventTypeId, e.locationId, l.displayName, sl.name AS sublocationName, sl2.name AS sublocationOverride, e.sublocationId, e.cover, e.private, e.hideTimestamps FROM event_instance AS ei LEFT JOIN event as e ON e.id = ei.eventID LEFT JOIN location AS l ON e.locationId = l.locationId LEFT JOIN sublocation AS sl on e.sublocationId = sl.id LEFT JOIN sublocation AS sl2 ON ei.sublocationId = sl2.id WHERE ei.date < ? AND ei.deleted = 0;");
 			} else {
-				eventsStmt = aspenConn.prepareStatement("SELECT ei.*, e.title, e.description, e.eventTypeId, e.locationId, l.displayName, sl.name AS sublocationName, sl2.name AS sublocationOverride, e.sublocationId, e.cover, e.private FROM event_instance AS ei LEFT JOIN event as e ON e.id = ei.eventID LEFT JOIN location AS l ON e.locationId = l.locationId LEFT JOIN sublocation AS sl on e.sublocationId = sl.id LEFT JOIN sublocation AS sl2 ON ei.sublocationId = sl2.id WHERE ei.date < ? AND (e.dateUpdated > ? OR ei.dateUpdated > ?) AND ei.deleted = 0;");
+				eventsStmt = aspenConn.prepareStatement("SELECT ei.*, e.title, e.description, e.eventTypeId, e.locationId, l.displayName, sl.name AS sublocationName, sl2.name AS sublocationOverride, e.sublocationId, e.cover, e.private, e.hideTimestamps FROM event_instance AS ei LEFT JOIN event as e ON e.id = ei.eventID LEFT JOIN location AS l ON e.locationId = l.locationId LEFT JOIN sublocation AS sl on e.sublocationId = sl.id LEFT JOIN sublocation AS sl2 ON ei.sublocationId = sl2.id WHERE ei.date < ? AND (e.dateUpdated > ? OR ei.dateUpdated > ?) AND ei.deleted = 0;");
 				deleteEventsStmt = aspenConn.prepareStatement("SELECT id FROM event_instance WHERE deleted = 1 AND dateUpdated > ?;");
 				eventsStmt.setLong(2, lastUpdateOfChangedEvents);
 				eventsStmt.setLong(3, lastUpdateOfChangedEvents);
@@ -180,13 +183,19 @@ public class AspenEventsIndexer {
 				solrDocument.addField("last_change", null);
 				//Make sure the start date exists
 				Date startDate = eventInfo.getStartDateTime(logEntry);
-
 				solrDocument.addField("start_date", startDate);
 				if (startDate == null) {
 					continue;
 				}
 
-				solrDocument.addField("start_date_sort", startDate.getTime() / 1000);
+				if (eventInfo.getHideTimestamps()) {
+					//sort hidden timestamp events to top of that day
+					solrDocument.addField("start_date_sort", eventInfo.getHideTimestampsStart(logEntry).getTime() / 1000);
+					solrDocument.addField("hidden_timestamps", "true");
+				} else {
+					solrDocument.addField("start_date_sort", startDate.getTime() / 1000);
+					solrDocument.addField("hidden_timestamps", "false");
+				}
 				Date endDate = eventInfo.getEndDateTime(logEntry);
 				solrDocument.addField("end_date", endDate);
 

--- a/code/web/RecordDrivers/AspenEventRecordDriver.php
+++ b/code/web/RecordDrivers/AspenEventRecordDriver.php
@@ -105,6 +105,7 @@ class AspenEventRecordDriver extends IndexRecordDriver {
 
 	$interface->assign('upcomingInstanceCount', $this->getEventObject()->getUpcomingInstanceCount() ?? 0);
 	$interface->assign('private', $this->isPrivate() ? 'private' : '');
+	$interface->assign('hiddenTimestamps', $this->hiddenTimestamps());
 
 //		require_once ROOT_DIR . '/sys/Events/EventsUsage.php';
 //		$eventsUsage = new EventsUsage();
@@ -169,6 +170,15 @@ class AspenEventRecordDriver extends IndexRecordDriver {
 		}else{
 			return false;
 		}
+	}
+
+	public function hiddenTimestamps() {
+		if (isset($this->fields['hidden_timestamps'])) {
+			if ($this->fields['hidden_timestamps'] == "true") {
+				return true;
+			};
+		}
+		return false;
 	}
 
 	public function getFullDescription() {

--- a/code/web/interface/themes/responsive/AspenEvents/event.tpl
+++ b/code/web/interface/themes/responsive/AspenEvents/event.tpl
@@ -75,7 +75,9 @@
 						<li>{translate text="End Date: " isPublicFacing=true}{$recordDriver->getEndDate()|date_format:"%a %b %e, %Y %l:%M%p"}</li>
 					{else}
 						<li>{translate text="Date: " isPublicFacing=true}{$recordDriver->getStartDate()|date_format:"%A %B %e, %Y"}</li>
-						<li>{translate text="Time: " isPublicFacing=true}{$recordDriver->getStartDate()|date_format:"%l:%M %p"} to {$recordDriver->getEndDate()|date_format:"%l:%M %p"}</li>
+						{if !$recordDriver->hiddenTimestamps()}
+							<li>{translate text="Time: " isPublicFacing=true}{$recordDriver->getStartDate()|date_format:"%l:%M %p"} to {$recordDriver->getEndDate()|date_format:"%l:%M %p"}</li>
+						{/if}
 					{/if}
 					<li>{translate text="Branch: " isPublicFacing=true}{$recordDriver->getBranch()}</li>
 					{if !empty($recordDriver->getRoom())}

--- a/code/web/interface/themes/responsive/Events/calendar.tpl
+++ b/code/web/interface/themes/responsive/Events/calendar.tpl
@@ -57,9 +57,11 @@
 									<div class="calendar-event-title">
 										<a href="{$event.link}" target="_blank" aria-label="{translate text=$event.title isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})">{$event.title}</a>
 									</div>
-									<div class="calendar-event-time {if $printEndTime}show-end-time{else}can-hide-end-time{/if}">
-										{$event.formattedTime}
-									</div>
+									{if !$event.hiddenTimestamps}
+										<div class="calendar-event-time {if $printEndTime}show-end-time{else}can-hide-end-time{/if}">
+											{$event.formattedTime}
+										</div>
+									{/if}
 									{if !empty($event.eventFields)}
 										{foreach from=$event.eventFields key=eventFieldName item=eventField}
 											{if $eventFieldName == 'description'}

--- a/code/web/interface/themes/responsive/RecordDrivers/Events/aspenEvent_result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Events/aspenEvent_result.tpl
@@ -32,12 +32,16 @@
 				<div class="row">
 					<div class="result-label col-tn-2">{translate text="Date" isPublicFacing=true} </div>
 					<div class="result-value col-tn-6 notranslate">
-						{if $allDayEvent}
-							{$start_date|date_format:"%a %b %e, %Y"}{translate text=" - All Day Event" isPublicFacing=true}
-						{elseif $multiDayEvent}
-							{$start_date|date_format:"%a %b %e, %Y %l:%M%p"} to {$end_date|date_format:"%a %b %e, %Y %l:%M%p"}
+						{if !$hiddenTimestamps}
+							{if $allDayEvent}
+								{$start_date|date_format:"%a %b %e, %Y"}{translate text=" - All Day Event" isPublicFacing=true}
+							{elseif $multiDayEvent}
+								{$start_date|date_format:"%a %b %e, %Y %l:%M%p"} to {$end_date|date_format:"%a %b %e, %Y %l:%M%p"}
+							{else}
+								{$start_date|date_format:"%a %b %e, %Y from %l:%M%p"} to {$end_date|date_format:"%l:%M%p"}
+							{/if}
 						{else}
-							{$start_date|date_format:"%a %b %e, %Y from %l:%M%p"} to {$end_date|date_format:"%l:%M%p"}
+							{$start_date|date_format:"%a %b %e, %Y"}
 						{/if}
 						{if !empty($isCancelled)}
 							&nbsp;<span class="label label-danger">{translate text="Cancelled" isPublicFacing=true}</span>

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -10112,6 +10112,17 @@ AspenDiscovery.Events = (function(){
 			return false;
 		},
 
+		toggleStartEndTimestamp: function () {
+			const hideTimestamps = $('#hideTimestamps');
+			if (hideTimestamps.is(":checked")) {
+				$("#propertyRowstartTime").hide();
+				$("#propertyRowendTime").hide();
+			} else {
+				$("#propertyRowstartTime").show();
+				$("#propertyRowendTime").hide();
+			}
+		},
+
 		getWeekofMonth: function (date) {
 			return date.week() - date.startOf('month').week() + 1;
 		},

--- a/code/web/interface/themes/responsive/js/aspen/events.js
+++ b/code/web/interface/themes/responsive/js/aspen/events.js
@@ -163,6 +163,17 @@ AspenDiscovery.Events = (function(){
 			return false;
 		},
 
+		toggleStartEndTimestamp: function () {
+			const hideTimestamps = $('#hideTimestamps');
+			if (hideTimestamps.is(":checked")) {
+				$("#propertyRowstartTime").hide();
+				$("#propertyRowendTime").hide();
+			} else {
+				$("#propertyRowstartTime").show();
+				$("#propertyRowendTime").hide();
+			}
+		},
+
 		getWeekofMonth: function (date) {
 			return date.week() - date.startOf('month').week() + 1;
 		},

--- a/code/web/release_notes/26.01.00.MD
+++ b/code/web/release_notes/26.01.00.MD
@@ -7,6 +7,15 @@
 //kirstien
 
 //kodi
+### Event Updates
+- Add ability to create events without timestamps (DIS-1712)(*KL*)
+
+<div markdown="1" class="settings">
+
+#### New Settings
+- Events > Manage Events > Hide Start and End Times for This Event
+
+</div>
 
 //leo
 ### E-Commerce Updates

--- a/code/web/services/Events/Calendar.php
+++ b/code/web/services/Events/Calendar.php
@@ -226,6 +226,10 @@ class Events_Calendar extends Action {
 						if (array_key_exists('reservation_state', $result) && in_array('Cancelled', $result['reservation_state'])) {
 							$isCancelled = true;
 						}
+						$hiddenTimestamps = false;
+						if (!empty($result['hidden_timestamps']) && $result['hidden_timestamps'] == "true") {
+							$hiddenTimestamps = true;
+						}
 						$url = "";
 						$eventFields = [];
 						if (str_starts_with($result['id'], 'communico')){
@@ -277,6 +281,7 @@ class Events_Calendar extends Action {
 							'link' => $url,
 							'formattedTime' => $formattedTime,
 							'isCancelled' => $isCancelled,
+							'hiddenTimestamps' => $hiddenTimestamps,
 							'eventFields' => $eventFields,
 						];
 					}

--- a/code/web/services/Events/Events.php
+++ b/code/web/services/Events/Events.php
@@ -86,6 +86,10 @@ class Events_Events extends ObjectEditor {
 		return 'https://help.aspendiscovery.org/help/catalog/events';
 	}
 
+	function getInitializationJs(): string {
+		return 'AspenDiscovery.Events.toggleStartEndTimestamp();';
+	}
+
 	function getBreadcrumbs(): array {
 		$breadcrumbs = [];
 		$breadcrumbs[] = new Breadcrumb('/Admin/Home', 'Administration Home');

--- a/code/web/sys/DBMaintenance/version_updates/26.01.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/26.01.00.php
@@ -17,6 +17,13 @@ function getUpdates26_01_00(): array {
 		//kirstien
 
 		//kodi
+		'toggle_timestamps_for_events' => [
+			'title' => 'Toggle Event Timestamps',
+			'description' => 'Toggle Event Timestamps',
+			'sql' => [
+				'ALTER TABLE event ADD COLUMN hideTimestamps TINYINT(1) NOT NULL DEFAULT 0'
+			]
+		], //toggle_timestamps_for_events
 
 		//leo
 

--- a/code/web/sys/Events/Event.php
+++ b/code/web/sys/Events/Event.php
@@ -18,6 +18,7 @@ class Event extends DataObject {
 	public $_typeFields = [];
 	public $startDate;
 	public $_startDateForList;
+	public $hideTimestamps;
 	public $startTime;
 	public $eventLength;
 	public $recurrenceOption;
@@ -205,6 +206,13 @@ class Event extends DataObject {
 				'label' => 'Event Date',
 				'description' => 'The date this event starts',
 				'onchange' => "return AspenDiscovery.Events.updateRecurrenceOptions(this.value);",
+			],
+			'hideTimestamps' => [
+				'property' => 'hideTimestamps',
+				'type' => 'checkbox',
+				'label' => 'Hide Start and End Times for This Event',
+				'description' => 'Hide the start and end times of the event',
+				'onchange' => 'return AspenDiscovery.Events.toggleStartEndTimestamp();',
 			],
 			'startTime' => [
 				'property' => 'startTime',

--- a/data_dir_setup/solr7/events/conf/schema.xml
+++ b/data_dir_setup/solr7/events/conf/schema.xml
@@ -128,6 +128,7 @@
 		<field name="library_scopes" type="unchanged_string" indexed="true" stored="false" multiValued="true"/>
 
 		<field name="private" type="unchanged_string" indexed="true" stored="true" multiValued="true" default="public"/>
+		<field name="hidden_timestamps" type="unchanged_string" indexed="true" stored="true" multiValued="false" default="false"/>
 
 		<!-- Field to get random titles -->
 		<dynamicField name="random*" type="random" indexed="true" stored="true"/>


### PR DESCRIPTION
Add setting to hide timestamps for events
Toggling this on hides timestamps in search results, calendar views, and event pages 
On Calendar and Search results events with no timestamps are sorted to the top of their event date 
Add new variable to solr schema for hiding timestamps Update release notes

Tested on my local instance of Aspen

NOTE: Solr files need to be updated on local instances and java files built for the repo