### PR TITLE
DIS-1837: Fix storing images in Web Builder

### DIFF
--- a/code/web/release_notes/26.01.00.MD
+++ b/code/web/release_notes/26.01.00.MD
@@ -234,6 +234,9 @@
 ### Usage Updates
 - Ensure Sideloads Usage Graphs display by passing the profile name appropriately. ([DIS-1766](https://aspen-discovery.atlassian.net/browse/DIS-1766)) (*CZ*)
 
+### Web Builder Updates
+- Fix database error when uploading new images with empty Hero Slider integer fields. ([DIS-1837](https://aspen-discovery.atlassian.net/browse/DIS-1837)) (*LM*)
+
 ### WorldPay Updates
 - Update finePaymentType from 6 to 7 in WorldPaySetting.php to ensure the correct payment type be applied to libraries. ([DIS-1783](https://aspen-discovery.atlassian.net/browse/DIS-1783)) (*YL*)
 - Fix WorldPay payment function call with incorrect arguments in template file. ([DIS-1783](https://aspen-discovery.atlassian.net/browse/DIS-1783)) (*YL*)

--- a/code/web/sys/File/ImageUpload.php
+++ b/code/web/sys/File/ImageUpload.php
@@ -41,6 +41,15 @@ class ImageUpload extends DataObject {
 		return ['id'];
 	}
 
+	public function getNumericColumnNames(): array {
+		return [
+			'aspectRatioWidth',
+			'aspectRatioHeight',
+			'startDate',
+			'endDate',
+		];
+	}
+
 	static $_objectStructure = [];
 	static function getObjectStructure(string $context = ''): array {
 		if (isset(self::$_objectStructure[$context]) && self::$_objectStructure[$context] !== null) {


### PR DESCRIPTION
There’s an issue when a user tries to upload a new image from the Web builder module. 
A database error araises

`SQLSTATE[22007]: Invalid datetime format: 1366 Incorrect integer value: '' for column aspen.image_uploads.aspectRatioWidth at row 1`

The base getNumericColumnNames() returns an empty array by default. Since ImageUpload doesn't override it, aspectRatioWidth is not treated as numeric - so empty strings get quoted and passed directly to MySQL instead of being converted to NULL.

Test plan

Before the patch:

1. Log in as an admin with permissions for the Web Builder module.
2. Enable the Web Builder module.
3. Go to Web Builder > Images.
4. Click "Add New" to upload a new image.
5. Fill in the required fields (Title, select an image file).
6. Set Image Type to "Web Builder Image".
7. Click Save.

Result: A database error appears: SQLSTATE[22007]: Invalid datetime format: 1366 Incorrect integer value: '' for column 'aspectRatioWidth'

After applying the patch:

8. Repeat steps 1–7.
Result: The image is saved successfully without any database errors.