### PR TITLE
DIS-2065: Optimize locked facets behaviors

### DIFF
--- a/code/web/interface/themes/responsive/Search/Recommend/SideFacets.tpl
+++ b/code/web/interface/themes/responsive/Search/Recommend/SideFacets.tpl
@@ -8,9 +8,15 @@
 			<div class="applied-filters">
 				{foreach from=$filterList item=filters key=field }
 					{foreach from=$filters item=filter}
-						<a class="btn btn-default btn-sm facetValueBadge" href="{$filter.removalUrl|escape}" aria-label="{translate text="Remove Filter" inAttribute=true isPublicFacing=true}">
+					{if !empty($filter.isLocked)}
+						<a class="btn btn-default btn-sm facetValueBadge" href="{$filter.removalUrl|escape}" onclick="return AspenDiscovery.Searches.unlockFacetAndRemove('{$filter.field}', '{$filter.removalUrl|escape}');" aria-label="{translate text="Unlock and remove Filter" inAttribute=true isPublicFacing=true}" data-filter-field="{$filter.field|escape}" data-filter-unscoped="{$filter.unscopedField|escape}" data-filter-value="{$filter.value|escape}" data-filter-display="{$filter.display|escape}" data-removal-url="{$filter.removalUrl|escape}">
+							<i class="fas fa-lock fa-lg fa-fw" style="display:inline; vertical-align: middle"></i> {$filter.display}
+						</a>
+					{else}
+						<a class="btn btn-default btn-sm facetValueBadge" href="{$filter.removalUrl|escape}" aria-label="{translate text="Remove Filter" inAttribute=true isPublicFacing=true}" data-filter-field="{$filter.field|escape}" data-filter-unscoped="{$filter.unscopedField|escape}" data-filter-value="{$filter.value|escape}" data-filter-display="{$filter.display|escape}" data-removal-url="{$filter.removalUrl|escape}">
 							<i class="fas fa-xmark text-danger remove-filter-icon" style="display:inline; vertical-align: middle"></i> {$filter.display}
 						</a>
+					{/if}
 					{/foreach}
 				{/foreach}
 			</div>

--- a/code/web/interface/themes/responsive/Search/Recommend/SideFacets.tpl
+++ b/code/web/interface/themes/responsive/Search/Recommend/SideFacets.tpl
@@ -26,20 +26,20 @@
 			<h3 id="narrow-search-label" class="sidebar-label">{translate text='Narrow Search' isPublicFacing=true}</h3>
 			<div id="facet-accordion" class="accordion">
 				{foreach from=$sideFacetSet item=cluster key=title name=facetSet}
-					{if count($cluster.list) > 0}
+					{if count($cluster.list) > 0 || !empty($cluster.locked)}
 						<div class="facetList">
-							<div id="facetToggle_{$title}" aria-controls="facetDetails_{$title}" class="facetTitle panel-title {if !empty($cluster.collapseByDefault) && empty($cluster.hasApplied)}collapsed{else}expanded{/if}" tabindex="0" role="button" aria-expanded="{if !empty($cluster.collapseByDefault) && empty($cluster.hasApplied)}false{else}true{/if}">
+							<div id="facetToggle_{$title}" aria-controls="facetDetails_{$title}" class="facetTitle panel-title {if !empty($cluster.locked)}expanded{elseif !empty($cluster.collapseByDefault) && empty($cluster.hasApplied)}collapsed{else}expanded{/if}" tabindex="0" role="button" aria-expanded="{if !empty($cluster.locked)}true{elseif !empty($cluster.collapseByDefault) && empty($cluster.hasApplied)}false{else}true{/if}">
 								{translate text=$cluster.label isPublicFacing=true}
 
 								{if !empty($cluster.canLock)}
-									<span class="facetLock pull-right" id="facetLock_{$title}" {if empty($cluster.hasApplied)}style="display: none"{/if} title="{translate text="Locking a facet will retain the selected filters in new searches until they are cleared" inAttribute=true isPublicFacing=true}">
+									<span class="facetLock pull-right" id="facetLock_{$title}" {if empty($cluster.hasApplied) && empty($cluster.locked)}style="display: none"{/if} title="{translate text="Locking a facet will retain the selected filters in new searches until they are cleared" inAttribute=true isPublicFacing=true}">
 										<a id="facetLock_lockIcon_{$title}" {if !empty($cluster.locked)}style="display: none"{/if} onclick="return AspenDiscovery.Searches.lockFacet('{$title}');"><i class="fas fa-lock-open fa-lg fa-fw" style="vertical-align: middle"></i></a>
 										<a id="facetLock_unlockIcon_{$title}" {if empty($cluster.locked)}style="display: none"{/if} onclick="return AspenDiscovery.Searches.unlockFacet('{$title}');"><i class="fas fa-lock fa-lg fa-fw" style="vertical-align: middle"></i></a>
 									</span>
 								{/if}
 
 							</div>
-							<div id="facetDetails_{$title}" class="facetDetails" {if !empty($cluster.collapseByDefault) && empty($cluster.hasApplied)}style="display:none"{/if} role="region" aria-labelledby="facetToggle_{$title}">
+							<div id="facetDetails_{$title}" class="facetDetails" {if !empty($cluster.locked)}style="display:block"{elseif !empty($cluster.collapseByDefault) && empty($cluster.hasApplied)}style="display:none"{/if} role="region" aria-labelledby="facetToggle_{$title}">
 
 								{if $title == 'publishDate' || $title == 'birthYear' || $title == 'deathYear' || $title == 'publishDateSort'}
 									{include file="Search/Recommend/yearFacetFilter.tpl" cluster=$cluster title=$title}

--- a/code/web/interface/themes/responsive/Search/Recommend/SideFacets.tpl
+++ b/code/web/interface/themes/responsive/Search/Recommend/SideFacets.tpl
@@ -9,7 +9,7 @@
 				{foreach from=$filterList item=filters key=field }
 					{foreach from=$filters item=filter}
 					{if !empty($filter.isLocked)}
