### PR TITLE
DIS-2184: Gale deletion fix

### DIFF
--- a/code/web/release_notes/26.03.01.MD
+++ b/code/web/release_notes/26.03.01.MD
@@ -1,0 +1,11 @@
+## Aspen Discovery Updates
+### Gale Updates
+- Fix Gale Search errors when settings are deleted immediately after performing a Gale search by handling missing settings gracefully. ([DIS-2184](https://aspen-discovery.atlassian.net/browse/DIS-2184)) (*YL*)
+- Add Gale settings deletion cleanup to reset galeSettingId and removes associated code rows.  ([DIS-2184](https://aspen-discovery.atlassian.net/browse/DIS-2184)) (*YL*)
+
+## This release includes code contributions from
+### ByWater Solutions
+- Yanjun Li (YL)
+
+### Grove
+- Mark Noble (MDN)

--- a/code/web/sys/Gale/GaleSetting.php
+++ b/code/web/sys/Gale/GaleSetting.php
@@ -131,6 +131,21 @@ class GaleSetting extends DataObject {
 		return $ret;
 	}
 
+	public function delete(bool $useWhere = false, bool $hardDelete = false) : bool|int {
+		$ret = parent::delete($useWhere, $hardDelete);
+		if ($ret && !empty($this->id)) {
+			$library = new Library();
+			$library->galeSettingsId = $this->id;
+			$library->find();
+			while ($library->fetch()) {
+				$library->galeSettingsId = -1;
+				$library->update();
+			}
+			$this->clearOneToManyOptions('GaleProductCode', 'settingId');
+		}
+		return $ret;
+	}
+
 	public function saveLibraries() : void {
 		if (isset ($this->_libraries) && is_array($this->_libraries)) {
 			$libraryList = Library::getLibraryList(!UserAccount::userHasPermission('Administer All Libraries'));

--- a/code/web/sys/SearchObject/GaleSearcher.php
+++ b/code/web/sys/SearchObject/GaleSearcher.php
@@ -372,10 +372,11 @@ class SearchObject_GaleSearcher extends SearchObject_BaseSearcher {
 		}
 		$facetSet = [];
 		$facetDefinitions = $this->getFacetDefinitions();
+		$settings = $this->getSettings();
 		foreach ($facetDefinitions as $facetKey => $facetDefinition) {
 			if ($facetKey === 'productCode') {
-				if ($this->getSettings() != null && !empty($this->getSettings()->getProductCodes())){
-					$productCodes = $this->getSettings()->getProductCodes();
+				if ($settings != null && !empty($settings->getProductCodes())){
+					$productCodes = $settings->getProductCodes();
 					foreach ($productCodes as $productCode) {
 						if (empty($productCode->productCode)) {
 							continue;
@@ -421,7 +422,7 @@ class SearchObject_GaleSearcher extends SearchObject_BaseSearcher {
 					'allowPastDates' => true,
 				];
 			} elseif ($facetKey === 'fullTextOnly') {
-				if (!$this->getSettings()->fullTextOnly) {
+				if ($settings != null && !$settings->fullTextOnly) {
 					$fullTextValue = 'fullTextOnly';
 					$isApplied = isset($this->filterList['fullTextOnly']) && in_array($fullTextValue, $this->filterList['fullTextOnly'], true);
 					$facetSet['fullTextOnly'] = [
@@ -452,9 +453,11 @@ class SearchObject_GaleSearcher extends SearchObject_BaseSearcher {
 		$facetDefinitions = $this->getFacetDefinitions();
 		$settings = $this->getSettings();
 		$productCodeLabels = [];
-		foreach ($settings->getProductCodes() as $productCode) {
-			if (!empty($productCode->productCode)) {
-				$productCodeLabels[$productCode->productCode] = $productCode->displayName ?: $productCode->productCode;
+		if ($settings != null) {
+			foreach ($settings->getProductCodes() as $productCode) {
+				if (!empty($productCode->productCode)) {
+					$productCodeLabels[$productCode->productCode] = $productCode->displayName ?: $productCode->productCode;
+				}
 			}
 		}
 
@@ -579,7 +582,7 @@ class SearchObject_GaleSearcher extends SearchObject_BaseSearcher {
 			}
 			return $galeSetting;
 		}
-		AspenError::raiseError(new AspenError('There are no Gale Settings set for this library system.'));
+		return null;
 	}	
 
 	private function getProductCode(): string {


### PR DESCRIPTION
When a Gale setting is deleted immediately after a Gale search (search term still present in the search bar), the Gale Searcher will throw an error. 
Linked libraries retain a stale galeSettingsId after deletion. 

We should handle missing settings gracefully and reset galeSettingsId to -1 for the linked libraries.

To test:
1. Add a Gale setting and select library
2. Perform a Gale search 
3. Go to Admin page and delete Gale setting, the search term still present in the search bar
4. See error "There are no Gale Settings set for this library system.".
5. See the search source still has "in Articles & Databse" for Gale
6. Apply the PR
7. See error disappear
8. Repeat step 1 - 3
9. See no error and no "in Articles & Databse" for Gale 