### PR TITLE
DIS-2097: Guard format sorting category lookup from invalid values

### DIFF
--- a/code/web/release_notes/26.03.00.MD
+++ b/code/web/release_notes/26.03.00.MD
@@ -167,6 +167,8 @@
 - Fix "Not Holdable" label missing for non-holdable items in Copies table. ([DIS-1973](https://aspen-discovery.atlassian.net/browse/DIS-1973)) (*YL*)
 - Ensure locked facets also hide non-locked facets in grouped works results until "View all formats" is expanded. ([DIS-1795](https://aspen-discovery.atlassian.net/browse/DIS-1795)) (*YL*)
 - updated Library object to pass value of reactivateDateNotRequired from catalog when getLibraryInfo is called. ((DIS-1652)[https://aspen-discovery.atlassian.net/browse/DIS-1652]) (*IT*)
+- Prevent format sorting from crashing when a grouped work has a blank or invalid grouping category. ([DIS-2097](https://aspen-discovery.atlassian.net/browse/DIS-2097)) (*YL*)
+
 
 ## This release includes code contributions from
 ### ByWater Solutions

--- a/code/web/sys/Grouping/GroupedWorkFormatSortingGroup.php
+++ b/code/web/sys/Grouping/GroupedWorkFormatSortingGroup.php
@@ -275,26 +275,27 @@ class GroupedWorkFormatSortingGroup extends DataObject {
 		return $ret;
 	}
 
-	private function getArrayNameForGroupingCategory($groupingCategory) : string {
-		$internalArrayName = null;
+	private function getArrayNameForGroupingCategory(string $groupingCategory): string {
+		static $logged = false;
+		global $logger;
 		switch ($groupingCategory) {
 			case 'book':
-				$internalArrayName = '_sortedBookFormats';
-				break;
+				return '_sortedBookFormats';
 			case 'comic':
-				$internalArrayName = '_sortedComicFormats';
-				break;
+				return '_sortedComicFormats';
 			case 'movie':
-				$internalArrayName = '_sortedMovieFormats';
-				break;
+				return '_sortedMovieFormats';
 			case 'music':
-				$internalArrayName = '_sortedMusicFormats';
-				break;
+				return '_sortedMusicFormats';
 			case 'other':
-				$internalArrayName = '_sortedOtherFormats';
-				break;
+				return '_sortedOtherFormats';
+			default:
+				if (!$logged && isset($logger)) {
+					$logger->log('Invalid grouping category: ' . $groupingCategory, Logger::LOG_WARNING);
+					$logged = true;
+				}
+				return '';
 		}
-		return $internalArrayName;
 	}
 
 	public function saveSortedFormats($groupingCategory) : void {


### PR DESCRIPTION
Some records in grouped works have an empty grouping_category, which triggers a PHP error when Aspen couldn’t recognize the formats. 
Error: 
GroupedWorkFormatSortingGroup::getArrayNameForGroupingCategory(): Return value must be of type string, null returned

To test:
1. Apply PR
2. Load Grouped work results page with a known blank/invalid grouping_category record
3. Confirm that the page renders without error. 