### PR TITLE
DIS-1471 QA fixes

### DIFF
--- a/code/web/services/API/SearchAPI.php
+++ b/code/web/services/API/SearchAPI.php
@@ -1760,8 +1760,8 @@ class SearchAPI extends AbstractAPI {
 						'textId' => $textId,
 						'label' => $browseCategory->label,
 						'source' => $source,
-						$subCategoriesKey => $hasSubcategories ? $subCatResult['subCategories'] : [],
-						$recordsKey => $results,
+						'subCategories' => $hasSubcategories ? $subCatResult['subCategories'] : [],
+						'records' => $results,
 					];
 				}
 			}
@@ -1897,7 +1897,7 @@ class SearchAPI extends AbstractAPI {
 		} else {
 			$label = explode('_', $_REQUEST['id']);
 		}
-		$id = $label[3];
+		$id = isset($label[3]) && $label[3] ? $label[3] : $id;
 		require_once ROOT_DIR . '/services/API/ListAPI.php';
 		$listApi = new ListAPI();
 		$records = $listApi->getSavedSearchTitles($id, $pageSize);
@@ -1930,7 +1930,8 @@ class SearchAPI extends AbstractAPI {
 		} else {
 			$label = explode('_', $_REQUEST['id']);
 		}
-		$id = $label[3];
+
+		$id = isset($label[3]) && $label[3] ? $label[3] : $id;
 		require_once ROOT_DIR . '/sys/UserLists/UserList.php';
 		$sourceList = new UserList();
 		$sourceList->id = $id;


### PR DESCRIPTION
- always use subCategories and records key to keep the sub-category tabs populating correctly in LiDA (specifically this is fixing the rendering of system_user_lists so that the user's lists display as sub-category tabs)
- Check if $label[3] is defined before trying to use it when searching for user lists