### PR TITLE
DIS-2128: Enhance optional filters behaviour by adding a 'More options' sentinel

### DIFF
--- a/code/web/interface/themes/responsive/Search/advanced.tpl
+++ b/code/web/interface/themes/responsive/Search/advanced.tpl
@@ -181,14 +181,25 @@
 																</div>
 															</div>
 														{else}
-															<select name="filter[]" class="form-control" aria-label="{translate text=$facetInfo.facetLabel inAttribute=true isPublicFacing=true}">
+															{assign var="facetValueCount" value=$facetInfo.values|@count}
+															<select name="filter[]"
+																id="facet-select-{$facetInfo.facetName}"
+																class="form-control"
+																aria-label="{translate text=$facetInfo.facetLabel inAttribute=true isPublicFacing=true}"
+																onchange="AspenDiscovery.Searches.onAdvancedFacetSelectChange(this)"
+																{if $facetValueCount <= 1}disabled="disabled"{/if}>
+																{assign var="shownOptions" value=0}
 																{foreach from=$facetInfo.values item="value" key="display"}
-																	{if strlen($display) > 0}
+																	{if strlen($display) > 0 && $shownOptions < 5}
 																		<option value="{$value.filter|escape}"{if !empty($value.selected)} selected="selected"{/if}>{$value.display|truncate:80}</option>
+																		{assign var="shownOptions" value=$shownOptions+1}
 																	{/if}
 																{/foreach}
+																{if $facetValueCount > 5}
+																	<option value="__browse__">{translate text="More options..." isPublicFacing=true}</option>
+																{/if}
 															</select>
-														{/if}
+																					{/if}
 													</div>
 												</div>
 											{/foreach}

--- a/code/web/interface/themes/responsive/Search/advancedSearchFacetPopup.tpl
+++ b/code/web/interface/themes/responsive/Search/advancedSearchFacetPopup.tpl
@@ -1,0 +1,41 @@
+<form role="form" id="advancedSearchFacetValuesForm">
+	<input type="hidden" name="facetName" id="advFacetName" value="{$facetName}">
+	<div class="form-group">
+		<label for="advFacetSearchTerm">{translate text="Search %1%" isPublicFacing=true 1=$facetTitlePlural}</label>
+		<div class="input-group input-group-sm">
+			<input type="text" name="facetSearchTerm" id="advFacetSearchTerm" class="form-control" onkeydown="AspenDiscovery.Searches.searchAdvancedFacetValuesKeyDown(event)"/>
+			<span class="btn btn-sm btn-primary input-group-addon" onclick="return AspenDiscovery.Searches.searchAdvancedFacetValues();">{translate text="Search" isPublicFacing=true}</span>
+		</div>
+	</div>
+</form>
+<div>
+	<div id="advFacetSearchResultsLoading" class="alert alert-info" style="display: none">
+		{translate text="Loading results" isPublicFacing=true}
+	</div>
+	<div id="advFacetSearchResultsPopularHelp" class="small text-muted" style="margin-bottom: 6px;">
+		{translate text="Or select from these popular %1%." 1=$facetTitlePlural isPublicFacing=true translateParameters=true}
+	</div>
+	<div id="advFacetSearchResults">
+		<ul class="list-unstyled adv-facet-list">
+			{foreach from=$topResults item=thisFacet}
+				<li class="adv-facet-item"
+					data-filter="{$thisFacet.filter|escape:'html'}"
+					data-display="{$thisFacet.display|escape:'html'}"
+					data-facet="{$facetName|escape:'html'}"
+					onclick="AspenDiscovery.Searches.setAdvancedSearchFacetValue(this); return false;"
+					style="cursor: pointer;">
+					{$thisFacet.display}
+				</li>
+			{/foreach}
+		</ul>
+	</div>
+	<style>
+		{literal}
+		.adv-facet-list { column-count: 2; column-gap: 0; margin: 0; }
+		.adv-facet-item { break-inside: avoid; padding: 4px 8px; }
+		.adv-facet-item:nth-child(odd)  { background-color: #f9f9f9; }
+		.adv-facet-item:nth-child(even) { background-color: #ffffff; }
+		.adv-facet-item:hover { background-color: #e8f0fe; }
+		{/literal}
+	</style>
+</div>

--- a/code/web/interface/themes/responsive/Search/advancedSearchFacetResults.tpl
+++ b/code/web/interface/themes/responsive/Search/advancedSearchFacetResults.tpl
@@ -1,0 +1,12 @@
+<ul class="list-unstyled adv-facet-list">
+	{foreach from=$facetSearchResults item=thisFacet}
+		<li class="adv-facet-item"
+			data-filter="{$thisFacet.filter|escape:'html'}"
+			data-display="{$thisFacet.display|escape:'html'}"
+			data-facet="{$facetName|escape:'html'}"
+			onclick="AspenDiscovery.Searches.setAdvancedSearchFacetValue(this); return false;"
+			style="cursor: pointer;">
+			{$thisFacet.display}
+		</li>
+	{/foreach}
+</ul>

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -19431,7 +19431,8 @@ AspenDiscovery.Searches = (function(){
 			}
 		})
 	});
