### PR TITLE
DIS-2136 Add scrollbar-gutter: stable

### DIFF
--- a/code/web/interface/themes/responsive/css/main.css
+++ b/code/web/interface/themes/responsive/css/main.css
@@ -7308,6 +7308,10 @@ td.hidden-inline-block-lg {
     display: none !important;
   }
 }
+html,
+body {
+  scrollbar-gutter: stable;
+}
 a,
 a:visited {
   color: #3174AF;

--- a/code/web/interface/themes/responsive/css/responsive_base.css
+++ b/code/web/interface/themes/responsive/css/responsive_base.css
@@ -7308,6 +7308,10 @@ td.hidden-inline-block-lg {
     display: none !important;
   }
 }
+html,
+body {
+  scrollbar-gutter: stable;
+}
 a,
 a:visited {
   color: #3174AF;
@@ -7642,6 +7646,12 @@ rapi-doc::part(textbox):focus {
   outline: 0;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
+}
+.pagination {
+  margin: 20px 0 10px;
+}
+.jump-to-page {
+  margin-bottom: 15px !important;
 }
 .ui-rater > span {
   vertical-align: top;
@@ -11207,10 +11217,6 @@ td[data-entry-id]:has(.date-edit:focus)::after {
   display: flex;
   width: 100%;
 }
-.slider-button {
-  cursor: pointer;
-  z-index: 2;
-}
 .slider-wrapper {
   display: flex;
   overflow: hidden;
@@ -11230,7 +11236,6 @@ td[data-entry-id]:has(.date-edit:focus)::after {
   width: 32px;
   height: 32px;
   border-radius: 50%;
-  background: #fff !important;
   border: 2px solid #000 !important;
   display: flex;
   align-items: center;

--- a/code/web/interface/themes/responsive/css/responsive_base.less
+++ b/code/web/interface/themes/responsive/css/responsive_base.less
@@ -13,6 +13,10 @@
 //
 //  Basic Style overrides
 //
+html, body {
+  scrollbar-gutter: stable;
+}
+
 a, a:visited{
   color: @link-color-resp;
 }

--- a/code/web/release_notes/26.04.00.MD
+++ b/code/web/release_notes/26.04.00.MD
@@ -12,6 +12,7 @@
 //myranda
 
 //stephen
+- Fix layout shift when modal opens ([DIS-2136](https://aspen-discovery.atlassian.net/browse/DIS-2136)) (*SW*)
 
 //yanjun
 


### PR DESCRIPTION
https://aspen-discovery.atlassian.net/browse/DIS-2136

The page shifts on Chromium when scrollbar shows/hides (for example opening a modal). This new-ish CSS property (baseline 2024) stabilizes that.

Should be ignored if not supported in the browser.