### PR TITLE
DIS-1889 Nonowned result cover images

### DIFF
--- a/code/web/interface/themes/responsive/RecordDrivers/Index/nonowned_result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Index/nonowned_result.tpl
@@ -2,7 +2,7 @@
 	<div class="row">
 		{if !empty($showCovers)}
 			<div class="coversColumn col-xs-3 col-sm-3{if !empty($viewingCombinedResults)} col-md-3 col-lg-2{/if} text-center" aria-hidden="true" role="presentation">
-				<img src="/bookcover.php?isn={$record.isbn|@formatISBN}&amp;{if !empty($record.issn)}{$record.issn}&amp;{/if}issn=size=medium&amp;{if !empty($record.upc)}upc={$record.upc}{/if}" class="listResultImage img-thumbnail img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}" tabindex="-1"/>
+				<img src="/bookcover.php?isn={$record.isbn|@formatISBN}&amp;{if !empty($record.issn)}issn={$record.issn}&amp;{/if}size=medium&amp;{if !empty($record.upc)}upc={$record.upc}{/if}" class="listResultImage img-thumbnail img-responsive {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}" tabindex="-1"/>
 			</div>
 		{/if}
 

--- a/code/web/release_notes/26.02.00.MD
+++ b/code/web/release_notes/26.02.00.MD
@@ -20,6 +20,8 @@ Fixed ARIA issues noted in axe DevTools and allowed tabbing through all subcateg
 // yanjun
 
 // imani
+- Added null to possible returns for loadGroupedWork in BookCoverProcessor because null can be returned from getGroupedWorkDriver for some record drivers. ((DIS-1889)[https://aspen-discovery.atlassian.net/browse/DIS-1889]) (*IT*)
+- moved issn= inside the if statement in the nonowned_result.tpl template so the link will render properly ((DIS-1889)[https://aspen-discovery.atlassian.net/browse/DIS-1889]) (*IT*)
 
 // alexander
 

--- a/code/web/sys/Covers/BookCoverProcessor.php
+++ b/code/web/sys/Covers/BookCoverProcessor.php
@@ -1481,7 +1481,7 @@ class BookCoverProcessor {
 		return false;
 	}
 
-	private function loadGroupedWork() : GroupedWorkDriver|false {
+	private function loadGroupedWork() : GroupedWorkDriver|false|null {
 		if ($this->groupedWork == null) {
 			// Include Search Engine Class
 			require_once ROOT_DIR . '/sys/SolrConnector/Solr.php';


### PR DESCRIPTION
to test:

-  find a grouped work with nonowned items and broken images (https://midlothian.aspendiscovery.org/GroupedWork/cc9eee56-9fed-efef-f425-f8cbbb298229-eng/Series  was an example but the fix is applied on their site now)
- apply the code
- the broken images should render properly now.
- if you don’t have access to a broken grouped work you can temporarily simulate the problem for all links by adding $this->groupedWork = null before the return line in loadGroupedWork in BookCoverProcessor
- this alternate testing method should result in broken images before the code from the fix is applied and a default cover image after the change is applied.
- If you use the alternate testing method be sure to delete the additional line of code after testing,.

