### PR TITLE
DIS-1725: Remove NintendoSwitch when NintendoSwitch2 is present

### DIFF
--- a/code/reindexer/src/org/aspen_discovery/format_classification/MarcRecordFormatClassifier.java
+++ b/code/reindexer/src/org/aspen_discovery/format_classification/MarcRecordFormatClassifier.java
@@ -1506,6 +1506,9 @@ public class MarcRecordFormatClassifier {
 			printFormats.clear();
 			printFormats.add("Zines");
 		}
+		if (printFormats.contains("NintendoSwitch2")) {
+			printFormats.remove("NintendoSwitch");
+		}
 		if (printFormats.contains("Kinect") || printFormats.contains("XBox360")  || printFormats.contains("Xbox360")
 				|| printFormats.contains("XboxOne") || printFormats.contains("XBoxSeriesX") || printFormats.contains("PlayStation")
 				|| printFormats.contains("PlayStation2") || printFormats.contains("PlayStation3")

--- a/code/web/release_notes/26.01.00.MD
+++ b/code/web/release_notes/26.01.00.MD
@@ -25,6 +25,8 @@
 - Stripe payments now respect the system's configured currency code and symbol, not just USD. ([DIS-1623](https://aspen-discovery.atlassian.net/browse/DIS-1709)) (*LS*)
 
 //yanjun
+### Other Updates
+- Remove "NintendoSwitch" format when "NintendoSwitch2" format is present. ([DIS-1725](https://aspen-discovery.atlassian.net/browse/DIS-1725)) (*YL*)
 
 //imani
 


### PR DESCRIPTION
When MARC record contains both “Nintendo Switch 2” and “Nintendo Switch”, the format classifier adds both NintendoSwitch2 and NintendoSwitch. Update MarcRecordFormatClassifier.filterPrintFormats() so that whenever NintendoSwitch2 is present, it removes NintendoSwitch from the formats set. 

To Test:
1. Find or create a MARC record that has both "Nintendo Switch 2" and "Nintendo Switch" in $538 
2. See the record format shows as "Nintendo Switch"
3. Apply PR
4. Force reindex the record and see format shows as "Nintendo Switch 2" 