-						<a class="btn btn-default btn-sm facetValueBadge" href="{$filter.removalUrl|escape}" onclick="return AspenDiscovery.Searches.unlockFacetAndRemove('{$filter.field}', '{$filter.removalUrl|escape}');" aria-label="{translate text="Unlock and remove Filter" inAttribute=true isPublicFacing=true}" data-filter-field="{$filter.field|escape}" data-filter-unscoped="{$filter.unscopedField|escape}" data-filter-value="{$filter.value|escape}" data-filter-display="{$filter.display|escape}" data-removal-url="{$filter.removalUrl|escape}">
+						<a class="btn btn-default btn-sm facetValueBadge" href="{$filter.removalUrl|escape}" onclick="return AspenDiscovery.Searches.unlockFacetAndRemove('{$filter.field}', '{$filter.removalUrl|escape}', '{$filter.value|escape:'javascript'}');" aria-label="{translate text="Unlock and remove Filter" inAttribute=true isPublicFacing=true}" data-filter-field="{$filter.field|escape}" data-filter-unscoped="{$filter.unscopedField|escape}" data-filter-value="{$filter.value|escape}" data-filter-display="{$filter.display|escape}" data-removal-url="{$filter.removalUrl|escape}">
 							<i class="fas fa-lock fa-lg fa-fw" style="display:inline; vertical-align: middle"></i> {$filter.display}
 						</a>
 					{else}

--- a/code/web/interface/themes/responsive/Search/Recommend/multiSelectFacet.tpl
+++ b/code/web/interface/themes/responsive/Search/Recommend/multiSelectFacet.tpl
@@ -13,7 +13,7 @@
 			<label for="{$title}_{$thisFacet.value|escapeCSS}">
 				<input type="checkbox" {if !empty($thisFacet.isApplied)}checked{/if} name="{$title}_{$thisFacet.value|escapeCSS}" id="{$title}_{$thisFacet.value|escapeCSS}"
 						{if !empty($thisFacet.isApplied) && !empty($thisFacet.isLocked)}
-							onclick="return AspenDiscovery.Searches.unlockFacetAndRemove('{$title}', '{$thisFacet.removalUrl|escape}');" onkeypress="return AspenDiscovery.Searches.unlockFacetAndRemove('{$title}', '{$thisFacet.removalUrl|escape}');"
+							onclick="return AspenDiscovery.Searches.unlockFacetAndRemove('{$title}', '{$thisFacet.removalUrl|escape}', '{$thisFacet.value|escape:'javascript'}');" onkeypress="return AspenDiscovery.Searches.unlockFacetAndRemove('{$title}', '{$thisFacet.removalUrl|escape}', '{$thisFacet.value|escape:'javascript'}');"
 						{else}
 							onclick="document.location = '{if !empty($thisFacet.isApplied)}{$thisFacet.removalUrl|escape}{else}{$thisFacet.url|escape}{/if}';" onkeypress="document.location = '{if !empty($thisFacet.isApplied)}{$thisFacet.removalUrl|escape}{else}{$thisFacet.url|escape}{/if}';"
 						{/if}>
@@ -66,7 +66,7 @@
 			<label for="{$title}_{$thisFacet.value|escapeCSS}">
 				<input type="checkbox" {if !empty($thisFacet.isApplied)}checked{/if} name="{$title}_{$thisFacet.value|escapeCSS}" id="{$title}_{$thisFacet.value|escapeCSS}"
 						{if !empty($thisFacet.isApplied) && !empty($thisFacet.isLocked)}
-							onclick="return AspenDiscovery.Searches.unlockFacetAndRemove('{$title}', '{$thisFacet.removalUrl|escape}');" onkeypress="return AspenDiscovery.Searches.unlockFacetAndRemove('{$title}', '{$thisFacet.removalUrl|escape}');"
+							onclick="return AspenDiscovery.Searches.unlockFacetAndRemove('{$title}', '{$thisFacet.removalUrl|escape}', '{$thisFacet.value|escape:'javascript'}');" onkeypress="return AspenDiscovery.Searches.unlockFacetAndRemove('{$title}', '{$thisFacet.removalUrl|escape}', '{$thisFacet.value|escape:'javascript'}');"
 						{else}
 							onclick="document.location = '{if !empty($thisFacet.isApplied)}{$thisFacet.removalUrl|escape}{else}{$thisFacet.url|escape}{/if}';" onkeypress="document.location = '{if !empty($thisFacet.isApplied)}{$thisFacet.removalUrl|escape}{else}{$thisFacet.url|escape}{/if}';"
 						{/if}>

--- a/code/web/interface/themes/responsive/Search/Recommend/multiSelectFacet.tpl
+++ b/code/web/interface/themes/responsive/Search/Recommend/multiSelectFacet.tpl
@@ -11,7 +11,12 @@
 		{/if}
 		<div class="facetValue">
 			<label for="{$title}_{$thisFacet.value|escapeCSS}">
-				<input type="checkbox" {if !empty($thisFacet.isApplied)}checked{/if} name="{$title}_{$thisFacet.value|escapeCSS}" id="{$title}_{$thisFacet.value|escapeCSS}" onclick="document.location = '{if !empty($thisFacet.isApplied)}{$thisFacet.removalUrl|escape}{else}{$thisFacet.url|escape}{/if}';" onkeypress="document.location = '{if !empty($thisFacet.isApplied)}{$thisFacet.removalUrl|escape}{else}{$thisFacet.url|escape}{/if}';">
+				<input type="checkbox" {if !empty($thisFacet.isApplied)}checked{/if} name="{$title}_{$thisFacet.value|escapeCSS}" id="{$title}_{$thisFacet.value|escapeCSS}"
+						{if !empty($thisFacet.isApplied) && !empty($thisFacet.isLocked)}
+							onclick="return AspenDiscovery.Searches.unlockFacetAndRemove('{$title}', '{$thisFacet.removalUrl|escape}');" onkeypress="return AspenDiscovery.Searches.unlockFacetAndRemove('{$title}', '{$thisFacet.removalUrl|escape}');"
+						{else}
+							onclick="document.location = '{if !empty($thisFacet.isApplied)}{$thisFacet.removalUrl|escape}{else}{$thisFacet.url|escape}{/if}';" onkeypress="document.location = '{if !empty($thisFacet.isApplied)}{$thisFacet.removalUrl|escape}{else}{$thisFacet.url|escape}{/if}';"
+						{/if}>
 				{$thisFacet.display}{if $facetCountsToShow == 1 || ($facetCountsToShow == 2 && empty($thisFacet.countIsApproximate))}{if !empty($thisFacet.count)}&nbsp;({if !empty($thisFacet.countIsApproximate)}{/if}{$thisFacet.count|number_format}){/if}{/if}
 			</label>
 		</div>
