### PR TITLE
DIS-2224:Ensure is integer when calculating

### DIFF
--- a/code/web/release_notes/26.03.03.MD
+++ b/code/web/release_notes/26.03.03.MD
@@ -1,0 +1,8 @@
+## Aspen Discovery Updates
+### Material Requests Updates
+- Fix the error for Update Selected Request when Manage Material Request has more than one page. ([DIS-2224](https://aspen-discovery.atlassian.net/browse/DIS-2224)) (*SSP*)
+
+## This release includes code contributions from
+
+### Bywater Solutions
+- Shipra Satish Poojary (SSP)

--- a/code/web/services/MaterialsRequest/ManageRequests.php
+++ b/code/web/services/MaterialsRequest/ManageRequests.php
@@ -397,7 +397,7 @@ class MaterialsRequest_ManageRequests extends Admin_Admin {
 			$interface->assign('materialsRequestsPerPage', $materialsRequestsPerPage);
 			$page = $_REQUEST['page'] ?? 1;
 			if (!isset($_REQUEST['exportAll'])) {
-				$materialsRequests->limit(($page - 1) * $materialsRequestsPerPage, $materialsRequestsPerPage);
+				$materialsRequests->limit(((int)$page - 1) * (int)$materialsRequestsPerPage,(int)$materialsRequestsPerPage);
 			}
 			$materialsRequestCount = $materialsRequests->count();
 


### PR DESCRIPTION
When Manage Material Requests has more than one page, updating selected requests will throw an error. 

To Test:
1. Have Material Requests for more than 30 entries
2. On either page, select one or multiple material requests
3. Click Update Selected Requests
4. See error: Unsupported operand types: string - int
5. Apply the PR
6. Click Update Selected Requests and see no error

