### PR TITLE
DIS-2205:  Update advanced search modal styling

### DIFF
--- a/code/web/interface/themes/responsive/Search/advancedSearchFacetPopup.tpl
+++ b/code/web/interface/themes/responsive/Search/advancedSearchFacetPopup.tpl
@@ -16,26 +16,22 @@
 		{translate text="Or select from these popular %1%." 1=$facetTitlePlural isPublicFacing=true translateParameters=true}
 	</div>
 	<div id="advFacetSearchResults">
-		<ul class="list-unstyled adv-facet-list">
-			{foreach from=$topResults item=thisFacet}
-				<li class="adv-facet-item"
-					data-filter="{$thisFacet.filter|escape:'html'}"
-					data-display="{$thisFacet.display|escape:'html'}"
-					data-facet="{$facetName|escape:'html'}"
-					onclick="AspenDiscovery.Searches.setAdvancedSearchFacetValue(this); return false;"
-					style="cursor: pointer;">
-					{$thisFacet.display}
-				</li>
-			{/foreach}
-		</ul>
+		<div class="container-12">
+			<div class="row moreFacetPopup">
+				{foreach from=$topResults item=thisFacet}
+					{strip}
+					<div class="checkboxFacet col-tn-12">
+						<label>
+							<input type="checkbox" class="advFacetCheckbox"
+								data-filter="{$thisFacet.filter|escape:'html'}"
+								data-display="{$thisFacet.display|escape:'html'}"
+								data-facet="{$facetName|escape:'html'}">
+							&nbsp;{$thisFacet.display}
+						</label>
+					</div>
+					{/strip}
+				{/foreach}
+			</div>
+		</div>
 	</div>
