### PR TITLE
DIS-1919: Dropdown city select for Sierra self registration

### DIFF
--- a/code/web/Drivers/Sierra.php
+++ b/code/web/Drivers/Sierra.php
@@ -2045,6 +2045,22 @@ class Sierra extends AbstractIlsDriver {
 							'isPublicFacing' => true,
 						]),
 					];
+				} elseif ($customField->ilsName == 'city' && $selfRegistrationForm->cityDropdown) {
+					$cityOptions = [];
+					$validCities = new SierraSelfRegistrationMunicipalityValues();
+					$validCities->municipalityType = 'city';
+					$validCities->find();
+					while ($validCities->fetch()) {
+						$cityOptions[$validCities->municipality] = $validCities->municipality;
+					}
+					$fields[$customField->section]['properties'][] = [
+						'property' => $customField->ilsName,
+						'type' => 'enum',
+						'values' => $cityOptions,
+						'label' => $customField->displayName,
+						'required' => $customField->required,
+						'note' => $customField->note,
+					];
 				} elseif ($customField->ilsName == 'state') {
 					if (!empty($library->validSelfRegistrationStates)){
 						$validStates = explode('|', $library->validSelfRegistrationStates);

--- a/code/web/release_notes/26.02.00.MD
+++ b/code/web/release_notes/26.02.00.MD
@@ -63,6 +63,9 @@
 
 </div>
 
+### Sierra Self Registration Updates
+- Add option to use a dropdown select for city in Sierra self registration forms ((DIS-1919)[https://aspen-discovery.atlassian.net/browse/DIS-1919]) (*KL*)
+
 // mark j
 ### Browse Category Updates
 - Fixed ARIA issues noted in axe DevTools and allowed tabbing through all subcategory buttons in accessible browse layout. ((DIS-1847)[https://aspen-discovery.atlassian.net/browse/DIS-1847]) (*MJ*)

--- a/code/web/sys/DBMaintenance/version_updates/26.02.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/26.02.00.php
@@ -153,6 +153,13 @@ function getUpdates26_02_00(): array {
 				) ENGINE=INNODB",
 			]
 		], //library_location_cloudsource_settings
+		'sierra_self_registation_form_city_dropdown' => [
+			'title' => 'Update Sierra Self Registration Form - City Dropdown Selection',
+			'description' => 'Add toggle to use cities defined in municipalities as a dropdown option in the Sierra Self Registration Form.',
+			'sql' => [
+				"ALTER TABLE self_registration_form_sierra ADD COLUMN cityDropdown tinyint(1) DEFAULT 0",
+			]
+		], //sierra_self_registation_form_city_dropdown
 
 		//yanjun
 

--- a/code/web/sys/SelfRegistrationForms/SierraSelfRegistrationForm.php
+++ b/code/web/sys/SelfRegistrationForms/SierraSelfRegistrationForm.php
@@ -29,6 +29,7 @@ class SierraSelfRegistrationForm extends DataObject {
 	public $selfRegUsePatronIdBarcode;
 	public $selfRegNoticePrefOptions;
 	public $addSelfRegNote;
+	public $cityDropdown;
 
 
 	private $_fields;
@@ -253,6 +254,14 @@ class SierraSelfRegistrationForm extends DataObject {
 				'description' => 'Automatically add a dated Circ Note in Sierra when patrons self register.',
 				'hideInLists' => true,
 				'default' => 1,
+			],
+			'cityDropdown' => [
+				'property' => 'cityDropdown',
+				'type' => 'checkbox',
+				'label' => 'City Dropdown',
+				'description' => 'Use a dropdown select option for city using municipalities defined below.',
+				'hideInLists' => true,
+				'default' => 0,
 			],
 			'municipalities' => [
 				'property' => 'municipalities',


### PR DESCRIPTION
Add option to use a dropdown select for city in Sierra self registration forms 
Dropdown is populated using the names of municipalityType "city" in the municipalities section. 
Update release notes

Tested on my local instance of Aspen