-	return{
+	return {
+		_advFacetCache: {},
 		searchGroups: [],
 		curPage: 1,
 		displayMode: 'list', // default display Mode for results
@@ -19812,6 +19813,88 @@ AspenDiscovery.Searches = (function(){
 					$("#facetSearchResults").html(data.message);
 				}
 			});
+		},
+
+		showAdvancedSearchFacetPopup: function (facetName) {
+			var cache = AspenDiscovery.Searches._advFacetCache;
+			if (cache[facetName]) {
+				var data = cache[facetName];
+				AspenDiscovery.showMessageWithButtons(data.title, data.modalBody, data.buttons);
+				return false;
+			}
+			var url = Globals.path + '/Search/AJAX?method=getAdvancedSearchFacetPopup&facetName=' + encodeURIComponent(facetName);
+			$.getJSON(url, function (data) {
+				if (data.success === true) {
+					cache[facetName] = data;
+					AspenDiscovery.showMessageWithButtons(data.title, data.modalBody, data.buttons);
+				} else {
+					AspenDiscovery.showMessage(data.title, data.message);
+				}
+			});
+			return false;
+		},
+
+		onAdvancedFacetSelectChange: function (selectEl) {
+			var $select = aspenJQ(selectEl);
+			var val     = $select.val();
+			if (val === '__browse__') {
+				$select.val($select.data('prevVal') || '');
+				var facetName = selectEl.id.replace('facet-select-', '');
+				AspenDiscovery.Searches.showAdvancedSearchFacetPopup(facetName);
+			} else {
+				$select.data('prevVal', val);
+			}
+		},
+
+		searchAdvancedFacetValuesKeyDown: function (e) {
+			if (e.keyCode === 9) {
+				AspenDiscovery.Searches.searchAdvancedFacetValues();
+			} else if (e.keyCode === 10 || e.keyCode === 13) {
+				e.preventDefault();
+				AspenDiscovery.Searches.searchAdvancedFacetValues();
+			}
+			return false;
+		},
+
+		searchAdvancedFacetValues: function () {
+			$("#advFacetSearchResultsPopularHelp").hide();
+			$("#advFacetSearchResultsLoading").show();
+			$("#advFacetSearchResults").html("");
+			var facetName   = $("#advFacetName").val();
+			var searchTerm  = $("#advFacetSearchTerm").val();
+			var url = Globals.path + '/Search/AJAX';
+			var params = {
+				'method':     'searchAdvancedFacetTerms',
+				'facetName':  facetName,
+				'searchTerm': searchTerm
+			};
+			$.getJSON(url, params, function (data) {
+				$("#advFacetSearchResultsLoading").hide();
+				if (data.success === true) {
+					$("#advFacetSearchResults").html(data.facetResults);
+				} else {
+					$("#advFacetSearchResults").html(data.message);
+				}
+			});
+		},
+
+		setAdvancedSearchFacetValue: function (el) {
+			var $el         = aspenJQ(el);
+			var filterValue = $el.attr('data-filter');
+			var displayText = $el.attr('data-display');
+			var facetName   = $el.attr('data-facet');
+			var $select = aspenJQ('#facet-select-' + facetName);
+			if ($select.length === 0) {
+				aspenJQ('#modalDialog').modal('hide');
+				return;
+			}
+			$select.val(filterValue);
+			if ($select.val() !== filterValue) {
+				$select.append(aspenJQ('<option>', {value: filterValue, text: displayText}));
+				$select.val(filterValue);
+			}
+			$select.data('prevVal', filterValue);
+			aspenJQ('#modalDialog').modal('hide');
 		}
 	}
 }(AspenDiscovery.Searches || {}));

--- a/code/web/interface/themes/responsive/js/aspen/searches.js
+++ b/code/web/interface/themes/responsive/js/aspen/searches.js
@@ -27,7 +27,8 @@ AspenDiscovery.Searches = (function(){
 			}
 		})
 	});
