### PR TITLE
DIS-2030: Hide Allowable Values for Select Lists 

### DIFF
--- a/code/web/interface/themes/responsive/js/aspen/events.js
+++ b/code/web/interface/themes/responsive/js/aspen/events.js
@@ -7,6 +7,15 @@ AspenDiscovery.Events = (function(){
 			$.getJSON(ajaxUrl);
 		},
 
+		toggleEventFieldAllowableValues: function() {
+			var toggleAllowableValues = function() {
+				var typeVal = $('#typeSelect').val();
+				$('#propertyRowallowableValues').toggle(typeVal === '3');
+			};
+			toggleAllowableValues();
+			$('#typeSelect').on('change', toggleAllowableValues);
+		},
+
 		//For Aspen Events
 		getEventTypesForLocation: function(locationId) {
 			var url = Globals.path + '/Events/AJAX';

--- a/code/web/release_notes/26.03.00.MD
+++ b/code/web/release_notes/26.03.00.MD
@@ -54,6 +54,9 @@
 ### Other Updates
 - Fix "Not Holdable" label missing for non-holdable items in Copies table. ([DIS-1973](https://aspen-discovery.atlassian.net/browse/DIS-1973)) (*YL*)
 
+### Events Updates
+- Hide "Allowable Values for Select Lists" when Field Type is not Select Lists to prevent unexpected edits that could cause indexing issues. ([DIS-2030](https://aspen-discovery.atlassian.net/browse/DIS-2030)) (*YL*)
+
 //imani
 ## Sierra Updates
 - Added default value of null to $lastResponseCode in Sierra driver ((DIS-1951)[https://aspen-discovery.atlassian.net/browse/DIS-1951]) (*IT*)

--- a/code/web/services/Events/EventFields.php
+++ b/code/web/services/Events/EventFields.php
@@ -54,6 +54,10 @@ class Events_EventFields extends ObjectEditor {
 		return 'https://help.aspendiscovery.org/help/catalog/events';
 	}
 
+	function getInitializationJs(): string {
+		return 'AspenDiscovery.Events.toggleEventFieldAllowableValues();';
+	}
+
 	function getBreadcrumbs(): array {
 		$breadcrumbs = [];
 		$breadcrumbs[] = new Breadcrumb('/Admin/Home', 'Administration Home');

--- a/code/web/sys/DBMaintenance/version_updates/26.03.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/26.03.00.php
@@ -30,6 +30,14 @@ function getUpdates26_03_00(): array {
 				'ALTER TABLE palace_project_settings ADD COLUMN requirePin TINYINT(1) DEFAULT 1',
 			]
 		], //allow_require_pin_for_palace_project
+		'clean_up_event_fields_allowable_values' => [
+			'title' => 'Clean up Event Fields Allowable Values when type is not select lists',
+			'description' => 'Clean up Event Fields Allowable Values when type is not select lists',
+			'continueOnError' => false,
+			'sql' => [
+				"UPDATE event_field SET allowableValues = '' WHERE type <> 3",
+			]
+		], //clean_up_event_fields_allowable_values
 
 		//imani
 


### PR DESCRIPTION
The Event Field → Allowable Values for Select Lists setting is only used for Select List fields. It should be hidden for other field types to avoid confusion and prevent unexpected edits that could cause indexing issues.

To test:
1. Apply PR
2. Attempt new Event Fields
3. Verify that "Allowable Values for Select Lists" field only shows when the Field Type is Select List