### PR TITLE
DIS-2072: fix: restore in events search options

### DIFF
--- a/code/web/Drivers/marmot_inc/SearchSources.php
+++ b/code/web/Drivers/marmot_inc/SearchSources.php
@@ -233,10 +233,7 @@ class SearchSources {
 			}
 
 			if (array_key_exists('Events', $enabledModules)) {
-				require_once ROOT_DIR . '/sys/Events/LibraryEventsSetting.php';
-				$libraryEventsSetting = new LibraryEventsSetting();
-				$libraryEventsSetting->libraryId = $library->libraryId;
-				if ($libraryEventsSetting->find(true)) {
+				if (isset($library->aspenEventsToInclude) && $library->aspenEventsToInclude != 0) {
 					$searchOptions['events'] = [
 						'name' => 'Events',
 						'description' => 'Search events at the library',

--- a/code/web/release_notes/26.04.00.MD
+++ b/code/web/release_notes/26.04.00.MD
@@ -18,6 +18,8 @@
 //jonah
 
 //chloe
+### Aspen Events Updates
+- Restore the 'in Event' search source option for library systems that start using the events module after upgrading to 25.11.00 or higher. ([DIS-2072](https://aspen-discovery.atlassian.net/browse/DIS-2072)) (*CZ*)
 
 //lucas
 

--- a/code/web/sys/DBMaintenance/version_updates/26.04.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/26.04.00.php
@@ -29,6 +29,14 @@ function getUpdates26_04_00(): array {
 		//galen
 
 		//chloe
+		'update_aspenEventsToInclude_default' => [
+			'title' => 'Update AspenEventsToInclude Default',
+			'description' => 'Have aspenEventsToInclude default to 0 (do not display events as a search source)',
+			'continueOnError' => false,
+			'sql' => [
+				"ALTER TABLE library MODIFY COLUMN aspenEventsToInclude INT DEFAULT 0",
+			],
+		], //update_aspenEventsToInclude_default
 
 		//mark j
 

--- a/code/web/sys/LibraryLocation/Library.php
+++ b/code/web/sys/LibraryLocation/Library.php
@@ -3729,10 +3729,11 @@ class Library extends DataObject {
 						'label' => 'Aspen Events to Include',
 						'description' => 'Which events to include when searching this library',
 						'values' => [
+							'0' => 'Do not show the option to search Events',
 							'1' => 'All events at all locations',
 							'2' => "Events that occur at one of this library's locations",
 						],
-						'default' => '2',
+						'default' => '0',
 					],
 					'eventsDefaultCalendarView' => [
 						'property' => 'eventsDefaultCalendarView',


### PR DESCRIPTION
NOTE:

since the default was originally set two `'2' => "Events that occur at one of this library's locations"`, this does mean that administrator will need to go and toggle this to 0 manually for any library system that meet the following criteria:

- Events are enabled for the Aspen system and
- They are set to default ('2') and
- Administrators do not in fact wish to have events search available at this library's site OR there are no events for this library site

If we think this will be a very common occurrence, we could consider writing a DB update script to identify and update such library systems automatically (no event type or events matching the library id and yet have aspenEventsToInclude set to 2).