-	return{
+	return {
+		_advFacetCache: {},
 		searchGroups: [],
 		curPage: 1,
 		displayMode: 'list', // default display Mode for results
@@ -408,6 +409,88 @@ AspenDiscovery.Searches = (function(){
 					$("#facetSearchResults").html(data.message);
 				}
 			});
+		},
+
+		showAdvancedSearchFacetPopup: function (facetName) {
+			var cache = AspenDiscovery.Searches._advFacetCache;
+			if (cache[facetName]) {
+				var data = cache[facetName];
+				AspenDiscovery.showMessageWithButtons(data.title, data.modalBody, data.buttons);
+				return false;
+			}
+			var url = Globals.path + '/Search/AJAX?method=getAdvancedSearchFacetPopup&facetName=' + encodeURIComponent(facetName);
+			$.getJSON(url, function (data) {
+				if (data.success === true) {
+					cache[facetName] = data;
+					AspenDiscovery.showMessageWithButtons(data.title, data.modalBody, data.buttons);
+				} else {
+					AspenDiscovery.showMessage(data.title, data.message);
+				}
+			});
+			return false;
+		},
+
+		onAdvancedFacetSelectChange: function (selectEl) {
+			var $select = aspenJQ(selectEl);
+			var val     = $select.val();
+			if (val === '__browse__') {
+				$select.val($select.data('prevVal') || '');
+				var facetName = selectEl.id.replace('facet-select-', '');
+				AspenDiscovery.Searches.showAdvancedSearchFacetPopup(facetName);
+			} else {
+				$select.data('prevVal', val);
+			}
+		},
+
+		searchAdvancedFacetValuesKeyDown: function (e) {
+			if (e.keyCode === 9) {
+				AspenDiscovery.Searches.searchAdvancedFacetValues();
+			} else if (e.keyCode === 10 || e.keyCode === 13) {
+				e.preventDefault();
+				AspenDiscovery.Searches.searchAdvancedFacetValues();
+			}
+			return false;
+		},
+
+		searchAdvancedFacetValues: function () {
+			$("#advFacetSearchResultsPopularHelp").hide();
+			$("#advFacetSearchResultsLoading").show();
+			$("#advFacetSearchResults").html("");
+			var facetName   = $("#advFacetName").val();
+			var searchTerm  = $("#advFacetSearchTerm").val();
+			var url = Globals.path + '/Search/AJAX';
+			var params = {
+				'method':     'searchAdvancedFacetTerms',
+				'facetName':  facetName,
+				'searchTerm': searchTerm
+			};
+			$.getJSON(url, params, function (data) {
+				$("#advFacetSearchResultsLoading").hide();
+				if (data.success === true) {
+					$("#advFacetSearchResults").html(data.facetResults);
+				} else {
+					$("#advFacetSearchResults").html(data.message);
+				}
+			});
+		},
+
+		setAdvancedSearchFacetValue: function (el) {
+			var $el         = aspenJQ(el);
+			var filterValue = $el.attr('data-filter');
+			var displayText = $el.attr('data-display');
+			var facetName   = $el.attr('data-facet');
+			var $select = aspenJQ('#facet-select-' + facetName);
+			if ($select.length === 0) {
+				aspenJQ('#modalDialog').modal('hide');
+				return;
+			}
+			$select.val(filterValue);
+			if ($select.val() !== filterValue) {
+				$select.append(aspenJQ('<option>', {value: filterValue, text: displayText}));
+				$select.val(filterValue);
+			}
+			$select.data('prevVal', filterValue);
+			aspenJQ('#modalDialog').modal('hide');
 		}
 	}
 }(AspenDiscovery.Searches || {}));

--- a/code/web/release_notes/26.04.00.MD
+++ b/code/web/release_notes/26.04.00.MD
@@ -19,7 +19,8 @@
 
 //chloe
 
