### PR TITLE
DIS-1795: Honor locked facet display in grouped works

### DIFF
--- a/code/web/RecordDrivers/GroupedWorkDriver.php
+++ b/code/web/RecordDrivers/GroupedWorkDriver.php
@@ -1889,8 +1889,37 @@ class GroupedWorkDriver extends IndexRecordDriver {
 			$selectedDetailedAvailability = null;
 			$selectedLanguages = [];
 			$selectedEcontentSources = [];
+			$filterList = [];
+			if (UserAccount::isLoggedIn()) {
+				$user = UserAccount::getActiveUserObj();
+				$lockedFacets = !empty($user->lockedFacets) ? json_decode($user->lockedFacets, true) : [];
+			} else {
+				$lockedFacets = $_SESSION['lockedFilters'] ?? [];
+			}
+			if (isset($lockedFacets)) {
+				foreach ($lockedFacets as $lockSection => $facets) {
+					if (!is_array($facets)) {
+						continue;
+					}
+					foreach ($facets as $facetName => $values) {
+						$values = is_array($values) ? $values : [$values];
+						foreach ($values as $value) {
+							if (is_string($value) && $value !== '') {
+								$filterList[] = $facetName . ':"' . $value . '"';
+							}
+						}
+					}
+				}
+			}
 			if (isset($_REQUEST['filter'])) {
 				foreach ($_REQUEST['filter'] as $filter) {
+					if (!in_array($filter, $filterList)) {
+						$filterList[] = $filter;
+					}
+				}
+			}
+			if (!empty($filterList)) {
+				foreach ($filterList as $filter) {
 					if (preg_match('/^format_category\w*:"?(.+?)"?$/', $filter, $matches)) {
 						$selectedFormatCategory[] = $matches[1];
 					} elseif (preg_match('/^format\w*:"?(.+?)"?$/', $filter, $matches)) {

--- a/code/web/release_notes/26.03.00.MD
+++ b/code/web/release_notes/26.03.00.MD
@@ -53,6 +53,7 @@
 
 ### Other Updates
 - Fix "Not Holdable" label missing for non-holdable items in Copies table. ([DIS-1973](https://aspen-discovery.atlassian.net/browse/DIS-1973)) (*YL*)
+- Ensure locked facets also hide non-locked facets in grouped works results until "View all formats" is expanded. ([DIS-1795](https://aspen-discovery.atlassian.net/browse/DIS-1795)) (*YL*)
 
 //imani
 ## Sierra Updates


### PR DESCRIPTION
To Reproduce
1. Log in as a patron.
2. Perform a search and set the Format facet to Book.
3. Verify that grouped works display only the Book format and hide other formats until “View all formats” is expanded.
4. Lock the Format facet.
5. Perform another search.
6. The locked facet is applied to filtering, but grouped works display all formats.
7. Repeat steps 2–6 while logged out.


To Test
1. Apply the PR.
2. Perform a search and set the Format facet to Book.
3. Verify that grouped works display only the Book format and hide other formats until “View all formats” is expanded.
4. Lock the Format facet.
5. Perform another search.
6. The locked facet is applied to filtering, and grouped works display only the Book format, with other formats hidden under “View all formats.”
7. Repeat steps 2–6 while logged out.