@@ -59,7 +64,12 @@
 		{/if}
 		<div class="facetValue">
 			<label for="{$title}_{$thisFacet.value|escapeCSS}">
-				<input type="checkbox" {if !empty($thisFacet.isApplied)}checked{/if} name="{$title}_{$thisFacet.value|escapeCSS}" id="{$title}_{$thisFacet.value|escapeCSS}" onclick="document.location = '{if !empty($thisFacet.isApplied)}{$thisFacet.removalUrl|escape}{else}{$thisFacet.url|escape}{/if}';" onkeypress="document.location = '{if !empty($thisFacet.isApplied)}{$thisFacet.removalUrl|escape}{else}{$thisFacet.url|escape}{/if}';">
+				<input type="checkbox" {if !empty($thisFacet.isApplied)}checked{/if} name="{$title}_{$thisFacet.value|escapeCSS}" id="{$title}_{$thisFacet.value|escapeCSS}"
+						{if !empty($thisFacet.isApplied) && !empty($thisFacet.isLocked)}
+							onclick="return AspenDiscovery.Searches.unlockFacetAndRemove('{$title}', '{$thisFacet.removalUrl|escape}');" onkeypress="return AspenDiscovery.Searches.unlockFacetAndRemove('{$title}', '{$thisFacet.removalUrl|escape}');"
+						{else}
+							onclick="document.location = '{if !empty($thisFacet.isApplied)}{$thisFacet.removalUrl|escape}{else}{$thisFacet.url|escape}{/if}';" onkeypress="document.location = '{if !empty($thisFacet.isApplied)}{$thisFacet.removalUrl|escape}{else}{$thisFacet.url|escape}{/if}';"
+						{/if}>
 				{$thisFacet.display}{if $facetCountsToShow == 1 || ($facetCountsToShow == 2 && empty($thisFacet.countIsApproximate))}{if !empty($thisFacet.count)}&nbsp;({if !empty($thisFacet.countIsApproximate)}{/if}{$thisFacet.count|number_format}){/if}{/if}
 			</label>
 		</div>

--- a/code/web/interface/themes/responsive/Search/Recommend/standardFacet.tpl
+++ b/code/web/interface/themes/responsive/Search/Recommend/standardFacet.tpl
@@ -9,7 +9,7 @@
 			<div class="narrowGroupHidden" id="narrowGroupHidden_{$title}" style="display:none">
 		{/if}
 		{if !empty($thisFacet.isApplied)}
-			<div class="facetValue"><i class="fas fa-check-circle fa-lg text-success" style="vertical-align: middle"></i> {$thisFacet.display} <a href="{$thisFacet.removalUrl|escape}" class="removeFacetLink"{if !empty($thisFacet.isLocked)} onclick="return AspenDiscovery.Searches.unlockFacetAndRemove('{$title}', '{$thisFacet.removalUrl|escape}');"{/if}>({translate text='remove' isPublicFacing=true})</a></div>
+			<div class="facetValue"><i class="fas fa-check-circle fa-lg text-success" style="vertical-align: middle"></i> {$thisFacet.display} <a href="{$thisFacet.removalUrl|escape}" class="removeFacetLink"{if !empty($thisFacet.isLocked)} onclick="return AspenDiscovery.Searches.unlockFacetAndRemove('{$title}', '{$thisFacet.removalUrl|escape}', '{$thisFacet.value|escape:'javascript'}');"{/if}>({translate text='remove' isPublicFacing=true})</a></div>
 		{else}
 			<div class="facetValue">{if $thisFacet.url !=null}<a href="{$thisFacet.url|escape}">{/if}{$thisFacet.display}{if $thisFacet.url !=null}</a>{/if}{if $facetCountsToShow == 1 || ($facetCountsToShow == 2 && empty($thisFacet.countIsApproximate))}{if $thisFacet.count != ''}&nbsp;({if !empty($thisFacet.countIsApproximate)}{/if}{$thisFacet.count|number_format}){/if}{/if}</div>
 		{/if}
@@ -45,7 +45,7 @@
 			<div class="narrowGroupHidden" id="narrowGroupHidden_{$title}" style="display:none">
 		{/if}
 		{if !empty($thisFacet.isApplied)}
-			<div class="facetValue"><i class="fas fa-check-circle fa-lg text-success" style="vertical-align: middle"></i> {$thisFacet.display} <a href="{$thisFacet.removalUrl|escape}" class="removeFacetLink"{if !empty($thisFacet.isLocked)} onclick="return AspenDiscovery.Searches.unlockFacetAndRemove('{$title}', '{$thisFacet.removalUrl|escape}');"{/if}>({translate text='remove' isPublicFacing=true})</a></div>
+			<div class="facetValue"><i class="fas fa-check-circle fa-lg text-success" style="vertical-align: middle"></i> {$thisFacet.display} <a href="{$thisFacet.removalUrl|escape}" class="removeFacetLink"{if !empty($thisFacet.isLocked)} onclick="return AspenDiscovery.Searches.unlockFacetAndRemove('{$title}', '{$thisFacet.removalUrl|escape}', '{$thisFacet.value|escape:'javascript'}');"{/if}>({translate text='remove' isPublicFacing=true})</a></div>
 		{else}
 			<div class="facetValue">{if $thisFacet.url !=null}<a href="{$thisFacet.url|escape}">{/if}{$thisFacet.display}{if $thisFacet.url !=null}</a>{/if}{if $facetCountsToShow == 1 || ($facetCountsToShow == 2 && empty($thisFacet.countIsApproximate))}{if $thisFacet.count != ''}&nbsp;({if !empty($thisFacet.countIsApproximate)}{/if}{$thisFacet.count|number_format}){/if}{/if}</div>
 		{/if}

--- a/code/web/interface/themes/responsive/Search/Recommend/standardFacet.tpl
+++ b/code/web/interface/themes/responsive/Search/Recommend/standardFacet.tpl
@@ -9,7 +9,7 @@
 			<div class="narrowGroupHidden" id="narrowGroupHidden_{$title}" style="display:none">
 		{/if}
 		{if !empty($thisFacet.isApplied)}
