### PR TITLE
DIS-1711: Hoopla branding update

### DIFF
--- a/code/reindexer/src/org/aspen_discovery/grouping/RecordGroupingProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/grouping/RecordGroupingProcessor.java
@@ -1069,7 +1069,7 @@ public class RecordGroupingProcessor {
 			}
 			getHooplaRecordRS.close();
 		}catch (Exception e){
-			logEntry.incErrors("Error grouping hoopla record " + hooplaId, e);
+			logEntry.incErrors("Error grouping Hoopla record " + hooplaId, e);
 		}
 		return null;
 	}

--- a/code/web/Drivers/HooplaDriver.php
+++ b/code/web/Drivers/HooplaDriver.php
@@ -518,7 +518,7 @@ class HooplaDriver extends AbstractEContentDriver {
 								'isPublicFacing' => true,
 							]),
 							'message' => translate([
-								'text' => 'We are unable to find a hoopla digital account for your library card. Please register to continue.',
+								'text' => 'We are unable to find a Hoopla digital account for your library card. Please register to continue.',
 								'isPublicFacing' => true,
 							]),
 							'buttons' => '<a class="btn btn-primary" href="' . $registrationUrl . '" target="_blank">' . translate(['text' => 'Register at Hoopla', 'isPublicFacing' => true]) . '</a>',
@@ -528,7 +528,7 @@ class HooplaDriver extends AbstractEContentDriver {
 									'isPublicFacing' => true,
 								]),
 								'message' => translate([
-									'text' => 'We are unable to find a hoopla digital account for your library card. Please register at %1%',
+									'text' => 'We are unable to find a Hoopla digital account for your library card. Please register at %1%',
 									1 => $registrationUrl,
 									'isPublicFacing' => true,
 								])
@@ -1001,7 +1001,7 @@ class HooplaDriver extends AbstractEContentDriver {
 								'isPublicFacing' => true,
 							]),
 							'message' => translate([
-								'text' => 'We are unable to find a hoopla digital account for your library card. Please register to continue.',
+								'text' => 'We are unable to find a Hoopla digital account for your library card. Please register to continue.',
 								'isPublicFacing' => true,
 							]),
 							'buttons' => '<a class="btn btn-primary" href="' . $registrationUrl . '" target="_blank">' .
@@ -1013,7 +1013,7 @@ class HooplaDriver extends AbstractEContentDriver {
 									'isPublicFacing' => true,
 								]),
 								'message' => translate([
-									'text' => 'We are unable to find a hoopla digital account for your library card. Please register at %1%',
+									'text' => 'We are unable to find a Hoopla digital account for your library card. Please register at %1%',
 									1 => $registrationUrl,
 									'isPublicFacing' => true,
 								])

--- a/code/web/interface/themes/responsive/MyAccount/hooplaCheckedOutTitle.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/hooplaCheckedOutTitle.tpl
@@ -7,7 +7,7 @@
 			<div class="col-xs-3 col-sm-4 col-md-3 checkedOut-covers-column">
 				<div class="row">
 					<div class="selectTitle hidden-xs col-sm-1">
-						&nbsp;{* Can't renew hoopla titles*}
+						&nbsp;{* Can't renew Hoopla titles*}
 					</div>
 					<div class="{*coverColumn *}text-center col-xs-12 col-sm-10">
 						{if $disableCoverArt != 1}{*TODO: should become part of $showCovers *}
@@ -26,7 +26,7 @@
 			</div>
 		{else}
 			<div class="col-xs-1">
-				&nbsp;{* Can't renew hoopla titles*}
+				&nbsp;{* Can't renew Hoopla titles*}
 			</div>
 		{/if}
 

--- a/code/web/release_notes/26.02.00.MD
+++ b/code/web/release_notes/26.02.00.MD
@@ -79,6 +79,7 @@
 - Update Hoopla checkout error handling to display clearer error messages to patrons when checkout fails.((DIS-1875)[https://aspen-discovery.atlassian.net/browse/DIS-1875]) (*YL*)
 - Display Hoopla Price in Staff View for Version 2. ((DIS-1792)[https://aspen-discovery.atlassian.net/browse/DIS-1792]) (*YL*)
 - Hoopla records now display the Edition as Abridged or Unabridged in both versions. ((DIS-1814) [https://aspen-discovery.atlassian.net/browse/DIS-1814]) (*YL*)
+- Hoopla branding update: all user-facing instances of "hoopla" are now "Hoopla". ((DIS-1711) [https://aspen-discovery.atlassian.net/browse/DIS-1711]) (*YL*)
 
 ### Other Updates
 - Prevent deletion of the opacAdmin role by hiding the delete button on the Permissions page. ([DIS-1892](https://aspen-discovery.atlassian.net/browse/DIS-1892)) (*YL*)

--- a/code/web/sys/Indexing/IndexingProfile.php
+++ b/code/web/sys/Indexing/IndexingProfile.php
@@ -930,7 +930,7 @@ class IndexingProfile extends DataObject {
 								'property' => 'doAutomaticEcontentSuppression',
 								'type' => 'checkbox',
 								'label' => 'Do Automatic eContent Suppression',
-								'description' => 'Whether or not eContent suppression for overdrive and hoopla records is done automatically',
+								'description' => 'Whether or not eContent suppression for OverDrive and Hoopla records is done automatically',
 								'default' => false,
 								'forcesReindex' => true,
 							],

--- a/code/web/sys/LibraryLocation/Library.php
+++ b/code/web/sys/LibraryLocation/Library.php
@@ -912,7 +912,7 @@ class Library extends DataObject {
 			'type' => 'enum',
 			'values' => $hooplaScopes,
 			'label' => 'Hoopla Scope',
-			'description' => 'The hoopla scope to use',
+			'description' => 'The Hoopla scope to use',
 			'hideInLists' => true,
 			'default' => -1,
 			'forcesReindex' => true,

--- a/code/web/sys/LibraryLocation/Location.php
+++ b/code/web/sys/LibraryLocation/Location.php
@@ -1275,7 +1275,7 @@ class Location extends DataObject {
 						'type' => 'enum',
 						'values' => $hooplaScopes,
 						'label' => 'Hoopla Scope',
-						'description' => 'The hoopla scope to use',
+						'description' => 'The Hoopla scope to use',
 						'hideInLists' => true,
 						'default' => -1,
 						'forcesReindex' => true,


### PR DESCRIPTION
Hoopla branding update: all user-facing instances of "hoopla" are now "Hoopla".