### PR TITLE
DIS-1908: Different checked out items should be displayed separately 

### DIFF
--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -529,7 +529,7 @@ class Koha extends AbstractIlsDriver {
 			$curCheckout = new Checkout();
 			$curCheckout->type = 'ils';
 			$curCheckout->source = $this->getIndexingProfile()->name;
-			$curCheckout->sourceId = $curRow['biblionumber'];
+			$curCheckout->sourceId = $curRow['issue_id'];
 			$allIssueIds[] = $curRow['issue_id'];
 			$curCheckout->userId = $patron->id;
 			$curCheckout->checkoutDate = strtotime($curRow['issuedate']);

--- a/code/web/release_notes/26.02.00.MD
+++ b/code/web/release_notes/26.02.00.MD
@@ -60,6 +60,9 @@ Improved focus states for search box fields and browse category buttons. ((DIS-1
 ### Other Updates
 - Prevent deletion of the opacAdmin role by hiding the delete button on the Permissions page. ([DIS-1892](https://aspen-discovery.atlassian.net/browse/DIS-1892)) (*YL*)
 
+### Koha Updates
+- Fix an issue where multiple checked out items from the same record were not displayed separately in My Account checked out titles. ([DIS-1908](https://aspen-discovery.atlassian.net/browse/DIS-1908)) (*YL*)
+
 // imani
 ### CloudLibrary updates
 - Only show cancel button if hold is not available because available holds will fail to cancel. ((DIS-1854)[https://aspen-discovery.atlassian.net/browse/DIS-1854]) (*IT*) 


### PR DESCRIPTION
For Koha libraries, patrons can check out multiple items from the same bibs. However, these items are not displayed separately in My Account → Checked Out Titles in Aspen.

In Koha, the items display correctly as individual checkouts.

In Aspen, items from the same record are grouped together and do not appear as separate checkouts.


To Test:
1. Check out several items from the same bib record
2. View Checked out titles and only see one bib with no item details 
3. Apply PR
4. Reload the checked out titles page
5. See each item is displaying separately