### PR TITLE
DIS-1439 Aspen Api Improvements

### DIFF
--- a/code/web/Action.php
+++ b/code/web/Action.php
@@ -129,12 +129,39 @@ abstract class Action
 		die();
 	}
 
-	protected function grantTokenAccess() : bool {
-		$key1 = base64_decode($_SERVER['PHP_AUTH_USER']);
-		$key2 = base64_decode($_SERVER['PHP_AUTH_PW']);
+	protected function extractOAuthCredentials(): void {
+		if (!isset($_SERVER['PHP_AUTH_USER']) && (isset($_SERVER['HTTP_AUTHORIZATION']) || isset($_SERVER['REDIRECT_HTTP_AUTHORIZATION']))) {
+			$authHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ?? '';
+			if (preg_match('/^Basic\s+(.*)$/i', $authHeader, $matches)) {
+				$credentials = base64_decode($matches[1]);
+				if (strpos($credentials, ':') !== false) {
+					list($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']) = explode(':', $credentials, 2);
+				}
+			}
+		}
+	}
+
+	protected function validateTokenCredentials(): bool {
+		$this->extractOAuthCredentials();
+
+		$key1 = $_SERVER['PHP_AUTH_USER'] ?? '';
+		$key2 = $_SERVER['PHP_AUTH_PW'] ?? '';
 		if (empty($key1) || empty($key2)) {
 			return false;
 		}
+
+		require_once ROOT_DIR . '/sys/Account/UserOAuthKey.php';
+		if (UserOAuthKey::isOAuthEnabled()) {
+			$user = UserOAuthKey::validateCredentials($key1, $key2);
+			if ($user !== false) {
+				global $oAuthUser;
+				$oAuthUser = $user;
+				return true;
+			}
+		}
+
+		$key1 = base64_decode($key1);
+		$key2 = base64_decode($key2);
 
 		if (method_exists($this, 'getLiDASlug')){
 			$lidaSlug = $this->getLiDASlug();
@@ -210,6 +237,21 @@ abstract class Action
 		}
 
 		return false;
+	}
+
+	protected function grantTokenAccess(): bool {
+		if (!$this->validateTokenCredentials()) {
+			return false;
+		}
+		
+		global $oAuthUser;
+		if (isset($oAuthUser) && $oAuthUser !== false) {
+			if (!$oAuthUser->hasPermission('Use All API Endpoints')) {
+				return false;
+			}
+		}
+		
+		return true;
 	}
 
 	abstract function getBreadcrumbs() : array;

--- a/code/web/index.php
+++ b/code/web/index.php
@@ -428,6 +428,11 @@ if ($isLoggedIn) {
 	$userIsStaff = $activeUserObject->isStaff();
 	$interface->assign('userIsStaff', $userIsStaff);
 	$interface->assign('showResetUsernameLink', $activeUserObject->showResetUsernameLink());
+
+	require_once ROOT_DIR . '/sys/Account/UserOAuthKey.php';
+	$enableUserOAuth = UserOAuthKey::isOAuthEnabled();
+	$interface->assign('enableUserOAuth', $enableUserOAuth);
+	$interface->assign('canUseApiKeys', $enableUserOAuth && $activeUserObject->hasPermission('Use API Keys'));
 } elseif ((isset($_POST['username']) && isset($_POST['password']) && ($action != 'Account' && $module != 'AJAX') && ($module != 'API')) || isset($_REQUEST['casLogin'])) {
 	//The user is trying to log in
 	try {

--- a/code/web/interface/themes/responsive/MyAccount/account-sidebar.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/account-sidebar.tpl
@@ -292,6 +292,9 @@
 								{if !empty($userIsStaff)}
 									<div class="myAccountLink"><a href="/MyAccount/StaffSettings">{translate text='Staff Settings' isPublicFacing=true}</a></div>
 								{/if}
+							{if !empty($canUseApiKeys)}
+								<div class="myAccountLink"><a href="/MyAccount/OAuthKeys">{translate text='API Keys' isPublicFacing=true}</a></div>
+							{/if}
 							{/if}
 						</div>
 					</div>

--- a/code/web/interface/themes/responsive/MyAccount/generateOAuthKeyForm.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/generateOAuthKeyForm.tpl
@@ -1,0 +1,6 @@
+{strip}
+	<div class="form-group">
+		<label for="keyName">{translate text="Key Name (e.g., \"Mobile App\", \"Third Party Service\")" isPublicFacing=true}</label>
+		<input type="text" class="form-control" id="keyName" name="keyName" placeholder="{translate text='Enter a descriptive name' isPublicFacing=true inAttribute=true}">
+	</div>
+{/strip}

--- a/code/web/interface/themes/responsive/MyAccount/oauthKeys.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/oauthKeys.tpl
@@ -1,0 +1,178 @@
+{strip}
+	<div id="main-content" class="col-md-12">
+		<h1>{translate text="API Keys" isPublicFacing=true}</h1>
+
+		{if !empty($error)}
+			<div class="alert alert-danger">{$error}</div>
+		{else}
+			<p>{translate text="API keys allow you to access Aspen Discovery's API with your user permissions. Keys are tied to your account and should be kept secure." isPublicFacing=true}</p>
+			<div class="alert alert-info">
+				<strong>{translate text="Usage:" isPublicFacing=true}</strong> {translate text="Include your credentials in the Authorization header as:" isPublicFacing=true} <code>Authorization: Basic &lt;base64-encoded clientId:clientSecret&gt;</code>
+			</div>
+
+			<div class="btn-toolbar" style="margin-bottom: 15px;">
+				<button class="btn btn-primary" onclick="AspenDiscovery.Account.showGenerateOAuthKeyForm()">
+					<i class="fas fa-plus"></i> {translate text="Generate New API Key" isPublicFacing=true}
+				</button>
+			</div>
+
+			{if $oauthKeys && count($oauthKeys) > 0}
+				<table class="table table-striped table-bordered">
+					<thead>
+						<tr>
+							<th>{translate text="Key Name" isPublicFacing=true}</th>
+							<th>{translate text="Client ID" isPublicFacing=true}</th>
+							<th>{translate text="Created" isPublicFacing=true}</th>
+							<th>{translate text="Last Used" isPublicFacing=true}</th>
+							<th>{translate text="Status" isPublicFacing=true}</th>
+							<th>{translate text="Actions" isPublicFacing=true}</th>
+						</tr>
+					</thead>
+					<tbody>
+						{foreach from=$oauthKeys item=key}
+							<tr id="oauth-key-{$key->id}">
+								<td>{$key->keyName}</td>
+								<td><code>{$key->clientId}</code></td>
+								<td>{$key->created|date_format:"%Y-%m-%d %H:%M"}</td>
+								<td>
+									{if $key->lastUsed}
+										{$key->lastUsed|date_format:"%Y-%m-%d %H:%M"}
+									{else}
+										{translate text="Never" isPublicFacing=true}
+									{/if}
+								</td>
+								<td>
+									<span id="status-{$key->id}" class="badge {if $key->isActive}badge-success{else}badge-secondary{/if}">
+										{if $key->isActive}{translate text="Active" isPublicFacing=true}{else}{translate text="Inactive" isPublicFacing=true}{/if}
+									</span>
+								</td>
+								<td>
+									<div class="btn-group btn-group-sm">
+										<button class="btn btn-sm btn-default" onclick="AspenDiscovery.Account.toggleOAuthKey({$key->id})" title="{translate text='Toggle Active/Inactive' inAttribute=true isPublicFacing=true}">
+											<i class="fas fa-toggle-on"></i>
+										</button>
+										<button class="btn btn-sm btn-danger" onclick="AspenDiscovery.Account.revokeOAuthKey({$key->id})" title="{translate text='Delete Key' inAttribute=true isPublicFacing=true}">
+											<i class="fas fa-trash"></i>
+										</button>
+									</div>
+								</td>
+							</tr>
+						{/foreach}
+					</tbody>
+				</table>
+			{else}
+				<div class="alert alert-info">
+					{translate text="You don't have any API keys yet. Generate one to get started." isPublicFacing=true}
+				</div>
+			{/if}
+		{/if}
+	</div>
+{/strip}
+
+{literal}
+<script type="text/javascript">
+	if (typeof AspenDiscovery.Account === 'undefined') {
+		AspenDiscovery.Account = {};
+	}
+
+	AspenDiscovery.Account.showGenerateOAuthKeyForm = function() {
+		var url = Globals.path + "/MyAccount/AJAX";
+		var params = {method: "getGenerateOAuthKeyForm"};
+		$.getJSON(url, params, function(data) {
+			AspenDiscovery.showMessageWithButtons(data.title, data.modalBody, data.modalButtons);
+		}).fail(AspenDiscovery.ajaxFail);
+		return false;
+	};
+
+	AspenDiscovery.Account.generateOAuthKey = function() {
+		var keyName = $('#keyName').val();
+		if (!keyName) {
+			AspenDiscovery.showMessage('Error', 'Please enter a key name');
+			return false;
+		}
+
+		var url = Globals.path + "/MyAccount/AJAX";
+		var params = {
+			method: 'generateOAuthKey',
+			keyName: keyName
+		};
+
+		$.getJSON(url, params, function(data) {
+			if (data.success) {
+				var credentials = data.clientId + ':' + data.clientSecret;
+				var encodedCredentials = btoa(credentials);
+				var messageBody = '<div class="alert alert-warning"><strong>Save these credentials now. You will not be able to see the secret again!</strong></div>' +
+					'<div class="form-group">' +
+					'<label>Client ID:</label>' +
+					'<input type="text" class="form-control" value="' + data.clientId + '" readonly onclick="this.select()">' +
+					'</div>' +
+					'<div class="form-group">' +
+					'<label>Client Secret:</label>' +
+					'<input type="text" class="form-control" value="' + data.clientSecret + '" readonly onclick="this.select()">' +
+					'</div>' +
+					'<hr>' +
+					'<div class="form-group">' +
+					'<label>Authorization Header:</label>' +
+					'<input type="text" class="form-control" value="Basic ' + encodedCredentials + '" readonly onclick="this.select()">' +
+					'<p class="help-block">Use this value in the <code>Authorization</code> header when making API requests.</p>' +
+					'</div>' +
+					'<p class="help-block">Click the fields above to select and copy the values.</p>';
+				AspenDiscovery.showMessage('API Key Generated', messageBody, false, true);
+			} else {
+				AspenDiscovery.showMessage('Error', data.message);
+			}
+		}).fail(AspenDiscovery.ajaxFail);
+
+		return false;
+	};
+
+	AspenDiscovery.Account.toggleOAuthKey = function(keyId) {
+		var url = Globals.path + "/MyAccount/AJAX";
+		var params = {
+			method: 'toggleOAuthKey',
+			keyId: keyId
+		};
+
+		$.getJSON(url, params, function(data) {
+			if (data.success) {
+				var statusBadge = $('#status-' + keyId);
+				if (data.isActive) {
+					statusBadge.removeClass('badge-secondary').addClass('badge-success').text('Active');
+				} else {
+					statusBadge.removeClass('badge-success').addClass('badge-secondary').text('Inactive');
+				}
+				AspenDiscovery.showMessage('Success', data.message);
+			} else {
+				AspenDiscovery.showMessage('Error', data.message);
+			}
+		}).fail(AspenDiscovery.ajaxFail);
+
+		return false;
+	};
+
+	AspenDiscovery.Account.revokeOAuthKey = function(keyId) {
+		if (!confirm('Are you sure you want to delete this API key? This action cannot be undone.')) {
+			return false;
+		}
+
+		var url = Globals.path + "/MyAccount/AJAX";
+		var params = {
+			method: 'revokeOAuthKey',
+			keyId: keyId
+		};
+
+		$.getJSON(url, params, function(data) {
+			if (data.success) {
+				$('#oauth-key-' + keyId).fadeOut(function() {
+					$(this).remove();
+				});
+				AspenDiscovery.showMessage('Success', data.message);
+			} else {
+				AspenDiscovery.showMessage('Error', data.message);
+			}
+		}).fail(AspenDiscovery.ajaxFail);
+
+		return false;
+	};
+</script>
+{/literal}

--- a/code/web/interface/themes/responsive/account-menu.tpl
+++ b/code/web/interface/themes/responsive/account-menu.tpl
@@ -136,6 +136,9 @@
 			{if !empty($userIsStaff)}
 				<div class="header-menu-option" ><a href="/MyAccount/StaffSettings">{translate text='Staff Settings' isPublicFacing=true}</a></div>
 			{/if}
+			{if !empty($canUseApiKeys)}
+				<div class="header-menu-option" ><a href="/MyAccount/OAuthKeys">{translate text='API Keys' isPublicFacing=true}</a></div>
+			{/if}
 
 			{if !empty($allowMasqueradeMode) && !$masqueradeMode}
 				{if !empty($canMasquerade)}

--- a/code/web/interface/themes/responsive/header-menu.tpl
+++ b/code/web/interface/themes/responsive/header-menu.tpl
@@ -133,6 +133,15 @@
 			{/if}
 		{/foreach}
 	{/if}
+	{if !empty($canUseApiKeys)}
+		<a href="/MyAccount/OAuthKeys">
+			<div class="header-menu-option">
+				<i class="fas fa-key fa-fw" role="presentation"></i>
+				<span>{translate text='API Keys' isPublicFacing=true}</span>
+			</div>
+		</a>
+	{/if}
+
 	{if !empty($masqueradeMode)}
 		<a class="btn btn-default btn-sm btn-block" onclick="AspenDiscovery.Account.endMasquerade()">{translate text="End Masquerade" isAdminFacing=true}</a>
 	{/if}

--- a/code/web/openapi/TestAPI_openapi.json
+++ b/code/web/openapi/TestAPI_openapi.json
@@ -1,0 +1,60 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test API",
+    "description": "Test API for validating OpenAPI-driven authorization",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "ping": {
+      "get": {
+        "summary": "Public endpoint - no auth required",
+        "x-aspen-authorization": {
+          "public": true
+        }
+      }
+    },
+    "whoami": {
+      "get": {
+        "summary": "Returns authenticated user info",
+        "x-aspen-authorization": {
+          "scope": "user"
+        }
+      }
+    },
+    "appInfo": {
+      "get": {
+        "summary": "Greenhouse/LiDA apps only",
+        "x-aspen-authorization": {
+          "scope": "greenhouse"
+        }
+      }
+    },
+    "adminCheck": {
+      "get": {
+        "summary": "Requires specific permission",
+        "x-aspen-authorization": {
+          "scope": "user",
+          "permissions": ["Administer All Collection Spotlights"]
+        }
+      }
+    },
+    "flexibleAuth": {
+      "get": {
+        "summary": "Accepts user OR greenhouse auth",
+        "x-aspen-authorization": {
+          "scope": ["user", "greenhouse"]
+        }
+      }
+    },
+    "noIpAccess": {
+      "get": {
+        "summary": "Blocked from IP whitelist access",
+        "x-aspen-authorization": {
+          "scope": "user",
+          "ipAllowed": false
+        }
+      }
+    }
+  }
+}

--- a/code/web/services/API/AbstractAPI.php
+++ b/code/web/services/API/AbstractAPI.php
@@ -176,4 +176,26 @@ abstract class AbstractAPI extends Action{
 			}
 		}
 	}
