### PR TITLE
DIS-1928: Fix sierra self-reg for Individual library

### DIFF
--- a/code/web/Drivers/Sierra.php
+++ b/code/web/Drivers/Sierra.php
@@ -2273,12 +2273,15 @@ class Sierra extends AbstractIlsDriver {
 
 			$params['patronType'] = (int)$selfRegistrationForm->selfRegPatronType;
 			$params['patronCodes'] = [
-				'pcode1' => $selfRegistrationForm->selfRegPcode1,
-				'pcode2' => $selfRegistrationForm->selfRegPcode2,
-				'pcode3' => (int)$selfRegistrationForm->selfRegPcode3,
-				'pcode4' => (int)$selfRegistrationForm->selfRegPcode4
+				'pcode1' => $selfRegistrationForm->selfRegPcode1 ?? '',
+				'pcode2' => $selfRegistrationForm->selfRegPcode2 ?? '',
+				'pcode3' => (int)$selfRegistrationForm->selfRegPcode3
 			];
-			$params['pMessage'] = $selfRegistrationForm->selfRegPatronMessage;
+			$pcode4 = $selfRegistrationForm->selfRegPcode4;
+			if (isset($pcode4) && (int)$pcode4 !== 0) {
+				$params['patronCodes']['pcode4'] = (int)$pcode4;
+			}
+			$params['pMessage'] = $selfRegistrationForm->selfRegPatronMessage ?? '';
 			if (!empty($_REQUEST['noticePreference'])) {
 				$params['fixedFields'] = [
 					'268' => [

--- a/code/web/release_notes/26.03.00.MD
+++ b/code/web/release_notes/26.03.00.MD
@@ -54,6 +54,10 @@
 ### Other Updates
 - Fix "Not Holdable" label missing for non-holdable items in Copies table. ([DIS-1973](https://aspen-discovery.atlassian.net/browse/DIS-1973)) (*YL*)
 
+### Sierra Updates
+- Fix self-registration for individual Sierra libraries that do not have pcode4 configured. When pcode1, pcode2, or pMessage are not configured, self-registration now sends empty strings instead of null.  ([DIS-1928](https://aspen-discovery.atlassian.net/browse/DIS-1928)) (*YL*)
+
+
 //imani
 ## Sierra Updates
 - Added default value of null to $lastResponseCode in Sierra driver ((DIS-1951)[https://aspen-discovery.atlassian.net/browse/DIS-1951]) (*IT*)


### PR DESCRIPTION
Currently, if a Sierra Individual library does not have pcode1–pcode4 or patron message configured for self-registration, Aspen sends the following JSON to Sierra and receives an error.
```
 "patronCodes": {
    "pcode1": null,
    "pcode2": null,
    "pcode3": 0,
    "pcode4": 0
  },

  "pMessage": null,
```
pcode4 is for Consortial Management Extension, which is not available for individual libraries. Only include pcode4 when set and non-zero.

To test:
Apply PR for Sierra individual library and see self-reg succeed. 