### PR TITLE
DIS-2045: InvoiceCloud cc service fee

### DIFF
--- a/code/web/release_notes/26.03.00.MD
+++ b/code/web/release_notes/26.03.00.MD
@@ -54,6 +54,9 @@
 ### Other Updates
 - Fix "Not Holdable" label missing for non-holdable items in Copies table. ([DIS-1973](https://aspen-discovery.atlassian.net/browse/DIS-1973)) (*YL*)
 
+### eCommerce Updates
+- Allow InvoiceCloud Settings > Credit Card Service Fee to be configured as a percentage (e.g. 2.45%) in addition to a fixed amount (e.g. $2.45).([DIS-2045](https://aspen-discovery.atlassian.net/browse/DIS-2045)) (*YL*)
+
 //imani
 ## Sierra Updates
 - Added default value of null to $lastResponseCode in Sierra driver ((DIS-1951)[https://aspen-discovery.atlassian.net/browse/DIS-1951]) (*IT*)

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -7788,8 +7788,13 @@ class MyAccount_AJAX extends JSON_Action {
 				$createInvoice->InvoiceNumber = $token;
 				$createInvoice->TypeID = intval($invoiceCloudSetting->invoiceTypeId);
 				$createInvoice->BalanceDue = $payment->totalPaid;
-				$createInvoice->CCServiceFee = $invoiceCloudSetting->ccServiceFee;
-				$createInvoice->ACHServiceFee = $invoiceCloudSetting->ccServiceFee;
+				$ccServiceFee = $invoiceCloudSetting->ccServiceFee;
+				if (isset($ccServiceFee) && str_contains($ccServiceFee, '%')) {
+					$percent = floatval(str_replace('%', '', $ccServiceFee));
+					$ccServiceFee = round($payment->totalPaid * ($percent / 100), 2);
+				}
+				$createInvoice->CCServiceFee = $ccServiceFee;
+				$createInvoice->ACHServiceFee = $ccServiceFee;
 				$createInvoice->DueDate = date('m/d/Y');
 				$createInvoice->InvoiceDate = date('m/d/Y');
 

--- a/code/web/sys/ECommerce/InvoiceCloudSetting.php
+++ b/code/web/sys/ECommerce/InvoiceCloudSetting.php
@@ -60,7 +60,7 @@ class InvoiceCloudSetting extends DataObject {
 				'property' => 'ccServiceFee',
 				'type' => 'text',
 				'label' => 'Credit Card Service Fee',
-				'description' => 'The credit card service fee',
+				'description' => 'The credit card service fee, can be a percentage or a fixed amount',
 				'hideInLists' => true,
 				'maxLength' => 50,
 			],


### PR DESCRIPTION
Currently in InvoiceCloud settings, Credit Card Service Fee can only be set as a fixed amount (e.g. $1.50).
Aspen should also allow the Credit Card Service Fee to be configured as a percentage (e.g. 1.5%). 

To test:
1. Apply PR.
2. In InvoiceCloud Settings, set Credit Card Service Fee to 1.5% and enable Force Debugging Logs 
3. Attempt to pay the fine
4. Check the External Request Log in Greenhouse, and see that CCServiceFee and ACHServiceFee are 1.5% of the total payment. 
5. Set Credit Card Service Fee to a fixed amount 1.50.
6. Attempt to pay the fine, check the log again and see CCServiceFee and ACHServiceFee are $1.50