### PR TITLE
DIS-1808 Add lazy loading facets

### DIFF
--- a/code/web/interface/themes/responsive/Search/Recommend/SideFacets.tpl
+++ b/code/web/interface/themes/responsive/Search/Recommend/SideFacets.tpl
@@ -26,9 +26,10 @@
 			<h3 id="narrow-search-label" class="sidebar-label">{translate text='Narrow Search' isPublicFacing=true}</h3>
 			<div id="facet-accordion" class="accordion">
 				{foreach from=$sideFacetSet item=cluster key=title name=facetSet}
-					{if count($cluster.list) > 0}
+					{* Show facets that have values loaded OR are placeholders for async loading *}
+					{if count($cluster.list) > 0 || (isset($cluster.loadedValues) && $cluster.loadedValues === false)}
 						<div class="facetList">
-							<div id="facetToggle_{$title}" aria-controls="facetDetails_{$title}" class="facetTitle panel-title {if !empty($cluster.collapseByDefault) && empty($cluster.hasApplied)}collapsed{else}expanded{/if}" tabindex="0" role="button" aria-expanded="{if !empty($cluster.collapseByDefault) && empty($cluster.hasApplied)}false{else}true{/if}">
+							<div id="facetToggle_{$title}" aria-controls="facetDetails_{$title}" class="facetTitle panel-title {if !empty($cluster.collapseByDefault) && empty($cluster.hasApplied)}collapsed{else}expanded{/if}" tabindex="0" role="button" aria-expanded="{if !empty($cluster.collapseByDefault) && empty($cluster.hasApplied)}false{else}true{/if}" data-facet-loaded="{if !empty($cluster.loadedValues) || count($cluster.list) > 0}true{else}false{/if}" data-search-id="{$searchId}" data-facet-name="{if !empty($cluster.field)}{$cluster.field}{else}{$title}{/if}">
 								{translate text=$cluster.label isPublicFacing=true}
 
 								{if !empty($cluster.canLock)}
@@ -40,7 +41,14 @@
 
 							</div>
 							<div id="facetDetails_{$title}" class="facetDetails" {if !empty($cluster.collapseByDefault) && empty($cluster.hasApplied)}style="display:none"{/if} role="region" aria-labelledby="facetToggle_{$title}">
+								{* Loading spinner for async facet loading *}
+								<div class="facet-loading-spinner" style="display:none; padding:15px; text-align:center;">
+									<i class="fas fa-spinner fa-spin"></i> {translate text="Loading..." isPublicFacing=true}
+								</div>
 
+								{* Facet content container *}
+								<div class="facet-list-container">
+								{if count($cluster.list) > 0}
 								{if $title == 'publishDate' || $title == 'birthYear' || $title == 'deathYear' || $title == 'publishDateSort'}
 									{include file="Search/Recommend/yearFacetFilter.tpl" cluster=$cluster title=$title}
 								{elseif $title == 'rating_facet'}
@@ -56,37 +64,49 @@
 								{else}
 									{include file="Search/Recommend/standardFacet.tpl" cluster=$cluster title=$title}
 								{/if}
+								{else}
+									{* Empty placeholder for unloaded facets *}
+								{/if}
+								</div>{* Close facet-list-container *}
 							</div>
 						</div>
 						<script type="text/javascript">
-							{* Initiate any checkbox with a data attribute set to data-switch=""  as a bootstrap switch *}
 							{literal}
-							$("#facetToggle_{/literal}{$title}{literal}").on('click', function() {
+							$("#facetToggle_{/literal}{$title}{literal}").on('click', function(e) {
+								e.preventDefault();
 								var toggleButton = $(this);
-								$(this).toggleClass('expanded');
-								$(this).toggleClass('collapsed');
-								$('#facetDetails_{/literal}{$title}{literal}').toggle()
-								if (toggleButton.attr("aria-expanded") === "true") {
-									$(this).attr("aria-expanded","false");
-								}
-								else if (toggleButton.attr("aria-expanded") === "false") {
-									$(this).attr("aria-expanded","true");
+
+								// Check if we need to load facet values first (async facet loading)
+								if (toggleButton.attr('data-facet-loaded') === 'false') {
+									AspenDiscovery.Searches.loadFacetValues(toggleButton);
+								} else {
+									// Normal expand/collapse toggle
+									toggleButton.toggleClass('expanded collapsed');
+									$('#facetDetails_{/literal}{$title}{literal}').toggle();
+									var isExpanded = toggleButton.attr("aria-expanded") === "true";
+									toggleButton.attr("aria-expanded", !isExpanded);
 								}
 								return false;
-							})
-							$("#facetToggle_{/literal}{$title}{literal}").on('keypress', function() {
-								var toggleButton = $(this);
-								$(this).toggleClass('expanded');
-								$(this).toggleClass('collapsed');
-								$('#facetDetails_{/literal}{$title}{literal}').toggle()
-								if (toggleButton.attr("aria-expanded") === "true") {
-									$(this).attr("aria-expanded","false");
+							});
+
+							$("#facetToggle_{/literal}{$title}{literal}").on('keypress', function(e) {
+								if (e.key === 'Enter' || e.key === ' ') {
+									e.preventDefault();
+									var toggleButton = $(this);
+
+									// Check if we need to load facet values first (async facet loading)
+									if (toggleButton.attr('data-facet-loaded') === 'false') {
+										AspenDiscovery.Searches.loadFacetValues(toggleButton);
+									} else {
+										// Normal expand/collapse toggle
+										toggleButton.toggleClass('expanded collapsed');
+										$('#facetDetails_{/literal}{$title}{literal}').toggle();
+										var isExpanded = toggleButton.attr("aria-expanded") === "true";
+										toggleButton.attr("aria-expanded", !isExpanded);
+									}
+									return false;
 								}
-								else if (toggleButton.attr("aria-expanded") === "false") {
-									$(this).attr("aria-expanded","true");
-								}
-								return false;
-							})
+							});
 							{/literal}
 						</script>
 					{/if}

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -19553,6 +19553,63 @@ AspenDiscovery.Searches = (function(){
 					$("#facetSearchResults").html(data.message);
 				}
 			});
+		},
+
+		/**
+		 * Load facet values asynchronously for collapsed facets
+		 * Part of async facet loading optimization
+		 * @param $facetElement - jQuery object for the facet toggle element
+		 */
+		loadFacetValues($facetElement) {
+			const facetId = $facetElement.attr('id');
+			const detailsId = facetId.replace('facetToggle_', 'facetDetails_');
+			const $facetDetails = $('#' + detailsId);
+
+			$facetDetails.find('.facet-loading-spinner').show();
+			$facetDetails.show();
+			$facetElement.removeClass('collapsed').addClass('expanded');
+			$facetElement.attr('aria-expanded', 'true');
+
+			const searchId = $facetElement.attr('data-search-id');
+			const facetName = $facetElement.attr('data-facet-name');
+
+			const url = Globals.path + '/Search/AJAX';
+			const params = {
+				method: 'getFacetValuesHTML',
+				searchId: searchId,
+				facetName: facetName
+			};
+
+			$.getJSON(url, params, function(response) {
+				$facetDetails.find('.facet-loading-spinner').hide();
+
+				if (response.success) {
+					$facetDetails.find('.facet-list-container').html(response.html);
+					$facetElement.attr('data-facet-loaded', 'true');
+					
+					// If the facet has no content, show a message
+					if (!response.html || response.html.trim() === '') {
+						$facetDetails.find('.facet-list-container').html(
+							'<p class="text-muted" style="padding: 10px;">' + 
+							'No values available' + 
+							'</p>'
+						);
+					}
+				} else {
+					// Show the server's translatable message in muted style for empty facets
+					$facetDetails.find('.facet-list-container').html(
+						'<p class="text-muted" style="padding: 10px;">' + 
+						(response.message || 'Error loading facet values') + 
+						'</p>'
+					);
+					$facetElement.attr('data-facet-loaded', 'true');
+				}
+			}).fail(function() {
+				$facetDetails.find('.facet-loading-spinner').hide();
+				$facetDetails.find('.facet-list-container').html(
+					'<p class="alert alert-danger">Error loading facet values. Please try again.</p>'
+				);
+			});
 		}
 	}
 }(AspenDiscovery.Searches || {}));

