### PR TITLE
DIS-1726:  Refactor Docker initialization

### DIFF
--- a/code/web/release_notes/26.01.00.MD
+++ b/code/web/release_notes/26.01.00.MD
@@ -41,7 +41,10 @@
 //lucas
 ### Docker Updates
 - Added support for updating settings from the configuration files (.ini) by using environment variables. ([DIS-1693](https://aspen-discovery.atlassian.net/browse/DIS-1693)) (*LM*)
-
+- Normalized logging messages from all the services ([DIS-1726](https://aspen-discovery.atlassian.net/browse/DIS-1726)) (*LM*)
+- Improved php-fpm initial configuration ([DIS-1726](https://aspen-discovery.atlassian.net/browse/DIS-1726)) (*LM*)
+- Fixed race condition in symlink creation during container startup ([DIS-1726](https://aspen-discovery.atlassian.net/browse/DIS-1726)) (*LM*)
+- Removed external Koha network dependency from docker-compose ([DIS-1726](https://aspen-discovery.atlassian.net/browse/DIS-1726)) (*LM*)
 //tomas
 
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,6 @@
 networks:
   net-aspen:
-  kohadev_kohanet:
-    external: true
+
 volumes:
   solr:
 

--- a/docker/files/php_fpm/php-fpm.conf
+++ b/docker/files/php_fpm/php-fpm.conf
@@ -12,19 +12,38 @@ pm.max_children = 6
 pm.start_servers = 2
 pm.min_spare_servers = 2
 pm.max_spare_servers = 5
+pm.process_idle_timeout = 10s
+pm.max_requests = 500
 chdir = /usr/local/aspen-discovery/code/web
 
 
-; Kill long-running requests after 300s
+; Status endpoint for monitoring and health checks
+pm.status_path = /php-fpm-status
+ping.path = /php-fpm-ping
+ping.response = pong
+
+
+; Request timeouts
 request_terminate_timeout = 300
+
+
+; Slow request logging (requests taking longer than 5s)
+slowlog = /proc/self/fd/2
+request_slowlog_timeout = 5s
+request_slowlog_trace_depth = 20
 
 
 ; Logging (stdout/stderr for Docker)
 access.log = /proc/self/fd/2
+access.format = "[%{%Y-%m-%d %H:%M:%S}t] [BACKEND] [ACCESS] %R %m %r%Q - %s %{mili}dms %{mega}MMB"
 catch_workers_output = yes
 decorate_workers_output = yes
 php_flag[log_errors] = on
 php_admin_value[error_log] = /proc/self/fd/2
+
+
+; Security
+security.limit_extensions = .php
 
 
 ; Session Settings
@@ -35,13 +54,12 @@ php_admin_value[session.auto_start] = 0
 php_admin_value[session.cookie_lifetime] = 0
 php_admin_value[session.gc_maxlifetime] = 6000
 
-
 ; Uncomment these lines if you want to show all errors
 ; php_admin_value[display_errors] = 1
 ; php_admin_value[error_reporting] = 2047
 
 
-; Memory Settings
+; Memory and Execution Settings
 php_admin_value[memory_limit] = 512M
 php_admin_value[max_execution_time] = 300
 php_admin_value[default_socket_timeout] = 300

--- a/docker/files/scripts/apache.sh
+++ b/docker/files/scripts/apache.sh
@@ -1,22 +1,39 @@
 #!/bin/bash
 
-# Function to log with timestamp
+# Colors for log output
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # No Color
+
 log() {
-    echo "$(date '+%Y-%m-%d %H:%M:%S') [APACHE] $1"
+    local level="${1:-INFO}"
+    local message="$2"
+    local color=""
+
+    case "$level" in
+        ERROR) color="$RED" ;;
+        WARN)  color="$YELLOW" ;;
+    esac
+
+    echo -e "[$(date '+%Y-%m-%d %H:%M:%S')] [APACHE] [${color}${level}${NC}] ${message}"
 }
 
-log "Starting Apache initialization"
+log_info()  { log "INFO" "$1"; }
+log_warn()  { log "WARN" "$1"; }
+log_error() { log "ERROR" "$1"; }
+
+log_info "Starting Apache initialization"
 
 export CONFIG_DIRECTORY="/usr/local/aspen-discovery/sites/${SITE_NAME}"
 
 # Function to handle shutdown signals
 shutdown_handler() {
-    log "Received shutdown signal, stopping Apache gracefully..."
+    log_info "Received shutdown signal, stopping Apache gracefully..."
     if [ -n "$APACHE_PID" ]; then
         kill -TERM "$APACHE_PID" 2>/dev/null || true
         wait "$APACHE_PID" 2>/dev/null || true
     fi
-    log "Apache stopped"
+    log_info "Apache stopped"
     exit 0
 }
 
@@ -25,7 +42,7 @@ trap shutdown_handler SIGTERM SIGINT SIGQUIT
 
 # Check if site configuration exists
 apacheConfFile="$CONFIG_DIRECTORY/httpd-${SITE_NAME}.conf"
-log "Waiting for site configuration: $apacheConfFile"
+log_info "Waiting for site configuration: $apacheConfFile"
 
 tries=0
 MAX_TRIES=10
@@ -33,56 +50,56 @@ MAX_TRIES=10
 while [ ! -f "$apacheConfFile" ]; do
     sleep 5
     ((tries++))
-    log "Waiting for configuration file... (attempt $tries/$MAX_TRIES)"
+    log_info "Waiting for configuration file... (attempt $tries/$MAX_TRIES)"
 
     if [ $tries -eq $MAX_TRIES ]; then
-        log "ERROR: Site configuration not found after $MAX_TRIES attempts. Exiting."
+        log_error "Site configuration not found after $MAX_TRIES attempts. Exiting."
         exit 1
     fi
 done
 
-log "Configuration file found: $apacheConfFile"
+log_info "Configuration file found: $apacheConfFile"
 
 # Prepare Apache environment
-log "Preparing Apache environment"
+log_info "Preparing Apache environment"
 mkdir -p /var/run/apache2
 chown -R www-data:www-data /var/run/apache2
 
 # Source environment variables
 if [ -f /etc/apache2/envvars ]; then
     source /etc/apache2/envvars
-    log "Apache environment variables loaded"
+    log_info "Apache environment variables loaded"
 else
-    log "WARNING: /etc/apache2/envvars not found"
+    log_warn "/etc/apache2/envvars not found"
 fi
 
 # Move to docker directory
 cd "/usr/local/aspen-discovery/docker/files/apache2/" || {
-    log "ERROR: Cannot change to docker directory"
+    log_error "Cannot change to docker directory"
     exit 1
 }
 
 # Set Apache configurations
-log "Setting Apache configurations"
+log_info "Setting Apache configurations"
 if ! php setApacheConf.php "$apacheConfFile"; then
-    log "ERROR: Apache configuration failed"
+    log_error "Apache configuration failed"
     exit 1
 fi
 
-log "Apache configuration completed successfully"
+log_info "Apache configuration completed successfully"
 
 # Validate Apache configuration
-log "Validating Apache configuration"
+log_info "Validating Apache configuration"
 if ! apache2 -t; then
-    log "ERROR: Apache configuration test failed"
+    log_error "Apache configuration test failed"
     exit 1
 fi
 
-log "Apache configuration is valid"
+log_info "Apache configuration is valid"
 
 
 # Start Apache and capture its PID
-log "Starting Apache in foreground mode..."
+log_info "Starting Apache in foreground mode..."
 exec apache2 -D FOREGROUND
 
 

--- a/docker/files/scripts/createDirs.php
+++ b/docker/files/scripts/createDirs.php
@@ -120,7 +120,6 @@ try {
 	
 	//Conf directory
 	DockerLogger::setPermissions("$configDir/conf", $newOwner, '755');
-	DockerLogger::setPermissions("$configDir/conf/config*", $newOwner, '755');
 	DockerLogger::setPermissions("$configDir/conf/php-fpm.conf", $newOwner, '755');
 	DockerLogger::setPermissions("$configDir/httpd-$siteName.conf", 'root', '644');
 	DockerLogger::setPermissions("$configDir/conf/crontab_settings.txt", 'root', '644');

--- a/docker/files/scripts/cron.sh
+++ b/docker/files/scripts/cron.sh
@@ -1,11 +1,28 @@
 #!/bin/bash
 
-# Function to log with timestamp
+# Colors for log output
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # No Color
+
 log() {
-    echo "$(date '+%Y-%m-%d %H:%M:%S') [CRON] $1"
+    local level="${1:-INFO}"
+    local message="$2"
+    local color=""
+
+    case "$level" in
+        ERROR) color="$RED" ;;
+        WARN)  color="$YELLOW" ;;
+    esac
+
+    echo -e "[$(date '+%Y-%m-%d %H:%M:%S')] [CRON] [${color}${level}${NC}] ${message}"
 }
 
-log "Starting Cron initialization"
+log_info()  { log "INFO" "$1"; }
+log_warn()  { log "WARN" "$1"; }
+log_error() { log "ERROR" "$1"; }
+
+log_info "Starting Cron initialization"
 
 export CONFIG_DIRECTORY="/usr/local/aspen-discovery/sites/${SITE_NAME}"
 
@@ -17,21 +34,21 @@ MAX_TRIES=10
 
 while [ ! -f "$confSiteFile" ]; do
 
-	log "Waiting for site configuration: $confSiteFile... (attempt $tries/$MAX_TRIES)"
+	log_info "Waiting for site configuration: $confSiteFile... (attempt $tries/$MAX_TRIES)"
 	sleep 5
 	((tries++))
 
 	if [ $tries -eq 10 ] ; then
-		log "ERROR: Site configuration not initialized. Skipping cron startup and waiting..."
+		log_error "Site configuration not initialized. Skipping cron startup and waiting..."
 		exit 1
 	fi
 
 done
 
 # Set crontab to be executed
-log "Setting crontab to be executed"
+log_info "Setting crontab to be executed"
 crontab -u root "$CONFIG_DIRECTORY/conf/crontab" >/proc/1/fd/1 2>/proc/1/fd/2
 
-log "Starting Cron in foreground mode..."
+log_info "Starting Cron in foreground mode..."
 # Start cron daemon
 cron -f -L 15 >/proc/1/fd/1 2>/proc/1/fd/2

--- a/docker/files/scripts/entrypoint.sh
+++ b/docker/files/scripts/entrypoint.sh
@@ -1,9 +1,27 @@
 #!/bin/bash
 set -e
 
+# Colors for log output
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # No Color
+
 log() {
-    echo "$(date '+%Y-%m-%d %H:%M:%S') [ENTRYPOINT] $1"
+    local level="${1:-INFO}"
+    local message="$2"
+    local color=""
+
+    case "$level" in
+        ERROR) color="$RED" ;;
+        WARN)  color="$YELLOW" ;;
+    esac
+
+    echo -e "[$(date '+%Y-%m-%d %H:%M:%S')] [ENTRYPOINT] [${color}${level}${NC}] ${message}"
 }
+
+log_info()  { log "INFO" "$1"; }
+log_warn()  { log "WARN" "$1"; }
+log_error() { log "ERROR" "$1"; }
 
 USER_NAME="www-data"
 SOURCE_DIR="/usr/local/aspen-discovery"
@@ -11,7 +29,7 @@ APACHE_LOG_DIR="/var/log/apache2"
 
 # Adjust user ID if needed
 if [[ -n "${LOCAL_USER_ID}" && "${LOCAL_USER_ID}" != "33" ]]; then
-	log "Setting UID for ${USER_NAME} to ${LOCAL_USER_ID}"
+	log_info "Setting UID for ${USER_NAME} to ${LOCAL_USER_ID}"
 	usermod -o -u "$LOCAL_USER_ID" "$USER_NAME"
 fi
 

--- a/docker/files/scripts/start.sh
+++ b/docker/files/scripts/start.sh
@@ -1,9 +1,27 @@
 #!/bin/bash
 set -e
 
+# Colors for log output
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # No Color
+
 log() {
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] [BACKEND] $1"
+    local level="${1:-INFO}"
+    local message="$2"
+    local color=""
+
+    case "$level" in
+        ERROR) color="$RED" ;;
+        WARN)  color="$YELLOW" ;;
+    esac
+
+    echo -e "[$(date '+%Y-%m-%d %H:%M:%S')] [BACKEND] [${color}${level}${NC}] ${message}"
 }
+
+log_info()  { log "INFO" "$1"; }
+log_warn()  { log "WARN" "$1"; }
+log_error() { log "ERROR" "$1"; }
 
 echo "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%"
 echo "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%"
@@ -21,7 +39,7 @@ echo "                                        "
 echo "                                        "
 
 
-log "Aspen Discovery starting for: ${SITE_NAME}"
+log_info "Aspen Discovery starting for: ${SITE_NAME}"
 
 export CONFIG_DIRECTORY="/usr/local/aspen-discovery/sites/$SITE_NAME"
 
@@ -31,24 +49,24 @@ cd "/usr/local/aspen-discovery/docker/files/scripts" || exit
 # Check if site configuration exists
 confSiteFile="$CONFIG_DIRECTORY/conf/config.ini"
 if [ ! -f "$confSiteFile" ] ; then
-	log "$confSiteFile not found. Generating..."
+	log_info "$confSiteFile not found. Generating..."
 	mkdir -p "$CONFIG_DIRECTORY"
 	if ! php createConfig.php "$CONFIG_DIRECTORY" ; then
-		log "ERROR: Failed to create instance config"
+		log_error "Failed to create instance config"
 		exit 1
 	fi
 fi
 
 # Sync environment variables to config files (runs every start)
-log "Syncing environment variables to config..."
+log_info "Syncing environment variables to config..."
 if ! php syncEnvToConfig.php ; then
-	log "WARNING: Environment sync failed, using existing config"
+	log_warn "Environment sync failed, using existing config"
 fi
 
 # Initialize Aspen database
-log "Initializing database";
+log_info "Initializing database"
 if ! php initDatabase.php ; then
-	log "ERROR: Database initialization failed"
+	log_error "Database initialization failed"
 	exit 1
 fi
 
@@ -60,9 +78,9 @@ if ! php initKohaLink.php ; then
 fi
 
 # Create missing dirs and fix ownership and permissions if needed
-log "Setting up data and log directories";
+log_info "Setting up data and log directories"
 if ! php createDirs.php ; then
-	log "ERROR: Directories creation and permission fixes failed"
+	log_error "Directories creation and permission fixes failed"
 	exit 1
 fi
 
@@ -96,14 +114,14 @@ for dir in "${directories[@]}"; do
     # Create symlink atomically (ln -sfn replaces existing symlink in one operation)
     ln -sfn "$dest" "$source"
 
-    log "Created symlink: $source → $dest"
+    log_info "Created symlink: $source → $dest"
 done
 
 # Run pending database updates
-log "Running pending database updates..."
+log_info "Running pending database updates..."
 php updateDatabase.php "$SITE_NAME"
 
 sudo -u www-data php /usr/local/aspen-discovery/docker/files/cron/checkBackgroundProcessesDocker.php $SITE_NAME >/proc/1/fd/1 2>/proc/1/fd/2
 
-log "Starting PHP-FPM in foreground mode..."
+log_info "Starting PHP-FPM in foreground mode..."
 php-fpm8.4 --test && exec php-fpm8.4 -F

--- a/docker/files/scripts/start.sh
+++ b/docker/files/scripts/start.sh
@@ -2,7 +2,7 @@
 set -e
 
 log() {
-    echo "$(date '+%Y-%m-%d %H:%M:%S') [BACKEND] $1"
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] [BACKEND] $1"
 }
 
 echo "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%"
@@ -82,18 +82,21 @@ for dir in "${directories[@]}"; do
     # Ensure persistent target directory exists
     mkdir -p "$dest"
 
-    # Move original data only if target is empty
-    if [ -d "$source" ] && [ "$(ls -A "$dest")" == "" ]; then
-        mv "$source"/* "$dest"/
+    # Move original data only if source is a real directory and target is empty
+    if [ -d "$source" ] && [ ! -L "$source" ] && [ "$(ls -A "$dest")" == "" ]; then
+        mv "$source"/* "$dest"/ 2>/dev/null || true
     fi
 
-    # Remove the source directory or symlink
-	rm -rf "$source"
+    # Remove source only if it's a real directory (not a symlink)
+    # This is required because ln -sfn can't replace a directory
+    if [ -d "$source" ] && [ ! -L "$source" ]; then
+        rm -rf "$source"
+    fi
 
-    # Create symlink
-    ln -s "$dest" "$source"
+    # Create symlink atomically (ln -sfn replaces existing symlink in one operation)
+    ln -sfn "$dest" "$source"
 
-	log "Created symlink: $source → $dest"
+    log "Created symlink: $source → $dest"
 done
 
 # Run pending database updates


### PR DESCRIPTION
This patch improves some aspects of the initialization of Aspen via Docker. 
The changes are : 

Add colored log levels (INFO, WARN, ERROR) to all shell scripts (start.sh, entrypoint.sh, apache.sh, cron.sh) matching the DockerLogger format with red for ERROR and yellow for WARN

Fix race condition in symlink creation during container startup

Enhance PHP-FPM configuration for production readiness

Remove redundant permission setting for config files

Remove external Koha network dependency from docker-compose