+
+	protected function getAuthenticatedUserForOpenAPI() {
+		global $oAuthUser;
+		if (isset($oAuthUser) && $oAuthUser !== false) {
+			if ($oAuthUser->source == 'admin') {
+				return false;
+			}
+			return $oAuthUser;
+		}
+		
+		if (isset($_SERVER['PHP_AUTH_USER'])) {
+			if ($this->grantTokenAccess()) {
+				global $oAuthUser;
+				if ($oAuthUser->source == 'admin') {
+					return false;
+				}
+				return $oAuthUser;
+			}
+		}
+		
+		return false;
+	}
 }

--- a/code/web/services/API/AbstractAPI.php
+++ b/code/web/services/API/AbstractAPI.php
@@ -12,6 +12,9 @@ abstract class AbstractAPI extends Action{
 		if ($this->checkIfLiDA()) {
 			$this->context = 'lida';
 		}
+		if (empty($this->apiName)) {
+			$this->apiName = (new ReflectionClass($this))->getShortName();
+		}
 	}
 
 	function checkIfLiDA(): bool {

--- a/code/web/services/API/AbstractAPI.php
+++ b/code/web/services/API/AbstractAPI.php
@@ -121,9 +121,7 @@ abstract class AbstractAPI extends Action{
 
 		global $oAuthUser;
 		if (isset($oAuthUser) && $oAuthUser !== false) {
-			if ($oAuthUser->source == 'admin') {
-				return false;
-			}
+			// Note: 'Use All API Endpoints' permission is checked in grantTokenAccess()
 
 			if (empty($_REQUEST['language'])) {
 				global $activeLanguage;
@@ -177,26 +175,42 @@ abstract class AbstractAPI extends Action{
 		}
 	}
 
-	protected function getAuthenticatedUserForOpenAPI() {
+	/**
+	 * Get authentication info for OpenAPI authorization
+	 * @return array ['user' => User|false, 'greenhouseAuth' => bool]
+	 */
+	protected function getAuthInfoForOpenAPI(): array {
 		global $oAuthUser;
+		
+		// Check if already authenticated via OAuth
 		if (isset($oAuthUser) && $oAuthUser !== false) {
-			if ($oAuthUser->source == 'admin') {
-				return false;
-			}
-			return $oAuthUser;
+			return ['user' => $oAuthUser, 'greenhouseAuth' => false];
 		}
 		
+		// Try to authenticate via Basic auth
+		// Use validateTokenCredentials() - OpenAPI authorizer handles permissions
 		if (isset($_SERVER['PHP_AUTH_USER'])) {
-			if ($this->grantTokenAccess()) {
+			if ($this->validateTokenCredentials()) {
 				global $oAuthUser;
-				if ($oAuthUser->source == 'admin') {
-					return false;
+				if (isset($oAuthUser) && $oAuthUser !== false) {
+					// OAuth authentication succeeded - we have a user
+					return ['user' => $oAuthUser, 'greenhouseAuth' => false];
+				} else {
+					// Greenhouse/LiDA keys - authorized but no user
+					return ['user' => false, 'greenhouseAuth' => true];
 				}
-				return $oAuthUser;
 			}
 		}
 		
-		return false;
+		return ['user' => false, 'greenhouseAuth' => false];
+	}
+	
+	/**
+	 * @deprecated Use getAuthInfoForOpenAPI() instead
+	 */
+	protected function getAuthenticatedUserForOpenAPI() {
+		$authInfo = $this->getAuthInfoForOpenAPI();
+		return $authInfo['user'];
 	}
 
 	protected function sendErrorResponse(string $error, int $code, ?string $message = null): void {
@@ -255,11 +269,13 @@ abstract class AbstractAPI extends Action{
 		$this->extractOAuthCredentials();
 		$this->extractBasicAuthCredentials();
 		
-		$user = $this->getAuthenticatedUserForOpenAPI();
+		$authInfo = $this->getAuthInfoForOpenAPI();
+		$user = $authInfo['user'];
+		$greenhouseAuth = $authInfo['greenhouseAuth'];
 		$ipAllowed = IPAddress::allowAPIAccessForClientIP();
 		
 		require_once ROOT_DIR . '/sys/API/OpenAPIAuthorizer.php';
-		$authResult = OpenAPIAuthorizer::authorize($this->apiName, $method, $user, $ipAllowed);
+		$authResult = OpenAPIAuthorizer::authorize($this->apiName, $method, $user, $ipAllowed, $greenhouseAuth);
 		
 		if (!$authResult['allowed']) {
 			$this->sendErrorResponse($authResult['error'], $authResult['code'], $authResult['message'] ?? null);
@@ -267,7 +283,7 @@ abstract class AbstractAPI extends Action{
 		}
 		
 		$this->authorizedUser = $user;
-		$this->authorizedScope = $authResult['scope'] ?? 'patron';
+		$this->authorizedScope = $authResult['scope'] ?? 'user';
 		
 		if (!method_exists($this, $method)) {
 			$this->sendErrorResponse('method_not_implemented', 501, "Method '$method' is defined but not implemented");
@@ -285,7 +301,7 @@ abstract class AbstractAPI extends Action{
 		return $this->authorizedScope;
 	}
 
-	protected function isStaffScope(): bool {
-		return $this->authorizedScope === 'staff';
+	protected function isSuperuserScope(): bool {
+		return $this->authorizedScope === 'superuser';
 	}
 }

--- a/code/web/services/API/AbstractAPI.php
+++ b/code/web/services/API/AbstractAPI.php
@@ -276,4 +276,16 @@ abstract class AbstractAPI extends Action{
 		
 		$this->executeAPIMethod($method);
 	}
+
+	protected function getAuthorizedUser() {
+		return $this->authorizedUser;
+	}
+
+	protected function getAuthorizedScope(): string {
+		return $this->authorizedScope;
+	}
+
+	protected function isStaffScope(): bool {
+		return $this->authorizedScope === 'staff';
+	}
 }

--- a/code/web/services/API/AbstractAPI.php
+++ b/code/web/services/API/AbstractAPI.php
@@ -198,4 +198,30 @@ abstract class AbstractAPI extends Action{
 		
 		return false;
 	}
+
+	protected function sendErrorResponse(string $error, int $code, ?string $message = null): void {
+		http_response_code($code);
+		header('Cache-Control: no-cache, must-revalidate');
+		
+		$response = ['error' => $error];
+		if ($message !== null) {
+			$response['message'] = $message;
+		}
+		
+		$output = json_encode($response);
+		
+		$method = $_GET['method'] ?? 'unknown';
+		ExternalRequestLogEntry::logRequest(
+			$this->apiName . '.' . $method,
+			$_SERVER['REQUEST_METHOD'],
+			$_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'],
+			getallheaders(),
+			'',
+			$code,
+			$output,
+			[]
+		);
+		
+		echo $output;
+	}
 }

--- a/code/web/services/API/AbstractAPI.php
+++ b/code/web/services/API/AbstractAPI.php
@@ -239,11 +239,46 @@ abstract class AbstractAPI extends Action{
 		echo $output;
 	}
 
-	protected function executeAPIMethod(string $method): void {
+	protected function executeAPIMethod(string $method, array $responseConfig = []): void {
 		require_once ROOT_DIR . '/sys/SystemLogging/APIUsage.php';
 		APIUsage::incrementStat($this->apiName, $method);
 		
-		$output = json_encode(['result' => $this->$method()]);
+		// Set content type header (can be overridden by response config)
+		$contentType = $responseConfig['contentType'] ?? 'application/json';
+		header('Content-type: ' . $contentType);
+		
+		// Set cache control - default to 3 hours, override with cacheMaxAge or noCache
+		if (!empty($responseConfig['noCache'])) {
+			header('Cache-Control: no-cache, must-revalidate');
+		} else {
+			$cacheMaxAge = $responseConfig['cacheMaxAge'] ?? 10800; // Default 3 hours
+			header('Cache-Control: max-age=' . (int)$cacheMaxAge);
+		}
+		
+		// Check if this is a raw response (no JSON wrapping)
+		$isRaw = !empty($responseConfig['raw']);
+		
+		if ($isRaw) {
+			// For raw responses, let the method handle output directly
+			// (e.g., getLogoFile outputs binary data and calls die())
+			$result = $this->$method();
+			
+			// If method returned something and didn't die(), output it
+			if ($result !== null && $result !== '') {
+				// Add XML declaration if needed
+				if (!empty($responseConfig['xmlDeclaration'])) {
+					echo '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
+				}
+				$output = $result;
+				echo $output;
+			} else {
+				$output = '';
+			}
+		} else {
+			// Standard JSON response
+			$output = json_encode(['result' => $this->$method()]);
+			echo $output;
+		}
 		
 		ExternalRequestLogEntry::logRequest(
 			$this->apiName . '.' . $method,
@@ -255,14 +290,12 @@ abstract class AbstractAPI extends Action{
 			$output,
 			[]
 		);
-		
-		echo $output;
 	}
 
 	protected function launchWithOpenAPI(): void {
 		$method = (isset($_GET['method']) && !is_array($_GET['method'])) ? $_GET['method'] : '';
 		
-		header('Content-type: application/json');
+		// Don't set Content-type here - let executeAPIMethod handle it based on response config
 		header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 		
 		$this->setActiveLanguage();
@@ -278,6 +311,7 @@ abstract class AbstractAPI extends Action{
 		$authResult = OpenAPIAuthorizer::authorize($this->apiName, $method, $user, $ipAllowed, $greenhouseAuth);
 		
 		if (!$authResult['allowed']) {
+			header('Content-type: application/json');
 			$this->sendErrorResponse($authResult['error'], $authResult['code'], $authResult['message'] ?? null);
 			return;
 		}
@@ -286,11 +320,15 @@ abstract class AbstractAPI extends Action{
 		$this->authorizedScope = $authResult['scope'] ?? 'user';
 		
 		if (!method_exists($this, $method)) {
+			header('Content-type: application/json');
 			$this->sendErrorResponse('method_not_implemented', 501, "Method '$method' is defined but not implemented");
 			return;
 		}
 		
-		$this->executeAPIMethod($method);
+		// Get response configuration from OpenAPI spec
+		$responseConfig = OpenAPIAuthorizer::getResponseConfig($this->apiName, $method);
+		
+		$this->executeAPIMethod($method, $responseConfig);
 	}
 
 	protected function getAuthorizedUser() {

--- a/code/web/services/API/AbstractAPI.php
+++ b/code/web/services/API/AbstractAPI.php
@@ -72,6 +72,18 @@ abstract class AbstractAPI extends Action{
 		return false;
 	}
 
+	protected function extractBasicAuthCredentials(): void {
+		if (!isset($_SERVER['PHP_AUTH_USER']) && (isset($_SERVER['HTTP_AUTHORIZATION']) || isset($_SERVER['REDIRECT_HTTP_AUTHORIZATION']))) {
+			$authHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ?? '';
+			if (preg_match('/^Basic\s+(.*)$/i', $authHeader, $matches)) {
+				$credentials = base64_decode($matches[1]);
+				if (strpos($credentials, ':') !== false) {
+					list($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']) = explode(':', $credentials, 2);
+				}
+			}
+		}
+	}
+
 	/**
 	 * @return array
 	 * @noinspection PhpUnused
@@ -98,6 +110,30 @@ abstract class AbstractAPI extends Action{
 	 * @return bool|User
 	 */
 	function getUserForApiCall() {
+		$this->extractBasicAuthCredentials();
+
+		global $oAuthUser;
+		if (isset($oAuthUser) && $oAuthUser !== false) {
+			if ($oAuthUser->source == 'admin') {
+				return false;
+			}
+
+			if (empty($_REQUEST['language'])) {
+				global $activeLanguage;
+				global $translator;
+				$userLanguage = new Language();
+				$userLanguage->code = $oAuthUser->interfaceLanguage;
+				if ($userLanguage->find(true)) {
+					if ($userLanguage->code != $activeLanguage->code) {
+						$activeLanguage = $userLanguage;
+						$translator = new Translator('lang', $userLanguage->code);
+					}
+				}
+			}
+
+			return $oAuthUser;
+		}
+
 		$user = false;
 		[$username, $password] = $this->loadUsernameAndPassword();
 		$user = UserAccount::validateAccount($username, $password);

--- a/code/web/services/API/AbstractAPI.php
+++ b/code/web/services/API/AbstractAPI.php
@@ -244,4 +244,36 @@ abstract class AbstractAPI extends Action{
 		
 		echo $output;
 	}
+
+	protected function launchWithOpenAPI(): void {
+		$method = (isset($_GET['method']) && !is_array($_GET['method'])) ? $_GET['method'] : '';
+		
+		header('Content-type: application/json');
+		header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+		
+		$this->setActiveLanguage();
+		$this->extractOAuthCredentials();
+		$this->extractBasicAuthCredentials();
+		
+		$user = $this->getAuthenticatedUserForOpenAPI();
+		$ipAllowed = IPAddress::allowAPIAccessForClientIP();
+		
+		require_once ROOT_DIR . '/sys/API/OpenAPIAuthorizer.php';
+		$authResult = OpenAPIAuthorizer::authorize($this->apiName, $method, $user, $ipAllowed);
+		
+		if (!$authResult['allowed']) {
+			$this->sendErrorResponse($authResult['error'], $authResult['code'], $authResult['message'] ?? null);
+			return;
+		}
+		
+		$this->authorizedUser = $user;
+		$this->authorizedScope = $authResult['scope'] ?? 'patron';
+		
+		if (!method_exists($this, $method)) {
+			$this->sendErrorResponse('method_not_implemented', 501, "Method '$method' is defined but not implemented");
+			return;
+		}
+		
+		$this->executeAPIMethod($method);
+	}
 }

--- a/code/web/services/API/AbstractAPI.php
+++ b/code/web/services/API/AbstractAPI.php
@@ -224,4 +224,24 @@ abstract class AbstractAPI extends Action{
 		
 		echo $output;
 	}
+
+	protected function executeAPIMethod(string $method): void {
+		require_once ROOT_DIR . '/sys/SystemLogging/APIUsage.php';
+		APIUsage::incrementStat($this->apiName, $method);
+		
+		$output = json_encode(['result' => $this->$method()]);
+		
+		ExternalRequestLogEntry::logRequest(
+			$this->apiName . '.' . $method,
+			$_SERVER['REQUEST_METHOD'],
+			$_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'],
+			getallheaders(),
+			'',
+			$_SERVER['REDIRECT_STATUS'] ?? 200,
+			$output,
+			[]
+		);
+		
+		echo $output;
+	}
 }

--- a/code/web/services/API/AbstractAPI.php
+++ b/code/web/services/API/AbstractAPI.php
@@ -2,6 +2,10 @@
 
 abstract class AbstractAPI extends Action{
 	protected $context;
+	protected string $apiName = '';
+	protected $authorizedUser = false;
+	protected string $authorizedScope = '';
+	
 	function __construct($context = 'external') {
 		parent::__construct(false);
 		$this->context = $context;

--- a/code/web/services/API/AbstractAPI.php
+++ b/code/web/services/API/AbstractAPI.php
@@ -165,4 +165,15 @@ abstract class AbstractAPI extends Action{
 
 		return $user;
 	}
+
+	protected function setActiveLanguage(): void {
+		global $activeLanguage;
+		if (isset($_GET['language'])) {
+			$language = new Language();
+			$language->code = $_GET['language'];
+			if ($language->find(true)) {
+				$activeLanguage = $language;
+			}
+		}
+	}
 }

--- a/code/web/services/API/SearchAPI.php
+++ b/code/web/services/API/SearchAPI.php
@@ -22,6 +22,8 @@ class SearchAPI extends AbstractAPI {
 			}
 		}
 
+		$this->extractOAuthCredentials();
+
 		//Check if user can access API with keys sent from LiDA
 		if (isset($_SERVER['PHP_AUTH_USER'])) {
 			if ($this->grantTokenAccess()) {

--- a/code/web/services/API/SystemAPI.php
+++ b/code/web/services/API/SystemAPI.php
@@ -396,8 +396,10 @@ class SystemAPI extends AbstractAPI {
 		$pay360Updates = getPay360Updates();
 		require_once ROOT_DIR . '/sys/DBMaintenance/gale_updates.php';
 		$galeUpdates = getGaleUpdates();
+		require_once ROOT_DIR . '/sys/DBMaintenance/api_oauth_updates.php';
+		$apiOAuthUpdates = getApiOAuthUpdates();
 
-		$baseUpdates = array_merge($library_location_updates, $summonUpdates, $cloudLibraryUpdates, $grapesWebBuilderUpdates, $communityEngagementUpdates, $talpaUpdates, $heycentricUpdates, $hooplaVersion2Updates, $pay360Updates, $galeUpdates);
+		$baseUpdates = array_merge($library_location_updates, $summonUpdates, $cloudLibraryUpdates, $grapesWebBuilderUpdates, $communityEngagementUpdates, $talpaUpdates, $heycentricUpdates, $hooplaVersion2Updates, $pay360Updates, $galeUpdates, $apiOAuthUpdates);
 
 		//Get version updates
 		require_once ROOT_DIR . '/sys/Utils/StringUtils.php';

--- a/code/web/services/API/TestAPI.php
+++ b/code/web/services/API/TestAPI.php
@@ -1,0 +1,111 @@
+<?php
+
+require_once ROOT_DIR . '/services/API/AbstractAPI.php';
+
+/**
+ * Test API for validating OpenAPI-driven authorization
+ * 
+ * This API uses the new launchWithOpenAPI() flow for spec-driven auth.
+ * Used for testing the OAuth permission system.
+ */
+class TestAPI extends AbstractAPI {
+	
+	function launch(): void {
+		$this->launchWithOpenAPI();
+	}
+
+	/**
+	 * Public endpoint - no authentication required
+	 */
+	function ping(): array {
+		return [
+			'success' => true,
+			'message' => 'pong',
+			'timestamp' => time(),
+			'scope' => $this->getAuthorizedScope()
+		];
+	}
+
+	/**
+	 * Authenticated endpoint - requires valid OAuth or Greenhouse auth
+	 */
+	function whoami(): array {
+		$user = $this->getAuthorizedUser();
+		
+		if ($user === false || $user === null) {
+			return [
+				'success' => true,
+				'authenticated' => false,
+				'scope' => $this->getAuthorizedScope(),
+				'message' => 'No user context (app-level or IP auth)'
+			];
+		}
+		
+		return [
+			'success' => true,
+			'authenticated' => true,
+			'scope' => $this->getAuthorizedScope(),
+			'user' => [
+				'id' => $user->id,
+				'username' => $user->username ?? $user->ils_barcode ?? 'unknown',
+				'displayName' => $user->displayName ?? $user->firstname . ' ' . $user->lastname
+			]
+		];
+	}
+
+	/**
+	 * Greenhouse-only endpoint
+	 */
+	function appInfo(): array {
+		return [
+			'success' => true,
+			'scope' => $this->getAuthorizedScope(),
+			'message' => 'This endpoint is for Greenhouse/LiDA apps only',
+			'serverTime' => date('c')
+		];
+	}
+
+	/**
+	 * Endpoint requiring specific permission
+	 */
+	function adminCheck(): array {
+		$user = $this->getAuthorizedUser();
+		
+		return [
+			'success' => true,
+			'scope' => $this->getAuthorizedScope(),
+			'message' => 'You have the required permission',
+			'user' => $user ? ($user->displayName ?? $user->username) : 'superuser'
+		];
+	}
+
+	/**
+	 * Endpoint that allows both user and greenhouse auth
+	 */
+	function flexibleAuth(): array {
+		$user = $this->getAuthorizedUser();
+		$scope = $this->getAuthorizedScope();
+		
+		return [
+			'success' => true,
+			'scope' => $scope,
+			'authMethod' => $user ? 'user' : 'app',
+			'message' => "Authenticated via $scope scope"
+		];
+	}
+
+	/**
+	 * Endpoint blocked from IP access
+	 */
+	function noIpAccess(): array {
+		return [
+			'success' => true,
+			'scope' => $this->getAuthorizedScope(),
+			'message' => 'IP whitelist cannot access this endpoint'
+		];
+	}
+
+	function getBreadcrumbs(): array {
+		return [];
+	}
+}

--- a/code/web/services/API/UserAPI.php
+++ b/code/web/services/API/UserAPI.php
@@ -30,6 +30,8 @@ class UserAPI extends AbstractAPI {
 			}
 		}
 
+		$this->extractBasicAuthCredentials();
+
 		if (isset($_SERVER['PHP_AUTH_USER'])) {
 			if ($this->grantTokenAccess()) {
 				if (in_array($method, [

--- a/code/web/services/API/UserAPI.php
+++ b/code/web/services/API/UserAPI.php
@@ -5021,6 +5021,20 @@ class UserAPI extends AbstractAPI {
 	 * @return bool|User
 	 */
 	function getUserForApiCall(?String $patronBarcode = null, ?String $patronPassword = null) : bool|User {
+		// Check for OAuth-authenticated user first
+		global $oAuthUser;
+		if (isset($oAuthUser) && $oAuthUser !== false) {
+			if ($oAuthUser->source == 'admin') {
+				return false;
+			}
+			return $oAuthUser;
+		}
+		
+		// Also check if we have an authorized user from OpenAPI flow
+		if ($this->authorizedUser !== false) {
+			return $this->authorizedUser;
+		}
+		
 		if ($this->context == 'internal') {
 			if ($patronBarcode == null && $patronPassword == null) {
 				return UserAccount::getActiveUserObj();

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -11753,6 +11753,31 @@ class MyAccount_AJAX extends JSON_Action {
 	}
 
 	/** @noinspection PhpUnused */
+	function getGenerateOAuthKeyForm(): array {
+		global $interface;
+
+		$user = UserAccount::getLoggedInUser();
+		if (!$user || !$user->hasPermission('Use API Keys')) {
+			return [
+				'success' => false,
+				'message' => 'You do not have permission to manage API keys',
+			];
+		}
+
+		return [
+			'title' => translate([
+				'text' => 'Generate API Key',
+				'isPublicFacing' => true,
+			]),
+			'modalBody' => $interface->fetch("MyAccount/generateOAuthKeyForm.tpl"),
+			'modalButtons' => "<button type='button' class='tool btn btn-primary' onclick='AspenDiscovery.Account.generateOAuthKey(); return false;'>" . translate([
+				'text' => 'Generate',
+				'isPublicFacing' => true,
+			]) . "</button>",
+		];
+	}
+
+	/** @noinspection PhpUnused */
 	function deleteListGroup(): array {
 		$result = [
 			'success' => false,
@@ -11834,6 +11859,190 @@ class MyAccount_AJAX extends JSON_Action {
 		}
 
 		return $result;
+	}
 
+	/** @noinspection PhpUnused */
+	function generateOAuthKey(): array {
+		$user = UserAccount::getLoggedInUser();
+		if (!$user) {
+			return [
+				'success' => false,
+				'message' => 'You must be logged in to generate OAuth keys',
+			];
+		}
+
+		require_once ROOT_DIR . '/sys/Account/UserOAuthKey.php';
+		if (!UserOAuthKey::isOAuthEnabled()) {
+			return [
+				'success' => false,
+				'message' => 'OAuth key generation is not enabled',
+			];
+		}
+
+		if (!$user->hasPermission('Use API Keys')) {
+			return [
+				'success' => false,
+				'message' => 'You do not have permission to manage API keys',
+			];
+		}
+
+		$keyName = $_REQUEST['keyName'] ?? 'API Key';
+
+		$result = UserOAuthKey::generateKeys($user->id, $keyName);
+		return $result;
+	}
+
+	/** @noinspection PhpUnused */
+	function getOAuthKeys(): array {
+		$user = UserAccount::getLoggedInUser();
+		if (!$user) {
+			return [
+				'success' => false,
+				'message' => 'You must be logged in to view OAuth keys',
+			];
+		}
+
+		require_once ROOT_DIR . '/sys/Account/UserOAuthKey.php';
+		if (!UserOAuthKey::isOAuthEnabled()) {
+			return [
+				'success' => false,
+				'message' => 'OAuth keys are not enabled',
+			];
+		}
+
+		if (!$user->hasPermission('Use API Keys')) {
+			return [
+				'success' => false,
+				'message' => 'You do not have permission to manage API keys',
+			];
+		}
+		$oauthKey = new UserOAuthKey();
+		$oauthKey->userId = $user->id;
+		$oauthKey->orderBy('created DESC');
+
+		$keys = [];
+		if ($oauthKey->find()) {
+			while ($oauthKey->fetch()) {
+				$keys[] = [
+					'id' => $oauthKey->id,
+					'keyName' => $oauthKey->keyName,
+					'clientId' => $oauthKey->clientId,
+					'created' => $oauthKey->created,
+					'lastUsed' => $oauthKey->lastUsed,
+					'isActive' => $oauthKey->isActive,
+				];
+			}
+		}
+
+		return [
+			'success' => true,
+			'keys' => $keys,
+		];
+	}
+
+	/** @noinspection PhpUnused */
+	function revokeOAuthKey(): array {
+		$user = UserAccount::getLoggedInUser();
+		if (!$user) {
+			return [
+				'success' => false,
+				'message' => 'You must be logged in to revoke OAuth keys',
+			];
+		}
+
+		require_once ROOT_DIR . '/sys/Account/UserOAuthKey.php';
+		if (!UserOAuthKey::isOAuthEnabled()) {
+			return [
+				'success' => false,
+				'message' => 'OAuth keys are not enabled',
+			];
+		}
+
+		if (!$user->hasPermission('Use API Keys')) {
+			return [
+				'success' => false,
+				'message' => 'You do not have permission to manage API keys',
+			];
+		}
+
+		$keyId = $_REQUEST['keyId'] ?? null;
+
+		if (!$keyId) {
+			return [
+				'success' => false,
+				'message' => 'Key ID is required',
+			];
+		}
+
+		$oauthKey = new UserOAuthKey();
+		$oauthKey->id = $keyId;
+		$oauthKey->userId = $user->id;
+
+		if ($oauthKey->find(true)) {
+			$oauthKey->delete();
+			return [
+				'success' => true,
+				'message' => 'OAuth key has been revoked',
+			];
+		}
+
+		return [
+			'success' => false,
+			'message' => 'Key not found or does not belong to you',
+		];
+	}
+
+	/** @noinspection PhpUnused */
+	function toggleOAuthKey(): array {
+		$user = UserAccount::getLoggedInUser();
+		if (!$user) {
+			return [
+				'success' => false,
+				'message' => 'You must be logged in to toggle OAuth keys',
+			];
+		}
+
+		require_once ROOT_DIR . '/sys/Account/UserOAuthKey.php';
+		if (!UserOAuthKey::isOAuthEnabled()) {
+			return [
+				'success' => false,
+				'message' => 'OAuth keys are not enabled',
+			];
+		}
+
+		if (!$user->hasPermission('Use API Keys')) {
+			return [
+				'success' => false,
+				'message' => 'You do not have permission to manage API keys',
+			];
+		}
+
+		$keyId = $_REQUEST['keyId'] ?? null;
+
+		if (!$keyId) {
+			return [
+				'success' => false,
+				'message' => 'Key ID is required',
+			];
+		}
+
+		$oauthKey = new UserOAuthKey();
+		$oauthKey->id = $keyId;
+		$oauthKey->userId = $user->id;
+
+		if ($oauthKey->find(true)) {
+			$oauthKey->isActive = $oauthKey->isActive ? 0 : 1;
+			$oauthKey->update();
+			return [
+				'success' => true,
+				'message' => $oauthKey->isActive ? 'Key activated' : 'Key deactivated',
+				'isActive' => $oauthKey->isActive,
+			];
+		}
+
+		return [
+			'success' => false,
+			'message' => 'Key not found or does not belong to you',
+		];
 	}
 }

--- a/code/web/services/MyAccount/OAuthKeys.php
+++ b/code/web/services/MyAccount/OAuthKeys.php
@@ -1,0 +1,45 @@
+<?php
+
+require_once ROOT_DIR . '/services/MyAccount/MyAccount.php';
+
+class MyAccount_OAuthKeys extends MyAccount {
+	function launch() {
+		global $interface;
+
+		$user = UserAccount::getLoggedInUser();
+
+		if ($user) {
+			require_once ROOT_DIR . '/sys/Account/UserOAuthKey.php';
+
+			if (!UserOAuthKey::isOAuthEnabled()) {
+				$interface->assign('error', 'OAuth key management is not enabled on this system.');
+			} elseif (!$user->hasPermission('Use API Keys')) {
+				$interface->assign('error', 'You do not have permission to manage API keys.');
+			} else {
+				$oauthKey = new UserOAuthKey();
+				$oauthKey->userId = $user->id;
+				$oauthKey->orderBy('created DESC');
+
+				$keys = [];
+				if ($oauthKey->find()) {
+					while ($oauthKey->fetch()) {
+						$keys[] = clone $oauthKey;
+					}
+				}
+
+				$interface->assign('oauthKeys', $keys);
+			}
+
+			$this->display('oauthKeys.tpl', 'API Keys');
+		} else {
+			$this->display('../MyAccount/login.tpl', 'Login');
+		}
+	}
+
+	function getBreadcrumbs(): array {
+		$breadcrumbs = [];
+		$breadcrumbs[] = new Breadcrumb('/MyAccount/Home', 'My Account');
+		$breadcrumbs[] = new Breadcrumb('', 'API Keys');
+		return $breadcrumbs;
+	}
+}

--- a/code/web/sys/API/OpenAPIAuthorizer.php
+++ b/code/web/sys/API/OpenAPIAuthorizer.php
@@ -139,6 +139,27 @@ class OpenAPIAuthorizer {
 		return self::getMethodConfig($apiClass, $method) !== null;
 	}
 	
+	/**
+	 * Get response configuration for a method
+	 * 
+	 * x-aspen-response options:
+	 * - raw: bool - Don't wrap response in ['result' => ...], output directly
+	 * - contentType: string - Override Content-Type header (default: application/json)
+	 * - cacheMaxAge: int - Set Cache-Control max-age in seconds
+	 * - xmlDeclaration: bool - Prepend XML declaration for XML responses
+	 * 
+	 * @param string $apiClass The API class name
+	 * @param string $method The method name
+	 * @return array Response configuration
+	 */
+	public static function getResponseConfig(string $apiClass, string $method): array {
+		$config = self::getMethodConfig($apiClass, $method);
+		if ($config === null) {
+			return [];
+		}
+		return $config['x-aspen-response'] ?? [];
+	}
+	
 	public static function clearCache(): void {
 		self::$specCache = [];
 	}

--- a/code/web/sys/API/OpenAPIAuthorizer.php
+++ b/code/web/sys/API/OpenAPIAuthorizer.php
@@ -3,7 +3,31 @@
 class OpenAPIAuthorizer {
 	private static array $specCache = [];
 	
-	public static function authorize(string $apiClass, string $method, $user, bool $ipAllowed = false): array {
+	/**
+	 * Authorize an API request based on OpenAPI spec
+	 * 
+	 * Scopes (can be string or array for OR logic):
+	 * - public: No authentication required
+	 * - greenhouse: Greenhouse/LiDA app-level auth
+	 * - user: Authenticated user (checks permissions array if present)
+	 * 
+	 * Bypasses (not scopes - these override scope checks):
+	 * - Whitelisted IP: Grants access unless endpoint sets ipAllowed: false
+	 * - Superuser: User with 'Use All API Endpoints' permission
+	 * 
+	 * Examples:
+	 *   "scope": "user"                        - Authenticated user
+	 *   "scope": "user", "permissions": [...]  - User with specific permissions
+	 *   "scope": ["user", "greenhouse"]        - Authenticated user OR app keys
+	 * 
+	 * @param string $apiClass The API class name
+	 * @param string $method The method name
+	 * @param mixed $user The authenticated user or false
+	 * @param bool $ipAllowed Whether request is from whitelisted IP
+	 * @param bool $greenhouseAuth Whether Greenhouse/LiDA auth succeeded
+	 * @return array Authorization result
+	 */
+	public static function authorize(string $apiClass, string $method, $user, bool $ipAllowed = false, bool $greenhouseAuth = false): array {
 		$config = self::getMethodConfig($apiClass, $method);
 		
 		if ($config === null) {
@@ -15,43 +39,78 @@ class OpenAPIAuthorizer {
 			];
 		}
 		
+		// Superuser bypass - 'Use All API Endpoints' grants full access
+		if ($user !== false && $user !== null && $user->hasPermission('Use All API Endpoints')) {
+			return ['allowed' => true, 'scope' => 'superuser'];
+		}
+		
 		$auth = $config['x-aspen-authorization'] ?? [];
 		
+		// Public endpoints - no auth required
 		if (!empty($auth['public']) && $auth['public'] === true) {
 			return ['allowed' => true, 'scope' => 'public'];
 		}
 		
+		// IP-based access (always checked first if allowed)
 		if ($ipAllowed) {
-			$scope = $auth['scope'] ?? 'ip';
 			if (!isset($auth['ipAllowed']) || $auth['ipAllowed'] === true) {
 				return ['allowed' => true, 'scope' => 'ip'];
 			}
 		}
 		
-		if ($user === false || $user === null) {
-			return [
-				'allowed' => false,
-				'error' => 'unauthorized',
-				'code' => 401,
-				'message' => 'Authentication required'
-			];
-		}
-		
-		$scope = $auth['scope'] ?? 'patron';
+		// Get scopes - can be string or array
+		$scopeConfig = $auth['scope'] ?? 'user';
+		$scopes = is_array($scopeConfig) ? $scopeConfig : [$scopeConfig];
 		$requiredPermissions = $auth['permissions'] ?? [];
 		
-		if ($scope === 'staff' && !empty($requiredPermissions)) {
-			if (!$user->hasPermission($requiredPermissions)) {
-				return [
-					'allowed' => false,
-					'error' => 'insufficient_permissions',
-					'code' => 403,
-					'message' => 'Required permissions: ' . implode(', ', $requiredPermissions)
-				];
+		// Try each scope (OR logic)
+		foreach ($scopes as $scope) {
+			$result = self::checkScope($scope, $user, $greenhouseAuth, $requiredPermissions);
+			if ($result['allowed']) {
+				return $result;
 			}
 		}
 		
-		return ['allowed' => true, 'scope' => $scope];
+		// None of the scopes matched - return appropriate error
+		if (in_array('user', $scopes) && $user !== false && !empty($requiredPermissions)) {
+			return [
+				'allowed' => false,
+				'error' => 'insufficient_permissions',
+				'code' => 403,
+				'message' => 'Required permissions: ' . implode(', ', $requiredPermissions)
+			];
+		}
+		
+		return [
+			'allowed' => false,
+			'error' => 'unauthorized',
+			'code' => 401,
+			'message' => 'Authentication required'
+		];
+	}
+	
+	/**
+	 * Check if a specific scope is satisfied
+	 */
+	private static function checkScope(string $scope, $user, bool $greenhouseAuth, array $requiredPermissions): array {
+		switch ($scope) {
+			case 'greenhouse':
+				if ($greenhouseAuth) {
+					return ['allowed' => true, 'scope' => 'greenhouse'];
+				}
+				break;
+				
+			case 'user':
+				if ($user !== false && $user !== null) {
+					if (!empty($requiredPermissions) && !$user->hasPermission($requiredPermissions)) {
+						return ['allowed' => false];
+					}
+					return ['allowed' => true, 'scope' => 'user'];
+				}
+				break;
+		}
+		
+		return ['allowed' => false];
 	}
 	
 	public static function getMethodConfig(string $apiClass, string $method): ?array {

--- a/code/web/sys/API/OpenAPIAuthorizer.php
+++ b/code/web/sys/API/OpenAPIAuthorizer.php
@@ -3,6 +3,57 @@
 class OpenAPIAuthorizer {
 	private static array $specCache = [];
 	
+	public static function authorize(string $apiClass, string $method, $user, bool $ipAllowed = false): array {
+		$config = self::getMethodConfig($apiClass, $method);
+		
+		if ($config === null) {
+			return [
+				'allowed' => false,
+				'error' => 'invalid_method',
+				'code' => 404,
+				'message' => "Method '$method' is not defined in the API specification"
+			];
+		}
+		
+		$auth = $config['x-aspen-authorization'] ?? [];
+		
+		if (!empty($auth['public']) && $auth['public'] === true) {
+			return ['allowed' => true, 'scope' => 'public'];
+		}
+		
+		if ($ipAllowed) {
+			$scope = $auth['scope'] ?? 'ip';
+			if (!isset($auth['ipAllowed']) || $auth['ipAllowed'] === true) {
+				return ['allowed' => true, 'scope' => 'ip'];
+			}
+		}
+		
+		if ($user === false || $user === null) {
+			return [
+				'allowed' => false,
+				'error' => 'unauthorized',
+				'code' => 401,
+				'message' => 'Authentication required'
+			];
+		}
+		
+		$scope = $auth['scope'] ?? 'patron';
+		$requiredPermissions = $auth['permissions'] ?? [];
+		
+		if ($scope === 'staff' && !empty($requiredPermissions)) {
+			if (!$user->hasPermission($requiredPermissions)) {
+				return [
+					'allowed' => false,
+					'error' => 'insufficient_permissions',
+					'code' => 403,
+					'message' => 'Required permissions: ' . implode(', ', $requiredPermissions)
+				];
+			}
+		}
+		
+		return ['allowed' => true, 'scope' => $scope];
+	}
+	
 	public static function getMethodConfig(string $apiClass, string $method): ?array {
 		$spec = self::loadSpec($apiClass);
 		$paths = $spec['paths'] ?? [];

--- a/code/web/sys/API/OpenAPIAuthorizer.php
+++ b/code/web/sys/API/OpenAPIAuthorizer.php
@@ -71,6 +71,19 @@ class OpenAPIAuthorizer {
 		return null;
 	}
 	
+	public static function getAllMethods(string $apiClass): array {
+		$spec = self::loadSpec($apiClass);
+		return array_keys($spec['paths'] ?? []);
+	}
+	
+	public static function methodExists(string $apiClass, string $method): bool {
+		return self::getMethodConfig($apiClass, $method) !== null;
+	}
+	
+	public static function clearCache(): void {
+		self::$specCache = [];
+	}
+	
 	private static function loadSpec(string $apiClass): array {
 		if (!isset(self::$specCache[$apiClass])) {
 			$specFile = ROOT_DIR . "/openapi/{$apiClass}_openapi.json";

--- a/code/web/sys/API/OpenAPIAuthorizer.php
+++ b/code/web/sys/API/OpenAPIAuthorizer.php
@@ -1,0 +1,45 @@
+<?php
+
+class OpenAPIAuthorizer {
+	private static array $specCache = [];
+	
+	public static function getMethodConfig(string $apiClass, string $method): ?array {
+		$spec = self::loadSpec($apiClass);
+		$paths = $spec['paths'] ?? [];
+		
+		if (isset($paths[$method])) {
+			$methodDef = $paths[$method];
+			foreach (['get', 'post', 'put', 'delete', 'patch'] as $httpMethod) {
+				if (isset($methodDef[$httpMethod])) {
+					return $methodDef[$httpMethod];
+				}
+			}
+			return $methodDef;
+		}
+		
+		return null;
+	}
+	
+	private static function loadSpec(string $apiClass): array {
+		if (!isset(self::$specCache[$apiClass])) {
+			$specFile = ROOT_DIR . "/openapi/{$apiClass}_openapi.json";
+			
+			if (file_exists($specFile)) {
+				$content = file_get_contents($specFile);
+				$spec = json_decode($content, true);
+				
+				if (json_last_error() !== JSON_ERROR_NONE) {
+					global $logger;
+					$logger->log("Failed to parse OpenAPI spec for $apiClass: " . json_last_error_msg(), Logger::LOG_ERROR);
+					self::$specCache[$apiClass] = ['paths' => []];
+				} else {
+					self::$specCache[$apiClass] = $spec;
+				}
+			} else {
+				self::$specCache[$apiClass] = ['paths' => []];
+			}
+		}
+		
+		return self::$specCache[$apiClass];
+	}
+}

--- a/code/web/sys/Account/UserOAuthKey.php
+++ b/code/web/sys/Account/UserOAuthKey.php
@@ -1,0 +1,174 @@
+<?php
+
+class UserOAuthKey extends DataObject {
+	public $__table = 'user_oauth_keys';
+	public $id;
+	public $userId;
+	public $keyName;
+	public $clientId;
+	public $clientSecret;
+	public $created;
+	public $lastUsed;
+	public $isActive;
+
+	static function getObjectStructure(string $context = ''): array {
+		return [
+			'id' => [
+				'property' => 'id',
+				'type' => 'label',
+				'label' => 'Id',
+				'description' => 'The unique id',
+			],
+			'userId' => [
+				'property' => 'userId',
+				'type' => 'hidden',
+				'label' => 'User Id',
+				'description' => 'The user this key belongs to',
+			],
+			'keyName' => [
+				'property' => 'keyName',
+				'type' => 'text',
+				'label' => 'Key Name',
+				'description' => 'A descriptive name for this API key',
+				'maxLength' => 100,
+				'required' => true,
+			],
+			'created' => [
+				'property' => 'created',
+				'type' => 'timestamp',
+				'label' => 'Created',
+				'description' => 'When the key was created',
+				'readOnly' => true,
+			],
+			'lastUsed' => [
+				'property' => 'lastUsed',
+				'type' => 'timestamp',
+				'label' => 'Last Used',
+				'description' => 'When the key was last used',
+				'readOnly' => true,
+			],
+			'isActive' => [
+				'property' => 'isActive',
+				'type' => 'checkbox',
+				'label' => 'Active',
+				'description' => 'Whether this key is active',
+				'default' => true,
+			],
+		];
+	}
+
+	public function getNumericColumnNames(): array {
+		return ['id', 'userId', 'isActive'];
+	}
+
+	public function getEncryptedFieldNames(): array {
+		return [];
+	}
+
+	public static function generateKeys(int $userId, string $keyName): array {
+		$oauthKey = new UserOAuthKey();
+		$oauthKey->userId = $userId;
+		$oauthKey->keyName = $keyName;
+		$oauthKey->clientId = bin2hex(random_bytes(16));
+		$plainSecret = bin2hex(random_bytes(32));
+		$oauthKey->clientSecret = password_hash($plainSecret, PASSWORD_ARGON2ID);
+		$oauthKey->created = time();
+		$oauthKey->isActive = 1;
+
+		if ($oauthKey->insert()) {
+			global $logger;
+			$logger->log("OAuth key '{$keyName}' (ID: {$oauthKey->id}) created for user {$userId}", Logger::LOG_NOTICE);
+
+			return [
+				'success' => true,
+				'clientId' => $oauthKey->clientId,
+				'clientSecret' => $plainSecret,
+				'id' => $oauthKey->id,
+				'warning' => 'Save this secret now. You will not be able to see it again.',
+			];
+		} else {
+			return [
+				'success' => false,
+				'message' => 'Failed to create OAuth key',
+			];
+		}
+	}
+
+	private static $failedAttempts = [];
+	private static $maxAttempts = 5;
+	private static $lockoutTime = 900;
+
+	public static function validateCredentials(string $clientId, string $clientSecret): User|bool {
+		$lockoutKey = 'oauth_' . $clientId;
+
+		if (isset(self::$failedAttempts[$lockoutKey])) {
+			$attempts = self::$failedAttempts[$lockoutKey];
+			if ($attempts['count'] >= self::$maxAttempts) {
+				if (time() - $attempts['first_attempt'] < self::$lockoutTime) {
+					global $logger;
+					$logger->log("OAuth key $clientId is locked out due to too many failed attempts", Logger::LOG_WARNING);
+					return false;
+				} else {
+					unset(self::$failedAttempts[$lockoutKey]);
+				}
+			}
+		}
+
+		$oauthKey = new UserOAuthKey();
+		$oauthKey->clientId = $clientId;
+		$oauthKey->isActive = 1;
+
+		if ($oauthKey->find(true)) {
+			if (password_verify($clientSecret, $oauthKey->clientSecret)) {
+				unset(self::$failedAttempts[$lockoutKey]);
+
+				$oauthKey->lastUsed = time();
+				$oauthKey->update();
+
+				require_once ROOT_DIR . '/sys/Account/User.php';
+				$user = new User();
+				$user->id = $oauthKey->userId;
+				if ($user->find(true)) {
+					return $user;
+				}
+			}
+		}
+
+		if (!isset(self::$failedAttempts[$lockoutKey])) {
+			self::$failedAttempts[$lockoutKey] = [
+				'count' => 1,
+				'first_attempt' => time(),
+			];
+		} else {
+			self::$failedAttempts[$lockoutKey]['count']++;
+		}
+
+		usleep(500000);
+
+		return false;
+	}
+
+	public static function isOAuthEnabled(): bool {
+		require_once ROOT_DIR . '/sys/SystemVariables.php';
+		$systemVariables = SystemVariables::getSystemVariables();
+		return $systemVariables && $systemVariables->enableUserOAuth == 1;
+	}
+
+	public function delete(bool $useWhere = false, bool $hardDelete = false): int|bool {
+		global $logger;
+		$logger->log("OAuth key '{$this->keyName}' (ID: {$this->id}) deleted for user {$this->userId}", Logger::LOG_WARNING);
+
+		$result = parent::delete($useWhere, $hardDelete);
+		return $result;
+	}
+
+	public function update(string $context = ''): int|bool {
+		if (isset($this->_data['isActive']) && $this->_data['isActive'] != $this->isActive) {
+			global $logger;
+			$status = $this->isActive ? 'activated' : 'deactivated';
+			$logger->log("OAuth key '{$this->keyName}' (ID: {$this->id}) {$status} for user {$this->userId}", Logger::LOG_NOTICE);
+		}
+
+		return parent::update($context);
+	}
+}

--- a/code/web/sys/DBMaintenance/api_oauth_updates.php
+++ b/code/web/sys/DBMaintenance/api_oauth_updates.php
@@ -1,0 +1,52 @@
+<?php /** @noinspection SqlResolve */
+function getApiOAuthUpdates(): array {
+	return [
+		'user_oauth_enable_system_variable' => [
+			'title' => 'Add User OAuth System Variable',
+			'description' => 'Add system variable to enable user OAuth key generation',
+			'continueOnError' => false,
+			'sql' => [
+				'ALTER TABLE system_variables ADD COLUMN enableUserOAuth TINYINT(1) DEFAULT 0',
+			]
+		], //user_oauth_enable_system_variable
+		'user_oauth_keys_table' => [
+			'title' => 'Create User OAuth Keys Table',
+			'description' => 'Create table to store user-specific OAuth keys for API authentication',
+			'continueOnError' => false,
+			'sql' => [
+				'CREATE TABLE IF NOT EXISTS user_oauth_keys (
+					id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+					userId INT(11) NOT NULL,
+					keyName VARCHAR(100) NOT NULL,
+					clientId VARCHAR(64) NOT NULL UNIQUE,
+					clientSecret VARCHAR(255) NOT NULL,
+					created INT(11) NOT NULL,
+					lastUsed INT(11) DEFAULT NULL,
+					isActive TINYINT(1) DEFAULT 1,
+					INDEX (userId),
+					INDEX (clientId),
+					INDEX (isActive),
+					FOREIGN KEY (userId) REFERENCES user(id) ON DELETE CASCADE
+				) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci',
+			]
+		], //user_oauth_keys_table
+		'user_oauth_permission' => [
+			'title' => 'Add Use API Keys Permission',
+			'description' => 'Add permission for users to create and manage their own API keys',
+			'continueOnError' => false,
+			'sql' => [
+				"INSERT INTO permissions (sectionName, name, requiredModule, weight, description) VALUES ('API', 'Use API Keys', '', 10, 'Allows users to create and manage OAuth API keys for their account. Can be assigned to any role including patron roles.')",
+				"INSERT INTO role_permissions(roleId, permissionId) VALUES ((SELECT roleId from roles where name='opacAdmin'), (SELECT id from permissions where name='Use API Keys'))",
+			]
+		], //user_oauth_permission
+		'use_all_api_endpoints_permission' => [
+			'title' => 'Add Use All API Endpoints Permission',
+			'description' => 'Add permission required for OAuth tokens to access API endpoints',
+			'continueOnError' => false,
+			'sql' => [
+				"INSERT INTO permissions (sectionName, name, requiredModule, weight, description) VALUES ('API', 'Use All API Endpoints', '', 20, 'Required for OAuth API keys to access API endpoints. This is a transitional permission while APIs are migrated to granular permissions.')",
+				"INSERT INTO role_permissions(roleId, permissionId) VALUES ((SELECT roleId from roles where name='opacAdmin'), (SELECT id from permissions where name='Use All API Endpoints'))",
+			]
+		], //use_all_api_endpoints_permission
+	];
+}

--- a/code/web/sys/SystemVariables.php
+++ b/code/web/sys/SystemVariables.php
@@ -55,6 +55,8 @@ class SystemVariables extends DataObject {
 	public $disable_user_agent_logging;
 	public $logFrequentCrons;
 	public $hooplaVersion;
+	public $enableUserOAuth;
+
 
 	static $_objectStructure = [];
 	static function getObjectStructure(string $context = ''): array {
@@ -445,6 +447,13 @@ class SystemVariables extends DataObject {
 				'label' => 'Log Frequent Cron Jobs',
 				'description' => 'Whether or not to log frequently running cron jobs (e.g., runs every few minutes).',
 				'note' => 'Frequent jobs include: ' . implode(', ', $frequentJobs) . '.',
+				'default' => false,
+			],
+			'enableUserOAuth' => [
+				'property' => 'enableUserOAuth',
+				'type' => 'checkbox',
+				'label' => 'Enable User OAuth Keys',
+				'description' => 'Allow users to generate OAuth API keys for their account that respect user permissions',
 				'default' => false,
 			],
 		];

--- a/sites/default/httpd-default.conf
+++ b/sites/default/httpd-default.conf
@@ -12,6 +12,7 @@
       Order allow,deny
       allow from all
       AllowOverride All
+      CGIPassAuth On
 
       # Friendly URLs
       <IfModule mod_rewrite.c>

--- a/sites/template.linux/httpd-{sitename}.conf
+++ b/sites/template.linux/httpd-{sitename}.conf
@@ -12,6 +12,7 @@
 		Require all granted
 		Options -Indexes -MultiViews
 		AllowOverride All
+		CGIPassAuth On
 
 		SetEnv aspen_server {sitename}
 

--- a/sites/template.mac/httpd-{sitename}.conf
+++ b/sites/template.mac/httpd-{sitename}.conf
@@ -12,6 +12,7 @@
 		Require all granted
 		Options -Indexes -MultiViews
 		AllowOverride All
+		CGIPassAuth On
 
 		SetEnv aspen_server {sitename}
 

--- a/sites/template.windows/httpd-{sitename}.conf
+++ b/sites/template.windows/httpd-{sitename}.conf
@@ -13,6 +13,7 @@
     Require all granted
     Options -Indexes -MultiViews
     AllowOverride All
+    CGIPassAuth On
 
     # Friendly URLs
     <IfModule mod_rewrite.c>


### PR DESCRIPTION
@mdnoble73 Another big one from me, I'm afraid. Apologies!

Some of this may change slightly but the general structure will remain the same (might swap to guard clauses etc)

First off, this is fully backwards compatible and will NOT break any existing API endpoints. I would like to eventually migrate the old api endpoint to use this new structure but it's important everything works in the meantime!

First set of patches adds oauth keys to Aspen. These are permission locked for the legacy endpoints and require you to have the superuser Administer all APIs permission for it to work. other than that, the structure is the same for legacy endpoints.
You can also disable the ability to create oauth tokens on a per role basis.

The second half of the patchset is the permissions work for apis. This rewrites how api's are structured and will instead use a different launch method. it has different scopes that define how the api endpoint can be authenticated (be it via greenhouse keys, ip, oauth) and these can be stored in an OR array in the openapi.json, so that becomes the source of truth.
You can then add permissions in there as well which will link by name to permissions that exist in the aspen db, so that a user who has the permission to do something in the UI with then have access in the api as well.
I've added a test endpoint there for you to have a play around with, it's in a do not push commit so it doesn't get accidentally merged!

Here is a md file with the general workflow:
[api-workflow.md](https://github.com/user-attachments/files/25233215/api-workflow.md)

The reasoning for this work is we need to be able to share an endpoint with LibraryOn for the events work and currently there was no secure way of doing this. It's part of a funded piece of work so we will be implementing this on our customer servers for testing within the next week or so, prior to the upstream here. That should ensure there are no edge cases or "nasties" that I've missed. Ideally, I'd like to extend this to properly use bearer tokens in the future and have expiration periods on the generated oauth tokens but this is a good foundational start that should be able to be extended later.

Again, tagging a few people that might want to stay updated:
@Chloe070196, @AlexanderBlanchardAC, @mrenvoize 