### PR TITLE
DIS-1897 Remove pickupLocation conditions to show Hold section in myP…

### DIFF
--- a/code/web/interface/themes/responsive/MyAccount/myPreferences.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/myPreferences.tpl
@@ -235,7 +235,7 @@
 							</div>
 						{/if}
 
-						{if !empty($isAssociatedWithILS) || !empty($showAlternateLibraryOptions)}
+						{if !empty($isAssociatedWithILS)}
 							<div class="panel" id="holdPreferencesPanel">
 								<a data-toggle="collapse" href="#holdPreferencesPanelBody" class="active">
 									<div class="panel-heading">

--- a/code/web/interface/themes/responsive/MyAccount/myPreferences.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/myPreferences.tpl
@@ -235,7 +235,7 @@
 							</div>
 						{/if}
 
-						{if !empty($isAssociatedWithILS) && ((!empty($allowRememberPickupLocation) && count($pickupLocations) > 1) || !empty($showAlternateLibraryOptions) || !empty($allowRememberPickupLocation))}
+						{if !empty($isAssociatedWithILS) || !empty($showAlternateLibraryOptions)}
 							<div class="panel" id="holdPreferencesPanel">
 								<a data-toggle="collapse" href="#holdPreferencesPanelBody" class="active">
 									<div class="panel-heading">

--- a/code/web/release_notes/26.02.00.MD
+++ b/code/web/release_notes/26.02.00.MD
@@ -119,6 +119,10 @@
 ### Other Updates
 - Fix an issue where database credentials were not URL-encoded, causing passwords containing special characters to fail. ((DIS-1896)[https://aspen-discovery.atlassian.net/browse/DIS-1896]) (*LM*)
 
+// stephen
+### MyAccount Updates
+- Fix an issue where hold helper messages can't be restored
+
 ## This release includes code contributions from
 ### ByWater Solutions
 - Yanjun Li (YL)
@@ -133,6 +137,7 @@
 - Kirstien Kroeger (KK)
 - Kodi Lein (KL)
 - Myranda Fuentes (MAF)
+- Stephen Wicks (SW)
 
 ### Open Fifth
 - Alexander Blanchard (AB)

--- a/code/web/release_notes/26.02.00.MD
+++ b/code/web/release_notes/26.02.00.MD
@@ -121,7 +121,7 @@
 
 // stephen
 ### MyAccount Updates
-- Fix an issue where hold helper messages can't be restored
+- Fix an issue where hold helper messages can't be restored ((DIS-1897)[https://aspen-discovery.atlassian.net/browse/DIS-1897]) (*SW*)
 
 ## This release includes code contributions from
 ### ByWater Solutions


### PR DESCRIPTION
DIS-1897: Fixes an issue where patrons don't see the option to restore hold helper messages if a pickup location setting is turned off