### PR TITLE
DIS-1896: Fix url-encoding issue with database credentials

### DIFF
--- a/code/koha_export/src/com/turning_leaf_technologies/koha_export/KohaExportMain.java
+++ b/code/koha_export/src/com/turning_leaf_technologies/koha_export/KohaExportMain.java
@@ -671,8 +671,8 @@ public class KohaExportMain {
 				kohaConnectionJDBC = "jdbc:mysql://" +
 						host + ":" + port +
 						"/" + databaseName +
-						"?user=" + user +
-						"&password=" + password +
+						"?user=" + URLEncoder.encode(user, StandardCharsets.UTF_8) +
+						"&password=" + URLEncoder.encode(password, StandardCharsets.UTF_8) +
 						"&useUnicode=yes&characterEncoding=UTF-8";
 				if (timezone != null && !timezone.isEmpty()) {
 					kohaConnectionJDBC += "&serverTimezone=" + URLEncoder.encode(timezone, StandardCharsets.UTF_8);

--- a/code/reindexer/src/org/aspen_discovery/reindexer/KohaRecordProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/KohaRecordProcessor.java
@@ -47,8 +47,8 @@ class KohaRecordProcessor extends IlsRecordProcessor {
 					String kohaConnectionJDBC = "jdbc:mysql://" +
 						host + ":" + port +
 						"/" + databaseName +
-						"?user=" + user +
-						"&password=" + password +
+						"?user=" + URLEncoder.encode(user, StandardCharsets.UTF_8) +
+						"&password=" + URLEncoder.encode(password, StandardCharsets.UTF_8) +
 						"&useUnicode=yes&characterEncoding=UTF-8";
 					if (timezone != null && !timezone.isEmpty()){
 						kohaConnectionJDBC += "&serverTimezone=" + URLEncoder.encode(timezone, StandardCharsets.UTF_8);

--- a/code/web/release_notes/26.02.00.MD
+++ b/code/web/release_notes/26.02.00.MD
@@ -87,6 +87,8 @@
 // lucas
 ### Web Builder Updates
 - Fix "View Image" button not appearing for uploaded images in WebBuilder. ((DIS-1832)[https://aspen-discovery.atlassian.net/browse/DIS-1832]) (*LM*)
+### Other Updates
+- Fix an issue where database credentials were not URL-encoded, causing passwords containing special characters to fail. ((DIS-1896)[https://aspen-discovery.atlassian.net/browse/DIS-1896]) (*LM*)
 
 ## This release includes code contributions from
 ### ByWater Solutions


### PR DESCRIPTION
This patch fixes an issue where database credentials (such as passwords) were not being URL-encoded properly, causing Koha database connections to fail.

Test plan

Requirements before starting:
The credentials for accessing the Koha database must contain special characters.

1. Start a fresh instance of Aspen.
2. Create a new account profile to connect Aspen with Koha.
3. Set the Koha database credentials in ILS Connection Configuration → Database Information.
4. Save the configuration.
5. Create a new indexing profile based on the recently created account profile and run a full index update.(Do not run this in production unless you are sure what you are doing.)
6. You will notice the error "Could not connect to the Koha database..." in the logs.
7. Apply the patch.
8. Repeat steps 1–5.
9. Congratulations — the full index update should now run successfully, confirming that the connection to the Koha database works correctly when using credentials with special characters.