-			<div class="facetValue"><i class="fas fa-check-circle fa-lg text-success" style="vertical-align: middle"></i> {$thisFacet.display} <a href="{$thisFacet.removalUrl|escape}" class="removeFacetLink">({translate text='remove' isPublicFacing=true})</a></div>
+			<div class="facetValue"><i class="fas fa-check-circle fa-lg text-success" style="vertical-align: middle"></i> {$thisFacet.display} <a href="{$thisFacet.removalUrl|escape}" class="removeFacetLink"{if !empty($thisFacet.isLocked)} onclick="return AspenDiscovery.Searches.unlockFacetAndRemove('{$title}', '{$thisFacet.removalUrl|escape}');"{/if}>({translate text='remove' isPublicFacing=true})</a></div>
 		{else}
 			<div class="facetValue">{if $thisFacet.url !=null}<a href="{$thisFacet.url|escape}">{/if}{$thisFacet.display}{if $thisFacet.url !=null}</a>{/if}{if $facetCountsToShow == 1 || ($facetCountsToShow == 2 && empty($thisFacet.countIsApproximate))}{if $thisFacet.count != ''}&nbsp;({if !empty($thisFacet.countIsApproximate)}{/if}{$thisFacet.count|number_format}){/if}{/if}</div>
 		{/if}
@@ -45,7 +45,7 @@
 			<div class="narrowGroupHidden" id="narrowGroupHidden_{$title}" style="display:none">
 		{/if}
 		{if !empty($thisFacet.isApplied)}
-			<div class="facetValue"><i class="fas fa-check-circle fa-lg text-success" style="vertical-align: middle"></i> {$thisFacet.display} <a href="{$thisFacet.removalUrl|escape}" class="removeFacetLink">({translate text='remove' isPublicFacing=true})</a></div>
+			<div class="facetValue"><i class="fas fa-check-circle fa-lg text-success" style="vertical-align: middle"></i> {$thisFacet.display} <a href="{$thisFacet.removalUrl|escape}" class="removeFacetLink"{if !empty($thisFacet.isLocked)} onclick="return AspenDiscovery.Searches.unlockFacetAndRemove('{$title}', '{$thisFacet.removalUrl|escape}');"{/if}>({translate text='remove' isPublicFacing=true})</a></div>
 		{else}
 			<div class="facetValue">{if $thisFacet.url !=null}<a href="{$thisFacet.url|escape}">{/if}{$thisFacet.display}{if $thisFacet.url !=null}</a>{/if}{if $facetCountsToShow == 1 || ($facetCountsToShow == 2 && empty($thisFacet.countIsApproximate))}{if $thisFacet.count != ''}&nbsp;({if !empty($thisFacet.countIsApproximate)}{/if}{$thisFacet.count|number_format}){/if}{/if}</div>
 		{/if}

--- a/code/web/interface/themes/responsive/Search/searchFacetPopup.tpl
+++ b/code/web/interface/themes/responsive/Search/searchFacetPopup.tpl
@@ -38,7 +38,7 @@
 							{strip}
 							<div class="checkboxFacet col-tn-12">
 								<label>
-								<input type="checkbox" class="facetSearchPopupValue" checked name="filter[]" value='{$facetName}:{if empty($thisFacet.value)}(""){else}"{$thisFacet.value|escape:url}"{/if}'>
+								<input type="checkbox" class="facetSearchPopupValue" checked name="filter[]" value='{$facetName}:{if empty($thisFacet.value)}(""){else}"{$thisFacet.value|escape:url}"{/if}' {if !empty($thisFacet.isLocked)} data-locked="1"{/if}>
 									&nbsp;
 									{$thisFacet.display}{if $facetCountsToShow == 1 || ($facetCountsToShow == 2 && empty($thisFacet.countIsApproximate))}{if !empty($thisFacet.count)}&nbsp;({if !empty($thisFacet.countIsApproximate)}{/if}{$thisFacet.count|number_format}){/if}{/if}
 								</label>
@@ -51,7 +51,7 @@
 							{if !($thisFacet.isApplied)}
 								<div class="checkboxFacet col-tn-12">
 									<label>
-									<input type="checkbox" class="facetSearchPopupValue" {if !empty($thisFacet.isApplied)}checked{/if} name="filter[]" value='{$facetName}:{if empty($thisFacet.value)}(""){else}"{$thisFacet.value|escape:url}"{/if}'>
+									<input type="checkbox" class="facetSearchPopupValue" {if !empty($thisFacet.isApplied)}checked{/if} name="filter[]" value='{$facetName}:{if empty($thisFacet.value)}(""){else}"{$thisFacet.value|escape:url}"{/if}' {if !empty($thisFacet.isLocked)} data-locked="1"{/if}>
 										&nbsp;
 										{$thisFacet.display}{if $facetCountsToShow == 1 || ($facetCountsToShow == 2 && empty($thisFacet.countIsApproximate))}{if !empty($thisFacet.count)}&nbsp;({if !empty($thisFacet.countIsApproximate)}{/if}{$thisFacet.count|number_format}){/if}{/if}
 									</label>

--- a/code/web/interface/themes/responsive/Search/searchFacetResults.tpl
+++ b/code/web/interface/themes/responsive/Search/searchFacetResults.tpl
@@ -4,7 +4,7 @@
 			{strip}
 			<div class="checkboxFacet col-tn-12">
 				<label>
-				<input type="checkbox" class="facetSearchPopupValue" checked name="filter[]" value='{$facetName}:{if empty($thisFacet.value)}(""){else}"{$thisFacet.value|escape:url}"{/if}'>
+				<input type="checkbox" class="facetSearchPopupValue" checked name="filter[]" value='{$facetName}:{if empty($thisFacet.value)}(""){else}"{$thisFacet.value|escape:url}"{/if}' {if !empty($thisFacet.isLocked)} data-locked="1"{/if}>
 					&nbsp;
 					{$thisFacet.display}{if $facetCountsToShow == 1 || ($facetCountsToShow == 2 && empty($thisFacet.countIsApproximate))}{if !empty($thisFacet.count)}&nbsp;({if !empty($thisFacet.countIsApproximate)}{/if}{$thisFacet.count|number_format}){/if}{/if}
 				</label>
