### PR TITLE
DIS-1812 Fix HooplProcessor2 item duplication

### DIFF
--- a/code/reindexer/src/org/aspen_discovery/reindexer/HooplaProcessor2.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/HooplaProcessor2.java
@@ -415,6 +415,7 @@ class HooplaProcessor2 {
 				baseItemInfo.setDateAdded(dateAdded);
 
 				ItemInfo instantItemInfo = null;
+				boolean instantItemHasScopes = false;
 				ItemInfo itemInfo;
 				for (Long scopeLibraryId : entitlementsByScope.keySet()) {
 					String hooplaType = entitlementsByScope.get(scopeLibraryId);
@@ -473,6 +474,7 @@ class HooplaProcessor2 {
 						itemInfo = instantItemInfo;
 					}
 
+					boolean scopeAddedForLibrary = false;
 					for (Scope scope : indexer.getScopes()) {
 						boolean okToAdd;
 						Long curScopeLibraryId = scope.getLibraryId();
@@ -490,10 +492,21 @@ class HooplaProcessor2 {
 							groupedWork.addScopingInfo(scope.getScopeName(), scopingInfo);
 							scopingInfo.setLibraryOwned(true);
 							scopingInfo.setLocallyOwned(true);
+							scopeAddedForLibrary = true;
 						}
 					}
-					hooplaRecord.addItem(itemInfo);
-
+					if (hooplaType.equalsIgnoreCase("Flex")) {
+						if (scopeAddedForLibrary) {
+							hooplaRecord.addItem(itemInfo);
+						}
+					}else{
+						if (scopeAddedForLibrary) {
+							instantItemHasScopes = true;
+						}
+					}
+				}
+				if (instantItemInfo != null && instantItemHasScopes) {
+					hooplaRecord.addItem(instantItemInfo);
 				}
 			}
 			productRS.close();

--- a/code/web/release_notes/26.01.00.MD
+++ b/code/web/release_notes/26.01.00.MD
@@ -120,6 +120,7 @@
 - Allow exporting Single Works using the new API Endpoints. ([DIS-1773](https://aspen-discovery.atlassian.net/browse/DIS-1773)) (*MDN*)
 - Add a cleanup step for Version 2 Hoopla Flex availability table updates so partially run migrations don’t leave bad rows that block the reset_scopeLibraryId_to_not_null update. ([DIS-1342](https://aspen-discovery.atlassian.net/browse/DIS-1342)) (*YL*)
 - Disable DB maintenance checkboxes for Hoopla V2 updates to prevent UI runs. ([DIS-1342](https://aspen-discovery.atlassian.net/browse/DIS-1342)) (*YL*)
+- Fix Hoopla v2 so instant titles no longer duplicate once per member library; instant items now remain a single shared record with all applicable library scopes.([DIS-1812](https://aspen-discovery.atlassian.net/browse/DIS-1812)) (*YL*)
 
 ### Indexing Updates
 - Properly determine format for original XBox records (previously gave a format of XBox 360). ([DIS-1719](https://aspen-discovery.atlassian.net/browse/DIS-1719)) (*MDN*)


### PR DESCRIPTION
Fix Hoopla v2 so instant titles no longer duplicate once per member library; instant items now remain a single shared record with all applicable library scopes.