### PR TITLE
DIS-1469: Add a saved search email notification preference to the patron account settings and trigger automatic emails to go out when the saved searches receive updates.

### DIFF
--- a/code/web/cron/updateSavedSearches.php
+++ b/code/web/cron/updateSavedSearches.php
@@ -36,6 +36,7 @@ if ($search->getNumResults() > 0) {
 	$searchUpdateLogEntry->update();
 	$allSearches = $search->fetchAll('id');
 	$numProcessed = 0;
+	$usersWithUpdatesToEmail = [];
 	foreach ($allSearches as $searchId) {
 		$searchEntry = new SearchEntry();
 		$searchEntry->id = $searchId;
@@ -115,6 +116,15 @@ if ($search->getNumResults() > 0) {
 						$notificationToken->__destruct();
 						$notificationToken = null;
 					}
+					// If the user wishes to receive saved search emails, keep track of those here.
+					if ($userForSearch->notifySavedSearches == TRUE) {
+						if (array_key_exists($userForSearch->email, $usersWithUpdatesToEmail)) {
+							$usersWithUpdatesToEmail[$userForSearch->email][] = $searchEntry->title;
+						}
+						else {
+							$usersWithUpdatesToEmail[$userForSearch->email] = [$searchEntry->title];
+						}
+					}
 				}
 			} else {
 				if ($searchEntry->hasNewResults) {
@@ -138,7 +148,33 @@ $searchUpdateLogEntry->addNote("Finished updating saved searches");
 $searchUpdateLogEntry->endTime = time();
 $searchUpdateLogEntry->update();
 
-$cronLogEntry->notes .= "<br/>Updated a total of " . $searchUpdateLogEntry->numUpdated. " searches";
+// Now that we know all of the searches that have updates, let's send a single email to each distinct email address from that set.
+require_once ROOT_DIR . '/sys/Email/Mailer.php';
+$mailer = new Mailer();
+foreach ($usersWithUpdatesToEmail as $emailAddress => $searchTitles) {
+	$body = translate([
+		'text' => 'There are new results appearing in your saved searches!',
+		'isPublicFacing' => true,
+	]) . "\r\n" . $configArray['Site']['url'] . '/Search/History';
+	$htmlBody = '<p>' . translate([
+		'text' => 'There are new results appearing in %1%your saved searches%2%!',
+		1 => '<a href="' . $configArray['Site']['url'] . '/Search/History">',
+		2 => '</a>',
+		'isPublicFacing' => true,
+	]) . '</p><ul>';
+	foreach ($searchTitles as $searchTitle) {
+		$body .= "\r\n" . $searchTitle;
+		$htmlBody .= '<li>' . $searchTitle . '</li>';
+	}
+	$htmlBody .= '</ul>';
+	$result = $mailer->send($emailAddress, translate([
+		'text' => "New Results in Your Saved Searches",
+		'isPublicFacing' => true,
+	]), $body, null, $htmlBody);
+}
+
+$numUpdated = ($searchUpdateLogEntry->numUpdated > 0) ? $searchUpdateLogEntry->numUpdated : 0;
+$cronLogEntry->notes .= "<br/>Updated a total of " . $numUpdated . " searches.";
 $cronLogEntry->endTime = time();
 $cronLogEntry->update();
 

--- a/code/web/interface/themes/responsive/MyAccount/myPreferences.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/myPreferences.tpl
@@ -441,7 +441,7 @@
 										</select>
 									</div>
 									<div class="form-group propertyRow">
-										<label for="notifySavedSearches" class="control-label">{translate text='Notify me by email when new titles are added to my saved searches.' isPublicFacing=true}</label>&nbsp;
+										<label for="notifySavedSearches" class="control-label">{translate text='Notify me by email when new titles are added to my saved searches' isPublicFacing=true}</label>&nbsp;
 											{if $edit == true}
 												<input type="checkbox" class="form-control" name="notifySavedSearches" id="notifySavedSearches" {if $profile->notifySavedSearches==1}checked='checked'{/if} data-switch="">
 											{else}

--- a/code/web/interface/themes/responsive/MyAccount/myPreferences.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/myPreferences.tpl
@@ -440,6 +440,14 @@
 											<option value="2" {if $profile->searchPreferenceLanguage == 2}selected{/if}>{translate text="Yes, only show my preferred language" isPublicFacing=true}</option>
 										</select>
 									</div>
+									<div class="form-group propertyRow">
+										<label for="notifySavedSearches" class="control-label">{translate text='Notify me by email when new titles are added to my saved searches.' isPublicFacing=true}</label>&nbsp;
+											{if $edit == true}
+												<input type="checkbox" class="form-control" name="notifySavedSearches" id="notifySavedSearches" {if $profile->notifySavedSearches==1}checked='checked'{/if} data-switch="">
+											{else}
+												&nbsp;{if $profile->notifySavedSearches==0} {translate text='No' isPublicFacing=true}{else} {translate text='Yes' isPublicFacing=true}{/if}
+											{/if}
+									</div> 
 
 									{* Course Reserves *}
 									{if !empty($validCourseReservesSorts)}

--- a/code/web/release_notes/26.03.00.MD
+++ b/code/web/release_notes/26.03.00.MD
@@ -6,6 +6,8 @@
 //kodi
 
 //mark j
+### Search Updates
+- Add a saved search email notification preference to the patron account settings and trigger automatic emails to go out when the saved searches receive updates. ([DIS-1469](https://aspen-discovery.atlassian.net/browse/DIS-1469)) (*MJ*)
 
 //myranda
 

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -57,6 +57,7 @@ class User extends DataObject {
 	public $checkoutInfoLastLoaded;
 	public $optInToAllCampaignLeaderboards;
 	public $campaignNotificationsByEmail;
+	public $notifySavedSearches;
 
 	public $onboardAppNotifications;
 	public $shouldAskBrightness;
@@ -1705,6 +1706,7 @@ class User extends DataObject {
 		$this->__set('showHoldHelpMessages', (isset($_POST['showHoldHelpMessages']) && $_POST['showHoldHelpMessages'] == 'on') ? 1 : 0);
 		$this->__set('promptToFreezeHoldsImmediately', (isset($_POST['promptToFreezeHoldsImmediately']) && $_POST['promptToFreezeHoldsImmediately'] == 'on') ? 1 : 0);
 		$this->__set('disableCirculationActions', (isset($_POST['disableCirculationActions']) && $_POST['disableCirculationActions'] == 'on') ? 0 : 1);
+		$this->__set('notifySavedSearches', (isset($_POST['notifySavedSearches']) && $_POST['notifySavedSearches'] == 'on') ? 1 : 0);
 		$homeLibrary = $this->getHomeLibrary();
 		if ($homeLibrary !== null && $homeLibrary->enableCostSavings) {
 			$this->__set('enableCostSavings', (isset($_POST['enableCostSavings']) && $_POST['enableCostSavings'] == 'on') ? 1 : 0);
@@ -2144,6 +2146,10 @@ class User extends DataObject {
 
 	public function areCirculationActionsDisabled(): bool {
 		return !$this->hasIlsConnection() || $this->disableCirculationActions;
+	}
+
+	public function areSavedSearchNotificationsEnabled(): bool {
+		return $this->notifySavedSearches;
 	}
 
 	public function getCirculatedRecordActions(string $source, string $recordId, bool $loadingLinkedUser = false): array {

--- a/code/web/sys/DBMaintenance/version_updates/26.03.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/26.03.00.php
@@ -32,6 +32,13 @@ function getUpdates26_03_00(): array {
 		//chloe
 
 		//mark j
+		'notify_saved_searches' => [
+			'title' => 'User - Allow patrons to choose if they want email notifications when saved searches are updated.',
+			'description' => 'Patrons will gain the choice within Your Preferences to have Aspen notify them via email when updates to their saved searches occur.',
+			'sql' => [
+				"ALTER TABLE user ADD COLUMN notifySavedSearches tinyint(1) NOT NULL DEFAULT 1",
+			]
+		], //notify_saved_searches
 
 		//lucas
 


### PR DESCRIPTION
DIS-1469: Add a saved search email notification preference to the patron account settings and trigger automatic emails to go out when the saved searches receive updates.