### PR TITLE
DIS 1924

### DIFF
--- a/code/web/release_notes/26.02.00.MD
+++ b/code/web/release_notes/26.02.00.MD
@@ -148,6 +148,7 @@
 - Update the logic for the display name of users in the Community Engagement admin view. ([DIS-1859](https://aspen-discovery.atlassian.net/browse/DIS-1859)) (*AB*) 
 - Add a breadcrumb back to Admin View from the individual Campaign tables pages. ([DIS-1553](https://aspen-discovery.atlassian.net/browse/DIS-1553)) (*AB*)
 - Fix masqerade mode not working on Community Engagement Admin View Page. ([DIS-1922](https://aspen-discovery.atlassian.net/browse/DIS-1922)) (*AB*)
+- Update how Community Engagement toast notifications are shown. ([DIS-1924](https://aspen-discovery.atlassian.net/browse/DIS-1924)) (*PA*)
 
 
 // chloe

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -11049,30 +11049,30 @@ class MyAccount_AJAX extends JSON_Action {
 							exit();
 						}
 
-						# Handle milestone progress notification
-						echo "event: ce_notification\n";
-						echo "data: " . json_encode(
-								array(
-									'id'=> $campaignMilestoneProgressEntry->id . '_ce_milestone_progress',
-									'title'=> translate(
-										[
-											'text' => 'Milestone progress! Good job!',
-											'isPublicFacing' => true
-										]
-									),
-									'body' => $campaignMilestoneUsersProgress->progress.'/'.$campaignMilestone->goal.' ' .$milestone->name,
-									'icon' => "fa-chart-line",
-									'link' => ['href' => '/MyAccount/MyCampaigns', 'text' => translate(
-										[
-											'text' => 'View all campaigns',
-											'isPublicFacing' => true
-										]
-									)]
-								)
-							) . "\n\n";
-
+						# Handle campaign completion notification
+						if ($userCampaign->completed && !$wantedOverflowProgress) {
+							echo "event: ce_notification\n";
+							echo "data: " . json_encode(
+									array(
+										'id'=> $campaignMilestoneProgressEntry->id . '_ce_campaign_completed',
+										'title'=> translate(
+											[
+												'text' => 'Campaign completed! Awesome!',
+												'isPublicFacing' => true
+											]
+										),
+										'body' => $campaign->name,
+										'icon' => "fa-medal",
+										'link' => ['href' => '/MyAccount/MyCampaigns', 'text' => translate(
+											[
+												'text' => 'View all campaigns',
+												'isPublicFacing' => true
+											]
+										)]
+									)
+								) . "\n\n";
 						# Handle milestone completion notification
-						if ($campaignMilestoneUsersProgress->progress >= $campaignMilestone->goal && !$wantedOverflowProgress) {
+						}elseif ($campaignMilestoneUsersProgress->progress >= $campaignMilestone->goal && !$wantedOverflowProgress) {
 							echo "event: ce_notification\n";
 							echo "data: " . json_encode(
 									array(
@@ -11093,22 +11093,20 @@ class MyAccount_AJAX extends JSON_Action {
 										)]
 									)
 								) . "\n\n";
-						}
-
-						# Handle campaign completion notification
-						if ($userCampaign->completed && !$wantedOverflowProgress) {
+						}else{
+							# Handle milestone progress notification
 							echo "event: ce_notification\n";
 							echo "data: " . json_encode(
 									array(
-										'id'=> $campaignMilestoneProgressEntry->id . '_ce_campaign_completed',
+										'id'=> $campaignMilestoneProgressEntry->id . '_ce_milestone_progress',
 										'title'=> translate(
 											[
-												'text' => 'Campaign completed! Awesome!',
+												'text' => 'Milestone progress! Good job!',
 												'isPublicFacing' => true
 											]
 										),
-										'body' => $campaign->name,
-										'icon' => "fa-medal",
+										'body' => $campaignMilestoneUsersProgress->progress.'/'.$campaignMilestone->goal.' ' .$milestone->name,
+										'icon' => "fa-chart-line",
 										'link' => ['href' => '/MyAccount/MyCampaigns', 'text' => translate(
 											[
 												'text' => 'View all campaigns',


### PR DESCRIPTION
This updates the behavior of community engagement toast notifications.
Given a campaign milestone progress entry, if a campaign is completed, only show the campaign completed notification.
If a campaign is not completed, but a milestone is, only show the milestone completed notification.
If both of the above are false, fallback to showing only the milestone progress notification.

Before:
1) A campaign milestone progress entry is picked up
2) It completed a milestone
3) It completed a campaign
RESULT-> All 3 notifications were shown

Now:
1) A campaign milestone progress entry is picked up
2) It completed a milestone
3) It completed a campaign
RESULT-> Only the campaign completed milestone is shown.

To test:
1) Create a reward, 2 milestones for ratings, and a campaign.
2) Ensure campaign start date is in the past, end date is in the future and all patron types, library and location access are enabled.
3) When creating the campaign, set both milestones created in 1). The first with a goal of 1, the 2nd with a goal of 2.
4) Masquerade as any regular user and enroll in that test campaign at <aspen_url>/MyAccount/MyCampaigns
5) Add a rating to any item
6) Notice only the 'Milestone completed' toast notification is shown.
7) Repeat 5. Notice only the 'Campaign completed' toast notification is shown.