### PR TITLE
DIS-2209: Add JDBC timeout to Sierra export connection

### DIFF
--- a/code/sierra_export_api/src/com/turning_leaf_technologies/sierra/SierraExportAPIMain.java
+++ b/code/sierra_export_api/src/com/turning_leaf_technologies/sierra/SierraExportAPIMain.java
@@ -1881,7 +1881,9 @@ public class SierraExportAPIMain {
 						"/" + databaseName +
 						"?user=" + user +
 						"&password=" + password +
-						"&ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactory";
+						"&ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactory" +
+						"&connectTimeout=30" +
+						"&socketTimeout=900";
 
 				sierraInstanceInformation = new SierraInstanceInformation();
 				sierraInstanceInformation.indexingProfileName = accountProfileRS.getString("recordSource");

--- a/code/web/release_notes/26.04.00.MD
+++ b/code/web/release_notes/26.04.00.MD
@@ -117,6 +117,9 @@
 ### Other Updates
 - Fix the issue where usage graph CSV export ignore the selected profile and instances filter. ([DIS-2143](https://aspen-discovery.atlassian.net/browse/DIS-2143)) (*YL*)
 
+### Sierra Updates
+- Add a JDBC timeout for Sierra export DB connections to prevent indefinite hangs when the Sierra database is unresponsive. ([DIS-2209](https://aspen-discovery.atlassian.net/browse/DIS-2209)) (*YL*)
+
 //imani
 
 //jonah


### PR DESCRIPTION
Sierra export can hang if the Sierra DB does not respond. Add a connection timeout parameter to the Sierra JDBC URL so the exporter fails fast instead of hanging indefinitely.