### PR TITLE
DIS-1982: Title Search Behavior (QA Upate)

### DIFF
--- a/code/web/sys/DBMaintenance/version_updates/26.03.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/26.03.00.php
@@ -73,6 +73,13 @@ function getUpdates26_03_00(): array {
 				"DELETE FROM permissions WHERE name = 'Administer Loan Rules'",
 			]
 		], //remove_unused_permission_loan_rules
+		'add_title_search_behavior_setting' => [
+			'title' => 'Title Search Behavior Setting',
+			'description' => 'Add title search behavior setting in system variables',
+			'sql' => [
+				"ALTER TABLE system_variables ADD COLUMN titleSearchBehavior INT DEFAULT 1",
+			]
+		], //add_title_search_behavior_setting
 
 		//yanjun
 		'require_pin_for_palace_project' => [

--- a/code/web/sys/SearchObject/AbstractGroupedWorkSearcher.php
+++ b/code/web/sys/SearchObject/AbstractGroupedWorkSearcher.php
@@ -520,7 +520,7 @@ abstract class SearchObject_AbstractGroupedWorkSearcher extends SearchObject_Sol
 	 * @return array
 	 */
 	public function getSearchSuggestions($searchTerm, $searchIndex) : array {
-		if ($searchIndex == 'Title' || $searchIndex == 'StartOfTitle' || $searchIndex == 'Series') {
+		if ($searchIndex == 'Title' || $searchIndex == 'AllTitles' || $searchIndex == 'StartOfTitle' || $searchIndex == 'Series') {
 			$suggestionHandler = 'title_suggest';
 		} elseif ($searchIndex == 'Author') {
 			$suggestionHandler = 'author_suggest';
@@ -1166,13 +1166,18 @@ abstract class SearchObject_AbstractGroupedWorkSearcher extends SearchObject_Sol
 	}
 
 	public function getSearchIndexes() : array {
+		$titleSearch = 'Title';
+		$systemVariables = SystemVariables::getSystemVariables();
+		if ($systemVariables && (int)$systemVariables->titleSearchBehavior == 1) {
+			$titleSearch = 'AllTitles';
+		}
 		return [
 			'Keyword' => translate([
 				'text' => 'Keyword',
 				'isPublicFacing' => true,
 				'inAttribute' => true,
 			]),
-			'Title' => translate([
+			$titleSearch => translate([
 				'text' => 'Title',
 				'isPublicFacing' => true,
 				'inAttribute' => true,

--- a/code/web/sys/SearchObject/GroupedWorkSearcher2.php
+++ b/code/web/sys/SearchObject/GroupedWorkSearcher2.php
@@ -429,7 +429,7 @@ class SearchObject_GroupedWorkSearcher2 extends SearchObject_AbstractGroupedWork
 				$handler = 'SubjectProper';
 			} elseif ($handler == 'AllFields') {
 				$handler = 'KeywordProper';
-			} elseif ($handler == 'Title') {
+			} elseif ($handler == 'Title' || $handler == 'AllTitles') {
 				$handler = 'TitleProper';
 			} elseif ($handler == 'Series') {
 				$handler = 'SeriesProper';

--- a/code/web/sys/SystemVariables.php
+++ b/code/web/sys/SystemVariables.php
@@ -28,6 +28,7 @@ class SystemVariables extends DataObject {
 	/** @noinspection PhpUnused */
 	public $indexVersion;
 	public $searchVersion;
+	public $titleSearchBehavior;
 	public $enableNovelistSeriesIntegration;
 	public $greenhouseUrl;
 	public $communityContentUrl;
@@ -194,6 +195,14 @@ class SystemVariables extends DataObject {
 						'description' => 'The Solr Core Version to search with.  In 22.06 and above this should be version 2 in most cases.',
 						'required' => true,
 						'default' => 2,
+					],
+					'titleSearchBehavior' => [
+						'property' => 'titleSearchBehavior',
+						'type' => 'enum',
+						'values' => [
+							1 => 'Exclude Alternate Titles',
+							2 => 'Include Alternate Titles',
+						]
 					],
 					'loadCoversFrom020z' => [
 						'property' => 'loadCoversFrom020z',

--- a/sites/default/conf/groupedWorksSearchSpecs2.yaml
+++ b/sites/default/conf/groupedWorksSearchSpecs2.yaml
@@ -188,6 +188,31 @@ SubjectProper:
     - era_proper:
       - [onephrase, 300]
 
+AllTitles:
+    QueryFields:
+        - title_exact:
+              - [localized_callnumber, 10000]
+        - title_left:
+              - [text_left, 8000]
+        - title_proper:
+              - [exact, 800]
+              - [onephrase, 500]
+              - [and, 200]
+        - title:
+              - [onephrase, 200]
+              - [and, 125]
+        - title_alt:
+              - [and, 100]
+        - title_new:
+              - [and, 50]
+        - series_proper:
+              - [exact, 800]
+              - [onephrase, 300]
+              - [and, 50]
+        - series:
+              - [exact, 600]
+              - [onephrase, 200]
+              - [and, 50]
 Title:
   QueryFields:
     - title_exact:


### PR DESCRIPTION
Add option in System Variables to keep old behavior or title searching that includes title_alt, title_new, series_proper, and series 
The default DB maintenance update sets it to the newer version  of title search, so libraries wishing to keep the old search matching behavior will need to update this in system variables

Tested on my local instance of Aspen