-	<style>
-		{literal}
-		.adv-facet-list { column-count: 2; column-gap: 0; margin: 0; }
-		.adv-facet-item { break-inside: avoid; padding: 4px 8px; }
-		.adv-facet-item:nth-child(odd)  { background-color: #f9f9f9; }
-		.adv-facet-item:nth-child(even) { background-color: #ffffff; }
-		.adv-facet-item:hover { background-color: #e8f0fe; }
-		{/literal}
-	</style>
 </div>

--- a/code/web/interface/themes/responsive/Search/advancedSearchFacetResults.tpl
+++ b/code/web/interface/themes/responsive/Search/advancedSearchFacetResults.tpl
@@ -1,12 +1,17 @@
-<ul class="list-unstyled adv-facet-list">
-	{foreach from=$facetSearchResults item=thisFacet}
-		<li class="adv-facet-item"
-			data-filter="{$thisFacet.filter|escape:'html'}"
-			data-display="{$thisFacet.display|escape:'html'}"
-			data-facet="{$facetName|escape:'html'}"
-			onclick="AspenDiscovery.Searches.setAdvancedSearchFacetValue(this); return false;"
-			style="cursor: pointer;">
-			{$thisFacet.display}
-		</li>
-	{/foreach}
-</ul>
+<div class="container-12">
+	<div class="row moreFacetPopup">
+		{foreach from=$facetSearchResults item=thisFacet}
+			{strip}
+			<div class="checkboxFacet col-tn-12">
+				<label>
+					<input type="checkbox" class="advFacetCheckbox"
+						data-filter="{$thisFacet.filter|escape:'html'}"
+						data-display="{$thisFacet.display|escape:'html'}"
+						data-facet="{$facetName|escape:'html'}">
+					&nbsp;{$thisFacet.display}
+				</label>
+			</div>
+			{/strip}
+		{/foreach}
+	</div>
+</div>

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -19951,16 +19951,31 @@ AspenDiscovery.Searches = (function(){
 
 		showAdvancedSearchFacetPopup: function (facetName) {
 			var cache = AspenDiscovery.Searches._advFacetCache;
-			if (cache[facetName]) {
-				var data = cache[facetName];
+			var show = function (data) {
 				AspenDiscovery.showMessageWithButtons(data.title, data.modalBody, data.buttons);
+				// Pre-check the checkbox matching the currently selected value
+				var currentVal = aspenJQ('#facet-select-' + facetName).val();
+				if (currentVal) {
+					aspenJQ('.advFacetCheckbox').filter(function () {
+						return aspenJQ(this).attr('data-filter') === currentVal;
+					}).prop('checked', true);
+				}
+				// Enforce single-select: checking one unchecks all others
+				aspenJQ('#modalDialog').off('change.advFacet').on('change.advFacet', '.advFacetCheckbox', function () {
+					if (aspenJQ(this).prop('checked')) {
+						aspenJQ('.advFacetCheckbox').not(this).prop('checked', false);
+					}
+				});
+			};
+			if (cache[facetName]) {
+				show(cache[facetName]);
 				return false;
 			}
 			var url = Globals.path + '/Search/AJAX?method=getAdvancedSearchFacetPopup&facetName=' + encodeURIComponent(facetName);
 			$.getJSON(url, function (data) {
 				if (data.success === true) {
 					cache[facetName] = data;
-					AspenDiscovery.showMessageWithButtons(data.title, data.modalBody, data.buttons);
+					show(data);
 				} else {
 					AspenDiscovery.showMessage(data.title, data.message);
 				}
@@ -20010,6 +20025,30 @@ AspenDiscovery.Searches = (function(){
 					$("#advFacetSearchResults").html(data.message);
 				}
 			});
+		},
+
+		applyAdvancedFacetSelections: function () {
+			var $checked = aspenJQ('.advFacetCheckbox:checked').first();
+			if ($checked.length === 0) {
+				aspenJQ('#modalDialog').modal('hide');
+				return;
+			}
+			var filterValue = $checked.attr('data-filter');
+			var displayText = aspenJQ('<div/>').html($checked.attr('data-display')).text();
+			var facetName   = $checked.attr('data-facet');
+			var $select = aspenJQ('#facet-select-' + facetName);
+			if ($select.length === 0) {
+				aspenJQ('#modalDialog').modal('hide');
+				return;
+			}
+			$select.find('option.adv-facet-dynamic').remove();
+			$select.val(filterValue);
+			if ($select.val() !== filterValue) {
+				$select.append(aspenJQ('<option>', {value: filterValue, text: displayText, 'class': 'adv-facet-dynamic'}));
+				$select.val(filterValue);
+			}
+			$select.data('prevVal', filterValue);
+			aspenJQ('#modalDialog').modal('hide');
 		},
 
 		setAdvancedSearchFacetValue: function (el) {

--- a/code/web/interface/themes/responsive/js/aspen/searches.js
+++ b/code/web/interface/themes/responsive/js/aspen/searches.js
@@ -430,16 +430,31 @@ AspenDiscovery.Searches = (function(){
 
 		showAdvancedSearchFacetPopup: function (facetName) {
 			var cache = AspenDiscovery.Searches._advFacetCache;
-			if (cache[facetName]) {
-				var data = cache[facetName];
+			var show = function (data) {
 				AspenDiscovery.showMessageWithButtons(data.title, data.modalBody, data.buttons);
+				// Pre-check the checkbox matching the currently selected value
+				var currentVal = aspenJQ('#facet-select-' + facetName).val();
+				if (currentVal) {
+					aspenJQ('.advFacetCheckbox').filter(function () {
+						return aspenJQ(this).attr('data-filter') === currentVal;
+					}).prop('checked', true);
+				}
+				// Enforce single-select: checking one unchecks all others
+				aspenJQ('#modalDialog').off('change.advFacet').on('change.advFacet', '.advFacetCheckbox', function () {
+					if (aspenJQ(this).prop('checked')) {
+						aspenJQ('.advFacetCheckbox').not(this).prop('checked', false);
+					}
+				});
+			};
+			if (cache[facetName]) {
+				show(cache[facetName]);
 				return false;
 			}
 			var url = Globals.path + '/Search/AJAX?method=getAdvancedSearchFacetPopup&facetName=' + encodeURIComponent(facetName);
 			$.getJSON(url, function (data) {
 				if (data.success === true) {
 					cache[facetName] = data;
-					AspenDiscovery.showMessageWithButtons(data.title, data.modalBody, data.buttons);
+					show(data);
 				} else {
 					AspenDiscovery.showMessage(data.title, data.message);
 				}
@@ -489,6 +504,30 @@ AspenDiscovery.Searches = (function(){
 					$("#advFacetSearchResults").html(data.message);
 				}
 			});
+		},
+
+		applyAdvancedFacetSelections: function () {
+			var $checked = aspenJQ('.advFacetCheckbox:checked').first();
+			if ($checked.length === 0) {
+				aspenJQ('#modalDialog').modal('hide');
+				return;
+			}
+			var filterValue = $checked.attr('data-filter');
+			var displayText = aspenJQ('<div/>').html($checked.attr('data-display')).text();
+			var facetName   = $checked.attr('data-facet');
+			var $select = aspenJQ('#facet-select-' + facetName);
+			if ($select.length === 0) {
+				aspenJQ('#modalDialog').modal('hide');
+				return;
+			}
+			$select.find('option.adv-facet-dynamic').remove();
+			$select.val(filterValue);
+			if ($select.val() !== filterValue) {
+				$select.append(aspenJQ('<option>', {value: filterValue, text: displayText, 'class': 'adv-facet-dynamic'}));
+				$select.val(filterValue);
+			}
+			$select.data('prevVal', filterValue);
+			aspenJQ('#modalDialog').modal('hide');
 		},
 
 		setAdvancedSearchFacetValue: function (el) {

--- a/code/web/release_notes/26.04.00.MD
+++ b/code/web/release_notes/26.04.00.MD
@@ -136,6 +136,7 @@
 //lucas
 ### Search Updates
 - Add ability to browse and search all available facet values from the Advanced Search page via a popup modal, with dropdowns capped at 5 values and a "More options..." entry to open the browser. ([DIS-2128](https://aspen-discovery.atlassian.net/browse/DIS-2128)) (*LM*)
+- Update the modal dialog opened by the “More options…” sentinel in 'Advanced Search' for consistency ([DIS-2205](https://aspen-discovery.atlassian.net/browse/DIS-2205)) (*LM*)
 ### Koha Updates
 - Fix Koha items being incorrectly suppressed when the inventory number (952$i) is set to 1. ([DIS-2127](https://aspen-discovery.atlassian.net/browse/DIS-2127)) (*LM*)
 

--- a/code/web/services/Search/AJAX.php
+++ b/code/web/services/Search/AJAX.php
@@ -833,16 +833,18 @@ class AJAX extends JSON_Action {
 			$interface->assign('topResults', $topResults);
 			$searchObject->close();
 
+			$applyLabel = translate(['text' => 'Apply', 'isPublicFacing' => true]);
+			$buttons = "<button class='btn btn-primary' onclick='AspenDiscovery.Searches.applyAdvancedFacetSelections()'>$applyLabel</button>";
 			return [
 				'success'   => true,
 				'title'     => translate([
-					'text'               => 'Browse %1%',
+					'text'               => 'More %1%',
 					'1'                  => $facetTitlePlural,
 					'isPublicFacing'     => true,
 					'translateParameters' => true,
 				]),
 				'modalBody' => $interface->fetch('Search/advancedSearchFacetPopup.tpl'),
-				'buttons'   => '',
+				'buttons'   => $buttons,
 			];
 		} else {
 			$searchObject->close();


### PR DESCRIPTION
This patch updates the modal dialog in [DIS-2128](https://aspen-discovery.atlassian.net/browse/DIS-2128) to use the same styles as other Aspen modals.

Also, fix a bug where selecting an option from the modal was accumulating entries at the end of the dropdown instead of replacing the previous selection. The dropdown now only shows the last chosen value.

[DIS-2128]: https://aspen-discovery.atlassian.net/browse/DIS-2128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