--- a/code/web/interface/themes/responsive/js/aspen/searches.js
+++ b/code/web/interface/themes/responsive/js/aspen/searches.js
@@ -359,6 +359,51 @@ AspenDiscovery.Searches = (function(){
 					$("#facetSearchResults").html(data.message);
 				}
 			});
+		},
+
+		/**
+		 * Load facet values asynchronously for collapsed facets
+		 * Part of async facet loading optimization
+		 * @param $facetElement - jQuery object for the facet toggle element
+		 */
+		loadFacetValues($facetElement) {
+			const facetId = $facetElement.attr('id');
+			const detailsId = facetId.replace('facetToggle_', 'facetDetails_');
+			const $facetDetails = $('#' + detailsId);
+
+			$facetDetails.find('.facet-loading-spinner').show();
+			$facetDetails.show();
+			$facetElement.removeClass('collapsed').addClass('expanded');
+			$facetElement.attr('aria-expanded', 'true');
+
+			const searchId = $facetElement.attr('data-search-id');
+			const facetName = $facetElement.attr('data-facet-name');
+
+			const url = Globals.path + '/Search/AJAX';
+			const params = {
+				method: 'getFacetValuesHTML',
+				searchId: searchId,
+				facetName: facetName
+			};
+
+			$.getJSON(url, params, function(response) {
+				$facetDetails.find('.facet-loading-spinner').hide();
+
+				if (response.success) {
+					$facetDetails.find('.facet-list-container').html(response.html);
+					$facetElement.attr('data-facet-loaded', 'true');
+				} else {
+					const errorMsg = response.message || 'Error loading facet values';
+					$facetDetails.find('.facet-list-container').html(
+						'<p class="alert alert-warning">' + errorMsg + '</p>'
+					);
+				}
+			}).fail(function() {
+				$facetDetails.find('.facet-loading-spinner').hide();
+				$facetDetails.find('.facet-list-container').html(
+					'<p class="alert alert-danger">Error loading facet values. Please try again.</p>'
+				);
+			});
 		}
 	}
 }(AspenDiscovery.Searches || {}));

