### PR TITLE
DIS-1792: Display Hoopla price for version 2

### DIFF
--- a/code/web/RecordDrivers/HooplaRecordDriver.php
+++ b/code/web/RecordDrivers/HooplaRecordDriver.php
@@ -105,7 +105,14 @@ class HooplaRecordDriver extends GroupedWorkSubDriver {
 
 		$rawData = $this->hooplaRawMetadata;
 		if (IPAddress::showDebuggingInformation()) {
-			$interface->assign('price', $rawData->price ?? 0);
+			if (isset($this->hooplaExtract->ppuPrice)) {
+				$price = $this->hooplaExtract->ppuPrice;
+			} elseif (isset($this->hooplaExtract->price)) {
+				$price = $this->hooplaExtract->price;
+			} else {
+				$price = 0;
+			}
+			$interface->assign('price', $price);
 		}
 		unset($rawData->price);
 

--- a/code/web/release_notes/26.02.00.MD
+++ b/code/web/release_notes/26.02.00.MD
@@ -18,6 +18,8 @@ Fixed ARIA issues noted in axe DevTools and allowed tabbing through all subcateg
 - Added the ability for libraries and patrons to freeze holds immediately as they are created. (DIS-1456) (*MJ*)
 
 // yanjun
+### Hoopla Updates
+- Display Hoopla Price in Staff View for Version 2. ((DIS-1792) [https://aspen-discovery.atlassian.net/browse/DIS-1792]) (*YL*)
 
 // imani
 


### PR DESCRIPTION
Hoopla Price is not showing on the Hoopla Version 2 in Staff View because the code was only checking for the price field from Version 1 rawdata, but Version 2 stores the price in a different field called ppuPrice

