### PR TITLE
DIS-1892: Prevent opacAdmin deletion

### DIFF
--- a/code/web/interface/themes/responsive/Admin/permissions.tpl
+++ b/code/web/interface/themes/responsive/Admin/permissions.tpl
@@ -14,7 +14,9 @@
 				{/foreach}
 			</select>
 			<div class="btn-group" style="padding-left: 1em; padding-top: 0">
-				<a class="btn btn-danger btn-sm" style="margin-bottom: 0" onclick="if (confirm('{translate text="Are you sure you want to delete this role" inAttribute=true isAdminFacing=true}')){ldelim}return AspenDiscovery.Admin.deleteRole({$selectedRole->roleId}){rdelim}else{ldelim}return false{rdelim}"><i class="fas fa-trash" role="presentation"></i> {translate text="Delete" isAdminFacing=true}</a>
+				{if $selectedRole->name != 'opacAdmin'}
+					<a class="btn btn-danger btn-sm" style="margin-bottom: 0" onclick="if (confirm('{translate text="Are you sure you want to delete this role" inAttribute=true isAdminFacing=true}')){ldelim}return AspenDiscovery.Admin.deleteRole({$selectedRole->roleId}){rdelim}else{ldelim}return false{rdelim}"><i class="fas fa-trash" role="presentation"></i> {translate text="Delete" isAdminFacing=true}</a>
+				{/if}
 				<a class="btn btn-default btn-sm" style="margin-bottom: 0"  onclick="return AspenDiscovery.Admin.showCreateRoleForm()"><i class="fas fa-plus" role="presentation"></i> {translate text="Create New Role" isAdminFacing=true}</a>
 			</div>
 		</div>

--- a/code/web/release_notes/26.02.00.MD
+++ b/code/web/release_notes/26.02.00.MD
@@ -18,6 +18,8 @@ Fixed ARIA issues noted in axe DevTools and allowed tabbing through all subcateg
 - Added the ability for libraries and patrons to freeze holds immediately as they are created. (DIS-1456) (*MJ*)
 
 // yanjun
+### Other Updates
+- Prevent deletion of the opacAdmin role by hiding the delete button on the Permissions page. ([DIS-1892](https://aspen-discovery.atlassian.net/browse/DIS-1892)) (*YL*)
 
 // imani
 


### PR DESCRIPTION
The opacAdmin role can currently be deleted from the Admin interface. When deleted, database updates will fail when queries attempt to add new permissions to the opacAdmin role.

To Test:
1. Go Administration Home >  System Administration > Administrators >  Permissions
2. Change role to opacAdmin and see opacAdmin can be deleted
3. Apply PR
4. Reload the page and see opacAdmin delete button is hidden 