### PR TITLE
DIS-1714: Suppress OverDrive kindle format 

### DIFF
--- a/code/java_shared_libraries/src/com/turning_leaf_technologies/indexing/IndexingUtils.java
+++ b/code/java_shared_libraries/src/com/turning_leaf_technologies/indexing/IndexingUtils.java
@@ -176,6 +176,7 @@ public class IndexingUtils {
 				overDriveScope.setIncludeAdult(overDriveScopesRS.getBoolean("includeAdult"));
 				overDriveScope.setIncludeTeen(overDriveScopesRS.getBoolean("includeTeen"));
 				overDriveScope.setIncludeKids(overDriveScopesRS.getBoolean("includeKids"));
+				overDriveScope.setSuppressKindleFormat(overDriveScopesRS.getBoolean("suppressKindleFormat"));
 				//Add the reading name for convience later. It is based on the OverDrive setting.
 				overDriveScope.setReaderName(overDriveScopesRS.getString("readerNameSetting"));
 

--- a/code/java_shared_libraries/src/com/turning_leaf_technologies/indexing/OverDriveScope.java
+++ b/code/java_shared_libraries/src/com/turning_leaf_technologies/indexing/OverDriveScope.java
@@ -8,6 +8,7 @@ public class OverDriveScope {
 	private boolean includeAdult;
 	private boolean includeTeen;
 	private boolean includeKids;
+	private boolean suppressKindleFormat;
 	//Reader Name from the OverDrive Setting
 	private String readerName;
 
@@ -57,6 +58,14 @@ public class OverDriveScope {
 
 	void setIncludeKids(boolean includeKids) {
 		this.includeKids = includeKids;
+	}
+
+	public boolean isSuppressKindleFormat() {
+		return suppressKindleFormat;
+	}
+
+	void setSuppressKindleFormat(boolean suppressKindleFormat) {
+		this.suppressKindleFormat = suppressKindleFormat;
 	}
 
 	public long getSettingId() {

--- a/code/reindexer/src/org/aspen_discovery/reindexer/OverDriveProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/OverDriveProcessor.java
@@ -236,6 +236,7 @@ class OverDriveProcessor {
 
 						//Load the formats for the record.  For Libby, we will create a separate item for each format.
 						HashSet<String> validFormats = loadOverDriveFormats(productId, identifier);
+						HashSet<String> scopeSuppressingKindleFormats = new HashSet<>();
 						if (validFormats.contains("Kindle Book")){
 							hasKindle = true;
 						}
@@ -428,6 +429,10 @@ class OverDriveProcessor {
 											groupedWork.addScopingInfo(scope.getScopeName(), scopingInfo);
 										}
 									} // End checking if we have availability
+									// Add scope to the list of scopes that ignore kindle
+									if (hasKindle && overDriveScope.isSuppressKindleFormat()) {
+										scopeSuppressingKindleFormats.add(scope.getScopeName());
+									}
 								} //End loop through all overdrive scopes for the scope
 							} // End looping through scopes
 							overDriveRecord.addItem(itemInfo);
@@ -439,10 +444,22 @@ class OverDriveProcessor {
 						if (hasKindle){
 							RecordInfo kindleRecord = groupedWork.addRelatedRecord("overdrive", "kindle", identifier);
 							kindleRecord.copyFrom(overDriveRecord);
+							boolean hasKindleInScope = false;
 							for (ItemInfo tmpItemInfo: kindleRecord.getRelatedItems()){
 								tmpItemInfo.setItemIdentifier(tmpItemInfo.getItemIdentifier() + ":kindle");
 								tmpItemInfo.setFormat("Kindle");
 								tmpItemInfo.setSubFormats("");
+
+								// Remove scopes that doesn't want kindle
+								HashMap<String, ScopingInfo> scopeInfo = tmpItemInfo.getScopingInfo();
+								scopeInfo.keySet().removeIf(scopeName -> scopeSuppressingKindleFormats.contains(scopeName));
+								if (!scopeInfo.isEmpty()) {
+									hasKindleInScope = true;
+								}
+							}
+							// If no kindle in scope, remove the record
+							if (!hasKindleInScope) {
+								groupedWork.removeRelatedRecord(kindleRecord);
 							}
 						}
 					}

--- a/code/web/release_notes/26.01.00.MD
+++ b/code/web/release_notes/26.01.00.MD
@@ -120,6 +120,16 @@
 ### Koha Updates
 - Now, if the allowMaxDaysToFreeze preference is enabled, the system calculates the maximum freeze period starting from the date the item was held (only Koha). ([DIS-1692](https://aspen-discovery.atlassian.net/browse/DIS-1692)) (*LM*)
 
+### OverDrive Updates
+- Allow library to suppress OverDrive kindle format per scope. ([DIS-1714](https://aspen-discovery.atlassian.net/browse/DIS-1714)) (*YL*)
+
+<div markdown="1" class="settings">
+
+#### New Settings
+- OverDrive > OverDrive Scopes > Suppress Kindle Format
+
+</div>
+
 ### Palace Project Updates
 - Improve performance of the Palace Project Indexer. ([DIS-1758](https://aspen-discovery.atlassian.net/browse/DIS-1758)) (*MDN*)
   - Allow Palace Project Settings to be processed in parallel. 

--- a/code/web/sys/DBMaintenance/version_updates/26.01.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/26.01.00.php
@@ -221,6 +221,14 @@ function getUpdates26_01_00(): array {
 		], //hero_slider_role_permissions
 
 		//yanjun
+		'overdrive_suppress_kindle_format' => [
+			'title' => 'OverDrive Suppress Kindle Format',
+			'description' => 'Allow OverDrive scopes to suppress Kindle format in the grouped work',
+			'continueOnError' => false,
+			'sql' => [
+				"ALTER TABLE overdrive_scopes ADD COLUMN suppressKindleFormat TINYINT(1) DEFAULT 0",
+			]
+		],
 
 		//imani
 

--- a/code/web/sys/OverDrive/OverDriveScope.php
+++ b/code/web/sys/OverDrive/OverDriveScope.php
@@ -10,7 +10,7 @@ class OverDriveScope extends DataObject {
 	public $includeAdult;
 	public $includeTeen;
 	public $includeKids;
-
+	public $ignoreKindleFormat;
 	protected $_libraries;
 	protected $_locations;
 
@@ -86,7 +86,14 @@ class OverDriveScope extends DataObject {
 				'default' => true,
 				'forcesReindex' => true,
 			],
-
+			'suppressKindleFormat' => [
+				'property' => 'suppressKindleFormat',
+				'type' => 'checkbox',
+				'label' => 'Suppress Kindle Format',
+				'description' => 'When checked, Kindle format will not display in the grouped work',
+				'default' => false,
+				'forcesReindex' => true,
+			],
 			'libraries' => [
 				'property' => 'libraries',
 				'type' => 'multiSelect',

--- a/code/web/sys/OverDrive/OverDriveScope.php
+++ b/code/web/sys/OverDrive/OverDriveScope.php
@@ -10,7 +10,7 @@ class OverDriveScope extends DataObject {
 	public $includeAdult;
 	public $includeTeen;
 	public $includeKids;
-	public $ignoreKindleFormat;
+	public $suppressKindleFormat;
 	protected $_libraries;
 	protected $_locations;
 


### PR DESCRIPTION
Many OverDrive records include a Kindle Book format, but some libraries would prefer not to have Kindle as a separate format in Aspen. Add per-scope control so an OverDrive scope can opt out of the Kindle format without affecting other scopes that still want it.

To Test
1. Library A and Library B have OverDrive enabled 
2. Find the grouped works that have both OverDrive ebook and Kindle formats, and the OverDrive records are from the shared collection, to ensure these grouped works have the same OverDrive records on both library A and library B catalogs 
3. Go to the library A's OverDrive Scope and select Suppress Kindle Format
4. Force reindex the grouped works 
5. Check the grouped work on Library A, OverDrive ebook format displays, and Kindle format disappears 
6. Check the grouped work on Library B, both OverDrive ebook and Kindle formats display