### PR TITLE
DIS-160 Preload Library Facet Settings

### DIFF
--- a/code/web/bootstrap.php
+++ b/code/web/bootstrap.php
@@ -24,6 +24,7 @@ require_once ROOT_DIR . '/sys/SystemLogging/ExternalRequestLogEntry.php';
 require_once ROOT_DIR . '/sys/LibraryLocation/Library.php';
 require_once ROOT_DIR . '/sys/LibraryLocation/Location.php';
 require_once ROOT_DIR . '/sys/LibraryLocation/HostInformation.php';
+require_once ROOT_DIR . '/sys/LibraryLocation/LibraryFacetSetting.php';
 require_once ROOT_DIR . '/Action.php';
 
 global $aspenUsage;

--- a/code/web/bootstrap_aspen.php
+++ b/code/web/bootstrap_aspen.php
@@ -7,7 +7,7 @@ loadSearchInformation();
 
 spl_autoload_register('aspen_autoloader', true, false);
 
-function requireSystemLibrariesAspen() {
+function requireSystemLibrariesAspen() : void {
 	// Require System Libraries
 	require_once ROOT_DIR . '/sys/SearchObject/SearchObjectFactory.php';
 	require_once ROOT_DIR . '/RecordDrivers/RecordDriverFactory.php';


### PR DESCRIPTION
Required to restore search objects even when not used explicitly