### PR TITLE
DIS-2123 Manage Materials Requests "All" sticky

### DIFF
--- a/code/web/release_notes/26.04.00.MD
+++ b/code/web/release_notes/26.04.00.MD
@@ -12,6 +12,7 @@
 //myranda
 
 //stephen
+- Fix issue on Manage Materials Request page where show "all" entries setting is not remembered ([DIS-2123](https://aspen-discovery.atlassian.net/browse/DIS-2123)) (*SW*)
 
 //yanjun
 

--- a/code/web/services/MaterialsRequest/ManageRequests.php
+++ b/code/web/services/MaterialsRequest/ManageRequests.php
@@ -384,7 +384,9 @@ class MaterialsRequest_ManageRequests extends Admin_Admin {
 				$pageDefaults = PageDefaults::getPageDefaultsForUser($user->id, 'MaterialsRequest', 'ManageRequests',null);
 				if ($pageDefaults !== null && !empty($pageDefaults->pageSize)) {
 					$materialsRequestsPerPage =  $pageDefaults->pageSize;
-				}else{
+				} else if ($pageDefaults->pageSize === 0) {
+					$materialsRequestsPerPage = 'all';
+				} else {
 					$materialsRequestsPerPage = 30;
 				}
 			}


### PR DESCRIPTION
https://aspen-discovery.atlassian.net/browse/DIS-2123

Setting this dropdown in Manage Materials Requests to "All" attempts to write "all" to user_page_defaults.pageSize, which is an INT column, so it gets set to 0.

ManageRequests.php line ~385 checks !empty($pageDefaults->pageSize) so this gets skipped and defaults to 30.

Here I add an additional check for 0 to correct it to 'all' which is what the template is expecting.

Possibly there is a more holistic approach to fixing this which involves removing "all" as the value but I'm not sure what the standard Aspen uses is, so I'm going with minimal code changes here.