### PR TITLE
DIS-1864: OverDrive QR Authentication

### DIFF
--- a/code/web/Drivers/OverDriveDriver.php
+++ b/code/web/Drivers/OverDriveDriver.php
@@ -255,6 +255,17 @@ class OverDriveDriver extends AbstractEContentDriver {
 			return false;
 		}
 		$patronTokenData = $memCache->get("overdrive_patron_token_{$settings->id}_{$homeLibrary->libraryId}_$patronBarcode");
+		if (!$forceNewConnection && $patronTokenData) {
+			return $patronTokenData;
+		}
+
+		if (!empty($settings->enableQRCodeAuth)) {
+			$qrTokenData = $this->getQRCodePatronToken($homeLibrary, $settings, $user, $forceNewConnection);
+			if ($qrTokenData) {
+				return $qrTokenData;
+			}
+		}
+
 		if ($forceNewConnection || !$patronTokenData) {
 			$tokenData = $this->_connectToAPI($user->getHomeLibrary(), $settings, $forceNewConnection, "connectToPatronAPI");
 			$timer->logTime("Connected to OverDrive API");
@@ -1995,15 +2006,157 @@ class OverDriveDriver extends AbstractEContentDriver {
 		return $this->overdriveApiHost[$settings->id];
 	}
 
-	private function getClientAuthString(OverDriveSetting $settings, ?LibraryOverDriveSettings $librarySettings) : ?string {
-		if (empty($librarySettings->clientKey) || empty($librarySettings->clientSecret)) {
-			if (empty($settings->clientSecret) || empty($settings->clientKey)) {
-				return null;
-			}else{
-				return $settings->clientKey . ':' . $settings->clientSecret;
-			}
-		}else{
-			return $librarySettings->clientKey . ':' . $librarySettings->clientSecret;
+	public function getClientCredentials(OverDriveSetting $settings, ?LibraryOverDriveSettings $librarySettings) : array {
+		$clientKey = null;
+		$clientSecret = null;
+		if ($librarySettings != null && !empty($librarySettings->clientKey) && !empty($librarySettings->clientSecret)) {
+			$clientKey = $librarySettings->clientKey;
+			$clientSecret = $librarySettings->clientSecret;
+		} elseif (!empty($settings->clientKey) && !empty($settings->clientSecret)) {
+			$clientKey = $settings->clientKey;
+			$clientSecret = $settings->clientSecret;
 		}
+		return [
+			'clientKey' => $clientKey ?? '',
+			'clientSecret' => $clientSecret ?? '',
+		];
+	}
+
+	private function getClientAuthString(OverDriveSetting $settings, ?LibraryOverDriveSettings $librarySettings) : ?string {
+		$credentials = $this->getClientCredentials($settings, $librarySettings);
+		if (empty($credentials['clientKey']) || empty($credentials['clientSecret'])) {
+			return null;
+		}
+		return $credentials['clientKey'] . ':' . $credentials['clientSecret'];
+	}
+
+	private function getQRCodePatronToken(Library $homeLibrary, OverDriveSetting $settings, User $user, bool $forceRefresh = false): ?stdClass {
+		if (empty($settings->enableQRCodeAuth)) {
+			return null;
+		}
+		$tokenRecord = $user->getOverDriveQrToken($settings->id);
+		if (!$tokenRecord) {
+			return null;
+		}
+
+		$needsRefresh = $forceRefresh || $tokenRecord->isExpired(60);
+		if ($needsRefresh) {
+			if (!empty($tokenRecord->refreshToken)) {
+				$librarySettings = $homeLibrary->getLibraryOverdriveSetting($settings->id);
+				$refreshedData = $this->refreshQRCodeToken($settings, $librarySettings, $tokenRecord->refreshToken);
+				if ($refreshedData) {
+					$user->saveOverDriveQrToken($settings->id, $refreshedData);
+					$this->cacheQRCodeToken($refreshedData, $settings, $homeLibrary, $user);
+					return $refreshedData;
+				} else {
+					$user->deleteOverDriveQrToken($settings->id);
+				}
+			} else {
+				$user->deleteOverDriveQrToken($settings->id);
+			}
+			return null;
+		}
+
+		$tokenData = $tokenRecord->toPatronTokenData();
+		$this->cacheQRCodeToken($tokenData, $settings, $homeLibrary, $user);
+		return $tokenData;
+	}
+
+	public function exchangeQRCodeAuthCode(OverDriveSetting $settings, ?LibraryOverDriveSettings $librarySettings, string $authCode): ?stdClass {
+		if (empty($settings->enableQRCodeAuth)) {
+			return null;
+		}
+		$credentials = $this->getClientCredentials($settings, $librarySettings);
+		if (empty($credentials['clientKey']) || empty($credentials['clientSecret'])) {
+			return null;
+		}
+
+		$url = "https://oauth-patron.overdrive.com/patrontoken/code";
+		$this->initCurlWrapper();
+		$this->apiCurlWrapper->setOption(CURLOPT_USERAGENT, "Mozilla/5.0");
+		$this->apiCurlWrapper->setOption(CURLOPT_RETURNTRANSFER, true);
+		$this->apiCurlWrapper->setOption(CURLOPT_SSL_VERIFYPEER, false);
+		$this->apiCurlWrapper->setOption(CURLOPT_FOLLOWLOCATION, 1);
+
+		$encodedAuthValue = base64_encode($credentials['clientKey'] . ':' . $credentials['clientSecret']);
+		global $interface;
+		$this->apiCurlWrapper->addCustomHeaders([
+			"Content-Type: application/x-www-form-urlencoded;charset=UTF-8",
+			"Authorization: Basic " . $encodedAuthValue,
+			"User-Agent: Aspen Discovery " . $interface->getVariable('aspenVersion'),
+		], true);
+
+		$postBody = http_build_query([
+			'grant_type' => 'authorization_code',
+			'code' => $authCode,
+		]);
+		$response = $this->apiCurlWrapper->curlPostPage($url, $postBody);
+		ExternalRequestLogEntry::logRequest('overdrive.qrCode.exchange', 'POST', $url, $this->apiCurlWrapper->getHeaders(), $postBody, $this->apiCurlWrapper->getResponseCode(), $response, []);
+
+		$data = json_decode($response);
+		global $logger;
+		if ($data && empty($data->error)) {
+			return $data;
+		} elseif ($data && isset($data->error)) {
+			$logger->log("OverDrive QR code authentication error: $data->error.", Logger::LOG_ERROR);
+		} else {
+			$logger->log("OverDrive QR code authentication returned unexpected response", Logger::LOG_ERROR);
+		}
+		return null;
+	}
+
+	private function refreshQRCodeToken(OverDriveSetting $settings, ?LibraryOverDriveSettings $librarySettings, string $refreshToken): ?stdClass {
+		if (empty($settings->enableQRCodeAuth)) {
+			return null;
+		}
+		$credentials = $this->getClientCredentials($settings, $librarySettings);
+		if (empty($credentials['clientKey']) || empty($credentials['clientSecret'])) {
+			return null;
+		}
+
+		$url = "https://oauth-patron.overdrive.com/patrontoken/refresh";
+		$this->initCurlWrapper();
+		$this->apiCurlWrapper->setOption(CURLOPT_USERAGENT, "Mozilla/5.0");
+		$this->apiCurlWrapper->setOption(CURLOPT_RETURNTRANSFER, true);
+		$this->apiCurlWrapper->setOption(CURLOPT_SSL_VERIFYPEER, false);
+		$this->apiCurlWrapper->setOption(CURLOPT_FOLLOWLOCATION, 1);
+
+		$encodedAuthValue = base64_encode($credentials['clientKey'] . ':' . $credentials['clientSecret']);
+		global $interface;
+		$this->apiCurlWrapper->addCustomHeaders([
+			"Content-Type: application/x-www-form-urlencoded;charset=UTF-8",
+			"Authorization: Basic " . $encodedAuthValue,
+			"User-Agent: Aspen Discovery " . $interface->getVariable('aspenVersion'),
+		], true);
+
+		$postBody = http_build_query([
+			'grant_type' => 'refresh_token',
+			'refresh_token' => $refreshToken,
+		]);
+		$response = $this->apiCurlWrapper->curlPostPage($url, $postBody);
+		ExternalRequestLogEntry::logRequest('overdrive.qrCode.refresh', 'POST', $url, $this->apiCurlWrapper->getHeaders(), $postBody, $this->apiCurlWrapper->getResponseCode(), $response, []);
+
+		$data = json_decode($response);
+		global $logger;
+		if ($data && empty($data->error)) {
+			return $data;
+		} elseif ($data && isset($data->error)) {
+			$logger->log("OverDrive QR code refresh error: {$data->error}", Logger::LOG_ERROR);
+		}
+		return null;
+	}
+
+	private function cacheQRCodeToken(stdClass $tokenData, OverDriveSetting $settings, Library $library, User $user): void {
+		if (empty($settings->enableQRCodeAuth)) {
+			return;
+		}
+		global $memCache;
+		$barcode = $user->getBarcode();
+		if (empty($barcode)) {
+			return;
+		}
+		$expiresIn = isset($tokenData->expires_in) ? (int)$tokenData->expires_in : 3600;
+		$ttl = max(60, $expiresIn - 10);
+		$memCache->set("overdrive_patron_token_{$settings->id}_{$library->libraryId}_$barcode", $tokenData, $ttl);
 	}
 }

--- a/code/web/Drivers/OverDriveDriver.php
+++ b/code/web/Drivers/OverDriveDriver.php
@@ -181,7 +181,7 @@ class OverDriveDriver extends AbstractEContentDriver {
 		return $this->_connectToAPI($activeLibrary, $settings, true, "getTokenData");
 	}
 
-	public function getPatronTokenData(OverDriveSetting $settings, User $user, bool $forceNewConnection = false) : bool|stdClass {
+	public function getPatronTokenData(OverDriveSetting $settings, User $user, bool $forceNewConnection = false) : bool|stdClass|null {
 		$userBarcode = $user->getBarcode();
 		if ($this->getRequirePin($settings, $user)) {
 			$userPin = $user->getPasswordOrPin();

--- a/code/web/Drivers/OverDriveDriver.php
+++ b/code/web/Drivers/OverDriveDriver.php
@@ -274,6 +274,8 @@ class OverDriveDriver extends AbstractEContentDriver {
 			$qrTokenData = $this->getQRCodePatronToken($homeLibrary, $settings, $user, $forceNewConnection);
 			if ($qrTokenData) {
 				return $qrTokenData;
+			} else {
+				return false;
 			}
 		}
 

--- a/code/web/Drivers/OverDriveDriver.php
+++ b/code/web/Drivers/OverDriveDriver.php
@@ -169,13 +169,24 @@ class OverDriveDriver extends AbstractEContentDriver {
 		return $baseUrl;
 	}
 
-	public function isCirculationEnabled(Library $activeLibrary, OverDriveSetting $settings) : bool {
+	public function isCirculationEnabled(Library $activeLibrary, OverDriveSetting $settings, ?User $user = null) : bool {
 		$librarySettings = $activeLibrary->getLibraryOverdriveSetting($settings->id);
 		if ($librarySettings == null) {
 			return false;
-		}else{
-			return (bool) $librarySettings->circulationEnabled;
 		}
+
+		if ($librarySettings->circulationEnabled) {
+			return true;
+		}
+
+		// If circulation is disabled but QR code auth is enabled, check if user has valid QR token.
+		// This will attempt to refresh the token if it's expired but has a refresh token.
+		if (!empty($settings->enableQRCodeAuth) && $user !== null) {
+			$qrTokenData = $this->getQRCodePatronToken($activeLibrary, $settings, $user);
+			return $qrTokenData !== null;
+		}
+
+		return false;
 	}
 	public function getTokenData(Library $activeLibrary, OverDriveSetting $settings) : false|stdClass|null {
 		return $this->_connectToAPI($activeLibrary, $settings, true, "getTokenData");
@@ -2100,7 +2111,7 @@ class OverDriveDriver extends AbstractEContentDriver {
 		} elseif ($data && isset($data->error)) {
 			$logger->log("OverDrive QR code authentication error: $data->error.", Logger::LOG_ERROR);
 		} else {
-			$logger->log("OverDrive QR code authentication returned unexpected response", Logger::LOG_ERROR);
+			$logger->log("OverDrive QR code authentication returned unexpected response.", Logger::LOG_ERROR);
 		}
 		return null;
 	}
@@ -2141,7 +2152,7 @@ class OverDriveDriver extends AbstractEContentDriver {
 		if ($data && empty($data->error)) {
 			return $data;
 		} elseif ($data && isset($data->error)) {
-			$logger->log("OverDrive QR code refresh error: {$data->error}", Logger::LOG_ERROR);
+			$logger->log("OverDrive QR code refresh error: $data->error", Logger::LOG_ERROR);
 		}
 		return null;
 	}

--- a/code/web/RecordDrivers/OverDriveRecordDriver.php
+++ b/code/web/RecordDrivers/OverDriveRecordDriver.php
@@ -996,7 +996,8 @@ class OverDriveRecordDriver extends GroupedWorkSubDriver {
 						$actionsByReader[$reader] = [
 							'accessOnline' => null,
 							'checkout' => null,
-							'placeHold' => null
+							'placeHold' => null,
+							'qrSignIn' => null
 						];
 					}
 
@@ -1008,28 +1009,34 @@ class OverDriveRecordDriver extends GroupedWorkSubDriver {
 						global $loginAllowedWhileOffline;
 						$activeLibrary = UserAccount::isLoggedIn() ? UserAccount::getActiveUserObj()->getHomeLibrary() : $library;
 						$activeSetting = $overDriveDriver->getActiveSettings();
-						// Show a link to the OverDrive record when the catalog is offline and can't do logins.
-						if ((!is_null($activeUser) && !$activeUser->isValidForEContentSource('overdrive')) || !$overDriveDriver->isCirculationEnabled($activeLibrary, $activeSetting, $activeUser) || ($offlineMode && !$loginAllowedWhileOffline)) {
-							$overDriveMetadata = $this->getOverDriveMetaData();
-							$crossRefId = $overDriveMetadata->getDecodedRawData()->crossRefId;
-							$productUrl = $overDriveDriver->getProductUrl($activeSetting, $crossRefId);
-
+						// Show a link to the OverDrive record when circulation is not enabled or catalog is offline.
+						if (!$overDriveDriver->isCirculationEnabled($activeLibrary, $activeSetting, $activeUser) || ($offlineMode && !$loginAllowedWhileOffline)) {
 							$librarySettings = $activeLibrary ? $activeLibrary->getLibraryOverdriveSetting($activeSetting->id) : null;
 							if (!empty($activeSetting->enableQRCodeAuth) && !is_null($activeUser) && $librarySettings && !$librarySettings->circulationEnabled) {
 								// If in this branch, it means no valid/refreshable token exists.
 								// Show "Sign in with QR Code" action to initiate authentication.
+								// Determine the intended action (checkout or hold) based on availability.
+								$intendedAction = $isAvailable ? 'checkout' : 'hold';
+								// Include record page URL, record ID, and action for flow resumption.
+								$recordUrl = '/GroupedWork/' . $this->getPermanentId() . '/Home';
+								$qrAuthUrl = '/OverDrive/QRCodeAuth?settingId=' . $activeSetting->id .
+									'&returnUrl=' . urlencode($recordUrl) .
+									'&recordId=' . urlencode($this->id) .
+									'&resumeAction=' . $intendedAction;
+
 								$actionsByReader[$readerName]['qrSignIn'] = [
 									'title' => translate([
 										'text' => 'Sign in with QR Code',
 										'isPublicFacing' => true,
 									]),
-									'url' => '/OverDrive/QRCodeAuth?settingId=' . $activeSetting->id,
-									'target' => 'blank',
-									'requireLogin' => true,
+									'url' => $qrAuthUrl,
 									'type' => 'overdrive_qr_signin',
 								];
 							}
 
+							$overDriveMetadata = $this->getOverDriveMetaData();
+							$crossRefId = $overDriveMetadata->getDecodedRawData()->crossRefId;
+							$productUrl = $overDriveDriver->getProductUrl($activeSetting, $crossRefId);
 							if (!empty($productUrl)) {
 								$actionsByReader[$readerName]['accessOnline'] = [
 									'title' => translate([
@@ -1037,7 +1044,7 @@ class OverDriveRecordDriver extends GroupedWorkSubDriver {
 										1 => $readerName,
 										'isPublicFacing' => true,
 									]),
-									'url' => $overDriveDriver->getProductUrl($activeSetting, $crossRefId),
+									'url' => $productUrl,
 									'target' => 'blank',
 									'requireLogin' => false,
 									'type' => 'overdrive_access_online',
@@ -1046,7 +1053,7 @@ class OverDriveRecordDriver extends GroupedWorkSubDriver {
 						} else {
 							if ($loadDefaultActions && (!$offlineMode || $loginAllowedWhileOffline)) {
 								if ($isAvailable) {
-									//Only one setting with a checkout link so far using this reader name
+									// Only one setting with a checkout link so far using this reader name.
 									$checkoutAction = [
 										'title' => translate([
 											'text' => "Borrow with %1%",
@@ -1082,22 +1089,23 @@ class OverDriveRecordDriver extends GroupedWorkSubDriver {
 									$actionsByReader[$readerName]['placeHold'] = $holdAction;
 								}
 							}
-						} //End checking if circulation is enabled
-					} // Loop through each setting
+						}
+					}
 
-					//Add the appropriate actions to the action array
 					foreach ($actionsByReader as $readerActions) {
 						if (!is_null($readerActions['checkout'])){
 							$this->_actions[] = $readerActions['checkout'];
 						}elseif (!is_null($readerActions['placeHold'])){
 							$this->_actions[] = $readerActions['placeHold'];
+						}elseif (!is_null($readerActions['qrSignIn'])){
+							$this->_actions[] = $readerActions['qrSignIn'];
 						}elseif (!is_null($readerActions['accessOnline'])){
 							$this->_actions[] = $readerActions['accessOnline'];
 						}
 					}
 
-				} // End checking if we should load default actions
-			} // End check of if we have any scopes that apply to the library
+				}
+			}
 
 			$this->_actions = array_merge($this->_actions, $this->getPreviewActions());
 		}

--- a/code/web/RecordDrivers/OverDriveRecordDriver.php
+++ b/code/web/RecordDrivers/OverDriveRecordDriver.php
@@ -1001,19 +1001,35 @@ class OverDriveRecordDriver extends GroupedWorkSubDriver {
 					}
 
 					foreach ($settingsToProcess as $settingId => $librarySettings) {
-						//Check to see if OverDrive circulation is enabled
 						require_once ROOT_DIR . '/Drivers/OverDriveDriver.php';
 						$overDriveDriver = OverDriveDriver::getOverDriveDriver($settingId);
 						$readerName = $overDriveDriver->getReaderName();
-						//Check if catalog is offline and login for eResources should be allowed for offline
 						global $offlineMode;
 						global $loginAllowedWhileOffline;
 						$activeLibrary = UserAccount::isLoggedIn() ? UserAccount::getActiveUserObj()->getHomeLibrary() : $library;
-						//Show a link to the OverDrive record when the catalog is offline and can't do logins
-						if ((!is_null($activeUser) && !$activeUser->isValidForEContentSource('overdrive')) || !$overDriveDriver->isCirculationEnabled($activeLibrary, $overDriveDriver->getActiveSettings()) || ($offlineMode && !$loginAllowedWhileOffline)) {
+						$activeSetting = $overDriveDriver->getActiveSettings();
+						// Show a link to the OverDrive record when the catalog is offline and can't do logins.
+						if ((!is_null($activeUser) && !$activeUser->isValidForEContentSource('overdrive')) || !$overDriveDriver->isCirculationEnabled($activeLibrary, $activeSetting, $activeUser) || ($offlineMode && !$loginAllowedWhileOffline)) {
 							$overDriveMetadata = $this->getOverDriveMetaData();
 							$crossRefId = $overDriveMetadata->getDecodedRawData()->crossRefId;
-							$productUrl = $overDriveDriver->getProductUrl($overDriveDriver->getActiveSettings(), $crossRefId);
+							$productUrl = $overDriveDriver->getProductUrl($activeSetting, $crossRefId);
+
+							$librarySettings = $activeLibrary ? $activeLibrary->getLibraryOverdriveSetting($activeSetting->id) : null;
+							if (!empty($activeSetting->enableQRCodeAuth) && !is_null($activeUser) && $librarySettings && !$librarySettings->circulationEnabled) {
+								// If in this branch, it means no valid/refreshable token exists.
+								// Show "Sign in with QR Code" action to initiate authentication.
+								$actionsByReader[$readerName]['qrSignIn'] = [
+									'title' => translate([
+										'text' => 'Sign in with QR Code',
+										'isPublicFacing' => true,
+									]),
+									'url' => '/OverDrive/QRCodeAuth?settingId=' . $activeSetting->id,
+									'target' => 'blank',
+									'requireLogin' => true,
+									'type' => 'overdrive_qr_signin',
+								];
+							}
+
 							if (!empty($productUrl)) {
 								$actionsByReader[$readerName]['accessOnline'] = [
 									'title' => translate([
@@ -1021,7 +1037,7 @@ class OverDriveRecordDriver extends GroupedWorkSubDriver {
 										1 => $readerName,
 										'isPublicFacing' => true,
 									]),
-									'url' => $overDriveDriver->getProductUrl($overDriveDriver->getActiveSettings(), $crossRefId),
+									'url' => $overDriveDriver->getProductUrl($activeSetting, $crossRefId),
 									'target' => 'blank',
 									'requireLogin' => false,
 									'type' => 'overdrive_access_online',

--- a/code/web/interface/themes/responsive/GroupedWork/full-record.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/full-record.tpl
@@ -162,3 +162,6 @@
 
 	</div>
 {/strip}
+<script>
+	AspenDiscovery.OverDrive.checkAutoAction();
+</script>

--- a/code/web/interface/themes/responsive/MyAccount/overDriveOptions.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/overDriveOptions.tpl
@@ -62,7 +62,7 @@
 					</form>
 					{if $qrAuthEnabled}
 						<h2>{translate text="%1% Single Sign-On" 1=$readerName isPublicFacing=true}</h2>
-						<p>{translate text="Link your Aspen account to %1% once and future checkouts can skip the sign-in screen. The button opens a new window provided by OverDrive." 1=$readerName isPublicFacing=true}</p>
+						<p>{translate text="Link your Aspen account to %1% once and future checkouts and holds can skip the sign-in screen. The button opens a window provided by OverDrive." 1=$readerName isPublicFacing=true}</p>
 						{foreach from=$qrAuthStatuses key=settingId item=status}
 							{assign var=setting value=$availableSettings.$settingId}
 							{if $setting}
@@ -88,7 +88,7 @@
 											<p class="text-muted">
 												{translate text="Not yet connected." isPublicFacing=true}
 											</p>
-											<a href="/OverDrive/QRCodeAuth?settingId={$settingId}" target="_blank" rel="noopener" class="btn btn-primary">
+											<a href="/OverDrive/QRCodeAuth?settingId={$settingId}" class="btn btn-primary">
 												{translate text="Connect with QR Code" isPublicFacing=true}
 											</a>
 										{/if}

--- a/code/web/interface/themes/responsive/MyAccount/overDriveOptions.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/overDriveOptions.tpl
@@ -53,6 +53,46 @@
 						</div>
 					{/if}
 				</form>
+				{if $qrAuthEnabled}
+					<h2>{translate text="%1% Single Sign-on" 1=$readerName isPublicFacing=true}</h2>
+					<p>{translate text="Link your Aspen account to %1% once and future checkouts can skip the sign-in screen. The button opens a new window provided by OverDrive." 1=$readerName isPublicFacing=true}</p>
+					{foreach from=$qrAuthStatuses key=settingId item=status}
+						{assign var=setting value=$availableSettings.$settingId}
+						{if $setting}
+							<div class="panel panel-default">
+								<div class="panel-heading">
+									<strong>{$setting->name}</strong>
+								</div>
+								<div class="panel-body">
+									{if $status.connected}
+										<p class="{if $status.expired}text-warning{else}text-success{/if}">
+											{if $status.expired}
+												{translate text="A saved session exists but needs to be refreshed. Aspen will refresh it automatically next time you access %1%." 1=$readerName isPublicFacing=true}
+											{else}
+												{translate text="Linked to your %1% account." 1=$readerName isPublicFacing=true}
+											{/if}
+										</p>
+										{if !empty($status.updated)}
+											<p class="help-block">
+												{translate text="Last updated %1%" 1=$status.updated|date_format:"%b %e, %l:%M %p" isPublicFacing=true}
+											</p>
+										{/if}
+										<a href="/OverDrive/QRCodeAuth?op=disconnect&settingId={$settingId}" class="btn btn-warning">
+											{translate text="Disconnect" isPublicFacing=true}
+										</a>
+									{else}
+										<p class="text-muted">
+											{translate text="Not yet connected." isPublicFacing=true}
+										</p>
+										<a href="/OverDrive/QRCodeAuth?op=start&settingId={$settingId}" target="_blank" rel="noopener" class="btn btn-primary">
+											{translate text="Connect with QR Code" isPublicFacing=true}
+										</a>
+									{/if}
+								</div>
+							</div>
+						{/if}
+					{/foreach}
+				{/if}
 
 				<script type="text/javascript">
 					{* Initiate any checkbox with a data attribute set to data-switch=""  as a bootstrap switch *}

--- a/code/web/interface/themes/responsive/MyAccount/overDriveOptions.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/overDriveOptions.tpl
@@ -67,9 +67,6 @@
 							{assign var=setting value=$availableSettings.$settingId}
 							{if $setting}
 								<div class="panel panel-default">
-									<div class="panel-heading">
-										<strong>{$setting->name}</strong>
-									</div>
 									<div class="panel-body">
 										{if $status.connected}
 											<p class="{if $status.expired}text-warning{else}text-success{/if}">

--- a/code/web/interface/themes/responsive/MyAccount/overDriveOptions.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/overDriveOptions.tpl
@@ -1,105 +1,113 @@
 {strip}
 	<div id="main-content">
 		{if !empty($loggedIn)}
-			{if !empty($profile->_web_note)}
-				<div class="row">
-					<div id="web_note" class="alert alert-info text-center col-xs-12">{$profile->_web_note}</div>
+			{if !empty($noHomeLibrary)}
+				<div class="page">
+					<div class="alert alert-warning">
+						{translate text="Your account does not have an associated home library. Please contact your library for assistance." isPublicFacing=true}
+					</div>
 				</div>
-			{/if}
-			{if !empty($accountMessages)}
-				{include file='systemMessages.tpl' messages=$accountMessages}
-			{/if}
-
-			<h1>{$readerName}</h1>
-			{if !empty($offline)}
-				<div class="alert alert-warning"><strong>{translate text=$offlineMessage isPublicFacing=true}</strong></div>
 			{else}
-				<form action="" method="post">
-					<input type="hidden" name="updateScope" value="overdrive">
-					<div class="form-group propertyRow">
-						<label for="overdriveEmail" class="control-label">{translate text='%1% Hold email' 1=$readerName isPublicFacing=true}</label>
-						{if $edit == true}<input name="overdriveEmail" id="overdriveEmail" class="form-control" value='{$profile->overdriveEmail|escape}' size='50' maxlength='75'>{else}{$profile->overdriveEmail|escape}{/if}
+				{if !empty($profile->_web_note)}
+					<div class="row">
+						<div id="web_note" class="alert alert-info text-center col-xs-12">{$profile->_web_note}</div>
 					</div>
-					<div class="form-group propertyRow">
-						<label for="promptForOverdriveEmail" class="control-label">{translate text='Prompt for %1% email' 1=$readerName isPublicFacing=true}</label>&nbsp;
-						{if $edit == true}
-							<input type="checkbox" name="promptForOverdriveEmail" id="promptForOverdriveEmail" {if $profile->promptForOverdriveEmail==1}checked='checked'{/if} data-switch="">
-						{else}
-							{if $profile->promptForOverdriveEmail==0}{translate text="No" isPublicFacing=true}{else}{translate text="Yes" isPublicFacing=true}{/if}
-						{/if}
-					</div>
-					<h2>{translate text="Default Lending Periods" isPublicFacing=true}</h2>
-					{foreach from=$availableSettings item=setting}
-						{assign var=settingId value=$setting->id}
-						{assign var="options" value=$optionsBySetting.$settingId}
-						{if !empty($options.lendingPeriods)}
-							<h3>{translate text=$setting->name isPublicFacing=true}</h3>
-							{foreach from=$options.lendingPeriods item=lendingPeriod}
-								<div class="form-group propertyRow">
-									<label class="control-label" id="{$lendingPeriod.formatType}_{$settingId}_Label">{translate text=$lendingPeriod.formatType isPublicFacing=true}&nbsp;
-										<select class="form-control" aria-labelledby="{$lendingPeriod.formatType}_{$settingId}_Label" name="{$lendingPeriod.formatType}_{$settingId}">
-										{foreach from=$lendingPeriod.options key=value item=optionName}
-											<option value="{$optionName}" {if $optionName == $lendingPeriod.lendingPeriod}selected{/if}>{translate text="%1% days" 1=$optionName isPublicFacing=true}</option>
-										{/foreach}
-										</select>
-									</label>
-								</div>
-							{/foreach}
-						{/if}
-					{/foreach}
-					{if empty($offline) && $edit == true}
-						<div class="form-group propertyRow">
-							<button type="submit" name="updateOverDrive" class="btn btn-sm btn-primary">{translate text="Update Options" isPublicFacing=true}</button>
-						</div>
-					{/if}
-				</form>
-				{if $qrAuthEnabled}
-					<h2>{translate text="%1% Single Sign-on" 1=$readerName isPublicFacing=true}</h2>
-					<p>{translate text="Link your Aspen account to %1% once and future checkouts can skip the sign-in screen. The button opens a new window provided by OverDrive." 1=$readerName isPublicFacing=true}</p>
-					{foreach from=$qrAuthStatuses key=settingId item=status}
-						{assign var=setting value=$availableSettings.$settingId}
-						{if $setting}
-							<div class="panel panel-default">
-								<div class="panel-heading">
-									<strong>{$setting->name}</strong>
-								</div>
-								<div class="panel-body">
-									{if $status.connected}
-										<p class="{if $status.expired}text-warning{else}text-success{/if}">
-											{if $status.expired}
-												{translate text="A saved session exists but needs to be refreshed. Aspen will refresh it automatically next time you access %1%." 1=$readerName isPublicFacing=true}
-											{else}
-												{translate text="Linked to your %1% account." 1=$readerName isPublicFacing=true}
-											{/if}
-										</p>
-										{if !empty($status.updated)}
-											<p class="help-block">
-												{translate text="Last updated %1%" 1=$status.updated|date_format:"%b %e, %l:%M %p" isPublicFacing=true}
-											</p>
-										{/if}
-										<a href="/OverDrive/QRCodeAuth?op=disconnect&settingId={$settingId}" class="btn btn-warning">
-											{translate text="Disconnect" isPublicFacing=true}
-										</a>
-									{else}
-										<p class="text-muted">
-											{translate text="Not yet connected." isPublicFacing=true}
-										</p>
-										<a href="/OverDrive/QRCodeAuth?op=start&settingId={$settingId}" target="_blank" rel="noopener" class="btn btn-primary">
-											{translate text="Connect with QR Code" isPublicFacing=true}
-										</a>
-									{/if}
-								</div>
-							</div>
-						{/if}
-					{/foreach}
+				{/if}
+				{if !empty($accountMessages)}
+					{include file='systemMessages.tpl' messages=$accountMessages}
 				{/if}
 
-				<script type="text/javascript">
-					{* Initiate any checkbox with a data attribute set to data-switch=""  as a bootstrap switch *}
-					{literal}
-					$(function(){ $('input[type="checkbox"][data-switch]').bootstrapSwitch()});
-					{/literal}
-				</script>
+				<h1>{$readerName}</h1>
+				{if !empty($offline)}
+					<div class="alert alert-warning"><strong>{translate text=$offlineMessage isPublicFacing=true}</strong></div>
+				{else}
+					<form action="" method="post">
+						<input type="hidden" name="updateScope" value="overdrive">
+						<div class="form-group propertyRow">
+							<label for="overdriveEmail" class="control-label">{translate text='%1% Hold email' 1=$readerName isPublicFacing=true}</label>
+							{if $edit == true}<input name="overdriveEmail" id="overdriveEmail" class="form-control" value='{$profile->overdriveEmail|escape}' size='50' maxlength='75'>{else}{$profile->overdriveEmail|escape}{/if}
+						</div>
+						<div class="form-group propertyRow">
+							<label for="promptForOverdriveEmail" class="control-label">{translate text='Prompt for %1% email' 1=$readerName isPublicFacing=true}</label>&nbsp;
+							{if $edit == true}
+								<input type="checkbox" name="promptForOverdriveEmail" id="promptForOverdriveEmail" {if $profile->promptForOverdriveEmail==1}checked='checked'{/if} data-switch="">
+							{else}
+								{if $profile->promptForOverdriveEmail==0}{translate text="No" isPublicFacing=true}{else}{translate text="Yes" isPublicFacing=true}{/if}
+							{/if}
+						</div>
+						<h2>{translate text="Default Lending Periods" isPublicFacing=true}</h2>
+						{foreach from=$availableSettings item=setting}
+							{assign var=settingId value=$setting->id}
+							{assign var="options" value=$optionsBySetting.$settingId}
+							{if !empty($options.lendingPeriods)}
+								<h3>{translate text=$setting->name isPublicFacing=true}</h3>
+								{foreach from=$options.lendingPeriods item=lendingPeriod}
+									<div class="form-group propertyRow">
+										<label class="control-label" id="{$lendingPeriod.formatType}_{$settingId}_Label">{translate text=$lendingPeriod.formatType isPublicFacing=true}&nbsp;
+											<select class="form-control" aria-labelledby="{$lendingPeriod.formatType}_{$settingId}_Label" name="{$lendingPeriod.formatType}_{$settingId}">
+											{foreach from=$lendingPeriod.options key=value item=optionName}
+												<option value="{$optionName}" {if $optionName == $lendingPeriod.lendingPeriod}selected{/if}>{translate text="%1% days" 1=$optionName isPublicFacing=true}</option>
+											{/foreach}
+											</select>
+										</label>
+									</div>
+								{/foreach}
+							{/if}
+						{/foreach}
+						{if empty($offline) && $edit == true}
+							<div class="form-group propertyRow">
+								<button type="submit" name="updateOverDrive" class="btn btn-sm btn-primary">{translate text="Update Options" isPublicFacing=true}</button>
+							</div>
+						{/if}
+					</form>
+					{if $qrAuthEnabled}
+						<h2>{translate text="%1% Single Sign-On" 1=$readerName isPublicFacing=true}</h2>
+						<p>{translate text="Link your Aspen account to %1% once and future checkouts can skip the sign-in screen. The button opens a new window provided by OverDrive." 1=$readerName isPublicFacing=true}</p>
+						{foreach from=$qrAuthStatuses key=settingId item=status}
+							{assign var=setting value=$availableSettings.$settingId}
+							{if $setting}
+								<div class="panel panel-default">
+									<div class="panel-heading">
+										<strong>{$setting->name}</strong>
+									</div>
+									<div class="panel-body">
+										{if $status.connected}
+											<p class="{if $status.expired}text-warning{else}text-success{/if}">
+												{if $status.expired}
+													{translate text="A saved session exists but needs to be refreshed. Aspen will refresh it automatically next time you access %1%." 1=$readerName isPublicFacing=true}
+												{else}
+													{translate text="Linked to your %1% account." 1=$readerName isPublicFacing=true}
+												{/if}
+											</p>
+											{if !empty($status.updated)}
+												<p class="help-block">
+													{translate text="Last updated %1%" 1=$status.updated|date_format:"%b %e, %l:%M %p" isPublicFacing=true}
+												</p>
+											{/if}
+											<a href="/OverDrive/QRCodeAuth?disconnect=1&settingId={$settingId}" class="btn btn-danger">
+												{translate text="Disconnect" isPublicFacing=true}
+											</a>
+										{else}
+											<p class="text-muted">
+												{translate text="Not yet connected." isPublicFacing=true}
+											</p>
+											<a href="/OverDrive/QRCodeAuth?settingId={$settingId}" target="_blank" rel="noopener" class="btn btn-primary">
+												{translate text="Connect with QR Code" isPublicFacing=true}
+											</a>
+										{/if}
+									</div>
+								</div>
+							{/if}
+						{/foreach}
+					{/if}
+
+					<script type="text/javascript">
+						{* Initiate any checkbox with a data attribute set to data-switch=""  as a bootstrap switch *}
+						{literal}
+						$(function(){ $('input[type="checkbox"][data-switch]').bootstrapSwitch()});
+						{/literal}
+					</script>
+				{/if}
 			{/if}
 		{else}
 			<div class="page">

--- a/code/web/interface/themes/responsive/OverDrive/qrCodeAuthRedirect.tpl
+++ b/code/web/interface/themes/responsive/OverDrive/qrCodeAuthRedirect.tpl
@@ -1,0 +1,26 @@
+{strip}
+	<div id="main-content" class="col-md-12">
+		<h1>{translate text="OverDrive Authentication Complete" isPublicFacing=true}</h1>
+		<div class="alert alert-success">
+			{if $autoTriggerCheckout}
+				{translate text="Completing your checkout..." isPublicFacing=true}
+			{elseif $autoTriggerHold}
+				{translate text="Placing your hold..." isPublicFacing=true}
+			{/if}
+		</div>
+		<p id="statusMessage">{translate text="Redirecting back to the item..." isPublicFacing=true}</p>
+	</div>
+
+	<script type="text/javascript">
+		{literal}
+		$(() => {
+			const recordId = '{/literal}{$recordId|escape:"javascript"}{literal}';
+			const returnUrl = '{/literal}{$returnUrl|escape:"javascript"}{literal}';
+			const action = '{/literal}{if $autoTriggerCheckout}checkout{elseif $autoTriggerHold}hold{/if}{literal}';
+			const separator = returnUrl.includes('?') ? '&' : '?';
+			const targetUrl = `${returnUrl}${separator}autoAction=${action}&autoRecordId=${encodeURIComponent(recordId)}`;
+			window.location.href = targetUrl;
+		});
+		{/literal}
+	</script>
+{/strip}

--- a/code/web/interface/themes/responsive/OverDrive/qrCodeAuthResult.tpl
+++ b/code/web/interface/themes/responsive/OverDrive/qrCodeAuthResult.tpl
@@ -1,0 +1,17 @@
+{strip}
+	<div class="container">
+		<div class="row">
+				<div class="col-xs-12 col-sm-10 col-sm-offset-1 col-md-8 col-md-offset-2">
+					<h1 class="text-center">{if !empty($qrResultTitle)}{$qrResultTitle}{else}{$readerName}{/if}</h1>
+				<div class="alert {if $qrResultSuccess}alert-success{else}alert-danger{/if}">
+					{$qrResultMessage}
+				</div>
+				<p class="text-center">
+					<a href="/MyAccount/OverDriveOptions" class="btn btn-primary">
+						{translate text="Return to %1% Options" 1=$readerName isPublicFacing=true}
+					</a>
+				</p>
+			</div>
+		</div>
+	</div>
+{/strip}

--- a/code/web/interface/themes/responsive/OverDrive/qrCodeAuthResult.tpl
+++ b/code/web/interface/themes/responsive/OverDrive/qrCodeAuthResult.tpl
@@ -1,17 +1,13 @@
 {strip}
-	<div class="container">
-		<div class="row">
-				<div class="col-xs-12 col-sm-10 col-sm-offset-1 col-md-8 col-md-offset-2">
-					<h1 class="text-center">{if !empty($qrResultTitle)}{$qrResultTitle}{else}{$readerName}{/if}</h1>
-				<div class="alert {if $qrResultSuccess}alert-success{else}alert-danger{/if}">
-					{$qrResultMessage}
-				</div>
-				<p class="text-center">
-					<a href="/MyAccount/OverDriveOptions" class="btn btn-primary">
-						{translate text="Return to %1% Options" 1=$readerName isPublicFacing=true}
-					</a>
-				</p>
-			</div>
+	<div id="main-content" class="col-md-12">
+		<h1>{if !empty($qrResultTitle)}{$qrResultTitle}{else}{$readerName}{/if}</h1>
+		<div class="alert {if $qrResultSuccess}alert-success{else}alert-danger{/if}">
+			{$qrResultMessage}
 		</div>
+		<p>
+			<a href="/MyAccount/OverDriveOptions" class="btn btn-primary">
+				{translate text="Return to %1% Options" 1=$readerName isPublicFacing=true}
+			</a>
+		</p>
 	</div>
 {/strip}

--- a/code/web/interface/themes/responsive/js/aspen/overdrive.js
+++ b/code/web/interface/themes/responsive/js/aspen/overdrive.js
@@ -337,6 +337,33 @@ AspenDiscovery.OverDrive = (function(){
 				}
 			);
 			return false;
+		},
+
+		checkAutoAction() {
+			const urlParams = new URLSearchParams(window.location.search);
+			const autoAction = urlParams.get('autoAction');
+			const autoRecordId = urlParams.get('autoRecordId');
+
+			if (autoAction && autoRecordId) {
+				// Remove parameters from URL to prevent re-triggering on refresh.
+				const cleanUrl = window.location.pathname + window.location.search
+					.replace(/[?&]autoAction=[^&]*/g, '')
+					.replace(/[?&]autoRecordId=[^&]*/g, '')
+					.replace(/^\?&/, '?')
+					.replace(/^&/, '?')
+					.replace(/\?$/, '');
+				if (window.history?.replaceState) {
+					window.history.replaceState({}, '', cleanUrl);
+				}
+
+				setTimeout(() => {
+					if (autoAction === 'checkout') {
+						AspenDiscovery.OverDrive.checkOutTitle(autoRecordId, null);
+					} else if (autoAction === 'hold') {
+						AspenDiscovery.OverDrive.placeHold(autoRecordId, null);
+					}
+				}, 500); // Small delay to ensure page is fully loaded.
+			}
 		}
 	}
 }(AspenDiscovery.OverDrive || {}));

--- a/code/web/release_notes/26.02.00.MD
+++ b/code/web/release_notes/26.02.00.MD
@@ -60,6 +60,18 @@ Improved focus states for search box fields and browse category buttons. ((DIS-1
 ### Other Updates
 - Prevent deletion of the opacAdmin role by hiding the delete button on the Permissions page. ([DIS-1892](https://aspen-discovery.atlassian.net/browse/DIS-1892)) (*YL*)
 
+### OverDrive Updates
+- Add OverDrive QR Code authentication so libraries using SSO for patron login can still use OverDrive in Aspen via the QR code flow. ([DIS-1864](https://aspen-discovery.atlassian.net/browse/DIS-1864)) (*LS*)
+  - To enable this feature, select "Enable Single Sign On with QR Code Authentication" in OverDrive settings and deselect "Circulation Enabled" for the targeted library.
+  - Once enabled, patrons can log in through My Account > OverDrive Options > Connect with QR Code. 
+
+<div markdown="1" class="settings">
+
+#### New Settings
+- OverDrive Settings > Enable Single Sign On with QR Code Authentication
+
+</div>
+
 // imani
 ### CloudLibrary updates
 - Only show cancel button if hold is not available because available holds will fail to cancel. ((DIS-1854)[https://aspen-discovery.atlassian.net/browse/DIS-1854]) (*IT*) 

--- a/code/web/services/MyAccount/OverDriveOptions.php
+++ b/code/web/services/MyAccount/OverDriveOptions.php
@@ -8,54 +8,57 @@ class MyAccount_OverDriveOptions extends MyAccount {
 		$user = UserAccount::getLoggedInUser();
 
 		if ($user) {
-			$patronHomeLibrary = $user->getHomeLibrary();
-			$availableSettings = $patronHomeLibrary->getOverdriveSettings();
-			$interface->assign('availableSettings', $availableSettings);
-			$qrStatuses = [];
-			if (!empty($availableSettings)) {
-				foreach ($availableSettings as $settingId => $setting) {
-					if (empty($setting->enableQRCodeAuth)) {
-						continue;
-					}
-					$token = $user->getOverDriveQrToken($setting->id);
-					if ($token) {
-						$qrStatuses[$setting->id] = [
-							'connected' => true,
-							'expired' => $token->isExpired(),
-							'expiresAt' => $token->expiresAt,
-							'updated' => $token->updated,
-						];
-					} else {
-						$qrStatuses[$setting->id] = [
-							'connected' => false,
-						];
-					}
-				}
-			}
-			$interface->assign('qrAuthStatuses', $qrStatuses);
-			$interface->assign('qrAuthEnabled', count($qrStatuses) > 0);
-
-			// Save/Update Actions
-			global $offlineMode;
-			if (isset($_POST['updateScope']) && !$offlineMode) {
-				$user->updateOverDriveOptions();
-
-				session_write_close();
-				$actionUrl = '/MyAccount/OverDriveOptions'; // redirect after form submit completion
-				header("Location: " . $actionUrl);
-				exit();
-			} elseif (!$offlineMode) {
-				$optionsForSetting = [];
-				foreach ($availableSettings as $setting) {
-					$optionsForSetting[$setting->id] = $user->getOverDriveOptions($setting->id);
-				}
-				$interface->assign('optionsBySetting', $optionsForSetting);
-				$interface->assign('edit', true);
-			} else {
-				$interface->assign('edit', false);
-			}
-
 			$interface->assign('profile', $user);
+			$patronHomeLibrary = $user->getHomeLibrary();
+			if ($patronHomeLibrary == null) {
+				$interface->assign('noHomeLibrary', true);
+			} else {
+				$availableSettings = $patronHomeLibrary->getOverdriveSettings();
+				$interface->assign('availableSettings', $availableSettings);
+				$qrStatuses = [];
+				if (!empty($availableSettings)) {
+					foreach ($availableSettings as $settingId => $setting) {
+						if (empty($setting->enableQRCodeAuth)) {
+							continue;
+						}
+						$token = $user->getOverDriveQrToken($setting->id);
+						if ($token) {
+							$qrStatuses[$setting->id] = [
+								'connected' => true,
+								'expired' => $token->isExpired(),
+								'expiresAt' => $token->expiresAt,
+								'updated' => $token->updated,
+							];
+						} else {
+							$qrStatuses[$setting->id] = [
+								'connected' => false,
+							];
+						}
+					}
+				}
+				$interface->assign('qrAuthStatuses', $qrStatuses);
+				$interface->assign('qrAuthEnabled', count($qrStatuses) > 0);
+
+				// Save/Update Actions
+				global $offlineMode;
+				if (isset($_POST['updateScope']) && !$offlineMode) {
+					$user->updateOverDriveOptions();
+
+					session_write_close();
+					$actionUrl = '/MyAccount/OverDriveOptions'; // redirect after form submit completion
+					header("Location: " . $actionUrl);
+					exit();
+				} elseif (!$offlineMode) {
+					$optionsForSetting = [];
+					foreach ($availableSettings as $setting) {
+						$optionsForSetting[$setting->id] = $user->getOverDriveOptions($setting->id);
+					}
+					$interface->assign('optionsBySetting', $optionsForSetting);
+					$interface->assign('edit', true);
+				} else {
+					$interface->assign('edit', false);
+				}
+			}
 		}
 
 		$readerName = new OverDriveDriver();

--- a/code/web/services/MyAccount/OverDriveOptions.php
+++ b/code/web/services/MyAccount/OverDriveOptions.php
@@ -17,7 +17,7 @@ class MyAccount_OverDriveOptions extends MyAccount {
 				$interface->assign('availableSettings', $availableSettings);
 				$qrStatuses = [];
 				if (!empty($availableSettings)) {
-					foreach ($availableSettings as $settingId => $setting) {
+					foreach ($availableSettings as $setting) {
 						if (empty($setting->enableQRCodeAuth)) {
 							continue;
 						}
@@ -45,7 +45,7 @@ class MyAccount_OverDriveOptions extends MyAccount {
 					$user->updateOverDriveOptions();
 
 					session_write_close();
-					$actionUrl = '/MyAccount/OverDriveOptions'; // redirect after form submit completion
+					$actionUrl = '/MyAccount/OverDriveOptions';
 					header("Location: " . $actionUrl);
 					exit();
 				} elseif (!$offlineMode) {

--- a/code/web/services/MyAccount/OverDriveOptions.php
+++ b/code/web/services/MyAccount/OverDriveOptions.php
@@ -11,6 +11,29 @@ class MyAccount_OverDriveOptions extends MyAccount {
 			$patronHomeLibrary = $user->getHomeLibrary();
 			$availableSettings = $patronHomeLibrary->getOverdriveSettings();
 			$interface->assign('availableSettings', $availableSettings);
+			$qrStatuses = [];
+			if (!empty($availableSettings)) {
+				foreach ($availableSettings as $settingId => $setting) {
+					if (empty($setting->enableQRCodeAuth)) {
+						continue;
+					}
+					$token = $user->getOverDriveQrToken($setting->id);
+					if ($token) {
+						$qrStatuses[$setting->id] = [
+							'connected' => true,
+							'expired' => $token->isExpired(),
+							'expiresAt' => $token->expiresAt,
+							'updated' => $token->updated,
+						];
+					} else {
+						$qrStatuses[$setting->id] = [
+							'connected' => false,
+						];
+					}
+				}
+			}
+			$interface->assign('qrAuthStatuses', $qrStatuses);
+			$interface->assign('qrAuthEnabled', count($qrStatuses) > 0);
 
 			// Save/Update Actions
 			global $offlineMode;

--- a/code/web/services/OverDrive/QRCodeAuth.php
+++ b/code/web/services/OverDrive/QRCodeAuth.php
@@ -10,13 +10,10 @@ require_once ROOT_DIR . '/sys/LibraryLocation/Library.php';
 require_once ROOT_DIR . '/sys/Account/User.php';
 
 class OverDrive_QRCodeAuth extends Action {
-	/**
-	 * @throws RandomException
-	 */
 	function launch() : void {
 		// Check if this is a completion callback from OverDrive (has 'code' parameter)
-		// or a disconnect request (has 'disconnect' parameter)
-		// Otherwise, start the QR code flow
+		// or a disconnect request (has 'disconnect' parameter).
+		// Otherwise, start the QR code flow.
 		if (isset($_REQUEST['code'])) {
 			$this->handleAuthComplete();
 		} elseif (isset($_REQUEST['disconnect'])) {
@@ -26,9 +23,6 @@ class OverDrive_QRCodeAuth extends Action {
 		}
 	}
 
-	/**
-	 * @throws RandomException
-	 */
 	private function startQRCodeFlow(): void {
 		$user = UserAccount::getLoggedInUser();
 		if (!$user) {
@@ -84,19 +78,38 @@ class OverDrive_QRCodeAuth extends Action {
 		}
 		if (empty($activeSetting->websiteId)) {
 			$this->displayResult(false, translate([
-				'text' => 'The OverDrive website id is missing for this collection.',
+				'text' => 'The OverDrive website ID is missing for this collection.',
 				'isPublicFacing' => true,
 			]));
 			return;
 		}
 
-		// Store state in session instead of URL parameters since OverDrive rejects URLs with query params
-		$_SESSION['overdrive_qr_auth_state'] = [
+		// Store state in memcache keyed by session ID to avoid session data loss.
+		// Session data gets cleared when user re-authenticates during the OAuth flow,
+		// but the session ID remains the same, so use it as a stable key.
+		$returnUrl = $_REQUEST['returnUrl'] ?? null;
+		$recordId = $_REQUEST['recordId'] ?? null;
+		$action = $_REQUEST['resumeAction'] ?? null; // 'checkout' or 'hold'
+
+		$stateData = [
 			'userId' => $user->id,
 			'settingId' => $activeSetting->id,
 			'libraryId' => $homeLibrary->libraryId,
 			'timestamp' => time(),
+			'returnUrl' => $returnUrl,
+			'recordId' => $recordId,
+			'action' => $action,
 		];
+
+		$sessionId = session_id();
+		global $memCache;
+		if ($memCache) {
+			$cacheKey = "overdrive_qr_auth_state_{$sessionId}";
+			$memCache->set($cacheKey, $stateData, 300); // 5 minutes
+		} else {
+			$_SESSION['overdrive_qr_auth_state'] = $stateData;
+			session_write_close();
+		}
 
 		global $configArray;
 		$baseUrl = rtrim($configArray['Site']['url'], '/');
@@ -188,6 +201,30 @@ class OverDrive_QRCodeAuth extends Action {
 		}
 
 		$user->saveOverDriveQrToken($setting->id, $tokenData);
+
+		if (!empty($stateData['returnUrl']) && !empty($stateData['recordId']) && !empty($stateData['action'])) {
+			$returnUrl = $stateData['returnUrl'];
+			$recordId = $stateData['recordId'];
+			$action = $stateData['action'];
+
+			if ($action === 'checkout') {
+				global $interface;
+				$interface->assign('autoTriggerCheckout', true);
+				$interface->assign('recordId', $recordId);
+				$interface->assign('returnUrl', $returnUrl);
+				$this->display('qrCodeAuthRedirect.tpl', 'Authentication Complete');
+				return;
+			} elseif ($action === 'hold') {
+				// Trigger hold via JavaScript on the return page
+				global $interface;
+				$interface->assign('autoTriggerHold', true);
+				$interface->assign('recordId', $recordId);
+				$interface->assign('returnUrl', $returnUrl);
+				$this->display('qrCodeAuthRedirect.tpl', 'Authentication Complete');
+				return;
+			}
+		}
+
 		$this->displayResult(true, translate([
 			'text' => 'Success! Your OverDrive account is ready for one-click checkouts.',
 			'isPublicFacing' => true,
@@ -220,20 +257,49 @@ class OverDrive_QRCodeAuth extends Action {
 			]));
 			return;
 		}
+
 		$user->deleteOverDriveQrToken($settingId);
+		global $memCache;
+		$barcode = $user->getBarcode();
+		if ($memCache && !empty($barcode) && $homeLibrary) {
+			$cacheKey = "overdrive_patron_token_{$settingId}_{$homeLibrary->libraryId}_{$barcode}";
+			$memCache->delete($cacheKey);
+		}
+
 		$this->displayResult(true, translate([
-			'text' => 'The saved Sora/OverDrive session has been removed.',
+			'text' => 'The saved %1% session has been removed.',
+			1 => $settings[$settingId]->readerName,
 			'isPublicFacing' => true,
 		]));
 	}
 
 	private function getStateData(): ?array {
-		if (!isset($_SESSION['overdrive_qr_auth_state'])) {
+		global $logger;
+		global $memCache;
+		$sessionId = session_id();
+		$stateData = null;
+		if ($memCache) {
+			$cacheKey = "overdrive_qr_auth_state_{$sessionId}";
+			$stateData = $memCache->get($cacheKey);
+			if ($stateData !== false) {
+				$memCache->delete($cacheKey);
+			}
+		}
+
+		// Fallback to session if memcache wasn't available or didn't have the data.
+		if ($stateData === null || $stateData === false) {
+			if (isset($_SESSION['overdrive_qr_auth_state'])) {
+				$stateData = $_SESSION['overdrive_qr_auth_state'];
+				unset($_SESSION['overdrive_qr_auth_state']);
+			}
+		}
+
+		if ($stateData === null || $stateData === false) {
 			return null;
 		}
-		$stateData = $_SESSION['overdrive_qr_auth_state'];
-		unset($_SESSION['overdrive_qr_auth_state']);
-		if (isset($stateData['timestamp']) && (time() - $stateData['timestamp']) > 900) {
+
+		// Check if expired (5 minutes)
+		if (isset($stateData['timestamp']) && (time() - $stateData['timestamp']) > 300) {
 			return null;
 		}
 

--- a/code/web/services/OverDrive/QRCodeAuth.php
+++ b/code/web/services/OverDrive/QRCodeAuth.php
@@ -10,42 +10,19 @@ require_once ROOT_DIR . '/sys/LibraryLocation/Library.php';
 require_once ROOT_DIR . '/sys/Account/User.php';
 
 class OverDrive_QRCodeAuth extends Action {
-	private const string STATE_CACHE_PREFIX = 'overdrive_qr_state_';
-
 	/**
 	 * @throws RandomException
 	 */
 	function launch() : void {
-		$operation = $_REQUEST['op'] ?? 'start';
-		switch ($operation) {
-			case 'start':
-				$this->startQRCodeFlow();
-				return;
-			case 'complete':
-				$this->handleAuthComplete();
-				return;
-			case 'abandon':
-				$this->displayResult(false, translate([
-					'text' => 'The authentication request was canceled before completion.',
-					'isPublicFacing' => true,
-				]));
-				return;
-			case 'error':
-				$errorDetail = $_REQUEST['error'] ?? '';
-				$this->displayResult(false, translate([
-					'text' => 'OverDrive returned an error while authorizing the account.%1%',
-					'1' => empty($errorDetail) ? '' : ' (' . $errorDetail . ')',
-					'isPublicFacing' => true,
-				]));
-				return;
-			case 'disconnect':
-				$this->disconnectSession();
-				return;
-			default:
-				$this->displayResult(false, translate([
-					'text' => 'Unknown request.',
-					'isPublicFacing' => true,
-				]));
+		// Check if this is a completion callback from OverDrive (has 'code' parameter)
+		// or a disconnect request (has 'disconnect' parameter)
+		// Otherwise, start the QR code flow
+		if (isset($_REQUEST['code'])) {
+			$this->handleAuthComplete();
+		} elseif (isset($_REQUEST['disconnect'])) {
+			$this->disconnectSession();
+		} else {
+			$this->startQRCodeFlow();
 		}
 	}
 
@@ -113,21 +90,20 @@ class OverDrive_QRCodeAuth extends Action {
 			return;
 		}
 
-		$state = bin2hex(random_bytes(16));
-		global $memCache;
-		$memCache->set(self::STATE_CACHE_PREFIX . $state, [
+		// Store state in session instead of URL parameters since OverDrive rejects URLs with query params
+		$_SESSION['overdrive_qr_auth_state'] = [
 			'userId' => $user->id,
 			'settingId' => $activeSetting->id,
 			'libraryId' => $homeLibrary->libraryId,
-		], 900);
+			'timestamp' => time(),
+		];
 
 		global $configArray;
 		$baseUrl = rtrim($configArray['Site']['url'], '/');
-		$redirectBase = $baseUrl . '/OverDrive/QRCodeAuth';
 		$params = [
-			'redirect_url' => $redirectBase . '?op=complete&state=' . $state,
-			'abandon_url' => $redirectBase . '?op=abandon&state=' . $state,
-			'error_url' => $redirectBase . '?op=error&state=' . $state,
+			'redirect_url' => $baseUrl . '/OverDrive/QRCodeAuth',
+			'abandon_url' => $baseUrl . '/OverDrive/QRCodeAuthCanceled',
+			'error_url' => $baseUrl . '/OverDrive/QRCodeAuthFailed',
 			'website_id' => $activeSetting->websiteId,
 			'client_id' => $credentials['clientKey'],
 		];
@@ -138,20 +114,19 @@ class OverDrive_QRCodeAuth extends Action {
 	}
 
 	private function handleAuthComplete(): void {
-		$state = $_REQUEST['state'] ?? '';
 		$code = $_REQUEST['code'] ?? '';
-		if (empty($state) || empty($code)) {
+		if (empty($code)) {
 			$this->displayResult(false, translate([
-				'text' => 'Missing information from OverDrive.',
+				'text' => 'Missing authorization code from OverDrive.',
 				'isPublicFacing' => true,
 			]));
 			return;
 		}
 
-		$stateData = $this->getStateData($state);
+		$stateData = $this->getStateData();
 		if ($stateData === null) {
 			$this->displayResult(false, translate([
-				'text' => 'Authentication session expired. Please try again.',
+				'text' => 'Authentication session expired or invalid. Please try again.',
 				'isPublicFacing' => true,
 			]));
 			return;
@@ -252,14 +227,17 @@ class OverDrive_QRCodeAuth extends Action {
 		]));
 	}
 
-	private function getStateData(string $state): ?array {
-		global $memCache;
-		$data = $memCache->get(self::STATE_CACHE_PREFIX . $state);
-		if ($data !== false) {
-			$memCache->delete(self::STATE_CACHE_PREFIX . $state);
-			return $data;
+	private function getStateData(): ?array {
+		if (!isset($_SESSION['overdrive_qr_auth_state'])) {
+			return null;
 		}
-		return null;
+		$stateData = $_SESSION['overdrive_qr_auth_state'];
+		unset($_SESSION['overdrive_qr_auth_state']);
+		if (isset($stateData['timestamp']) && (time() - $stateData['timestamp']) > 900) {
+			return null;
+		}
+
+		return $stateData;
 	}
 
 	private function displayResult(bool $success, string $message): void {
@@ -273,7 +251,7 @@ class OverDrive_QRCodeAuth extends Action {
 			'isPublicFacing' => true,
 		]);
 		$interface->assign('qrResultTitle', $pageTitle);
-		$this->display('OverDrive/qrCodeAuthResult.tpl', $pageTitle);
+		$this->display('qrCodeAuthResult.tpl', $pageTitle);
 	}
 
 	function getBreadcrumbs(): array {

--- a/code/web/services/OverDrive/QRCodeAuth.php
+++ b/code/web/services/OverDrive/QRCodeAuth.php
@@ -1,0 +1,282 @@
+<?php
+
+use Random\RandomException;
+
+require_once ROOT_DIR . '/Action.php';
+require_once ROOT_DIR . '/Drivers/OverDriveDriver.php';
+require_once ROOT_DIR . '/sys/UserAccount.php';
+require_once ROOT_DIR . '/sys/OverDrive/OverDriveSetting.php';
+require_once ROOT_DIR . '/sys/LibraryLocation/Library.php';
+require_once ROOT_DIR . '/sys/Account/User.php';
+
+class OverDrive_QRCodeAuth extends Action {
+	private const string STATE_CACHE_PREFIX = 'overdrive_qr_state_';
+
+	/**
+	 * @throws RandomException
+	 */
+	function launch() : void {
+		$operation = $_REQUEST['op'] ?? 'start';
+		switch ($operation) {
+			case 'start':
+				$this->startQRCodeFlow();
+				return;
+			case 'complete':
+				$this->handleAuthComplete();
+				return;
+			case 'abandon':
+				$this->displayResult(false, translate([
+					'text' => 'The authentication request was canceled before completion.',
+					'isPublicFacing' => true,
+				]));
+				return;
+			case 'error':
+				$errorDetail = $_REQUEST['error'] ?? '';
+				$this->displayResult(false, translate([
+					'text' => 'OverDrive returned an error while authorizing the account.%1%',
+					'1' => empty($errorDetail) ? '' : ' (' . $errorDetail . ')',
+					'isPublicFacing' => true,
+				]));
+				return;
+			case 'disconnect':
+				$this->disconnectSession();
+				return;
+			default:
+				$this->displayResult(false, translate([
+					'text' => 'Unknown request.',
+					'isPublicFacing' => true,
+				]));
+		}
+	}
+
+	/**
+	 * @throws RandomException
+	 */
+	private function startQRCodeFlow(): void {
+		$user = UserAccount::getLoggedInUser();
+		if (!$user) {
+			$this->displayResult(false, translate([
+				'text' => 'Please sign in to link your Sora/OverDrive account.',
+				'isPublicFacing' => true,
+			]));
+			return;
+		}
+
+		$driver = new OverDriveDriver();
+		$availableSettings = $driver->getAvailableSettings();
+		if (empty($availableSettings)) {
+			$this->displayResult(false, translate([
+				'text' => 'No OverDrive collections are configured for this library.',
+				'isPublicFacing' => true,
+			]));
+			return;
+		}
+
+		$requestSettingId = isset($_REQUEST['settingId']) ? (int)$_REQUEST['settingId'] : null;
+		if ($requestSettingId !== null && isset($availableSettings[$requestSettingId])) {
+			$activeSetting = $availableSettings[$requestSettingId];
+		} else {
+			$activeSetting = reset($availableSettings);
+		}
+
+		if (empty($activeSetting->enableQRCodeAuth)) {
+			$this->displayResult(false, translate([
+				'text' => 'QR code authentication is not enabled for this OverDrive collection.',
+				'isPublicFacing' => true,
+			]));
+			return;
+		}
+
+		$homeLibrary = $user->getHomeLibrary();
+		if ($homeLibrary == null) {
+			$this->displayResult(false, translate([
+				'text' => 'Unable to determine your library for OverDrive access.',
+				'isPublicFacing' => true,
+			]));
+			return;
+		}
+
+		$librarySettings = $homeLibrary->getLibraryOverdriveSetting($activeSetting->id);
+		$credentials = $driver->getClientCredentials($activeSetting, $librarySettings);
+		if (empty($credentials['clientKey']) || empty($credentials['clientSecret'])) {
+			$this->displayResult(false, translate([
+				'text' => 'OverDrive client credentials have not been configured.',
+				'isPublicFacing' => true,
+			]));
+			return;
+		}
+		if (empty($activeSetting->websiteId)) {
+			$this->displayResult(false, translate([
+				'text' => 'The OverDrive website id is missing for this collection.',
+				'isPublicFacing' => true,
+			]));
+			return;
+		}
+
+		$state = bin2hex(random_bytes(16));
+		global $memCache;
+		$memCache->set(self::STATE_CACHE_PREFIX . $state, [
+			'userId' => $user->id,
+			'settingId' => $activeSetting->id,
+			'libraryId' => $homeLibrary->libraryId,
+		], 900);
+
+		global $configArray;
+		$baseUrl = rtrim($configArray['Site']['url'], '/');
+		$redirectBase = $baseUrl . '/OverDrive/QRCodeAuth';
+		$params = [
+			'redirect_url' => $redirectBase . '?op=complete&state=' . $state,
+			'abandon_url' => $redirectBase . '?op=abandon&state=' . $state,
+			'error_url' => $redirectBase . '?op=error&state=' . $state,
+			'website_id' => $activeSetting->websiteId,
+			'client_id' => $credentials['clientKey'],
+		];
+
+		$target = 'https://oauth-patron.overdrive.com/device/initiate?' . http_build_query($params, '', '&', PHP_QUERY_RFC3986);
+		header("Location: $target");
+		exit();
+	}
+
+	private function handleAuthComplete(): void {
+		$state = $_REQUEST['state'] ?? '';
+		$code = $_REQUEST['code'] ?? '';
+		if (empty($state) || empty($code)) {
+			$this->displayResult(false, translate([
+				'text' => 'Missing information from OverDrive.',
+				'isPublicFacing' => true,
+			]));
+			return;
+		}
+
+		$stateData = $this->getStateData($state);
+		if ($stateData === null) {
+			$this->displayResult(false, translate([
+				'text' => 'Authentication session expired. Please try again.',
+				'isPublicFacing' => true,
+			]));
+			return;
+		}
+
+		$user = UserAccount::getLoggedInUser();
+		if (!$user || $user->id != $stateData['userId']) {
+			$user = new User();
+			$user->id = $stateData['userId'];
+			if (!$user->find(true)) {
+				$this->displayResult(false, translate([
+					'text' => 'Unable to load the user account for this session.',
+					'isPublicFacing' => true,
+				]));
+				return;
+			}
+		}
+
+		$setting = new OverDriveSetting();
+		$setting->id = $stateData['settingId'];
+		if (!$setting->find(true)) {
+			$this->displayResult(false, translate([
+				'text' => 'Unable to load the OverDrive collection for this request.',
+				'isPublicFacing' => true,
+			]));
+			return;
+		}
+
+		if (empty($setting->enableQRCodeAuth)) {
+			$this->displayResult(false, translate([
+				'text' => 'This OverDrive collection does not allow QR code authentication.',
+				'isPublicFacing' => true,
+			]));
+			return;
+		}
+
+		$library = new Library();
+		$library->libraryId = $stateData['libraryId'];
+		if (!$library->find(true)) {
+			$library = $user->getHomeLibrary();
+			if (!$library) {
+				$this->displayResult(false, translate([
+					'text' => 'Unable to determine which library should be used for this OverDrive account.',
+					'isPublicFacing' => true,
+				]));
+				return;
+			}
+		}
+
+		$librarySettings = $library->getLibraryOverdriveSetting($setting->id);
+		$driver = OverDriveDriver::getOverDriveDriver($setting->id);
+		$tokenData = $driver->exchangeQRCodeAuthCode($setting, $librarySettings, $code);
+		if (!$tokenData) {
+			$this->displayResult(false, translate([
+				'text' => 'OverDrive did not provide an access token. Please try again.',
+				'isPublicFacing' => true,
+			]));
+			return;
+		}
+
+		$user->saveOverDriveQrToken($setting->id, $tokenData);
+		$this->displayResult(true, translate([
+			'text' => 'Success! Your OverDrive account is ready for one-click checkouts.',
+			'isPublicFacing' => true,
+		]));
+	}
+
+	private function disconnectSession(): void {
+		$user = UserAccount::getLoggedInUser();
+		if (!$user) {
+			$this->displayResult(false, translate([
+				'text' => 'Please sign in to change this setting.',
+				'isPublicFacing' => true,
+			]));
+			return;
+		}
+		$settingId = isset($_REQUEST['settingId']) ? (int)$_REQUEST['settingId'] : 0;
+		if ($settingId <= 0) {
+			$this->displayResult(false, translate([
+				'text' => 'Missing OverDrive setting identifier.',
+				'isPublicFacing' => true,
+			]));
+			return;
+		}
+		$homeLibrary = $user->getHomeLibrary();
+		$settings = $homeLibrary ? $homeLibrary->getOverdriveSettings() : [];
+		if (!isset($settings[$settingId]) || empty($settings[$settingId]->enableQRCodeAuth)) {
+			$this->displayResult(false, translate([
+				'text' => 'QR code authentication is not available for this collection.',
+				'isPublicFacing' => true,
+			]));
+			return;
+		}
+		$user->deleteOverDriveQrToken($settingId);
+		$this->displayResult(true, translate([
+			'text' => 'The saved Sora/OverDrive session has been removed.',
+			'isPublicFacing' => true,
+		]));
+	}
+
+	private function getStateData(string $state): ?array {
+		global $memCache;
+		$data = $memCache->get(self::STATE_CACHE_PREFIX . $state);
+		if ($data !== false) {
+			$memCache->delete(self::STATE_CACHE_PREFIX . $state);
+			return $data;
+		}
+		return null;
+	}
+
+	private function displayResult(bool $success, string $message): void {
+		global $interface;
+		$readerNameDriver = new OverDriveDriver();
+		$interface->assign('readerName', $readerNameDriver->getReaderName());
+		$interface->assign('qrResultSuccess', $success);
+		$interface->assign('qrResultMessage', $message);
+		$pageTitle = translate([
+			'text' => 'OverDrive Authentication',
+			'isPublicFacing' => true,
+		]);
+		$interface->assign('qrResultTitle', $pageTitle);
+		$this->display('OverDrive/qrCodeAuthResult.tpl', $pageTitle);
+	}
+
+	function getBreadcrumbs(): array {
+		return [];
+	}
+}

--- a/code/web/services/OverDrive/QRCodeAuthCanceled.php
+++ b/code/web/services/OverDrive/QRCodeAuthCanceled.php
@@ -1,0 +1,41 @@
+<?php
+
+require_once ROOT_DIR . '/Action.php';
+require_once ROOT_DIR . '/Drivers/OverDriveDriver.php';
+require_once ROOT_DIR . '/sys/UserAccount.php';
+
+class OverDrive_QRCodeAuthCanceled extends Action {
+	function launch() : void {
+		// Clean up session state data
+		$this->cleanupStateData();
+
+		$this->displayResult(false, translate([
+			'text' => 'The authentication request was canceled before completion.',
+			'isPublicFacing' => true,
+		]));
+	}
+
+	private function cleanupStateData(): void {
+		if (isset($_SESSION['overdrive_qr_auth_state'])) {
+			unset($_SESSION['overdrive_qr_auth_state']);
+		}
+	}
+
+	private function displayResult(bool $success, string $message): void {
+		global $interface;
+		$readerNameDriver = new OverDriveDriver();
+		$interface->assign('readerName', $readerNameDriver->getReaderName());
+		$interface->assign('qrResultSuccess', $success);
+		$interface->assign('qrResultMessage', $message);
+		$pageTitle = translate([
+			'text' => 'OverDrive Authentication',
+			'isPublicFacing' => true,
+		]);
+		$interface->assign('qrResultTitle', $pageTitle);
+		$this->display('qrCodeAuthResult.tpl', $pageTitle);
+	}
+
+	function getBreadcrumbs(): array {
+		return [];
+	}
+}

--- a/code/web/services/OverDrive/QRCodeAuthFailed.php
+++ b/code/web/services/OverDrive/QRCodeAuthFailed.php
@@ -1,0 +1,44 @@
+<?php
+
+require_once ROOT_DIR . '/Action.php';
+require_once ROOT_DIR . '/Drivers/OverDriveDriver.php';
+require_once ROOT_DIR . '/sys/UserAccount.php';
+
+class OverDrive_QRCodeAuthFailed extends Action {
+	function launch() : void {
+		$errorDetail = $_REQUEST['error'] ?? '';
+
+		// Clean up session state data
+		$this->cleanupStateData();
+
+		$this->displayResult(false, translate([
+			'text' => 'OverDrive returned an error while authorizing the account.%1%',
+			'1' => empty($errorDetail) ? '' : ' (' . $errorDetail . ')',
+			'isPublicFacing' => true,
+		]));
+	}
+
+	private function cleanupStateData(): void {
+		if (isset($_SESSION['overdrive_qr_auth_state'])) {
+			unset($_SESSION['overdrive_qr_auth_state']);
+		}
+	}
+
+	private function displayResult(bool $success, string $message): void {
+		global $interface;
+		$readerNameDriver = new OverDriveDriver();
+		$interface->assign('readerName', $readerNameDriver->getReaderName());
+		$interface->assign('qrResultSuccess', $success);
+		$interface->assign('qrResultMessage', $message);
+		$pageTitle = translate([
+			'text' => 'OverDrive Authentication',
+			'isPublicFacing' => true,
+		]);
+		$interface->assign('qrResultTitle', $pageTitle);
+		$this->display('qrCodeAuthResult.tpl', $pageTitle);
+	}
+
+	function getBreadcrumbs(): array {
+		return [];
+	}
+}

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -961,6 +961,13 @@ class User extends DataObject {
 							if ($libraryOverDriveSetting->circulationEnabled) {
 								return true;
 							}
+
+							require_once ROOT_DIR . '/sys/OverDrive/OverDriveSetting.php';
+							$overDriveSetting = new OverDriveSetting();
+							$overDriveSetting->id = $libraryOverDriveSetting->settingId;
+							if ($overDriveSetting->find(true) && !empty($overDriveSetting->enableQRCodeAuth)) {
+								return true;
+							}
 						}
 						return false;
 					} else {
@@ -2158,6 +2165,7 @@ class User extends DataObject {
 				'url' => "/MyAccount/CheckedOut",
 				'requireLogin' => false,
 				'btnType' => 'btn-info',
+				'type' => $source . '_checked_out',
 			];
 		} elseif ($this->isRecordOnHold($source, $recordId)) {
 			$actions[] = [
@@ -2172,7 +2180,8 @@ class User extends DataObject {
 				'url' => "/MyAccount/Holds",
 				'requireLogin' => false,
 				'btnType' => 'btn-info',
-				'id' => 'onHoldAction' . $recordId
+				'id' => 'onHoldAction' . $recordId,
+				'type' => $source . '_on_hold',
 			];
 		}
 		if (!$loadingLinkedUser) {

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -66,6 +66,8 @@ class User extends DataObject {
 	private $_permissions;
 	private $_masqueradingRoles;
 	private $_additionalAdministrationLocations;
+	/** @var UserOverDriveQRCodeToken[] */
+	private $_overDriveQrTokens = null;
 
 	public $interfaceLanguage;
 	public $searchPreferenceLanguage;
@@ -3798,6 +3800,62 @@ class User extends DataObject {
 		return $overDriveDriver->getOptions($this);
 	}
 
+	public function getOverDriveQrToken(int $settingId): ?UserOverDriveQRCodeToken {
+		if ($this->_overDriveQrTokens === null) {
+			$this->loadOverDriveQrTokens();
+		}
+		return $this->_overDriveQrTokens[$settingId] ?? null;
+	}
+
+	private function loadOverDriveQrTokens(): void {
+		$this->_overDriveQrTokens = [];
+		require_once ROOT_DIR . '/sys/OverDrive/UserOverDriveQRCodeToken.php';
+		$token = new UserOverDriveQRCodeToken();
+		$token->userId = $this->id;
+		if ($token->find()) {
+			while ($token->fetch()) {
+				$this->_overDriveQrTokens[$token->settingId] = clone $token;
+			}
+		}
+	}
+
+	public function saveOverDriveQrToken(int $settingId, stdClass $tokenData): void {
+		require_once ROOT_DIR . '/sys/OverDrive/UserOverDriveQRCodeToken.php';
+		$token = $this->getOverDriveQrToken($settingId);
+		if ($token === null) {
+			$token = new UserOverDriveQRCodeToken();
+			$token->userId = $this->id;
+			$token->settingId = $settingId;
+		}
+		$token->applyTokenResponse($tokenData);
+		if (empty($token->id)) {
+			$token->insert();
+		} else {
+			$token->update();
+		}
+		$this->_overDriveQrTokens[$settingId] = $token;
+	}
+
+	public function deleteOverDriveQrToken(int $settingId): void {
+		if ($this->_overDriveQrTokens === null) {
+			$this->loadOverDriveQrTokens();
+		}
+		if (isset($this->_overDriveQrTokens[$settingId])) {
+			$token = $this->_overDriveQrTokens[$settingId];
+			if (!empty($token->id)) {
+				$token->delete();
+			}
+			unset($this->_overDriveQrTokens[$settingId]);
+		} else {
+			require_once ROOT_DIR . '/sys/OverDrive/UserOverDriveQRCodeToken.php';
+			$token = new UserOverDriveQRCodeToken();
+			$token->userId = $this->id;
+			$token->settingId = $settingId;
+			if ($token->find(true) && !empty($token->id)) {
+				$token->delete();
+			}
+		}
+	}
 	function completeFinePayment(UserPayment $payment): array {
 		if (
 			$payment->completed ||

--- a/code/web/sys/DBMaintenance/version_updates/26.02.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/26.02.00.php
@@ -91,6 +91,37 @@ function getUpdates26_02_00(): array {
 		//kodi
 
 		//yanjun
+		'overdrive_qr_sessions' => [
+			'title' => 'OverDrive QR Sessions Table',
+			'description' => 'Store QR code authentication tokens for OverDrive/Sora users.',
+			'continueOnError' => false,
+			'sql' => [
+				"CREATE TABLE IF NOT EXISTS overdrive_qr_sessions (
+					id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+					userId INT NOT NULL,
+					settingId INT NOT NULL,
+					accessToken TEXT,
+					refreshToken TEXT,
+					tokenType VARCHAR(50),
+					scope TEXT,
+					expiresAt INT,
+					created INT,
+					updated INT,
+					UNIQUE KEY user_setting (userId, settingId),
+					INDEX settingId (settingId),
+					CONSTRAINT fk_overdrive_qr_user FOREIGN KEY (userId) REFERENCES user(id) ON DELETE CASCADE,
+					CONSTRAINT fk_overdrive_qr_setting FOREIGN KEY (settingId) REFERENCES overdrive_settings(id) ON DELETE CASCADE
+				) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci"
+			]
+		], //overdrive_qr_sessions
+		'overdrive_settings_enable_qr' => [
+			'title' => 'Enable QR authentication flag',
+			'description' => 'Add flag to OverDrive settings to toggle QR code authentication features.',
+			'continueOnError' => false,
+			'sql' => [
+				"ALTER TABLE overdrive_settings ADD COLUMN enableQRCodeAuth TINYINT(1) DEFAULT 0"
+			]
+		], //overdrive_settings_enable_qr
 
 		//imani
 		'add_configuration_for_index_process' => [

--- a/code/web/sys/OverDrive/OverDriveSetting.php
+++ b/code/web/sys/OverDrive/OverDriveSetting.php
@@ -155,6 +155,7 @@ class OverDriveSetting extends DataObject {
 				'type' => 'checkbox',
 				'label' => 'Enable Single Sign On with QR Code Authentication',
 				'description' => 'Allow Aspen to use OverDrive\'s QR code authentication flow for this setting.',
+				'note' => 'When enabled, no fallback ILS authentication is performed. Disable "Circulation Enabled" for any libraries to which this should apply.',
 				'default' => 0,
 			],
 			'numExtractionThreads' => [

--- a/code/web/sys/OverDrive/OverDriveSetting.php
+++ b/code/web/sys/OverDrive/OverDriveSetting.php
@@ -16,6 +16,7 @@ class OverDriveSetting extends DataObject {
 	public $productsKey;
 	public $runFullUpdate;
 	public $showLibbyPromo;
+	public $enableQRCodeAuth;
 	/** @noinspection PhpUnused */
 	public $allowLargeDeletes;
 	/** @noinspection PhpUnused */
@@ -148,6 +149,13 @@ class OverDriveSetting extends DataObject {
 				'label' => 'Show Libby promo in checkout fulfillment interface',
 				'description' => 'Whether or not to show the Libby promo ad in the fulfillment interface',
 				'default' => 1,
+			],
+			'enableQRCodeAuth' => [
+				'property' => 'enableQRCodeAuth',
+				'type' => 'checkbox',
+				'label' => 'Enable Single Sign On with QR Code Authentication',
+				'description' => 'Allow Aspen to use OverDrive\'s QR code authentication flow for this setting.',
+				'default' => 0,
 			],
 			'numExtractionThreads' => [
 				'property' => 'numExtractionThreads',

--- a/code/web/sys/OverDrive/UserOverDriveQRCodeToken.php
+++ b/code/web/sys/OverDrive/UserOverDriveQRCodeToken.php
@@ -1,0 +1,64 @@
+<?php /** @noinspection PhpMissingFieldTypeInspection */
+
+class UserOverDriveQRCodeToken extends DataObject {
+	public $__table = 'overdrive_qr_sessions';
+	public $id;
+	public $userId;
+	public $settingId;
+	public $accessToken;
+	public $refreshToken;
+	public $tokenType;
+	public $scope;
+	public $expiresAt;
+	public $created;
+	public $updated;
+
+	public function getNumericColumnNames(): array {
+		return [
+			'id',
+			'userId',
+			'settingId',
+			'expiresAt',
+			'created',
+			'updated',
+		];
+	}
+
+	public function getEncryptedFieldNames(): array {
+		return [
+			'accessToken',
+			'refreshToken',
+		];
+	}
+
+	public function isExpired(int $gracePeriod = 0): bool {
+		if (empty($this->expiresAt)) {
+			return true;
+		}
+		return $this->expiresAt <= (time() + $gracePeriod);
+	}
+
+	public function applyTokenResponse(stdClass $tokenData): void {
+		$this->accessToken = $tokenData->access_token ?? '';
+		$this->refreshToken = $tokenData->refresh_token ?? '';
+		$this->tokenType = $tokenData->token_type ?? 'Bearer';
+		$this->scope = $tokenData->scope ?? '';
+		$expiresIn = $tokenData->expires_in ?? 0;
+		$this->expiresAt = time() + (int)$expiresIn;
+		if (empty($this->created)) {
+			$this->created = time();
+		}
+		$this->updated = time();
+	}
+
+	public function toPatronTokenData(): stdClass {
+		$data = new stdClass();
+		$data->access_token = $this->accessToken;
+		$data->refresh_token = $this->refreshToken;
+		$data->token_type = $this->tokenType ?? 'Bearer';
+		$data->scope = $this->scope ?? '';
+		$remaining = max(0, ($this->expiresAt ?? 0) - time());
+		$data->expires_in = $remaining;
+		return $data;
+	}
+}


### PR DESCRIPTION
OverDrive provides an alternative method of patron authentication that uses a QR code flow. For more details, see [OverDrive QR Code Authenticate](https://developer.overdrive.com/api-docs/authentication/qr-code-authentication).

Aspen can implement this so that libraries using SSO for patron login can still interact with OverDrive records through Aspen by using the QR code authentication.

To Test:
1. Apply PR and apply QR code from OverDrive 
2. In OverDrive settings, select "Enable Single Sign On with QR Code Authentication" in OverDrive settings and deselect "Circulation Enabled" for the targeted library. 
3. Log in as a patron and go to MyAccount/OverDriveOptions -> Connect with QR Code
2. Scan the QR code and log in on your phone (select "RheniumTwo" as the login library)
3. Checkout OverDrive records 
4. Go back to MyAccount/OverDriveOptions -> Disconnect
5. Search for an OverDrive record and see "Sign in with QR Code" on the action button. 
6. Scan the QR code and log in on your phone
7. The title will be checked out once you are logged in