### PR TITLE
DIS-264: Update GA3 tracking ID setting to GA4 Measurement ID setting

### DIFF
--- a/code/web/sys/Enrichment/GoogleApiSetting.php
+++ b/code/web/sys/Enrichment/GoogleApiSetting.php
@@ -38,8 +38,8 @@ class GoogleApiSetting extends DataObject {
 			'googleAnalyticsTrackingId' => [
 				'property' => 'googleAnalyticsTrackingId',
 				'type' => 'text',
-				'label' => 'Google Analytics Tracking ID',
-				'description' => 'The Google analytics Tracking ID to use',
+				'label' => 'Google Analytics Measurement ID',
+				'description' => 'The Google Analytics Measurement ID to use globally or as a fallback value',
 			],
 			'googleBooksKey' => [
 				'property' => 'googleBooksKey',


### PR DESCRIPTION
Minor if it's too late to get in, but the new per library settings use the correct GA4 term for ID settings, but the old one uses the GA3 terminology. Could be considered part of DIS-264 or DIS-1588.