### PR TITLE
DIS-1706: Full name for months on calendar

### DIFF
--- a/code/web/interface/themes/responsive/Events/calendar.tpl
+++ b/code/web/interface/themes/responsive/Events/calendar.tpl
@@ -10,7 +10,7 @@
 		<div class="col-tn-2 col-sm-1 calendar-nav-cell"><a class="btn btn-default" href="" onclick='return AspenDiscovery.Events.getPrintListOptions({if !empty($weekNumber)}{$weekNumber}{else}""{/if}, {if !empty($monthNumber)}{$monthNumber}{else}""{/if}, {$yearNumber})'>{translate text="Print Options" isPublicFacing=true} </a></div>
 	</div>
 	<div class="calendar {if $useWeek}week-view{/if}">
-		<div class="row calendar-nav">
+		<div class="row calendar-nav" id="fullScreenCalendar">
 			<div class="calendar-nav-cell col-tn-2 col-sm-1 align"><a class="btn btn-default" href="{$prevLink}" style="position:absolute;left: 0;"><i class="fas fa-caret-left" role="presentation"></i> {translate text="Previous" isPublicFacing=true}</a></div>
 			<div class="calendar-nav-cell col-tn-8 col-sm-10 text-center calendar-current-month">{$calendarMonth}</div>
 			{if $useWeek}
@@ -19,6 +19,20 @@
 				<div class="calendar-nav-cell col-tn-2 col-sm-1"><a class="btn btn-default" href="{$weekLink}" style="position:absolute;right: 0">{translate text="Show Week" isPublicFacing=true} </a></div>
 			{/if}
 			<div class="calendar-nav-cell col-tn-2 col-sm-1"><a class="btn btn-default" href="{$nextLink}" style="position:absolute;right: 0">{translate text="Next" isPublicFacing=true} <i class="fas fa-caret-right"></i></a></div>
+		</div>
+		<div id="smallScreenCalendar">
+			<div class="row calendar-nav">
+				<div class="calendar-nav-cell col-tn-12 text-center calendar-current-month">{$calendarMonth}</div>
+			</div>
+			<div class="row calendar-nav">
+				<div class="calendar-nav-cell col-tn-4"><a class="btn btn-default" href="{$prevLink}"><i class="fas fa-caret-left" role="presentation"></i> {translate text="Previous" isPublicFacing=true}</a></div>
+				{if $useWeek}
+					<div class="calendar-nav-cell col-tn-4"><a class="btn btn-default" href="{$monthLink}">{translate text="Show Month" isPublicFacing=true} </a></div>
+				{else}
+					<div class="calendar-nav-cell col-tn-4"><a class="btn btn-default" href="{$weekLink}">{translate text="Show Week" isPublicFacing=true} </a></div>
+				{/if}
+				<div class="calendar-nav-cell col-tn-4"><a class="btn btn-default" href="{$nextLink}">{translate text="Next" isPublicFacing=true} <i class="fas fa-caret-right"></i></a></div>
+			</div>
 		</div>
 
 		<div class="calendar-header">

--- a/code/web/interface/themes/responsive/css/calendar.less
+++ b/code/web/interface/themes/responsive/css/calendar.less
@@ -1,6 +1,16 @@
 .calendar{
 	margin: 10px;
 }
+@media screen and (max-width: 550px) {
+  #fullScreenCalendar {
+    display: none;
+  }
+}
+@media screen and (min-width: 551px) {
+  #smallScreenCalendar {
+    display: none;
+  }
+}
 .calendar-nav{
 	display: flex;
 	flex-direction: row;

--- a/code/web/interface/themes/responsive/css/main.css
+++ b/code/web/interface/themes/responsive/css/main.css
@@ -11415,6 +11415,16 @@ td[data-entry-id]:has(.date-edit:focus)::after {
 .calendar {
   margin: 10px;
 }
+@media screen and (max-width: 550px) {
+  #fullScreenCalendar {
+    display: none;
+  }
+}
+@media screen and (min-width: 551px) {
+  #smallScreenCalendar {
+    display: none;
+  }
+}
 .calendar-nav {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
Update so when viewing the calendar on small screens, the month displays above the buttons for the calendar navigation

Tested on my local instance of Aspen