--- a/code/web/interface/themes/responsive/js/aspen/searches.js
+++ b/code/web/interface/themes/responsive/js/aspen/searches.js
@@ -392,11 +392,23 @@ AspenDiscovery.Searches = (function(){
 				if (response.success) {
 					$facetDetails.find('.facet-list-container').html(response.html);
 					$facetElement.attr('data-facet-loaded', 'true');
+					
+					// If the facet has no content, show a message
+					if (!response.html || response.html.trim() === '') {
+						$facetDetails.find('.facet-list-container').html(
+							'<p class="text-muted" style="padding: 10px;">' + 
+							'No values available' + 
+							'</p>'
+						);
+					}
 				} else {
-					const errorMsg = response.message || 'Error loading facet values';
+					// Show the server's translatable message in muted style for empty facets
 					$facetDetails.find('.facet-list-container').html(
-						'<p class="alert alert-warning">' + errorMsg + '</p>'
+						'<p class="text-muted" style="padding: 10px;">' + 
+						(response.message || 'Error loading facet values') + 
+						'</p>'
 					);
+					$facetElement.attr('data-facet-loaded', 'true');
 				}
 			}).fail(function() {
 				$facetDetails.find('.facet-loading-spinner').hide();

--- a/code/web/release_notes/26.02.00.MD
+++ b/code/web/release_notes/26.02.00.MD
@@ -1,4 +1,11 @@
 ## Aspen Discovery Updates
+
+### Search Updates
+- Make search results page more responsive by loading facets asynchronously. ([DIS-1808](https://aspen-discovery.atlassian.net/browse/DIS-1808)) (*LS*)
+- Add library-level setting to toggle async facet loading. ([DIS-1808](https://aspen-discovery.atlassian.net/browse/DIS-1808)) (*TC*)
+  - Added enableAsyncFacetLoading setting to library configuration for controlling async facet loading behavior
+  - Provides admin control over search performance optimization while maintaining backward compatibility
+
 // mark n
 ### Administration Updates
 - Ensure individual objects cannot be deleted if deletes are prevented for the object type. ([DIS-1818](https://aspen-discovery.atlassian.net/browse/DIS-1818)) (*MDN*)
@@ -161,6 +168,7 @@
 
 ### Theke Solutions
 - Lucas Montoya (LM)
+- Tomas Cohen Arazi (TC)
 
 ## Special Testing thanks to
 - 

--- a/code/web/services/Author/Home.php
+++ b/code/web/services/Author/Home.php
@@ -20,7 +20,7 @@ class Author_Home extends ResultsAction {
 		}
 
 		//Check to see if the year has been set and if so, convert to a filter and resend.
-		$dateFilters = ['publishDate'];
+		$dateFilters = ['publishDate', 'publishDateSort'];
 		foreach ($dateFilters as $dateFilter) {
 			if ((isset($_REQUEST[$dateFilter . 'yearfrom']) && !empty($_REQUEST[$dateFilter . 'yearfrom'])) || (isset($_REQUEST[$dateFilter . 'yearto']) && !empty($_REQUEST[$dateFilter . 'yearto']))) {
 				$queryParams = $_GET;

--- a/code/web/services/Search/AJAX.php
+++ b/code/web/services/Search/AJAX.php
@@ -827,6 +827,200 @@ class AJAX extends Action {
 		}
 	}
 
+	/**
+	 * Get facet values HTML for async loading of collapsed facets
+	 * This is part of the async facet loading optimization.
+	 *
+	 * @return array
+	 * @noinspection PhpUnused
+	 * @throws ReflectionException
+	 */
+	function getFacetValuesHTML(): array {
+		$searchId = $_REQUEST['searchId'] ?? null;
+		$facetName = $_REQUEST['facetName'] ?? null;
+
+		if (!is_numeric($searchId) || empty($facetName)) {
+			return [
+				'success' => false,
+				'message' => translate([
+					'text' => 'Invalid parameters',
+					'isPublicFacing' => true,
+				])
+			];
+		}
+
+		require_once ROOT_DIR . '/services/API/SearchAPI.php';
+		$searchAPI = new SearchAPI();
+		/** @var SearchObject_GroupedWorkSearcher2 $restoredSearch */
+		$restoredSearch = $searchAPI->restoreSearch($searchId);
+
+		if (empty($restoredSearch)) {
+			return [
+				'success' => false,
+				'message' => translate([
+					'text' => 'Could not restore search',
+					'isPublicFacing' => true,
+				])
+			];
+		}
+
+		$facetConfig = $restoredSearch->getFacetConfig();
+		if (!array_key_exists($facetName, $facetConfig)) {
+			return [
+				'success' => false,
+				'message' => translate([
+					'text' => 'Facet not found',
+					'isPublicFacing' => true,
+				])
+			];
+		}
+
+		$facetSetting = $facetConfig[$facetName];
+		$allFacetConfig = $restoredSearch->getFacetConfig();
+		$originalLimit = $restoredSearch->getLimit();
+
+		$restoredSearch->setLimit(0);
+		// Replace facet config with ONLY the requested facet.
+		$restoredSearch->clearFacets();
+		$restoredSearch->addFacet($facetName, $facetSetting);
+		$restoredSearch->setBypassAsyncFacetLogic(true);
+		$restoredSearch->processSearch(false, true, true);
+
+		// Restore original settings.
+		$restoredSearch->setBypassAsyncFacetLogic(false);
+		$restoredSearch->clearFacets();
+		foreach ($allFacetConfig as $key => $setting) {
+			$restoredSearch->addFacet($key, $setting);
+		}
+		$restoredSearch->setLimit($originalLimit);
+
+		// Get facet data for the requested facet.
+		$facetList = $restoredSearch->getFacetList([$facetName => $facetSetting]);
+
+		if (!isset($facetList[$facetName])) {
+			return [
+				'success' => false,
+				'message' => translate([
+					'text' => 'No facet data returned',
+					'isPublicFacing' => true,
+				])
+			];
+		}
+
+		global $interface;
+		$cluster = $facetList[$facetName];
+
+		// Do special processing for certain facet types.
+		if (preg_match('/time_since_added/i', $facetName)) {
+			require_once ROOT_DIR . '/sys/Recommend/SideFacets.php';
+			$sideFacets = new SideFacets($restoredSearch, '');
+			$cluster = $sideFacets->updateTimeSinceAddedFacet($cluster);
+		} elseif ($facetName == 'rating_facet') {
+			require_once ROOT_DIR . '/sys/Recommend/SideFacets.php';
+			$sideFacets = new SideFacets($restoredSearch, '');
+			$cluster = $sideFacets->updateUserRatingsFacet($cluster);
+		}
+
+		// Apply facet settings to cluster.
+		if ($facetSetting->sortMode == 'alphabetically') {
+			asort($cluster['list']);
+		}
+		if ($facetSetting->numEntriesToShowByDefault > 0) {
+			$cluster['valuesToShow'] = $facetSetting->numEntriesToShowByDefault;
+		}
+		if ($facetSetting->showAsDropDown) {
+			$cluster['showAsDropDown'] = $facetSetting->showAsDropDown;
+		}
+		if ($facetSetting->multiSelect) {
+			$cluster['multiSelect'] = $facetSetting->multiSelect;
+		}
+
+		global $logger;
+		$logger->log("Facet $facetName: useMoreFacetPopup={$facetSetting->useMoreFacetPopup}, count=" . count($cluster['list']) . ", numEntriesToShowByDefault={$facetSetting->numEntriesToShowByDefault}, numTotalEntriesToShowInMore={$facetSetting->numTotalEntriesToShowInMore}", Logger::LOG_DEBUG);
+
+		if ($facetSetting->useMoreFacetPopup && count($cluster['list']) > $facetSetting->numEntriesToShowByDefault) {
+			$cluster['showMoreFacetPopup'] = true;
+			$facetsList = $cluster['list'];
+			if ($facetSetting->multiSelect) {
+				$tmpList = $cluster['list'];
+				$cluster['list'] = [];
+				// Make sure all applied facets are shown first
+				foreach ($tmpList as $key => $value) {
+					if ($value['isApplied']) {
+						$cluster['list'][$key] = $value;
+						unset($cluster[$key]);
+					}
+				}
+				$tmpList = array_slice($facetsList, 0, $facetSetting->numEntriesToShowByDefault);
+				$cluster['list'] = array_merge($cluster['list'], $tmpList);
+				$cluster['fullUnsortedList'] = array_merge($cluster['list'], $facetsList);
+			} else {
+				$cluster['list'] = array_slice($facetsList, 0, $facetSetting->numEntriesToShowByDefault);
+				$cluster['fullUnsortedList'] = $facetsList;
+			}
+
+			$sortedList = [];
+			foreach ($facetsList as $key => $value) {
+				$sortedList[strtolower($key) . $key] = $value;
+			}
+			ksort($sortedList);
+			$cluster['sortedList'] = $sortedList;
+		} else {
+			$cluster['showMoreFacetPopup'] = false;
+		}
+		$cluster['collapseByDefault'] = $facetSetting->collapseByDefault;
+		$cluster['displayNamePlural'] = empty($facetSetting->displayNamePlural) ? $facetSetting->displayName : $facetSetting->displayNamePlural;
+
+		// Check if facet is locked.
+		$lockSection = $restoredSearch->getSearchName();
+		if (UserAccount::isLoggedIn()) {
+			$user = UserAccount::getActiveUserObj();
+			$lockedFacets = !empty($user->lockedFacets) ? json_decode($user->lockedFacets, true) : [];
+		} else {
+			$lockedFacets = $_SESSION['lockedFilters'] ?? [];
+		}
+		$lockedFacets = $lockedFacets[$lockSection] ?? [];
+		$cluster['locked'] = array_key_exists($facetName, $lockedFacets);
+		$cluster['canLock'] = $facetSetting->canLock;
+
+		$interface->assign('cluster', $cluster);
+		$interface->assign('title', $facetName);
+		$interface->assign('searchId', $searchId);
+
+		$searchLibrary = Library::getActiveLibrary();
+		$location = Location::getSearchLocation();
+		if ($location != null) {
+			$groupedWorkDisplaySettings = $location->getGroupedWorkDisplaySettings();
+		} else {
+			$groupedWorkDisplaySettings = $searchLibrary->getGroupedWorkDisplaySettings();
+		}
+		$hasSearchableFacets = !empty($groupedWorkDisplaySettings->hasSearchableFacets);
+		$interface->assign('hasSearchableFacets', $hasSearchableFacets);
+
+		// Determine which template to use based on facet configuration.
+		$template = 'Search/Recommend/standardFacet.tpl';
+
+		// Check for special facet types by name first
+		if ($facetName == 'publishDate' || $facetName == 'birthYear' || $facetName == 'deathYear' || $facetName == 'publishDateSort') {
+			$template = 'Search/Recommend/yearFacetFilter.tpl';
+		} elseif ($facetName == 'rating_facet') {
+			$template = 'Search/Recommend/ratingFacet.tpl';
+		} elseif ($facetName == 'lexile_score' || $facetName == 'accelerated_reader_reading_level' || $facetName == 'accelerated_reader_point_value') {
+			$template = 'Search/Recommend/sliderFacet.tpl';
+		} elseif ($facetName == 'start_date') {
+			$template = 'Search/Recommend/calendarFacet.tpl';
+		} elseif (!empty($facetSetting->showAsDropDown)) {
+			$template = 'Search/Recommend/dropDownFacet.tpl';
+		} elseif (!empty($facetSetting->multiSelect)) {
+			$template = 'Search/Recommend/multiSelectFacet.tpl';
+		}
+
+		return [
+			'success' => true,
+			'html' => $interface->fetch($template)
+		];
+	}
+
 	function getBreadcrumbs(): array {
 		return [];
 	}

--- a/code/web/services/Search/AJAX.php
+++ b/code/web/services/Search/AJAX.php
@@ -884,7 +884,20 @@ class AJAX extends Action {
 		$restoredSearch->clearFacets();
 		$restoredSearch->addFacet($facetName, $facetSetting);
 		$restoredSearch->setBypassAsyncFacetLogic(true);
-		$restoredSearch->processSearch(false, true, true);
+		$searchResult = $restoredSearch->processSearch(false, true, true);
+
+		// Check if search failed
+		if ($searchResult instanceof AspenError) {
+			global $logger;
+			$logger->log("getFacetValuesHTML failed for facet $facetName: " . $searchResult->toString(), Logger::LOG_ERROR);
+			return [
+				'success' => false,
+				'message' => translate([
+					'text' => 'Search error occurred',
+					'isPublicFacing' => true,
+				])
+			];
+		}
 
 		// Restore original settings.
 		$restoredSearch->setBypassAsyncFacetLogic(false);
@@ -999,20 +1012,34 @@ class AJAX extends Action {
 
 		// Determine which template to use based on facet configuration.
 		$template = 'Search/Recommend/standardFacet.tpl';
+		$isFormBasedFacet = false;
 
 		// Check for special facet types by name first
 		if ($facetName == 'publishDate' || $facetName == 'birthYear' || $facetName == 'deathYear' || $facetName == 'publishDateSort') {
 			$template = 'Search/Recommend/yearFacetFilter.tpl';
+			$isFormBasedFacet = true;
 		} elseif ($facetName == 'rating_facet') {
 			$template = 'Search/Recommend/ratingFacet.tpl';
 		} elseif ($facetName == 'lexile_score' || $facetName == 'accelerated_reader_reading_level' || $facetName == 'accelerated_reader_point_value') {
 			$template = 'Search/Recommend/sliderFacet.tpl';
+			$isFormBasedFacet = true;
 		} elseif ($facetName == 'start_date') {
 			$template = 'Search/Recommend/calendarFacet.tpl';
+			$isFormBasedFacet = true;
 		} elseif (!empty($facetSetting->showAsDropDown)) {
 			$template = 'Search/Recommend/dropDownFacet.tpl';
 		} elseif (!empty($facetSetting->multiSelect)) {
 			$template = 'Search/Recommend/multiSelectFacet.tpl';
+			$isFormBasedFacet = true;
+		}
+
+		// For form-based facets, pass search parameters to preserve search state.
+		// Needed because GET form submissions discard the action URL's query string.
+		if ($isFormBasedFacet) {
+			$interface->assign('fullPath', $restoredSearch->renderSearchUrl());
+			$interface->assign('searchTerms', $restoredSearch->getSearchTerms() ?? []);
+			$interface->assign('restoredFilters', $restoredSearch->getFilterList() ?? []);
+			$interface->assign('searchSource', $restoredSearch->getSearchSource());
 		}
 
 		return [

--- a/code/web/services/Search/AJAX.php
+++ b/code/web/services/Search/AJAX.php
@@ -924,14 +924,11 @@ class AJAX extends Action {
 		$cluster = $facetList[$facetName];
 
 		// Do special processing for certain facet types.
-		if (preg_match('/time_since_added/i', $facetName)) {
+		if (preg_match('/time_since_added/i', $facetName) || $facetName == 'rating_facet') {
 			require_once ROOT_DIR . '/sys/Recommend/SideFacets.php';
 			$sideFacets = new SideFacets($restoredSearch, '');
-			$cluster = $sideFacets->updateTimeSinceAddedFacet($cluster);
-		} elseif ($facetName == 'rating_facet') {
-			require_once ROOT_DIR . '/sys/Recommend/SideFacets.php';
-			$sideFacets = new SideFacets($restoredSearch, '');
-			$cluster = $sideFacets->updateUserRatingsFacet($cluster);
+			$updateFunction = $facetName == 'rating_facet' ? 'updateUserRatingsFacet' : 'updateTimeSinceAddedFacet';
+			$cluster = call_user_func([$sideFacets, $updateFunction], $cluster);
 		}
 
 		// Apply facet settings to cluster.
@@ -1014,13 +1011,16 @@ class AJAX extends Action {
 		$template = 'Search/Recommend/standardFacet.tpl';
 		$isFormBasedFacet = false;
 
+		$yearFacetList = ['publishDate', 'birthYear', 'deathYear', 'publishDateSort'];
+		$sliderFacetList = ['lexile_score', 'accelerated_reader_reading_level', 'accelerated_reader_point_value'];
+
 		// Check for special facet types by name first
-		if ($facetName == 'publishDate' || $facetName == 'birthYear' || $facetName == 'deathYear' || $facetName == 'publishDateSort') {
+		if (in_array($facetName, $yearFacetList)) {
 			$template = 'Search/Recommend/yearFacetFilter.tpl';
 			$isFormBasedFacet = true;
 		} elseif ($facetName == 'rating_facet') {
 			$template = 'Search/Recommend/ratingFacet.tpl';
-		} elseif ($facetName == 'lexile_score' || $facetName == 'accelerated_reader_reading_level' || $facetName == 'accelerated_reader_point_value') {
+		} elseif (in_array($facetName, $sliderFacetList)) {
 			$template = 'Search/Recommend/sliderFacet.tpl';
 			$isFormBasedFacet = true;
 		} elseif ($facetName == 'start_date') {

--- a/code/web/services/Search/AJAX.php
+++ b/code/web/services/Search/AJAX.php
@@ -901,7 +901,7 @@ class AJAX extends Action {
 			return [
 				'success' => false,
 				'message' => translate([
-					'text' => 'No facet data returned',
+					'text' => 'No values available',
 					'isPublicFacing' => true,
 				])
 			];

--- a/code/web/sys/DBMaintenance/version_updates/26.02.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/26.02.00.php
@@ -15,6 +15,15 @@ function getUpdates26_02_00(): array {
 			 ]
 		 ], //name*/
 
+		'async_facet_loading' => [
+			'title' => 'Async Facet Loading Configuration',
+			'description' => 'Add enableAsyncFacetLoading setting to library table for configurable async facet loading',
+			'continueOnError' => false,
+			'sql' => [
+				'ALTER TABLE library ADD COLUMN IF NOT EXISTS enableAsyncFacetLoading TINYINT(1) DEFAULT 1 COMMENT "Enable async loading of collapsed facets to improve initial search performance" AFTER groupedWorkDisplaySettingId'
+			]
+		], //async_facet_loading
+
 		//mark n
 		'force_reindex_of_all_titles_in_lists' => [
 			'title' => 'Force Reindex of All Titles in Lists',

--- a/code/web/sys/LibraryLocation/Library.php
+++ b/code/web/sys/LibraryLocation/Library.php
@@ -84,6 +84,7 @@ class Library extends DataObject {
 	public $_themes;
 	public $layoutSettingId;  //Link to LayoutSetting
 	public $groupedWorkDisplaySettingId; //Link to GroupedWorkDisplaySettings
+	public $enableAsyncFacetLoading; //Enable async loading of collapsed facets
 
 	public $browseCategoryGroupId;
 
@@ -568,7 +569,8 @@ class Library extends DataObject {
 			'squareSettingId',
 			'stripeSettingId',
 			'heyCentricSettingId',
-			'pay360SettingId'
+			'pay360SettingId',
+			'enableAsyncFacetLoading'
 		];
 	}
 
@@ -3318,6 +3320,16 @@ class Library extends DataObject {
 				'default' => $defaultSettingId,
 				'permissions' => ['Library Catalog Options'],
 				'forcesReindex' => true,
+			],
+
+			'enableAsyncFacetLoading' => [
+				'property' => 'enableAsyncFacetLoading',
+				'type' => 'checkbox',
+				'label' => 'Enable Async Facet Loading',
+				'description' => 'Load facet values asynchronously when users expand collapsed facets to improve initial search performance',
+				'hideInLists' => true,
+				'default' => 1,
+				'permissions' => ['Library Catalog Options'],
 			],
 
 			// Searching //

--- a/code/web/sys/Recommend/SideFacets.php
+++ b/code/web/sys/Recommend/SideFacets.php
@@ -46,6 +46,38 @@ class SideFacets implements RecommendationInterface {
 	 */
 	public function init(): void {}
 
+	/** getEventSettings
+	 * 
+	 * Helper used for getting appropriate event settings given facet type
+	 * 
+	 * @access private
+	 */
+
+	private function getEventSettings(?LibraryEventsFacetSetting $facetSettings) : ?DataObject {
+		switch ($facetSettings->settingSource) {
+			case 'communico':
+				require_once ROOT_DIR . '/sys/Events/CommunicoSetting.php';
+				$eventSettings = new CommunicoSetting;
+				break;
+			case 'springshare':
+				require_once ROOT_DIR . '/sys/Events/SpringshareLibCalSetting.php';
+				$eventSettings = new SpringshareLibCalSetting;
+				break;
+			case 'assabet':
+				require_once ROOT_DIR . '/sys/Events/AssabetSetting.php';
+				$eventSettings = new AssabetSetting;
+				break;
+			default:
+				require_once ROOT_DIR . '/sys/Events/LMLibraryCalendarSetting.php';
+				$eventSettings = new LMLibraryCalendarSetting;
+				break;
+		}
+		
+		$eventSettings->id = $facetSettings->settingId;
+		
+		return $eventSettings->find(true) ? $eventSettings : null;
+	}
+
 	/* process
 	 *
 	 * Called after the SearchObject has performed its main search.  This may be
@@ -117,34 +149,10 @@ class SideFacets implements RecommendationInterface {
 				$interface->assign('facetCountsToShow', $facetSettings->getFacetGroup()->eventFacetCountsToShow);
 
 				//if there are multiple integrations being used for one library, the first setting found will be used
-				if ($facetSettings->settingSource == 'communico') {
-					require_once ROOT_DIR . '/sys/Events/CommunicoSetting.php';
-					$eventSettings = new CommunicoSetting;
-					$eventSettings->id = $facetSettings->settingId;
-					if ($eventSettings->find(true)) {
-						$interface->assign('maxEventDate', strtotime("+" . $eventSettings->numberOfDaysToIndex . " days"));
-					}
-				} else if ($facetSettings->settingSource == 'springshare') {
-					require_once ROOT_DIR . '/sys/Events/SpringshareLibCalSetting.php';
-					$eventSettings = new SpringshareLibCalSetting;
-					$eventSettings->id = $facetSettings->settingId;
-					if ($eventSettings->find(true)) {
-						$interface->assign('maxEventDate', strtotime("+" . $eventSettings->numberOfDaysToIndex . " days"));
-					}
-				} else if ($facetSettings->settingSource == 'assabet') {
-					require_once ROOT_DIR . '/sys/Events/AssabetSetting.php';
-					$eventSettings = new AssabetSetting;
-					$eventSettings->id = $facetSettings->settingId;
-					if ($eventSettings->find(true)) {
-						$interface->assign('maxEventDate', strtotime("+" . $eventSettings->numberOfDaysToIndex . " days"));
-					}
-				} else {
-					require_once ROOT_DIR . '/sys/Events/LMLibraryCalendarSetting.php';
-					$eventSettings = new LMLibraryCalendarSetting;
-					$eventSettings->id = $facetSettings->settingId;
-					if ($eventSettings->find(true)) {
-						$interface->assign('maxEventDate', strtotime("+" . $eventSettings->numberOfDaysToIndex . " days"));
-					}
+				$eventSettings = $this->getEventSettings($facetSettings);
+
+				if ($eventSettings->find(true)) {
+					$interface->assign('maxEventDate', strtotime("+" . $eventSettings->numberOfDaysToIndex . " days"));
 				}
 			}
 		} else {

--- a/code/web/sys/Recommend/SideFacets.php
+++ b/code/web/sys/Recommend/SideFacets.php
@@ -44,8 +44,7 @@ class SideFacets implements RecommendationInterface {
 	 *
 	 * @access  public
 	 */
-	public function init() {
-	}
+	public function init(): void {}
 
 	/* process
 	 *
@@ -55,7 +54,7 @@ class SideFacets implements RecommendationInterface {
 	 *
 	 * @access  public
 	 */
-	public function process() : void {
+	public function process(): void {
 		global $interface;
 		global $library;
 
@@ -74,6 +73,31 @@ class SideFacets implements RecommendationInterface {
 		//Process the side facet set to handle the Added In Last facet which we only want to be
 		//visible if there is not a value selected for the facet (makes it single select
 		$sideFacets = $this->searchObject->getFacetList($this->mainFacets);
+
+		// Mark loaded facets and create placeholders for facets that weren't loaded
+		foreach ($this->facetSettings as $facetKey => $facetSetting) {
+			if ($facetSetting->showAboveResults) {
+				continue;
+			}
+
+			if (isset($sideFacets[$facetKey])) {
+				$sideFacets[$facetKey]['loadedValues'] = true;
+				if (!isset($sideFacets[$facetKey]['field'])) {
+					$sideFacets[$facetKey]['field'] = $facetKey;
+				}
+			} else {
+				$sideFacets[$facetKey] = [
+					'field' => $facetKey,
+					'field_name' => $facetKey,
+					'label' => $facetSetting->displayName,
+					'displayNamePlural' => $facetSetting->displayNamePlural,
+					'list' => [],
+					'hasApplied' => false,
+					'loadedValues' => false, // Flag to indicate values not loaded.
+					'multiSelect' => $facetSetting->multiSelect,
+				];
+			}
+		}
 
 		$lockSection = $this->searchObject->getSearchName();
 		if (UserAccount::isLoggedIn()) {
@@ -183,9 +207,10 @@ class SideFacets implements RecommendationInterface {
 		}
 
 		$interface->assign('sideFacetSet', $sideFacets);
+		$interface->assign('searchId', $this->searchObject->getSearchId());
 	}
 
-	private function updateTimeSinceAddedFacet($timeSinceAddedFacet) {
+	public function updateTimeSinceAddedFacet(array $timeSinceAddedFacet): array {
 		//See if there is a value selected
 		$valueSelected = false;
 		foreach ($timeSinceAddedFacet['list'] as $facetValue) {
@@ -243,7 +268,7 @@ class SideFacets implements RecommendationInterface {
 		return $timeSinceAddedFacet;
 	}
 
-	private function updateUserRatingsFacet($userRatingFacet) {
+	public function updateUserRatingsFacet(array $userRatingFacet): array {
 		global $interface;
 		$ratingApplied = false;
 		$ratingLabels = [];
@@ -267,7 +292,7 @@ class SideFacets implements RecommendationInterface {
 		return $userRatingFacet;
 	}
 
-	private function updateStartDateRatingsFacet($startDateFacet) {
+	private function updateStartDateRatingsFacet(array $startDateFacet): array {
 		if (!isset($_REQUEST['filter'])) {
 			return $startDateFacet;
 		}
@@ -306,10 +331,16 @@ class SideFacets implements RecommendationInterface {
 	 * @access  public
 	 * @return  string      The template to use to display the recommendations.
 	 */
-	public function getTemplate() : string {
+	public function getTemplate(): string {
 		return 'Search/Recommend/SideFacets.tpl';
 	}
 
+	/**
+	 * @param $facetKey
+	 * @param array $sideFacets
+	 * @param FacetSetting $facetSetting
+	 * @return array
+	 */
 	private function applyFacetSettings(string $facetKey, array $sideFacets, FacetSetting $facetSetting, array $lockedFacets): array {
 		//Do additional handling of the display
 		if ($facetSetting->sortMode == 'alphabetically') {

--- a/code/web/sys/SearchObject/GroupedWorkSearcher2.php
+++ b/code/web/sys/SearchObject/GroupedWorkSearcher2.php
@@ -171,18 +171,29 @@ class SearchObject_GroupedWorkSearcher2 extends SearchObject_AbstractGroupedWork
 		$facetConfig = $this->getFacetConfig();
 		$availabilityToggleId = null;
 		foreach ($this->filterList as $field => $filter) {
+			// Extract actual field name from first filter if available
+			// filterList may be keyed by display name (e.g., "Literary Form") instead of field name (e.g., "literary_form")
+			$actualFieldName = $field;
+			if (is_array($filter) && !empty($filter)) {
+				$firstFilter = reset($filter);
+				if (is_array($firstFilter) && isset($firstFilter['field'])) {
+					$actualFieldName = $firstFilter['field'];
+				}
+			}
+			
 			$multiSelect = false;
 			$fieldPrefix = '';
-			if (isset($facetConfig[$field])) {
+			if (isset($facetConfig[$actualFieldName])) {
 				/** @var FacetSetting $facetInfo */
-				$facetInfo = $facetConfig[$field];
+				$facetInfo = $facetConfig[$actualFieldName];
 				$facetName = $facetInfo->getFacetName(2);
 				$facetKey = empty($facetInfo->id) ? $facetName : $facetInfo->id;
 				$multiSelect = $facetInfo->multiSelect || $facetName == 'availability_toggle';
 				$fieldPrefix = "{!tag=$facetKey}";
+				$field = $actualFieldName; // Use actual field name for query
 			} else {
 				//This is either a field we need to convert from the old schema to new schema or valid field from advanced search we aren't seeing here
-				$tmpFieldName = substr($field, 0, strrpos($field, '_'));
+				$tmpFieldName = substr($actualFieldName, 0, strrpos($actualFieldName, '_'));
 				if (isset($facetConfig[$tmpFieldName])) {
 					$facetInfo = $facetConfig[$tmpFieldName];
 					$facetName = $facetInfo->getFacetName(2);
@@ -191,8 +202,23 @@ class SearchObject_GroupedWorkSearcher2 extends SearchObject_AbstractGroupedWork
 					$multiSelect = $facetInfo->multiSelect || $facetName == 'availability_toggle';
 					$fieldPrefix = "{!tag=$facetKey}";
 				} else {
-					if (in_array($field, $validFields)) {
-						$facetName = $field;
+					if (in_array($actualFieldName, $validFields)) {
+						$facetName = $actualFieldName;
+						$field = $actualFieldName;
+						// If multiple values, use multiSelect (OR logic)
+						if (count($filter) > 1) {
+							$multiSelect = true;
+							$facetKey = $actualFieldName;
+							$fieldPrefix = "{!tag=$facetKey}";
+						}
+					} elseif (count($filter) > 1) {
+						// If we have multiple values for the same field but no facet config,
+						// default to multiSelect (OR logic) to avoid impossible AND conditions
+						$facetName = $actualFieldName;
+						$field = $actualFieldName;
+						$multiSelect = true;
+						$facetKey = $actualFieldName;
+						$fieldPrefix = "{!tag=$facetKey}";
 					} else {
 						//Unknown field
 						continue;

--- a/code/web/sys/SearchObject/GroupedWorkSearcher2.php
+++ b/code/web/sys/SearchObject/GroupedWorkSearcher2.php
@@ -16,6 +16,13 @@ class SearchObject_GroupedWorkSearcher2 extends SearchObject_AbstractGroupedWork
 	private ?string $fieldsToReturn = null;
 
 	/**
+	 * Flag to bypass async facet loading logic.
+	 * When true, all facets in facetConfig will be loaded regardless of collapseByDefault settings.
+	 * Used for async facet loading requests where we explicitly want to load a specific facet.
+	 */
+	private bool $bypassAsyncFacetLogic = false;
+
+	/**
 	 * Constructor. Initialise some details about the server
 	 *
 	 * @access  public
@@ -313,11 +320,37 @@ class SearchObject_GroupedWorkSearcher2 extends SearchObject_AbstractGroupedWork
 			$facetSet['limit'] = $this->facetLimit;
 			foreach ($facetConfig as $facetField => $facetInfo) {
 				if ($facetInfo instanceof FacetSetting) {
+					$shouldLoad = true;
+					$facetName = $facetInfo->getFacetName(2);
+
+					if (!$this->bypassAsyncFacetLogic) {
+						// Skip loading only if collapsed AND has no active filters AND is not a top facet.
+						if ($facetInfo->collapseByDefault && !$facetInfo->showAboveResults) {
+							$hasAppliedFilter = false;
+
+							// Check all variations of field name for active filters.
+							foreach ($this->filterList as $field => $filter) {
+								if ($field == $facetField ||
+									$field == $facetName ||
+									str_starts_with($field, $facetName . '_')) {
+									$hasAppliedFilter = true;
+									break;
+								}
+							}
+
+							if (!$hasAppliedFilter) {
+								$shouldLoad = false;
+							}
+						}
+
+						if (!$shouldLoad) {
+							continue;
+						}
+					}
+
 					$isMultiSelect = $facetInfo->multiSelect;
 					$additionalTags = '';
-					$facetName = $facetInfo->getFacetName(2);
 					if ($facetName == 'availability_toggle' || $facetName == "availability_toggle_$solrScope") {
-						//$isEditionField = true;
 						$isMultiSelect = true;
 						$additionalTags = 'edition_info,edition_info_available_at,edition_info_format_category,edition_info_format';
 					} elseif ($facetName == 'available_at' || $facetName == "available_at_$solrScope") {
@@ -1051,5 +1084,16 @@ class SearchObject_GroupedWorkSearcher2 extends SearchObject_AbstractGroupedWork
 				$this->facetOptions["f.$facetName.facet.limit"] = $facet->numTotalEntriesToShowInMore;
 			}
 		}
+	}
+
+	/**
+	 * Set whether to bypass async facet loading logic.
+	 * When set to true, all facets in facetConfig will be loaded regardless of collapseByDefault settings.
+	 * This is used for async facet loading requests where we explicitly want to load a specific facet.
+	 *
+	 * @param bool $bypass Whether to bypass async facet loading logic
+	 */
+	public function setBypassAsyncFacetLogic(bool $bypass): void {
+		$this->bypassAsyncFacetLogic = $bypass;
 	}
 }

--- a/code/web/sys/SearchObject/GroupedWorkSearcher2.php
+++ b/code/web/sys/SearchObject/GroupedWorkSearcher2.php
@@ -324,8 +324,13 @@ class SearchObject_GroupedWorkSearcher2 extends SearchObject_AbstractGroupedWork
 					$facetName = $facetInfo->getFacetName(2);
 
 					if (!$this->bypassAsyncFacetLogic) {
-						// Skip loading only if collapsed AND has no active filters AND is not a top facet.
-						if ($facetInfo->collapseByDefault && !$facetInfo->showAboveResults) {
+						// Check if async facet loading is enabled for this library
+						$library = Library::getActiveLibrary();
+						$asyncFacetLoadingEnabled = !empty($library->enableAsyncFacetLoading);
+						
+						if ($asyncFacetLoadingEnabled) {
+							// Skip loading only if collapsed AND has no active filters AND is not a top facet.
+							if ($facetInfo->collapseByDefault && !$facetInfo->showAboveResults) {
 							$hasAppliedFilter = false;
 
 							// Check all variations of field name for active filters.
@@ -341,6 +346,7 @@ class SearchObject_GroupedWorkSearcher2 extends SearchObject_AbstractGroupedWork
 							if (!$hasAppliedFilter) {
 								$shouldLoad = false;
 							}
+						}
 						}
 
 						if (!$shouldLoad) {

--- a/code/web/sys/SearchObject/SolrSearcher.php
+++ b/code/web/sys/SearchObject/SolrSearcher.php
@@ -295,12 +295,26 @@ abstract class SearchObject_SolrSearcher extends SearchObject_BaseSearcher {
 		$facetConfig = $this->getFacetConfig();
 		foreach ($this->filterList as $field => $filter) {
 			/** @var FacetSetting $facetInfo */
-			$facetInfo = $facetConfig[$field];
-			$fieldPrefix = "";
-			if ($facetInfo->multiSelect) {
+			$facetInfo = $facetConfig[$field] ?? null;
+			
+			// Default to multiSelect behavior if facetInfo is missing and multiple values exist
+			$isMultiSelect = false;
+			$facetKey = $field;
+			
+			if ($facetInfo !== null) {
+				$isMultiSelect = $facetInfo->multiSelect;
 				$facetKey = empty($facetInfo->id) ? $facetInfo->facetName : $facetInfo->id;
+			} elseif (count($filter) > 1) {
+				// If we have multiple values for the same field but no facet config,
+				// default to multiSelect (OR logic) to avoid impossible AND conditions
+				$isMultiSelect = true;
+			}
+			
+			$fieldPrefix = "";
+			if ($isMultiSelect) {
 				$fieldPrefix = "{!tag={$facetKey}}";
 			}
+			
 			$fieldValue = "";
 			$okToAdd = false;
 			foreach ($filter as $value) {
@@ -316,7 +330,7 @@ abstract class SearchObject_SolrSearcher extends SearchObject_BaseSearcher {
 					}
 				}
 				if ($okToAdd) {
-					if ($facetInfo->multiSelect) {
+					if ($isMultiSelect) {
 						if (!empty($fieldValue)) {
 							$fieldValue .= ' OR ';
 						}
@@ -326,7 +340,7 @@ abstract class SearchObject_SolrSearcher extends SearchObject_BaseSearcher {
 					}
 				}
 			}
-			if ($facetInfo->multiSelect) {
+			if ($isMultiSelect) {
 				$filterQuery[] = "$fieldPrefix$field:($fieldValue)";
 			}
 		}


### PR DESCRIPTION
This patchset implements an opt-in facet lazy loading mechanism. This has been requested by partners requiring better search performance.

A configuration entry is added at the library-level, for enabling/disabling it.

To test:
1. Apply the code to your working branch
2. Run the upgrade (a new column should get added, no errors)
3. Perform a search
=> SUCCESS: Notice search. results and facets show up
4. Expand some facets
=> SUCCESS: The facet values are displayed
5. Enable lazy loading facets for 'main' library at Aspen admin > Primary configuration > Library Systems > Main library > Edit > Enable Async Facet Loading
6. Repeat 3
=> SUCCESS: Searching unmodified
7. Repeat 4
=> SUCCESS: Facets have a spinning icon and then show the values.
8. Make sure you test a facet with no values
=> SUCCESS: They display 'No values available' and can be collapsed i.e. work as they intuitively should
9. Merge and let users enjoy it :-D