### PR TITLE
DIS-2143 Usage graph export

### DIFF
--- a/code/web/release_notes/26.04.00.MD
+++ b/code/web/release_notes/26.04.00.MD
@@ -70,6 +70,9 @@
 ### Koha Updates
 - Material Requests item type list now respects branch limits; only formats available for the patron’s home library are shown. ([DIS-2151](https://aspen-discovery.atlassian.net/browse/DIS-2151)) (*YL*)
 
+### Other Updates
+- Fix the issue where usage graph CSV export ignore the selected profile and instances filter. ([DIS-2143](https://aspen-discovery.atlassian.net/browse/DIS-2143)) (*YL*)
+
 //imani
 
 //jonah

--- a/code/web/services/Admin/AbstractUsageGraphs.php
+++ b/code/web/services/Admin/AbstractUsageGraphs.php
@@ -18,6 +18,7 @@ abstract class Admin_AbstractUsageGraphs extends Admin_Admin {
 		} else {
 			$instanceName = '';
 		}
+		$profileName = $_REQUEST['profileName'] ?? '';
 
 		// includes dashboard subsection name in title if relevant
 		$subSectionName = $_REQUEST['subSection'] ?? '';
@@ -33,6 +34,8 @@ abstract class Admin_AbstractUsageGraphs extends Admin_Admin {
 		$interface->assign('graphTitle', $sectionTitle);
 		$interface->assign('showCSVExportButton', true);
 		$interface->assign('propName', 'exportToCSV');
+		$interface->assign('profileName', $profileName);
+		$interface->assign('instance', $instanceName);
 
 		$this->assignGraphSpecificTitle($stat);
 		$this->getAndSetInterfaceDataSeries($stat, $instanceName);


### PR DESCRIPTION
In the ILS Dashboard and Sideloads Dashboard, when viewing a specific instance and profile’s side load usage graph and clicking “Export to CSV”, the export CSV will include all the sideloads' and all instances' data. And see the warning <b>Warning</b>:  Undefined variable $profileName in <b>/usr/local/aspen-discovery/code/web/services/ILS/UsageGraphs.php</b> on line <b>38</b><br /> in the CSV file.

To test: Attempt to export a CSV from the usage graph for a specific instance and for all instances. Verify that the CSV data matches the data displayed in the interface.