### PR TITLE
DIS-1936 Palace Project Require PIN checkbox

### DIFF
--- a/code/web/Drivers/PalaceProjectDriver.php
+++ b/code/web/Drivers/PalaceProjectDriver.php
@@ -825,8 +825,14 @@ class PalaceProjectDriver extends AbstractEContentDriver {
 		} else {
 			$aspenVersion = 'Primary';
 		}
+		$settings = $this->getSettings();
+		if ($settings->requirePin) {
+			$authorization = base64_encode("$patron->ils_barcode:$patron->ils_password");
+		}else{
+			$authorization = base64_encode("$patron->ils_barcode");
+		}
 		return [
-			'Authorization: Basic ' . base64_encode("$patron->ils_barcode:$patron->ils_password"),
+			'Authorization: Basic ' . $authorization,
 			'Accept: application/opds+json',
 			'User-Agent: Aspen Discovery ' . $aspenVersion,
 		];

--- a/code/web/release_notes/26.03.00.MD
+++ b/code/web/release_notes/26.03.00.MD
@@ -12,6 +12,15 @@
 //stephen
 
 //yanjun
+### Palace Project Updates
+- Allow library to choose whether or not to require a PIN for Palace Project. ([DIS-1936](https://aspen-discovery.atlassian.net/browse/DIS-1936)) (*YL*)
+
+<div markdown="1" class="settings">
+
+#### New Settings
+- Palace Project Settings > Require PIN for Palace Project
+
+</div>
 
 //imani
 

--- a/code/web/sys/DBMaintenance/version_updates/26.03.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/26.03.00.php
@@ -22,6 +22,14 @@ function getUpdates26_03_00(): array {
 		//kodi
 
 		//yanjun
+		'require_pin_for_palace_project' => [
+			'title' => 'Add Require PIN for Palace Project Setting',
+			'description' => 'Add Require PIN for Palace Project Setting',
+			'continueOnError' => false,
+			'sql' => [
+				'ALTER TABLE palace_project_settings ADD COLUMN requirePin TINYINT(1) DEFAULT 1',
+			]
+		], //allow_require_pin_for_palace_project
 
 		//imani
 

--- a/code/web/sys/PalaceProject/PalaceProjectSetting.php
+++ b/code/web/sys/PalaceProject/PalaceProjectSetting.php
@@ -8,6 +8,7 @@ class PalaceProjectSetting extends DataObject {
 	public $name;
 	public $apiUrl;
 	public $libraryId;
+	public $requirePin;
 	public $runFullUpdate;
 	/** @noinspection PhpUnused */
 	public $lastUpdateOfChangedRecords;
@@ -59,6 +60,13 @@ class PalaceProjectSetting extends DataObject {
 				'label' => 'Library ID / Short name',
 				'description' => 'The Library Identifier or Short name ',
 				'maxLength' => 50,
+			],
+			'requirePin' => [
+				'property' => 'requirePin',
+				'type' => 'checkbox',
+				'label' => 'Require PIN for Palace Project',
+				'description' => 'Whether or not to require a PIN for Palace Project',
+				'default' => 1,
 			],
 			'runFullUpdate' => [
 				'property' => 'runFullUpdate',


### PR DESCRIPTION
For the Palace Project, libraries can choose whether to require a PIN for login; Aspen should support this. 

To Test:
1. Apply the PR.
2. If Palace Project is set to not require PIN: 
    - On Aspen, in Palace Project Settings, check “Require PIN for Palace Project”. Try a checkout and see the error message "A valid library card barcode number and PIN are required."
    - Uncheck “Require PIN for Palace Project”. Try a checkout and confirm it succeeds.
3. If Palace Project is set to require PIN: 
    - On Aspen, in Palace Project Settings, check “Require PIN for Palace Project”. Try a checkout and confirm it succeeds.
    - Uncheck “Require PIN for Palace Project”. Try a checkout and see the error message "A valid library card barcode number and PIN are required."
