### PR TITLE
DIS-2190 Fix Web Builder Resource export error

### DIFF
--- a/code/web/release_notes/26.04.00.MD
+++ b/code/web/release_notes/26.04.00.MD
@@ -39,6 +39,9 @@
 ### eCommerce Updates
 - Format Invoice Cloud BalanceDue to 2 decimals places. ([DIS-2131](https://aspen-discovery.atlassian.net/browse/DIS-2131)) (*YL*)
 
+### Greenhouse Updates
+- Fix Web Builder Resource export in Greenhouse by supporting library links in both formats, preventing export failures or empty exports. ([DIS-2190](https://aspen-discovery.atlassian.net/browse/DIS-2190)) (*YL*)
+
 //imani
 
 //jonah

--- a/code/web/sys/DB/LibraryLinkedObject.php
+++ b/code/web/sys/DB/LibraryLinkedObject.php
@@ -11,7 +11,7 @@ abstract class DB_LibraryLinkedObject extends DataObject {
 		$selectedLibraries = $selectedFilters['libraries'];
 		$linkedLibraryIds = $this->getLinkedLibraryIds();
 		foreach ($selectedLibraries as $libraryId) {
-			if (in_array($libraryId, $linkedLibraryIds, true)) {
+			if (in_array((string)$libraryId, $linkedLibraryIds, true)) {
 				$okToExport = true;
 				break;
 			}
@@ -42,9 +42,9 @@ abstract class DB_LibraryLinkedObject extends DataObject {
 		foreach ($libraries as $key => $value) {
 			if (is_array($value)) {
 				// checkboxWithOptions format: libraryId => [options]
-				$libraryIds[] = $key;
+				$libraryIds[] = (string)$key;
 			} else {
-				$libraryIds[] = $value;
+				$libraryIds[] = (string)$value;
 			}
 		}
 		return $libraryIds;

--- a/code/web/sys/DB/LibraryLinkedObject.php
+++ b/code/web/sys/DB/LibraryLinkedObject.php
@@ -9,8 +9,9 @@ abstract class DB_LibraryLinkedObject extends DataObject {
 	public function okToExport(array $selectedFilters): bool {
 		$okToExport = parent::okToExport($selectedFilters);
 		$selectedLibraries = $selectedFilters['libraries'];
+		$linkedLibraryIds = $this->getLinkedLibraryIds();
 		foreach ($selectedLibraries as $libraryId) {
-			if (array_key_exists($libraryId, $this->getLibraries())) {
+			if (in_array($libraryId, $linkedLibraryIds, true)) {
 				$okToExport = true;
 				break;
 			}
@@ -21,15 +22,32 @@ abstract class DB_LibraryLinkedObject extends DataObject {
 	public function getLinksForJSON(): array {
 		$links = [];
 		$allLibraries = Library::getLibraryListAsObjects(false);
-		$libraries = $this->getLibraries();
 		$links['libraries'] = [];
-		foreach ($libraries as $libraryId) {
+		foreach ($this->getLinkedLibraryIds() as $libraryId) {
 			if (array_key_exists($libraryId, $allLibraries)) {
 				$library = $allLibraries[$libraryId];
 				$links['libraries'][$libraryId] = empty($library->subdomain) ? $library->ilsCode : $library->subdomain;
 			}
 		}
 		return $links;
+	}
+
+	protected function getLinkedLibraryIds(): array {
+		$libraries = $this->getLibraries();
+		if (empty($libraries) || !is_array($libraries)) {
+			return [];
+		}
+
+		$libraryIds = [];
+		foreach ($libraries as $key => $value) {
+			if (is_array($value)) {
+				// checkboxWithOptions format: libraryId => [options]
+				$libraryIds[] = $key;
+			} else {
+				$libraryIds[] = $value;
+			}
+		}
+		return $libraryIds;
 	}
 
 	public function loadRelatedLinksFromJSON($jsonData, $mappings, string $overrideExisting = 'keepExisting'): bool {


### PR DESCRIPTION
Exporting Web Builder Resources fails and shows the error below:
```
Cannot access offset of type array on array
[27] - /usr/local/aspen-discovery/code/web/sys/DB/LibraryLinkedObject.php
DB_LibraryLinkedObject->getLinksForJSON [416] - /usr/local/aspen-discovery/code/web/sys/WebBuilder/WebResource.php
WebResource->getLinksForJSON [1246] - /usr/local/aspen-discovery/code/web/sys/DB/DataObject.php
DataObject->getJSONString [458] - /usr/local/aspen-discovery/code/web/services/Greenhouse/ExportAspenData.php
Greenhouse_ExportAspenData->exportObjects [386] - /usr/local/aspen-discovery/code/web/services/Greenhouse/ExportAspenData.php
Greenhouse_ExportAspenData->launch [908] - /usr/local/aspen-discovery/code/web/index.php
```

because library links for Web Builder Resources were stored in checkboxWithOptions format. 

To test:
1. Go to Greenhouse > Export Aspen Data, select Web Builder Resources, associated libraries and locations
2. Export the data and see the error.
3. Apply PR
4. Export Web Builder Resources again 
5. Export successfully. 