### PR TITLE
DIS-2215: Fix silent error in EBSCOhost settings when API is unreachable or EBSCO credentials are not yet configured

### DIFF
--- a/code/web/release_notes/26.05.00.MD
+++ b/code/web/release_notes/26.05.00.MD
@@ -18,6 +18,8 @@
 //chloe
 
 //lucas
+### EBSCO Updates
+- Fix fatal error in EBSCOhost settings when API is unreachable or EBSCO credentials are not yet configured. ([DIS-2215](https://aspen-discovery.atlassian.net/browse/DIS-2215)) (*LM*)
 
 //pedro
 

--- a/code/web/services/EBSCO/EBSCOhostSettings.php
+++ b/code/web/services/EBSCO/EBSCOhostSettings.php
@@ -81,8 +81,16 @@ class EBSCO_EBSCOhostSettings extends ObjectEditor {
 			/** @var EBSCOhostSetting $curObject */
 			$curObject = $this->getExistingObjectById($id);
 			$searchSettings = $curObject->getSearchSettings();
+			$connectionFailed = false;
 			foreach ($searchSettings as $searchSetting) {
-				$searchSetting->updateDatabasesFromEBSCOhost();
+				if (!$searchSetting->updateDatabasesFromEBSCOhost()) {
+					$connectionFailed = true;
+				}
+			}
+			if ($connectionFailed) {
+				global $interface;
+				$interface->assign('updateMessage', 'EBSCO connection failed. Credentials may be invalid or the EBSCO API is unreachable.');
+				$interface->assign('updateMessageIsError', $connectionFailed);
 			}
 		}
 		parent::viewIndividualObject($structure);

--- a/code/web/sys/Ebsco/EBSCOhostSearchSetting.php
+++ b/code/web/sys/Ebsco/EBSCOhostSearchSetting.php
@@ -187,7 +187,7 @@ class EBSCOhostSearchSetting extends DataObject {
 		return parent::delete($useWhere, $hardDelete);
 	}
 
-	public function updateDatabasesFromEBSCOhost() : void {
+	public function updateDatabasesFromEBSCOhost() : bool {
 		$currentDatabases = $this->getDatabases();
 		/** @var SearchObject_EbscohostSearcher $ebscohostSearch */
 		$ebscohostSearch = SearchObjectFactory::initSearchObject('Ebscohost');
@@ -199,6 +199,9 @@ class EBSCOhostSearchSetting extends DataObject {
 		}
 
 		$databaseList = $ebscohostSearch->getDatabases();
+		if (empty($databaseList)) {
+			return false;
+		}
 		//Get a list of all databases that exist to check for things that have been removed.
 		$removedDatabases = [];
 		foreach ($currentDatabases as $currentDatabase) {
@@ -244,6 +247,7 @@ class EBSCOhostSearchSetting extends DataObject {
 		foreach ($removedDatabases as $databaseInfo) {
 			$databaseInfo->delete();
 		}
+		return true;
 	}
 
 	public function saveDatabases() : void {

--- a/code/web/sys/SearchObject/EbscohostSearcher.php
+++ b/code/web/sys/SearchObject/EbscohostSearcher.php
@@ -764,6 +764,11 @@ class SearchObject_EbscohostSearcher extends SearchObject_BaseSearcher {
 	public function getDatabases(): array {
 		$databases = [];
 		$searchOptions = $this->getSearchOptions();
+		if ($searchOptions == null) {
+			global $logger;
+			$logger->log('EBSCOhost getDatabases: getSearchOptions() returned null — credentials may be invalid or the EBSCO API is unreachable', Logger::LOG_WARNING);
+			return $databases;
+		}
 		/** @var SimpleXMLElement $dbInfo */
 		foreach ($searchOptions->dbInfo->db as $dbInfo) {
 			$shortName = (string)$dbInfo->attributes()['shortName'];


### PR DESCRIPTION
Visiting the EBSCOhost Settings page (add/edit) caused a fatal foreach() on null error when EBSCO credentials were not yet configured or the EBSCO API was unreachable. getDatabases() called getSearchOptions() without guarding against a null response, crashing the admin UI silently. This fix adds a null guard,improves logging, and surfaces a user-friendly error message to the admin.

Test Plan:

Before:

1. Set up an EBSCOhost integration with invalid credentials (or no credentials)
2. Navigate to /EBSCO/EBSCOhostSettings
3. Click to add a new setting or edit an existing one — observe a fatal error

After:

4. Repeat steps 1–2
5. Click to add a new setting or edit an existing one — no fatal error occurs
6. Verify a red alert banner is displayed: "EBSCO connection failed. Credentials may be invalid or the EBSCO API is unreachable."
7. Verify a warning is logged in the Aspen logs with the same message
8. Configure valid credentials and repeat — verify the page loads normally with no warning