### PR TITLE
DIS-1782: Increase SHAREit search connection timeout

### DIFF
--- a/code/web/release_notes/26.01.00.MD
+++ b/code/web/release_notes/26.01.00.MD
@@ -192,6 +192,7 @@
 - Update commons lang library name. ([DIS-1764](https://aspen-discovery.atlassian.net/browse/DIS-1764)) (*AB*)
 - Added default values to NOT NULL columns in indexing_profile table schema and IndexingProfile::insert() to support UI-based profile creation. ([DIS-1777](https://aspen-discovery.atlassian.net/browse/DIS-1777)) (*LM*)
 - Fixed PHP warning "Attempt to read property 'isBot' on string" that occurred when "Disable User Agent Tracking" was enabled. ([DIS-1657](https://aspen-discovery.atlassian.net/browse/DIS-1657)) (*MDN*)
+- Increase SHAREit search connection timeout for large collections. ([DIS-1782](https://aspen-discovery.atlassian.net/browse/DIS-1782)) (*YL*)
 
 ## This release includes code contributions from
 ### ByWater Solutions

--- a/code/web/sys/InterLibraryLoan/ShareIt.php
+++ b/code/web/sys/InterLibraryLoan/ShareIt.php
@@ -36,6 +36,7 @@ class ShareIt {
 
 			//Process the search in SHAREit
 			$searchRequestWrapper = new CurlWrapper();
+			$searchRequestWrapper->setConnectTimeout(50);
 			$searchRequestWrapper->addCustomHeaders([
 				'Accept: application/json',
 				'Content-Type: application/json',


### PR DESCRIPTION
Some libraries have large SHAREit collections, and search requests can take 30+ seconds to complete. The default connection timeout causes these searches to fail.

Increase the connection timeout to 50 seconds to accommodate larger collection searches.