### PR TITLE
DIS-2131: Format BalanceDue to 2 decimals places

### DIFF
--- a/code/web/release_notes/26.04.00.MD
+++ b/code/web/release_notes/26.04.00.MD
@@ -14,6 +14,8 @@
 //stephen
 
 //yanjun
+### eCommerce Updates
+- Format Invoice Cloud BalanceDue to 2 decimals places. ([DIS-2131](https://aspen-discovery.atlassian.net/browse/DIS-2131)) (*YL*)
 
 //imani
 

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -7789,7 +7789,7 @@ class MyAccount_AJAX extends JSON_Action {
 				$createInvoice = new StdClass();
 				$createInvoice->InvoiceNumber = $token;
 				$createInvoice->TypeID = intval($invoiceCloudSetting->invoiceTypeId);
-				$createInvoice->BalanceDue = $payment->totalPaid;
+				$createInvoice->BalanceDue = number_format((float)$payment->totalPaid, 2, '.', '');
 				$ccServiceFee = $invoiceCloudSetting->ccServiceFee;
 				if (isset($ccServiceFee) && str_contains($ccServiceFee, '%')) {
 					$percent = floatval(str_replace('%', '', $ccServiceFee));


### PR DESCRIPTION
BalanceDue is currently assigned directly from $payment->totalPaid, which can include more than 2 decimal places and cause the payment to fail. We should format the value to 2 decimals. 

To test:
1. Create a payment with totalPaid that has more than 2 decimals, or hardcode a totalPaid with more than 2 decimals (eg 1.2345)
2. Verify BalanceDue is sent as 1.23
3. Repeat step 1 with totalPaid as a whole number (eg 10) , verify BalanceDue is sent as 10.00
4. Repeat step 1 with totalPaid as a number more than a thousand (eg 1,234.322), verify BalanceDue is sent as 1234.32 