### PR TITLE
DIS-1783: WorldPay Fixes

### DIFF
--- a/code/web/interface/themes/responsive/MyAccount/worldPayPayments.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/worldPayPayments.tpl
@@ -69,7 +69,7 @@
 				document.getElementById("{$userId}LineItems").value = lineItems;
 				{/if}
 
-				var paymentId = AspenDiscovery.Account.createWorldPayOrder('#fines{$userId}', '#formattedTotal{$userId}', 'fine');
+				var paymentId = AspenDiscovery.Account.createWorldPayOrder('#fines{$userId}', 'fine');
 				var returnUrl = document.getElementById("{$userId}ReturnUrl").value;
 				var cancelUrl = document.getElementById("{$userId}CancelUrl").value;
 
@@ -113,7 +113,7 @@
 			{/if}
 
 
-			var paymentId = AspenDiscovery.Account.createWorldPayOrder('#fines{$userId}', '#formattedTotal{$userId}', 'fine');
+			var paymentId = AspenDiscovery.Account.createWorldPayOrder('#fines{$userId}', 'fine');
 			var returnUrl = document.getElementById("{$userId}ReturnUrl").value;
 			var cancelUrl = document.getElementById("{$userId}CancelUrl").value;
 
@@ -128,5 +128,4 @@
 	</script>
 	{/if}
 {/strip}
-
 

--- a/code/web/release_notes/26.01.00.MD
+++ b/code/web/release_notes/26.01.00.MD
@@ -184,6 +184,10 @@
 ### Usage Updates
 - Ensure Sideloads Usage Graphs display by passing the profile name appropriately. ([DIS-1766](https://aspen-discovery.atlassian.net/browse/DIS-1766)) (*CZ*)
 
+### WorldPay Updates
+- Update finePaymentType from 6 to 7 in WorldPaySetting.php to ensure the correct payment type be applied to libraries. ([DIS-1783](https://aspen-discovery.atlassian.net/browse/DIS-1783)) (*YL*)
+- Fix WorldPay payment function call with incorrect arguments in template file. ([DIS-1783](https://aspen-discovery.atlassian.net/browse/DIS-1783)) (*YL*)
+
 ### Other Updates
 - Visit Library option in the Locations Modal opens a new tab. ([DIS-1632](https://aspen-discovery.atlassian.net/browse/DIS-1632))
 - Automatically insert translation terms in English when Google Translate is active when they are first viewed. ([DIS-1700](https://aspen-discovery.atlassian.net/browse/DIS-1700)) (*MDN*)

--- a/code/web/sys/ECommerce/WorldPaySetting.php
+++ b/code/web/sys/ECommerce/WorldPaySetting.php
@@ -146,14 +146,14 @@ class WorldPaySetting extends DataObject {
 				if (in_array($libraryId, $this->_libraries)) {
 					//We want to apply the scope to this library
 					if ($library->worldPaySettingId != $this->id) {
-						$library->finePaymentType = 6;
+						$library->finePaymentType = 7;
 						$library->worldPaySettingId = $this->id;
 						$library->update();
 					}
 				} else {
 					//It should not be applied to this scope. Only change if it was applied to the scope
 					if ($library->worldPaySettingId == $this->id) {
-						if ($library->finePaymentType == 6) {
+						if ($library->finePaymentType == 7) {
 							$library->finePaymentType = 0;
 						}
 						$library->worldPaySettingId = -1;


### PR DESCRIPTION
Ensure WorldPay libraries use payment type 7 and fix template JS call 

Fix createWorldPayOrder() JavaScript function in worldPayPayments.tpl was being called with 3 arguments, but only accepts 2. 


The WorldPay finePaymentType was incorrectly set to 6 instead of 7 in WorldPaySetting.php, causing the wrong payment type to be applied to libraries.