### PR TITLE
DIS-2013: Remove Unused Administer Loan Rules Permission

### DIFF
--- a/code/web/release_notes/26.03.00.MD
+++ b/code/web/release_notes/26.03.00.MD
@@ -70,6 +70,9 @@
 ### Symphony Updates
 - Add translation map for bill/fine reasons ([DIS-1968](https://aspen-discovery.atlassian.net/browse/DIS-1968)) (*KL*)
 
+### Other Updates
+- Remove unused Administer Loan Rules permission ([DIS-2013](https://aspen-discovery.atlassian.net/browse/DIS-2013)) (*KL*)
+
 //mark j
 ### Saved Search Updates
 - Add a saved search email notification preference to the patron account settings and trigger automatic emails to go out when the saved searches receive updates. ([DIS-1469](https://aspen-discovery.atlassian.net/browse/DIS-1469)) (*MJ*)

--- a/code/web/sys/Administration/Role.php
+++ b/code/web/sys/Administration/Role.php
@@ -147,7 +147,6 @@ class Role extends DataObject {
 				'Administer Languages',
 				'Administer LibraryMarket LibraryCalendar Settings',
 				'Administer List Indexing Settings',
-				'Administer Loan Rules',
 				'Administer Modules',
 				'Administer Open Archives',
 				'Administer OverDrive',
@@ -233,7 +232,6 @@ class Role extends DataObject {
 			],
 			'Super Cataloger' => [
 				'Administer Indexing Profiles',
-				'Administer Loan Rules',
 				'Administer Translation Maps',
 				'Administer Wikipedia Integration',
 				'Download MARC Records',

--- a/code/web/sys/DBMaintenance/version_updates/26.03.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/26.03.00.php
@@ -46,6 +46,14 @@ function getUpdates26_03_00(): array {
 			]
 		],
 		//add_bill_reason_translation_map
+		'remove_unused_permission_loan_rules' => [
+			'title' => 'Remove unused permission loan rules',
+			'description' => 'Remove unused permission loan rules at all times',
+			'sql' => [
+				"DELETE FROM role_permissions WHERE permissionId = (SELECT id FROM permissions WHERE name = 'Administer Loan Rules')",
+				"DELETE FROM permissions WHERE name = 'Administer Loan Rules'",
+			]
+		], //remove_unused_permission_loan_rules
 
 		//yanjun
 		'require_pin_for_palace_project' => [


### PR DESCRIPTION
Remove permission from Role.php
Run sql query to remove permission from admins
Run sql query to delete permission from permissions table
Update release notes

Tested on my local instance of Aspen