### PR TITLE
DIS-2187 Link to all holds after successful hold

### DIFF
--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -18894,7 +18894,7 @@ AspenDiscovery.Record = (function () {
 					} else if (data.needsIllRequest) {
 						AspenDiscovery.showMessageWithButtons(data.title, data.modalBody, data.modalButtons);
 					} else {
-						AspenDiscovery.showMessage(data.title, data.message, false, data.autologout);
+						AspenDiscovery.showMessageWithButtons(data.title, data.message, data.modalButtons, data.autologout);
 						var existingButton = $("#onHoldAction" + id);
 						if (existingButton.length === 0) {
 							$(data.viewHoldsAction).insertBefore('#actionButton' + id);
@@ -19057,7 +19057,7 @@ AspenDiscovery.Record = (function () {
 						AspenDiscovery.showMessageWithButtons(data.title, data.modalBody, data.modalButtons);
 					} else {
 						AspenDiscovery.Record.volumeHoldInProgress = false;
-						AspenDiscovery.showMessage(data.title, data.message, false, autoLogOut);
+						AspenDiscovery.showMessageWithButtons(data.title, data.message, data.modalButtons, autoLogOut);
 						AspenDiscovery.Account.loadMenuData();
 					}
 				} else {

--- a/code/web/interface/themes/responsive/js/aspen/record.js
+++ b/code/web/interface/themes/responsive/js/aspen/record.js
@@ -382,7 +382,7 @@ AspenDiscovery.Record = (function () {
 					} else if (data.needsIllRequest) {
 						AspenDiscovery.showMessageWithButtons(data.title, data.modalBody, data.modalButtons);
 					} else {
-						AspenDiscovery.showMessage(data.title, data.message, false, data.autologout);
+						AspenDiscovery.showMessageWithButtons(data.title, data.message, data.modalButtons, data.autologout);
 						var existingButton = $("#onHoldAction" + id);
 						if (existingButton.length === 0) {
 							$(data.viewHoldsAction).insertBefore('#actionButton' + id);
@@ -545,7 +545,7 @@ AspenDiscovery.Record = (function () {
 						AspenDiscovery.showMessageWithButtons(data.title, data.modalBody, data.modalButtons);
 					} else {
 						AspenDiscovery.Record.volumeHoldInProgress = false;
-						AspenDiscovery.showMessage(data.title, data.message, false, autoLogOut);
+						AspenDiscovery.showMessageWithButtons(data.title, data.message, data.modalButtons, autoLogOut);
 						AspenDiscovery.Account.loadMenuData();
 					}
 				} else {

--- a/code/web/release_notes/26.04.00.MD
+++ b/code/web/release_notes/26.04.00.MD
@@ -98,6 +98,8 @@
 - Fix layout shift when modal opens ([DIS-2136](https://aspen-discovery.atlassian.net/browse/DIS-2136)) (*SW*)
 - Fix issue on Manage Materials Request page where show "all" entries setting is not remembered ([DIS-2123](https://aspen-discovery.atlassian.net/browse/DIS-2123)) (*SW*)
 - Add large cover modal view for individual records ([DIS-2119](https://aspen-discovery.atlassian.net/browse/DIS-2119)) (*SW*)
+### Hold Updates
+- Link to all holds after successful hold ([DIS-2187](https://aspen-discovery.atlassian.net/browse/DIS-2187)) (*SW*)
 
 //yanjun
 ### eCommerce Updates

--- a/code/web/services/Record/AJAX.php
+++ b/code/web/services/Record/AJAX.php
@@ -1274,6 +1274,7 @@ class Record_AJAX extends JSON_Action {
 					];
 					if (isset($return['viewHoldsAction'])) {
 						$results['viewHoldsAction'] = $return['viewHoldsAction'];
+						$results['modalButtons'] = $return['modalButtons'];
 					}
 					if ($confirmationNeeded) {
 						$results['modalButtons'] = '<a href="#" class="btn btn-primary" onclick="return AspenDiscovery.Record.confirmHold(\'Record\', \'' . $shortId . '\', ' . $return['confirmationId'] . ')">' . translate([
@@ -1290,6 +1291,7 @@ class Record_AJAX extends JSON_Action {
 							UserAccount::softLogout();
 						}
 						$results['autologout'] = true;
+						$results['modalButtons'] = null;
 						$alreadyLoggedOut = true;
 					}
 				}

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -2494,6 +2494,10 @@ class User extends DataObject {
 			]);
 
 			$result['viewHoldsAction'] = "<a id='onHoldAction$recordId' href='/MyAccount/Holds' class='btn btn-sm btn-info btn-wrap' title='$viewHoldsText'>$viewHoldsText</a>";
+			if (!empty($result['api']['action'])) {
+				$buttonText = $result['api']['text'] ?? "Go to Holds";
+				$result['modalButtons'] = "<a href='/MyAccount/Holds' class='btn btn-primary btn-wrap'>$buttonText</a>";
+			}
 
 			//If we have a cached account summary, add one to the number of unavailable holds (no ILSs move a hold to active immediately)
 			$accountSummary = $this->getCachedAccountSummary('ils');
@@ -2522,6 +2526,11 @@ class User extends DataObject {
 			]);
 
 			$result['viewHoldsAction'] = "<a id='onHoldAction$recordId' href='/MyAccount/Holds' class='btn btn-sm btn-info btn-wrap' title='$viewHoldsText'>$viewHoldsText</a>";
+
+			if (!empty($result['api']['action'])) {
+				$buttonText = $result['api']['text'] ?? "Go to Holds";
+				$result['modalButtons'] = "<a href='/MyAccount/Holds' class='btn btn-primary btn-wrap'>$buttonText</a>";
+			}
 
 			$accountSummary = $this->getCachedAccountSummary('ils');
 			$accountSummary->incrementNumberOfUnavailableHolds();
@@ -2595,6 +2604,10 @@ class User extends DataObject {
 			]);
 
 			$result['viewHoldsAction'] = "<a id='onHoldAction$recordId' href='/MyAccount/Holds' class='btn btn-sm btn-info btn-wrap' title='{$viewHoldsText}'>{$viewHoldsText}</a>";
+			if (!empty($result['api']['action'])) {
+				$buttonText = $result['api']['text'] ?? "Go to Holds";
+				$result['modalButtons'] = "<a href='/MyAccount/Holds' class='btn btn-primary btn-wrap'>$buttonText</a>";
+			}
 
 			//Update account summary and ensure holds reload
 			$accountSummary = $this->getCachedAccountSummary('ils');


### PR DESCRIPTION
https://aspen-discovery.atlassian.net/browse/DIS-2187

Adds a button to the modal after a successful hold that links to the holds page, except when using Sierra.

Should work for regular hold, hold on volume, and hold on specific item

Doesn't display the button when the user checks "Log me out after requesting the item" since this will most likely break in all cases. Sets buttons to null in that case.