### PR TITLE
DIS-2044: Fix event field checkbox persistence

### DIFF
--- a/code/web/release_notes/26.03.00.MD
+++ b/code/web/release_notes/26.03.00.MD
@@ -54,6 +54,9 @@
 ### Other Updates
 - Fix "Not Holdable" label missing for non-holdable items in Copies table. ([DIS-1973](https://aspen-discovery.atlassian.net/browse/DIS-1973)) (*YL*)
 
+### Events Updates
+- Fixed event field checkboxes not persisting after toggling on the Event edit form. ([DIS-2044](https://aspen-discovery.atlassian.net/browse/DIS-2044)) (*YL*)
+
 //imani
 ## Sierra Updates
 - Added default value of null to $lastResponseCode in Sierra driver ((DIS-1951)[https://aspen-discovery.atlassian.net/browse/DIS-1951]) (*IT*)

--- a/code/web/sys/Events/EventFieldSet.php
+++ b/code/web/sys/Events/EventFieldSet.php
@@ -164,8 +164,6 @@ class EventFieldSet extends DataObject {
 				];
 				if ($type == 'enum') {
 					$structure[$field->id]['values'] = explode("\n", $field->allowableValues);
-				} else if ($type == 'checkbox') {
-					$structure[$field->id]['returnValueForUnchecked'] = true;
 				}
 			}
 		}


### PR DESCRIPTION
Event field checkboxes on the Events edit form do not save correctly when toggled. 

To reproduce:
1. Go to Aspen Events → Manage Events → Event Fields and create a new Event Field of type Checkbox.
2. Go to Aspen Events → Manage Events and create a new Event associated with the Event Type that includes the checkbox field.
3. Select the checkbox and save 
4. See the checkbox is saved as chekced. Check DB value as “1” 
5. Uncheck the checkbox and save
6. See the checkbox is saved as unchecked. Check DB value as “0” 
7. Check the checkbox again and save
8. See the checkbox stays unchecked. Check DB value as “0” 

To Test:
1. Apply PR
2. Create a new Event
3. Select the checkbox and save 
4. See the checkbox is saved as chekced. Check DB value as “1” 
5. Uncheck the checkbox and save
6. See the checkbox is saved as unchecked. Check DB value as “0” 
7. Check the checkbox again and save
8. See the checkbox is saved as checked. Check DB value as “1” 