### PR TITLE
DIS-1882: Fix return on list if contains deleted item

### DIFF
--- a/code/web/release_notes/26.02.00.MD
+++ b/code/web/release_notes/26.02.00.MD
@@ -15,6 +15,7 @@
 - Add Search API endpoint getHomeScreenFeed for retrieving Home Screen Links and Browse Categories. ([DIS-886](https://aspen-discovery.atlassian.net/browse/DIS-886)) (*KK*)
 - Add System API endpoints getHomeScreenLinks and getHomeScreenLinksByGroup for retrieving Home Screen Links either by library/location ID or Home Screen Link Group ID. ([DIS-886](https://aspen-discovery.atlassian.net/browse/DIS-886))  (*KK*)
 - In List API, add pagination to getUserLists and getListGroupDetails. ([DIS-1848](https://aspen-discovery.atlassian.net/browse/DIS-1848)) (*KK*)
+- In Search API, fix an issue where lists with deleted items were returning as an associative array and causing the browse category to display empty in LiDA. ([DIS-1882](https://aspen-discovery.atlassian.net/browse/DIS-1882)) (*KK*)
 
 ### Aspen LiDA Updates
 - Add Home Screen Link functionality for customizing the Home Screen. ([DIS-886](https://aspen-discovery.atlassian.net/browse/DIS-886)) (*KK*)

--- a/code/web/services/API/SearchAPI.php
+++ b/code/web/services/API/SearchAPI.php
@@ -2654,6 +2654,11 @@ class SearchAPI extends AbstractAPI {
 						$sourceList->id = $browseCategory->sourceListId;
 						if ($sourceList->find(true)) {
 							$records = $sourceList->getBrowseRecordsRaw(($pageToLoad - 1) * $pageSize, $pageSize, $isLida, $appVersion);
+							// Convert to indexed array if it's an associative array
+							if (is_array($records) && !empty($records)) {
+								$records = array_values($records);
+							}
+
 							$response['message'] = 'Results found for browse category';
 						} else {
 							$records = [];


### PR DESCRIPTION
solr seemed to return an associative array when a list contained deleted items; in these cases, convert the returned records into an indexed array for consistent API data