### PR TITLE
DIS-1789 Fix Comprise payment amount formatting 

### DIFF
--- a/code/web/release_notes/26.02.00.MD
+++ b/code/web/release_notes/26.02.00.MD
@@ -18,6 +18,8 @@ Fixed ARIA issues noted in axe DevTools and allowed tabbing through all subcateg
 - Added the ability for libraries and patrons to freeze holds immediately as they are created. (DIS-1456) (*MJ*)
 
 // yanjun
+### eCommerce Report
+- Fix Comprise API amount formatting to use plain decimal format without thousands separators for large donations. ((DIS-1789) [https://aspen-discovery.atlassian.net/browse/DIS-1789]) (*YL*)
 
 // imani
 

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -6688,9 +6688,6 @@ class MyAccount_AJAX extends JSON_Action {
 				$currencyCode = $variables->currencyCode;
 			}
 
-			$currencyFormatter = new NumberFormatter($activeLanguage->locale . '@currency=' . $currencyCode, NumberFormatter::CURRENCY);
-			$currencyFormatter->setSymbol(NumberFormatter::CURRENCY_SYMBOL, '');
-
 			/** @var Library $userLibrary */ /** @var UserPayment $payment */
 			/** @var User $patron */
 			if ($transactionType == 'donation') {
@@ -6730,7 +6727,7 @@ class MyAccount_AJAX extends JSON_Action {
 				}
 				$paymentRequestUrl .= '&UserName=' . urlencode($compriseSettings->username);
 				$paymentRequestUrl .= '&Password=' . urlencode($compriseSettings->password);
-				$paymentRequestUrl .= '&Amount=' . $currencyFormatter->format($payment->totalPaid);
+				$paymentRequestUrl .= '&Amount=' . number_format($payment->totalPaid, 2, '.', '');
 				if ($transactionType == 'donation') {
 					$paymentRequestUrl .= "&URLPostBack=" . urlencode($configArray['Site']['url'] . '/Comprise/Complete');
 					$paymentRequestUrl .= "&URLReturn=" . urlencode($configArray['Site']['url'] . '/Donations/DonationCompleted?id=' . $payment->id);


### PR DESCRIPTION
When a patron submits a large Comprise donation (e.g., $1,000), Aspen formats the Amount parameter with a thousands separator (amount=1,000.00). Comprise expects a plain decimal amount=1000.00, so the comma causes the request to fall back to a $0.01 card validation and the donation never completes. Update the Comprise payment builder to send amounts without grouping so large donations are processed successfully.

To Test:
1. Set up Comprise for your library.
2. Attempt to make a donation larger than $999
3. The payment fails
4. Apply this PR
5. Attempt to make the donation again
6. Payment succeeds