### PR TITLE
DIS-1960 Update reading history cronjob should access local API locally

### DIFF
--- a/code/cron/src/com/turning_leaf_technologies/cron/Cron.java
+++ b/code/cron/src/com/turning_leaf_technologies/cron/Cron.java
@@ -23,6 +23,12 @@ public class Cron {
 	 * @param args command line parameters passed
 	 */
 	public static void main(String[] args) {
+		// Java refuses to send the Host header set via setRequestProperty unless restricted headers are allowed.
+		// This must be set before the first HttpURLConnection is loaded, so it must happen here rather than in
+		// the process that needs it. UpdateReadingHistoryTask uses the Host header to route requests made via
+		// localhost to the correct virtual host.
+		System.setProperty("sun.net.http.allowRestrictedHeaders", "true");
+
 		String serverName;
 		if (args.length == 0) {
 			serverName = AspenStringUtils.getInputFromCommandLine("Please enter the server name");

--- a/code/cron/src/com/turning_leaf_technologies/cron/reading_history/UpdateReadingHistoryTask.java
+++ b/code/cron/src/com/turning_leaf_technologies/cron/reading_history/UpdateReadingHistoryTask.java
@@ -68,6 +68,8 @@ public class UpdateReadingHistoryTask implements Runnable {
 				retry = false;
 				// Call the patron API to get their checked out items.
 				// Use localhost to avoid the request leaving the server and being subject to WAF rules.
+				// The Host header routes the request to the correct virtual host. Sending it requires
+				// allowing restricted headers, which is enabled in Cron.main().
 				String hostName = new URL(aspenUrl).getHost();
 				URL patronApiUrl = new URL("http://localhost/API/UserAPI?method=updatePatronReadingHistory&username=" + URLEncoder.encode(ilsBarcode, StandardCharsets.UTF_8));
 				HttpURLConnection conn = (HttpURLConnection) patronApiUrl.openConnection();

--- a/code/cron/src/com/turning_leaf_technologies/cron/reading_history/UpdateReadingHistoryTask.java
+++ b/code/cron/src/com/turning_leaf_technologies/cron/reading_history/UpdateReadingHistoryTask.java
@@ -67,8 +67,11 @@ public class UpdateReadingHistoryTask implements Runnable {
 				}
 				retry = false;
 				// Call the patron API to get their checked out items.
-				URL patronApiUrl = new URL(aspenUrl + "/API/UserAPI?method=updatePatronReadingHistory&username=" + URLEncoder.encode(ilsBarcode, StandardCharsets.UTF_8));
+				// Use localhost to avoid the request leaving the server and being subject to WAF rules.
+				String hostName = new URL(aspenUrl).getHost();
+				URL patronApiUrl = new URL("http://localhost/API/UserAPI?method=updatePatronReadingHistory&username=" + URLEncoder.encode(ilsBarcode, StandardCharsets.UTF_8));
 				HttpURLConnection conn = (HttpURLConnection) patronApiUrl.openConnection();
+				conn.setRequestProperty("Host", hostName);
 				// Give 10 seconds for connection timeout and 10 minutes for read timeout.
 				conn.setConnectTimeout(10000);
 				conn.setReadTimeout(600000);

--- a/code/web/release_notes/26.07.00.MD
+++ b/code/web/release_notes/26.07.00.MD
@@ -21,6 +21,9 @@
 
 // lucas
 
+### Reading History Updates
+- Update reading history cron job to make API requests via localhost instead of the public URL, preventing requests from leaving the server and being subject to WAF rules. ([DIS-1960](https://aspen-discovery.atlassian.net/browse/DIS-1960)) (*KMH*)
+
 ## This release includes code contributions from
 ### ByWater Solutions
 - Yanjun Li (YL)


### PR DESCRIPTION
UpdateReadingHistoryTask makes an API call to updatePatronReadingHistory via the Aspen URL. In cases where a server is not exposed directly to the Internet, this causes the request to leave the network and return which is less efficient and makes the request subject to any WAF that may be in front of the server. The request should access localhost and set the host name in the request accordingly so apache will handle it correctly. This will prevent the request from leaving the server itself!

Test Plan

1) Apply this patch
2) Rebuild the cron jar
3) Run the UpdateReadingHistory cron job against a server with reading history users
4) Confirm reading history updates complete successfully (check cron log for updated counts, no new errors)
5) Confirm the requests no longer leave the server: each Aspen site has its own Apache access log (/var/log/aspen-discovery/{sitename}/access.log). Tail the log for the site being updated and note the updatePatronReadingHistory requests now come from 127.0.0.1 (or ::1) with status 200
6) On a multi-tenant server, run the cron for each tenant and confirm the requests appear in the access log of the *correct* site (not the default/first virtual host), and that reading history is updated for the right users on each tenant
7) Confirm reading history counts match a run from before the patch (no users newly failing)