-//lucas
+### Search Updates
+- Add ability to browse and search all available facet values from the Advanced Search page via a popup modal, with dropdowns capped at 5 values and a "More options..." entry to open the browser. ([DIS-2128](https://aspen-discovery.atlassian.net/browse/DIS-2128)) (*LM*)
 
 //galen
 

--- a/code/web/services/Search/AJAX.php
+++ b/code/web/services/Search/AJAX.php
@@ -756,6 +756,110 @@ class AJAX extends Action {
 	}
 
 	/** @noinspection PhpUnused */
+	function getAdvancedSearchFacetPopup() : array {
+		global $interface;
+		$facetName = $_REQUEST['facetName'];
+		$interface->assign('facetName', $facetName);
+
+		$searchObject = SearchObjectFactory::initSearchObject();
+		$searchObject->initAdvancedFacets();
+		$searchObject->disableLogging();
+		$searchObject->processSearch(false, true);
+
+		$facetConfig = $searchObject->getFacetConfig();
+		if (array_key_exists($facetName, $facetConfig)) {
+			$config = $facetConfig[$facetName];
+			if (is_object($config)) {
+				$facetTitle = $config->displayName;
+				$facetTitlePlural = $config->displayNamePlural;
+			} else {
+				$facetTitle = $facetName;
+				$facetTitlePlural = $facetName;
+			}
+			$interface->assign('facetTitle', $facetTitle);
+			$interface->assign('facetTitlePlural', $facetTitlePlural);
+
+			$allFacets = $searchObject->getFacetList();
+			$topResults = [];
+			if (isset($allFacets[$facetName])) {
+				$rawList = $allFacets[$facetName]['list'];
+				ksort($rawList, SORT_NATURAL | SORT_FLAG_CASE);
+				foreach ($rawList as $item) {
+					$topResults[] = [
+						'filter'  => $facetName . ':"' . $item['value'] . '"',
+						'display' => $item['display'],
+						'value'   => $item['value'],
+					];
+				}
+			}
+			$interface->assign('topResults', $topResults);
+			$searchObject->close();
+
+			return [
+				'success'   => true,
+				'title'     => translate([
+					'text'               => 'Browse %1%',
+					'1'                  => $facetTitlePlural,
+					'isPublicFacing'     => true,
+					'translateParameters' => true,
+				]),
+				'modalBody' => $interface->fetch('Search/advancedSearchFacetPopup.tpl'),
+				'buttons'   => '',
+			];
+		} else {
+			$searchObject->close();
+			return [
+				'success' => false,
+				'title'   => translate(['text' => 'Error', 'isPublicFacing' => true]),
+				'message' => translate(['text' => 'That facet could not be found', 'isPublicFacing' => true]),
+			];
+		}
+	}
+
+	/** @noinspection PhpUnused */
+	function searchAdvancedFacetTerms() : array {
+		global $interface;
+		$facetName  = $_REQUEST['facetName'];
+		$searchTerm = $_REQUEST['searchTerm'];
+		$interface->assign('facetName', $facetName);
+
+		$searchObject = SearchObjectFactory::initSearchObject();
+		$searchObject->initAdvancedFacets();
+		$searchObject->disableLogging();
+		$searchObject->addFacetSearch($facetName, $searchTerm);
+		$searchObject->processSearch(false, true);
+
+		$allFacets = $searchObject->getFacetList();
+		$searchObject->close();
+
+		if (isset($allFacets[$facetName])) {
+			$rawList = $allFacets[$facetName]['list'];
+			ksort($rawList, SORT_NATURAL | SORT_FLAG_CASE);
+			$results = [];
+			foreach ($rawList as $item) {
+				$results[] = [
+					'filter'  => $facetName . ':"' . $item['value'] . '"',
+					'display' => $item['display'],
+					'value'   => $item['value'],
+				];
+			}
+			$interface->assign('facetSearchResults', $results);
+			return [
+				'success'      => true,
+				'facetResults' => $interface->fetch('Search/advancedSearchFacetResults.tpl'),
+			];
+		} else {
+			return [
+				'success' => false,
+				'message' => "<div class='alert alert-warning'>" . translate([
+					'text'           => 'No results match your search',
+					'isPublicFacing' => true,
+				]) . '</div>',
+			];
+		}
+	}
+
+	/** @noinspection PhpUnused */
 	function searchFacetTerms() : array {
 		global $interface;
 		$searchId = $_REQUEST['searchId'];


### PR DESCRIPTION
The advanced search dropdowns could only show a fixed set of facet values hardcoded in the configuration. If a facet had many possible values (e.g. dozens of languages or formats), users had no way to see or select values beyond what was visible in the dropdown — they were simply hidden with no alternative.

  This development gives users a way to browse and search the full list of available values for any facet directly from the advanced search page, without leaving the page or modifying any configuration.

  Test Plan

  Before patching:

  1. Navigate to the Advanced Search page.
  2. Locate a facet dropdown that has more than 5 available values (e.g. Language or Format).
  3. Open the dropdown — see that all values are listed directly in the dropdown, scrollable, no cap.
  4. Select any value — it is applied as a filter normally.
  5. Locate a facet that has only 1 available value — see that the dropdown is still enabled and interactive.

  After patching:

  6. Repeat steps 1–2.
  7. Open the dropdown — see at most 5 values, followed by a "More options..." entry at the bottom.
  8. Select one of the 5 visible values — it applies normally, no popup opens.
  9. Select "More options..." — the dropdown resets to its previous value and a modal popup opens.
  10. In the popup, see a list of the most popular facet values displayed in a 2-column layout.
  11. Click any value in the popup list — the popup closes and the dropdown updates to that value.
  12. Reopen the popup (select "More options..." again), type a keyword in the search field, and press Search or hit Enter.
  13. See the results list update to show only matching values.
  14. Click a result — popup closes and the dropdown reflects the chosen value.
  15. Repeat step 5 — confirm a facet with ≤1 value is now disabled (not interactive).