### PR TITLE
DIS-1832: Fix 'View Image' button - WebBuilder

### DIFF
--- a/code/web/release_notes/26.02.00.MD
+++ b/code/web/release_notes/26.02.00.MD
@@ -23,6 +23,8 @@
 // galen
 
 // lucas
+### Web Builder Updates
+- Fix "View Image" button not appearing for uploaded images in WebBuilder. ((DIS-1832)[https://aspen-discovery.atlassian.net/browse/DIS-1832]) (*LM*)
 
 ## This release includes code contributions from
 ### ByWater Solutions

--- a/code/web/services/WebBuilder/Images.php
+++ b/code/web/services/WebBuilder/Images.php
@@ -72,7 +72,7 @@ class WebBuilder_Images extends ObjectEditor {
 
 	function getAdditionalObjectActions(?DataObject $existingObject): array {
 		$objectActions = [];
-		if ($existingObject instanceof FileUpload && !empty($existingObject->id)) {
+		if ($existingObject instanceof ImageUpload && !empty($existingObject->id)) {
 			$objectActions[] = [
 				'text' => 'View Image',
 				'url' => '/WebBuilder/ViewImage?id=' . $existingObject->id,


### PR DESCRIPTION
This patch fixes an issue where the “View Image” button is not displayed properly.

Test plan

Before the patch:

1.  Log in as an admin with permissions for the Web Builder module.
2. Enable the Web Builder module.
3. Go to Web Builder > Images.
4. Upload a new image.
The “View Image” button is missing (it does not appear).

After applying the patch:

- Repeat steps 1–4.
5. The “View Image” button is now visible again.
 