### PR TITLE
DIS-1927: Reset Hoopla Last Record Processed

### DIFF
--- a/code/hoopla_export/src/com/turning_leaf_technologies/hoopla/HooplaExporter2.java
+++ b/code/hoopla_export/src/com/turning_leaf_technologies/hoopla/HooplaExporter2.java
@@ -557,7 +557,15 @@ public class HooplaExporter2 {
 								logEntry.incErrors("Error updating lastRecordProcessed ", e);
 							}
 						} else {
+							// No more records to extact from global content
 							startToken = null;
+							try {
+								updateLastRecordProcessedStmt.setString(1, "0");
+								updateLastRecordProcessedStmt.setLong(2, settingsId);
+								updateLastRecordProcessedStmt.executeUpdate();
+							} catch (SQLException e) {
+								logEntry.incErrors("Error updating lastRecordProcessed ", e);
+							}
 						}
 
 					}
@@ -592,7 +600,6 @@ public class HooplaExporter2 {
 			logEntry.saveResults();
 			logEntry.addNote("Completed " + numRecordsToExtract + " global content updates");
 			logEntry.saveResults();
-
 		} catch (SQLException e) {
 			logEntry.incErrors("Error updating settings", e);
 		}

--- a/code/web/release_notes/26.03.00.MD
+++ b/code/web/release_notes/26.03.00.MD
@@ -54,6 +54,9 @@
 ### Other Updates
 - Fix "Not Holdable" label missing for non-holdable items in Copies table. ([DIS-1973](https://aspen-discovery.atlassian.net/browse/DIS-1973)) (*YL*)
 
+### Hoopla Updates
+- Fix an issue where “Last Record Processed” does not reset when there are no more records to extract for Global Content. ([DIS-1927](https://aspen-discovery.atlassian.net/browse/DIS-1927)) (*YL*)
+
 //imani
 ## Sierra Updates
 - Added default value of null to $lastResponseCode in Sierra driver ((DIS-1951)[https://aspen-discovery.atlassian.net/browse/DIS-1951]) (*IT*)


### PR DESCRIPTION
Currently on Hoopla version 2, "Last Record Processed" will not be reset to 0 after successful global content extraction. 

Apply this PR and see "Last Record Processed" resets to 0 for each run that calls the global content endpoint. 