### PR TITLE
DIS-1174: Create skip to main content links

### DIFF
--- a/code/web/interface/themes/responsive/layout.tpl
+++ b/code/web/interface/themes/responsive/layout.tpl
@@ -61,6 +61,9 @@
 </head>
 <body class="module_{$module} action_{$action}{if !empty($masqueradeMode)} masqueradeMode{/if}{if !empty($loggedIn)} loggedIn{else} loggedOut{/if}" id="{$module}-{$action}{if $module=="WebBuilder" && $action=="BasicPage" || $action=="PortalPage" || $action=="GrapesPage"}-{$id}{/if}" dir="{if $userLang->isRTL()}rtl{else}auto{/if}">
 {strip}
+	<a class="screen-reader-text" href="#main" id="skip-to-main-content">
+		<span>{translate text="Skip to main content" isPublicFacing=true}</span>
+	</a>
 	{if !empty($showTopOfPageButton) && empty($minimalInterface)}
 	<a class="top-link hide" href="" id="js-top">
 		<i class="fas fa-arrow-up fa-2x fa-fw" role="presentation"></i>
@@ -139,7 +142,7 @@
 							{include file="breadcrumbs.tpl"}
 							</div>
 						{/if}
-						<div role="main">
+						<div id="main" role="main">
 							{if !empty($module)}
 								{include file="$module/$pageTemplate"}
 							{else}
@@ -154,7 +157,7 @@
 							{include file="breadcrumbs.tpl"}
 							</div>
 						{/if}
-						<div role="main">
+						<div id="main" role="main">
 							{if !empty($module)}
 								{include file="$module/$pageTemplate"}
 							{else}

--- a/code/web/interface/themes/responsive/standalone-layout.tpl
+++ b/code/web/interface/themes/responsive/standalone-layout.tpl
@@ -37,6 +37,9 @@
 	{include file="masquerade-top-navbar.tpl"}
 {/if}
 {strip}
+	<a class="screen-reader-text" href="#main" id="skip-to-main-content">
+		<span>{translate text="Skip to main content" isPublicFacing=true}</span>
+	</a>
 	<div {if empty($fullWidthTheme)}class="container"{/if} id="page-container">
 {*
 		{if !empty($systemMessage)}
@@ -63,7 +66,7 @@
 		<div id="content-container">
 			<div class="row">
 				<div class="col-xs-12" id="main-content">
-					<div role="main">
+					<div id="main" role="main">
 						{if !empty($module)}
 							{include file="$module/$pageTemplate"}
 						{else}

--- a/code/web/release_notes/26.04.00.MD
+++ b/code/web/release_notes/26.04.00.MD
@@ -58,6 +58,10 @@
 ### Grouping Updates
 - Rename 'Manual Grouped Works' to 'Custom Grouped Works' ([DIS-2051](https://aspen-discovery.atlassian.net/browse/DIS-2051)) (*BJ*)
 
+//other
+### Accessibility Updates
+- Added skip to main content links and ids for page templates. ([DIS-1174](https://aspen-discovery.atlassian.net/browse/DIS-1174)) (*RI*)
+
 ## This release includes code contributions from
 ### ByWater Solutions
 - Yanjun Li (YL)
@@ -82,6 +86,9 @@
 
 ### Open Fifth
 - Chloe Zermatten (CZ)
+
+### SELCO (Southeastern Libraries Cooperating)
+- Ranelle Irwin (RI)
 
 ### Theke Solutions
 - Lucas Montoya (LM)


### PR DESCRIPTION
Adding improvement to bypass navigation areas for screen-reader and keyboard users.

Testing:
After applying and loading page, use keyboard's Tab key. A visible Skip to main content link should appear.
Using Enter on this link should move the focus to where role="main" is assigned.

First pull request here (and I'm not usually a developer) so let me know if I did anything incorrectly!