### PR TITLE
DIS-1879: Removed the "Select/Deselect All" option from list of checked out titles if the account has no renewable items.

### DIFF
--- a/code/web/interface/themes/responsive/MyAccount/checkoutsList.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/checkoutsList.tpl
@@ -16,7 +16,7 @@
 			</div>
 		</div>
 
-		{if count($transList) > 1 && ($source=='all' || $source=='ils')}
+		{if count($transList) > 1 && $renewableCheckouts >= 1 && ($source=='all' || $source=='ils')}
 			<div class="row">
 				<div class="col-xs-12">
 					<label for="selectAll_{$source}" class="control-label checkbox"> {translate text="Select/Deselect All" isPublicFacing=true} <input id="selectAll_{$source}" type="checkbox" onclick="$('#renewForm_{$source} .titleSelect').prop('checked', $('#selectAll_{$source}').is(':checked'));"></label>

--- a/code/web/release_notes/26.02.00.MD
+++ b/code/web/release_notes/26.02.00.MD
@@ -15,7 +15,10 @@
 Fixed ARIA issues noted in axe DevTools and allowed tabbing through all subcategory buttons in accessible browse layout. ((DIS-1847) [https://aspen-discovery.atlassian.net/browse/DIS-1847]) (*MJ*)
 
 ### Hold Updates
-- Added the ability for libraries and patrons to freeze holds immediately as they are created. (DIS-1456) (*MJ*)
+- Added the ability for libraries and patrons to freeze holds immediately as they are created. ((DIS-1456) [https://aspen-discovery.atlassian.net/browse/DIS-1456]) (*MJ*)
+
+### My Account Updates
+- Removed the "Select/Deselect All" option from list of checked out titles if the account has no renewable items. ((DIS-1879) [https://aspen-discovery.atlassian.net/browse/DIS-1879]) (*MJ*)
 
 // yanjun
 


### PR DESCRIPTION
DIS-1879: Removed the "Select/Deselect All" option from list of checked out titles if the account has no renewable items.