### PR TITLE
DIS-1780 Make OverDrive deletion check hour configurable

### DIFF
--- a/code/overdrive_extract/src/com/turning_leaf_technologies/overdrive/ExtractOverDriveInfo.java
+++ b/code/overdrive_extract/src/com/turning_leaf_technologies/overdrive/ExtractOverDriveInfo.java
@@ -97,7 +97,8 @@ class ExtractOverDriveInfo {
 		boolean checkForDeletedRecords = false;
 		Calendar rightNow = Calendar.getInstance();
 		int hour = rightNow.get(Calendar.HOUR_OF_DAY);
-		if (hour == 8){
+		int configuredDeletionHour = settings.getDeletionCheckHour();
+		if (configuredDeletionHour >= 0 && hour == configuredDeletionHour){
 			checkForDeletedRecords = true;
 		}
 

--- a/code/overdrive_extract/src/com/turning_leaf_technologies/overdrive/OverDriveSetting.java
+++ b/code/overdrive_extract/src/com/turning_leaf_technologies/overdrive/OverDriveSetting.java
@@ -18,6 +18,7 @@ public class OverDriveSetting {
 	private final boolean allowLargeDeletes;
 	private final boolean enableRequestLogging;
 	private final int numRetriesOnError;
+	private final int deletionCheckHour;
 	private final HashSet<String> productsToUpdate = new HashSet<>();
 	private final HashSet<String> productsToUpdateNextTime = new HashSet<>();
 
@@ -38,6 +39,7 @@ public class OverDriveSetting {
 		lastUpdateOfChangedRecords = settingRS.getLong("lastUpdateOfChangedRecords");
 		enableRequestLogging = settingRS.getBoolean("enableRequestLogging");
 		numRetriesOnError = Math.max(1, settingRS.getInt("numRetriesOnError"));
+		deletionCheckHour = settingRS.getInt("deletionCheckHour");
 		String productsToUpdateStr = settingRS.getString("productsToUpdate");
 		if (productsToUpdateStr == null){
 			productsToUpdateStr = "";
@@ -107,6 +109,10 @@ public class OverDriveSetting {
 
 	public String getReaderName() {
 		return readerName;
+	}
+
+	public int getDeletionCheckHour() {
+		return deletionCheckHour;
 	}
 
 }

--- a/code/web/release_notes/26.01.00.MD
+++ b/code/web/release_notes/26.01.00.MD
@@ -129,6 +129,10 @@
 
 ### OverDrive Updates
 - Allow library to suppress OverDrive kindle format per scope. ([DIS-1714](https://aspen-discovery.atlassian.net/browse/DIS-1714)) (*YL*)
+- Add configurable deletion check hour to prevent timing collisions with peak business hours. ([DIS-1780](https://aspen-discovery.atlassian.net/browse/DIS-1780)) (*TC*)
+  - Deletion check hour can now be set to any hour 0-23 or disabled with -1
+  - Defaults to 8 AM to maintain existing behavior
+  - Allows moving intensive operations to off-peak hours to improve user experience
 
 <div markdown="1" class="settings">
 
@@ -238,6 +242,7 @@
 
 ### Theke Solutions
 - Lucas Montoya (LM)
+- Tomas Cohen Arazi (TC)
 
 ## Special Testing thanks to
 - Myranda Fuentes (Grove)

--- a/code/web/sys/DBMaintenance/version_updates/26.01.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/26.01.00.php
@@ -267,5 +267,15 @@ function getUpdates26_01_00(): array {
 		]
 	], //user_payments_stripe_receipt_url
 
+	//tomas
+	'overdrive_configurable_deletion_check_hour' => [
+		'title' => 'OverDrive - Add Configurable Deletion Check Hour',
+		'description' => 'Add deletionCheckHour column to overdrive_settings to allow configuring when deletion checks run',
+		'continueOnError' => false,
+		'sql' => [
+			'ALTER TABLE overdrive_settings ADD COLUMN deletionCheckHour INT DEFAULT 8 AFTER name'
+		]
+	], //overdrive_configurable_deletion_check_hour
+
 	];
 }

--- a/code/web/sys/OverDrive/OverDriveSetting.php
+++ b/code/web/sys/OverDrive/OverDriveSetting.php
@@ -30,6 +30,8 @@ class OverDriveSetting extends DataObject {
 	public $lastUpdateOfAllRecords;
 	/** @noinspection PhpUnused */
 	public $enableRequestLogging;
+	/** @noinspection PhpUnused */
+	public $deletionCheckHour;
 
 	public $_scopes;
 	public $_librarySettings;
@@ -195,6 +197,15 @@ class OverDriveSetting extends DataObject {
 				'label' => 'Enable Request Logging',
 				'description' => 'Whether or not request logging is done while extracting from Aspen.',
 				'default' => 0,
+			],
+			'deletionCheckHour' => [
+				'property' => 'deletionCheckHour',
+				'type' => 'integer',
+				'label' => 'Deletion Check Hour',
+				'description' => 'Hour of day (0-23) when deletion check runs. Set to -1 to disable deletion checks.',
+				'default' => 8,
+				'min' => -1,
+				'max' => 23,
 			],
 			'librarySettingsSection' => [
 				'property' => 'librarySettingsSection',


### PR DESCRIPTION
- Add deletionCheckHour setting to OverDriveSetting (PHP and Java)
- Allow administrators to configure when deletion check runs (0-23)
- Set to -1 to disable deletion checks entirely
- Default remains 8 AM for backward compatibility
- Includes database migration script

This addresses performance issues where the 8 AM deletion check was overwhelming Solr during peak hours on large collections.