### PR TITLE
 DIS-1342: Optimize Hoopla V2 DB Update

### DIFF
--- a/code/web/interface/themes/responsive/Admin/dbMaintenance.tpl
+++ b/code/web/interface/themes/responsive/Admin/dbMaintenance.tpl
@@ -32,7 +32,18 @@
 					{elseif strpos($update.status, 'fail') !== false || strpos($update.status, 'error') !== false} danger
 					{/if}"
 					{if !empty($update.alreadyRun) && empty($update.status)} style="display:none"{/if}>
-						<td><input type="checkbox" name="selected[{$updateKey}]"{if empty($update.alreadyRun)} checked="checked"{/if} class="selectedUpdate" id="{$updateKey}"></td>
+						<td><input type="checkbox" name="selected[{$updateKey}]"
+								{if !empty($update.hooplaVersion2)}
+									disabled="disabled"
+								{elseif empty($update.alreadyRun)}
+									checked="checked"
+								{/if}
+								class="selectedUpdate"
+								id="{$updateKey}">
+							{if !empty($update.hooplaVersion2)}
+								<div class="text-muted small">{translate text="Run via Hoopla Version 2 background process above" isAdminFacing=true}</div>
+							{/if}
+						</td>
 						<td><label for="{$updateKey}">{$update.title}</label></td>
 						<td>{$update.description}</td>
 						<td>{if !empty($update.alreadyRun)}{translate text="Yes" isAdminFacing=true}{else}{translate text="No" isAdminFacing=true}{/if}</td>

--- a/code/web/release_notes/26.01.00.MD
+++ b/code/web/release_notes/26.01.00.MD
@@ -107,6 +107,8 @@
 
 ### Hoopla Updates
 - Allow exporting Single Works using the new API Endpoints. ([DIS-1773](https://aspen-discovery.atlassian.net/browse/DIS-1773)) (*MDN*)
+- Add a cleanup step for Version 2 Hoopla Flex availability table updates so partially run migrations don’t leave bad rows that block the reset_scopeLibraryId_to_not_null update. ([DIS-1342](https://aspen-discovery.atlassian.net/browse/DIS-1342)) (*YL*)
+- Disable DB maintenance checkboxes for Hoopla V2 updates to prevent UI runs. ([DIS-1342](https://aspen-discovery.atlassian.net/browse/DIS-1342)) (*YL*)
 
 ### Indexing Updates
 - Properly determine format for original XBox records (previously gave a format of XBox 360). ([DIS-1719](https://aspen-discovery.atlassian.net/browse/DIS-1719)) (*MDN*)

--- a/code/web/services/Admin/DBMaintenance.php
+++ b/code/web/services/Admin/DBMaintenance.php
@@ -57,11 +57,14 @@ class Admin_DBMaintenance extends Admin_Admin {
 		//Check to see which updates have already been performed.
 		$availableUpdates = $systemAPI->checkWhichUpdatesHaveRun($availableUpdates);
 
+		// Check for Hoopla V2 Updates
 		$showHooplaVersion2BackgroundButton = false;
 		foreach ($hooplaVersion2UpdateKeys as $hooplaUpdateKey) {
-			if (isset($availableUpdates[$hooplaUpdateKey]) && empty($availableUpdates[$hooplaUpdateKey]['alreadyRun'])) {
-				$showHooplaVersion2BackgroundButton = true;
-				break;
+			if (isset($availableUpdates[$hooplaUpdateKey])) {
+				$availableUpdates[$hooplaUpdateKey]['hooplaVersion2'] = true;
+				if (!$showHooplaVersion2BackgroundButton && empty($availableUpdates[$hooplaUpdateKey]['alreadyRun'])) {
+					$showHooplaVersion2BackgroundButton = true;
+				}
 			}
 		}
 		$interface->assign('showHooplaVersion2BackgroundButton', $showHooplaVersion2BackgroundButton);

--- a/code/web/sys/DBMaintenance/hoopla_version2_updates.php
+++ b/code/web/sys/DBMaintenance/hoopla_version2_updates.php
@@ -167,6 +167,14 @@ function getHooplaVersion2Updates(): array {
 						)"
 				]
 			], //migrate_hoopla_data_to_new_structure
+			'cleanup_bad_data_in_hoopla_flex_availability' => [
+				'title' => 'Cleanup hoopla_flex_availability rows without scope',
+				'description' => 'Remove hoopla_flex_availability rows that are still missing a scopeLibraryId before enforcing NOT NULL',
+				'continueOnError' => false,
+				'sql' => [
+					'DELETE FROM hoopla_flex_availability WHERE scopeLibraryId IS NULL OR scopeLibraryId = 0'
+				]
+			], //cleanup_bad_data_in_hoopla_flex_availability
 			'reset_scopeLibraryId_to_not_null' => [
 				'title' => 'Reset scopeLibraryId to not null',
 				'description' => 'Reset scopeLibraryId to not null',


### PR DESCRIPTION
 Disable DB maintenance checkboxes for Hoopla V2 updates so the v2 updates can only be run through background process. 