@@ -18,7 +18,7 @@
 				{if $isMultiSelect}
 					<div class="checkboxFacet col-tn-12">
 						<label>
-						<input type="checkbox" {if !empty($thisFacet.isApplied)}checked{/if} name="filter[]" value='{$facetName}:{if empty($thisFacet.value)}(""){else}"{$thisFacet.value|escape:url}"{/if}'>
+						<input type="checkbox" {if !empty($thisFacet.isApplied)}checked{/if} name="filter[]" value='{$facetName}:{if empty($thisFacet.value)}(""){else}"{$thisFacet.value|escape:url}"{/if}'{if !empty($thisFacet.isLocked)} data-locked="1"{/if}>
 							&nbsp;
 							{$thisFacet.display}{if $facetCountsToShow == 1 || ($facetCountsToShow == 2 && empty($thisFacet.countIsApproximate))}{if !empty($thisFacet.count)}&nbsp;({if !empty($thisFacet.countIsApproximate)}{/if}{$thisFacet.count|number_format}){/if}{/if}
 						</label>

--- a/code/web/interface/themes/responsive/js/aspen/results-list.js
+++ b/code/web/interface/themes/responsive/js/aspen/results-list.js
@@ -24,6 +24,30 @@ AspenDiscovery.ResultsList = (function(){
 
 		processMultiSelectMoreFacetForm: function(formId, fieldName){
 			var newUrl = location.origin + location.pathname + "?";
+			var unlockRequests = [];
+			var unlockValues = [];
+			var unlockUrl = Globals.path + "/Search/AJAX";
+
+			function extractFacetValue(filterValue, fieldName) {
+				if (!filterValue) {
+					return null;
+				}
+				var decoded = decodeURIComponent(filterValue.substring(fieldName.length + 1));
+				if (decoded === '("")') {
+					return "";
+				}
+				return (decoded.length >= 2 && decoded[0] === '"' && decoded[decoded.length - 1] === '"')
+					? decoded.substring(1, decoded.length - 1) : decoded;
+			}
+
+			$(".modal-body " + formId + " input[type=checkbox][data-locked='1']").each(function () {
+				if (!$(this).is(":checked")) {
+					var value = extractFacetValue($(this).attr('value'), fieldName);
+					if (value !== null) {
+						unlockValues.push(value);
+					}
+				}
+			});
 			//Remove existing parameters for the facet from the url
 			var existingQuery = location.search.substr(1);
 			var firstTerm = true;
@@ -64,7 +88,17 @@ AspenDiscovery.ResultsList = (function(){
 				newUrl += (name + '=' + value);
 			});
 
-			document.location.href = newUrl;
+			if (unlockValues.length > 0) {
+				for (var i = 0; i < unlockValues.length; i++) {
+					var params = "method=unlockFacet&facet=" + encodeURIComponent(fieldName) + "&value=" + encodeURIComponent(unlockValues[i]);
+					unlockRequests.push($.getJSON(unlockUrl + "?" + params));
+				}
+				$.when.apply($, unlockRequests).always(function () {
+					document.location.href = newUrl;
+				});
+			} else {
+				document.location.href = newUrl;
+			}
 			return false;
 		},
 

--- a/code/web/interface/themes/responsive/js/aspen/searches.js
+++ b/code/web/interface/themes/responsive/js/aspen/searches.js
@@ -325,12 +325,13 @@ AspenDiscovery.Searches = (function(){
 				var $badge = $(this);
 				var removalUrl = $badge.data("removal-url");
 				var display = $badge.data("filter-display");
+				var value = $badge.data("filter-value");
 				$badge.off("click.locked");
 				if (isLocked) {
 					$badge.attr("aria-label", "Unlock and remove Filter");
 					$badge.on("click.locked", function(e){
 						e.preventDefault();
-						AspenDiscovery.Searches.unlockFacetAndRemove(clusterName, removalUrl);
+						AspenDiscovery.Searches.unlockFacetAndRemove(clusterName, removalUrl, value);
 					});
 					$badge.html('<i class="fas fa-lock fa-lg fa-fw" style="display:inline; vertical-align: middle"></i> ' + display);
 				} else {
@@ -340,10 +341,15 @@ AspenDiscovery.Searches = (function(){
 			});
 		},
 
-		unlockFacetAndRemove: function (clusterName, removalUrl) {
+		unlockFacetAndRemove: function (clusterName, removalUrl, facetValue) {
 			event.stopPropagation();
 			var url = Globals.path + "/Search/AJAX";
-			var params = "method=unlockFacet&facet=" + encodeURIComponent(clusterName);
+			var params;
+			if (facetValue !== undefined && facetValue !== null && facetValue !== "") {
+				params = "method=unlockFacet&facet=" + encodeURIComponent(clusterName) + "&value=" + encodeURIComponent(facetValue);
+			} else {
+				params = "method=unlockFacet&facet=" + encodeURIComponent(clusterName);
+			}
 			var fullUrl = url + "?" + params;
 			$.getJSON(fullUrl,
 				function(data) {

--- a/code/web/interface/themes/responsive/js/aspen/searches.js
+++ b/code/web/interface/themes/responsive/js/aspen/searches.js
@@ -288,6 +288,7 @@ AspenDiscovery.Searches = (function(){
 					if (data.success === true){
 						$("#facetLock_lockIcon_" + clusterName).hide();
 						$("#facetLock_unlockIcon_" + clusterName).show();
+						AspenDiscovery.Searches.updateAppliedFilterBadges(clusterName, true);
 					}else{
 						AspenDiscovery.showMessage('Error', data.message, true);
 					}
@@ -306,6 +307,48 @@ AspenDiscovery.Searches = (function(){
 					if (data.success === true){
 						$("#facetLock_lockIcon_" + clusterName).show();
 						$("#facetLock_unlockIcon_" + clusterName).hide();
+						AspenDiscovery.Searches.updateAppliedFilterBadges(clusterName, false);
+					}else{
+						AspenDiscovery.showMessage('Error', data.message, true);
+					}
+				}
+			);
+			return false;
+		},
+
+		updateAppliedFilterBadges: function (clusterName, isLocked) {
+			var $badges = $(".applied-filters .facetValueBadge").filter(function() {
+				var $badge = $(this);
+				return $badge.data("filter-field") === clusterName || $badge.data("filter-unscoped") === clusterName;
+			});
+			$badges.each(function() {
+				var $badge = $(this);
+				var removalUrl = $badge.data("removal-url");
+				var display = $badge.data("filter-display");
+				$badge.off("click.locked");
+				if (isLocked) {
+					$badge.attr("aria-label", "Unlock and remove Filter");
+					$badge.on("click.locked", function(e){
+						e.preventDefault();
+						AspenDiscovery.Searches.unlockFacetAndRemove(clusterName, removalUrl);
+					});
+					$badge.html('<i class="fas fa-lock fa-lg fa-fw" style="display:inline; vertical-align: middle"></i> ' + display);
+				} else {
+					$badge.attr("aria-label", "Remove Filter");
+					$badge.html('<i class="fas fa-xmark text-danger remove-filter-icon" style="display:inline; vertical-align: middle"></i> ' + display);
+				}
+			});
+		},
+
+		unlockFacetAndRemove: function (clusterName, removalUrl) {
+			event.stopPropagation();
+			var url = Globals.path + "/Search/AJAX";
+			var params = "method=unlockFacet&facet=" + encodeURIComponent(clusterName);
+			var fullUrl = url + "?" + params;
+			$.getJSON(fullUrl,
+				function(data) {
+					if (data.success === true){
+						window.location = removalUrl;
 					}else{
 						AspenDiscovery.showMessage('Error', data.message, true);
 					}

--- a/code/web/release_notes/26.03.00.MD
+++ b/code/web/release_notes/26.03.00.MD
@@ -135,6 +135,14 @@
 ### Sierra Updates
 - Fix self-registration for individual Sierra libraries that do not have pcode4 configured. When pcode1, pcode2, or pMessage are not configured, self-registration now sends empty strings instead of null.  ([DIS-1928](https://aspen-discovery.atlassian.net/browse/DIS-1928)) (*YL*)
 
+### Facets Updates
+- Optimize locked facets to better align with patron workflows. ([DIS-2065](https://aspen-discovery.atlassian.net/browse/DIS-2065)) (*YL*)
+  - When a facet is locked, the facet heading shows a lock icon (instead of unlock) and Applied Filters show a lock icon for locked values (instead of a remove icon). Newly selected (unlocked) values still show the remove icon so patrons can tell which filters are locked and which are not.
+  - Unlocking a single locked value from Applied Filters or from the facet list under Narrow Your Results now only unlocks and removes that value; other locked values in the same group stay locked. Patrons can still unlock all locked values in a group via the lock icon in the facet heading.
+  - Unlocking a locked value from the “More” modal also removes that value from the locked list so it does not reappear on the next search.
+  - Locked facets are always shown in the sidebar even when the current search returns no results for those facet values; missing locked facets appear as stub panels and locked facet groups automatically expand so patrons can see and unlock them.
+  - Applied facet values are always shown at the top of their facet groups.
+
 
 //imani
 ## Sierra Updates

--- a/code/web/services/Search/AJAX.php
+++ b/code/web/services/Search/AJAX.php
@@ -531,6 +531,7 @@ class AJAX extends Action {
 		$activeSearch = $searchObject->loadLastSearch();
 		$lockSection = $activeSearch->getSearchName();
 		$facetToUnlock = $_REQUEST['facet'];
+		$facetValueToUnlock = $_REQUEST['value'] ?? null;
 
 		if (UserAccount::isLoggedIn()) {
 			$user = UserAccount::getActiveUserObj();
@@ -540,7 +541,14 @@ class AJAX extends Action {
 		}
 
 		if (isset($lockedFacets[$lockSection][$facetToUnlock])) {
-			unset($lockedFacets[$lockSection][$facetToUnlock]);
+			if (!empty($facetValueToUnlock) && is_array($lockedFacets[$lockSection][$facetToUnlock])) {
+				$lockedFacets[$lockSection][$facetToUnlock] = array_values(array_diff($lockedFacets[$lockSection][$facetToUnlock], [$facetValueToUnlock]));
+				if (empty($lockedFacets[$lockSection][$facetToUnlock])) {
+					unset($lockedFacets[$lockSection][$facetToUnlock]);
+				}
+			} else {
+				unset($lockedFacets[$lockSection][$facetToUnlock]);
+			}
 			if (UserAccount::isLoggedIn()) {
 				$user = UserAccount::getActiveUserObj();
 				$user->lockedFacets = json_encode($lockedFacets);

--- a/code/web/services/Search/AJAX.php
+++ b/code/web/services/Search/AJAX.php
@@ -666,11 +666,35 @@ class AJAX extends Action {
 						$appliedFacetValues = $appliedFacets[$facetTitle];
 						ksort($appliedFacetValues);
 					}
+					$lockSection = $restoredSearch->getSearchName();
+					if (UserAccount::isLoggedIn()) {
+						$user = UserAccount::getActiveUserObj();
+						$lockedFacets = !empty($user->lockedFacets) ? json_decode($user->lockedFacets, true) : [];
+					} else {
+						$lockedFacets = $_SESSION['lockedFilters'] ?? [];
+					}
+					$lockedValues = $lockedFacets[$lockSection][$facetName] ?? [];
+					if (!empty($lockedValues)) {
+						foreach ($appliedFacetValues as &$appliedFacetValue) {
+							if (!empty($appliedFacetValue['value']) && in_array($appliedFacetValue['value'], $lockedValues, true)) {
+								$appliedFacetValue['isLocked'] = true;
+							}
+						}
+						unset($appliedFacetValue);
+					}
 					$interface->assign('appliedFacetValues', $appliedFacetValues);
 
 					$allFacets = $restoredSearch->getFacetList();
 					$topResults = $allFacets[$facetName];
 					ksort($topResults['list'], SORT_NATURAL | SORT_FLAG_CASE);
+					if (!empty($lockedValues)) {
+						foreach ($topResults['list'] as &$facetValue) {
+							if (!empty($facetValue['value']) && in_array($facetValue['value'], $lockedValues, true)) {
+								$facetValue['isLocked'] = true;
+							}
+						}
+						unset($facetValue);
+					}
 					$interface->assign('topResults', $topResults['list']);
 					$buttons = '';
 					if ($isMultiSelect) {
@@ -770,12 +794,36 @@ class AJAX extends Action {
 						$appliedFacetValues = $appliedFacets[$facetTitle];
 						ksort($appliedFacetValues, SORT_NATURAL | SORT_FLAG_CASE);
 					}
+					$lockSection = $restoredSearch->getSearchName();
+					if (UserAccount::isLoggedIn()) {
+						$user = UserAccount::getActiveUserObj();
+						$lockedFacets = !empty($user->lockedFacets) ? json_decode($user->lockedFacets, true) : [];
+					} else {
+						$lockedFacets = $_SESSION['lockedFilters'] ?? [];
+					}
+					$lockedValues = $lockedFacets[$lockSection][$facetName] ?? [];
+					if (!empty($lockedValues)) {
+						foreach ($appliedFacetValues as &$appliedFacetValue) {
+							if (!empty($appliedFacetValue['value']) && in_array($appliedFacetValue['value'], $lockedValues, true)) {
+								$appliedFacetValue['isLocked'] = true;
+							}
+						}
+						unset($appliedFacetValue);
+					}
 					$interface->assign('appliedFacetValues', $appliedFacetValues);
 
 					$allFacets = $newSearch->getFacetList();
 					if (isset($allFacets[$facetName])) {
 						$facetSearchResults = $allFacets[$facetName];
 						ksort($facetSearchResults['list'], SORT_NATURAL | SORT_FLAG_CASE);
+						if (!empty($lockedValues)) {
+							foreach ($facetSearchResults['list'] as &$facetValue) {
+								if (!empty($facetValue['value']) && in_array($facetValue['value'], $lockedValues, true)) {
+									$facetValue['isLocked'] = true;
+								}
+							}
+							unset($facetValue);
+						}
 						$interface->assign('facetSearchResults', $facetSearchResults['list']);
 						return [
 							'success' => true,

--- a/code/web/sys/Recommend/SideFacets.php
+++ b/code/web/sys/Recommend/SideFacets.php
@@ -181,6 +181,24 @@ class SideFacets implements RecommendationInterface {
 				$sideFacets = $this->applyFacetSettings($facetKey, $sideFacets, $facetSetting, $lockedFacets);
 			}
 		}
+		// Add locked facets to the side facets
+		$lockedFacetKeys = array_keys($lockedFacets);
+		$missingLockedFacets = array_diff($lockedFacetKeys, array_keys($sideFacets));
+		if (!empty($missingLockedFacets)) {
+			foreach ($missingLockedFacets as $facetKey) {
+				$facetSetting = $this->facetSettings[$facetKey] ?? null;
+				$label = ($facetSetting instanceof FacetSetting) ? $facetSetting->displayName : $facetKey;
+				$sideFacets[$facetKey] = [
+					'label' => $label,
+					'list' => [],
+					'locked' => true,
+					'collapseByDefault' => true,
+					'canLock' => true,
+					'valuesToShow' => 5,
+				];
+			}
+		}
+
 
 		$interface->assign('sideFacetSet', $sideFacets);
 	}

--- a/code/web/sys/Recommend/SideFacets.php
+++ b/code/web/sys/Recommend/SideFacets.php
@@ -73,6 +73,7 @@ class SideFacets implements RecommendationInterface {
 		$lockedValuesByUnscoped = [];
 		foreach ($lockedFacets as $lockedFacetKey => $lockedValues) {
 			$unscopedKey = $this->searchObject->getUnscopedFieldName($lockedFacetKey);
+			// To make sure the scoped field (e.g. available_at_main) still shows as locked even when the field names differ.
 			if (!isset($lockedValuesByUnscoped[$unscopedKey])) {
 				$lockedValuesByUnscoped[$unscopedKey] = [];
 			}
@@ -356,6 +357,10 @@ class SideFacets implements RecommendationInterface {
 		if ($facetSetting->sortMode == 'alphabetically') {
 			asort($sideFacets[$facetKey]['list']);
 		}
+		$lockedValues = $lockedFacets[$facetKey] ?? [];
+		if (!empty($sideFacets[$facetKey]['list'])) {
+			$sideFacets[$facetKey]['list'] = $this->reorderFacetValues($sideFacets[$facetKey]['list'], $lockedValues);
+		}
 		if ($facetSetting->numEntriesToShowByDefault > 0) {
 			$sideFacets[$facetKey]['valuesToShow'] = $facetSetting->numEntriesToShowByDefault;
 		}
@@ -369,18 +374,8 @@ class SideFacets implements RecommendationInterface {
 			$sideFacets[$facetKey]['showMoreFacetPopup'] = true;
 			$facetsList = $sideFacets[$facetKey]['list'];
 			if ($facetSetting->multiSelect) {
-				$tmpList = $sideFacets[$facetKey]['list'];
-				$sideFacets[$facetKey]['list'] = [];
-				//Make sure all applied facets are shown first
-				foreach ($tmpList as $key => $value) {
-					if ($value['isApplied']) {
-						$sideFacets[$facetKey]['list'][$key] = $value;
-						unset($sideFacets[$key]);
-					}
-				}
-				$tmpList = array_slice($facetsList, 0, $facetSetting->numEntriesToShowByDefault);
-				$sideFacets[$facetKey]['list'] = array_merge($sideFacets[$facetKey]['list'], $tmpList);
-				$sideFacets[$facetKey]['fullUnsortedList'] = array_merge($sideFacets[$facetKey]['list'], $facetsList);
+				$sideFacets[$facetKey]['list'] = array_slice($facetsList, 0, $facetSetting->numEntriesToShowByDefault);
+				$sideFacets[$facetKey]['fullUnsortedList'] = $facetsList;
 			} else {
 				$sideFacets[$facetKey]['list'] = array_slice($facetsList, 0, $facetSetting->numEntriesToShowByDefault);
 				$sideFacets[$facetKey]['fullUnsortedList'] = $facetsList;
@@ -401,5 +396,31 @@ class SideFacets implements RecommendationInterface {
 		$sideFacets[$facetKey]['canLock'] = $facetSetting->canLock;
 		$sideFacets[$facetKey]['displayNamePlural'] = empty($facetSetting->displayNamePlural) ? $facetSetting->displayName : $facetSetting->displayNamePlural;
 		return $sideFacets;
+	}
+
+	/**
+	 * Reorder the facet values to alwasy show applied values, then the other values
+	 * @param array $facetList
+	 * @param array $lockedValues
+	 * @return array
+	 */
+	private function reorderFacetValues(array $facetList, array $lockedValues): array {
+		if (empty($facetList)) {
+			return $facetList;
+		}
+		$applied = [];
+		$other = [];
+		foreach ($facetList as $key => $value) {
+			if (!empty($lockedValues) && isset($value['value']) && in_array($value['value'], $lockedValues, true)) {
+				$value['isLocked'] = true;
+			}
+			if (!empty($value['isApplied'])) {
+				$applied[$key] = $value;
+			} else {
+				$other[$key] = $value;
+			}
+		}
+		return $applied + $other;
+
 	}
 }

--- a/code/web/sys/Recommend/SideFacets.php
+++ b/code/web/sys/Recommend/SideFacets.php
@@ -62,19 +62,6 @@ class SideFacets implements RecommendationInterface {
 		$interface->assign('hasSearchableFacets', $this->searchObject->hasSearchableFacets());
 		$interface->assign('removeAllFiltersUrl', $this->searchObject->getRemoveAllFiltersUrl());
 
-		//Get applied facets
-		$filterList = $this->searchObject->getFilterList();
-		foreach ($filterList as $facetKey => $facet) {
-			//Remove any top facets since the removal links are displayed above results
-			if (str_starts_with($facet[0]['field'], 'availability_toggle')) {
-				unset($filterList[$facetKey]);
-			}
-		}
-		$interface->assign('filterList', $filterList);
-		//Process the side facet set to handle the Added In Last facet which we only want to be
-		//visible if there is not a value selected for the facet (makes it single select
-		$sideFacets = $this->searchObject->getFacetList($this->mainFacets);
-
 		$lockSection = $this->searchObject->getSearchName();
 		if (UserAccount::isLoggedIn()) {
 			$user = UserAccount::getActiveUserObj();
@@ -83,6 +70,42 @@ class SideFacets implements RecommendationInterface {
 			$lockedFacets = $_SESSION['lockedFilters'] ?? [];
 		}
 		$lockedFacets = $lockedFacets[$lockSection] ?? [];
+		$lockedValuesByUnscoped = [];
+		foreach ($lockedFacets as $lockedFacetKey => $lockedValues) {
+			$unscopedKey = $this->searchObject->getUnscopedFieldName($lockedFacetKey);
+			if (!isset($lockedValuesByUnscoped[$unscopedKey])) {
+				$lockedValuesByUnscoped[$unscopedKey] = [];
+			}
+			if (is_array($lockedValues)) {
+				$lockedValuesByUnscoped[$unscopedKey] = array_values(array_unique(array_merge($lockedValuesByUnscoped[$unscopedKey], $lockedValues)));
+			}
+		}
+
+		//Get applied facets
+		$filterList = $this->searchObject->getFilterList();
+		foreach ($filterList as $facetKey => &$facet) {
+			//Remove any top facets since the removal links are displayed above results
+			if (str_starts_with($facet[0]['field'], 'availability_toggle')) {
+				unset($filterList[$facetKey]);
+				continue;
+			}
+			foreach ($facet as &$filter) {
+				if (!empty($filter['field']) && array_key_exists('value', $filter)) {
+					$unscopedField = $this->searchObject->getUnscopedFieldName($filter['field']);
+					$filter['unscopedField'] = $unscopedField;
+					$lockedValues = $lockedFacets[$filter['field']] ?? ($lockedValuesByUnscoped[$unscopedField] ?? []);
+					if (!empty($lockedValues) && in_array($filter['value'], $lockedValues)) {
+						$filter['isLocked'] = true;
+					}
+				}
+			}
+			unset($filter);
+		}
+		unset($facet);
+		$interface->assign('filterList', $filterList);
+		//Process the side facet set to handle the Added In Last facet which we only want to be
+		//visible if there is not a value selected for the facet (makes it single select
+		$sideFacets = $this->searchObject->getFacetList($this->mainFacets);
 
 		//Figure out which counts to show.
 		$searchSource = $_REQUEST['searchSource'];


### PR DESCRIPTION
This enhancement modifies the behavior of locked facets to better align with patrons’ workflows:
1. When a patron selects a facet and locks the facet, the unlock icon in the facet heading changes to a lock icon. And in “Applied Filters”, the facet will displays a lock icon instead of a remove icon. See screenshot #4:
2. When one or more facets are locked and the patron selects an additional facet for the current search, Aspen displays lock icons for the locked facets and a remove icon for the newly selected (unlocked) facet.
3. When a patron unlocks a locked facet from “Applied Filters” or from the Facets list under “Narrow Your Results”, the locked facet is both unlocked and removed. 
4. Patrons can still unlock all locked facets within the same group by clicking the lock icon in the facet heading.
5. Patrons can also unlock a locked facet from the “More” modal.
6. If a patron locks a facet and performs a new search that returns no results for that locked value, the lock icon remains visible and the facet group automatically expands. 

To test:
1. Apply PR and log in as patron
2. After locking a facet, the facet heading shows a closed lock icon instead of an open lock.
3. Lock multiple facets and add an additional facet from the same facet group. See locked values show a lock icon; newly applied (unlocked) values show a remove (X or -) icon.
4. Unlock one from Applied Filters: Clicking a locked value in Applied Filters removes only that value and unlocks it; other locked values in the same facet stay locked.
5. Unlock one from facet list: Deselecting a locked value under Narrow Your Results removes and unlocks only that value; other locked values in that facet stay locked.
6. Unlock one from More modal: Unchecking a locked value in the “More” modal and applying removes and unlocks only that value; other locked values stay locked.
7. Unlock all from heading: Clicking the lock icon in the facet heading unlocks the whole facet; all its values are no longer locked.
8. Locked facet with no results: After a search that returns no results for a locked facet, that facet still appears in the sidebar and is expanded.
9. See applied values appear at the top of their facet group in Narrow Your Results.
10. New search keeps locks: Running a new search keeps locked values applied and showing lock icons.
11. No lock, normal remove: When no facet is locked, Applied Filters and facet list show only remove (X) behavior, no lock icons.
12. Repeat all the above steps when logged out. 