### PR TITLE
DIS-1951 Sierra response code default of null added

### DIFF
--- a/code/web/Drivers/Sierra.php
+++ b/code/web/Drivers/Sierra.php
@@ -6,7 +6,7 @@ use PgSql\Connection;
 class Sierra extends AbstractIlsDriver {
 	protected string $urlIdRegExp = "~.*/([0-9]*)$~";
 	private ?stdClass $sierraToken = null;
-	private ?int $lastResponseCode;
+	private ?int $lastResponseCode = null;
 	/** @noinspection PhpPropertyOnlyWrittenInspection */
 	private ?int $lastError = null;
 	private ?string $lastErrorMessage = null;

--- a/code/web/release_notes/26.03.00.MD
+++ b/code/web/release_notes/26.03.00.MD
@@ -14,7 +14,8 @@
 //yanjun
 
 //imani
-
+## Sierra Updates
+- Added default value of null to $lastResponseCode in Sierra driver ((DIS-1951)[https://aspen-discovery.atlassian.net/browse/DIS-1951]) (*IT*)
 //alexander
 
 //chloe


### PR DESCRIPTION
log in with an aspen connected to Sierra. and check the error logs to make sure  “Typed property Sierra::$lastResponseCode must not be accessed before initialization” is not occurring.