### PR TITLE
DIS-2248: Improve EBSCOhost connection error logging and user feedback

### DIFF
--- a/code/web/release_notes/26.05.00.MD
+++ b/code/web/release_notes/26.05.00.MD
@@ -20,6 +20,7 @@
 //lucas
 ### EBSCO Updates
 - Fix fatal error in EBSCOhost settings when API is unreachable or EBSCO credentials are not yet configured. ([DIS-2215](https://aspen-discovery.atlassian.net/browse/DIS-2215)) (*LM*)
+- Improve EBSCOhost connection error logging and display actual EBSCO error messages in the admin UI. ([DIS-2248](https://aspen-discovery.atlassian.net/browse/DIS-2248)) (*LM*)
 
 //pedro
 

--- a/code/web/services/EBSCO/EBSCOhostSettings.php
+++ b/code/web/services/EBSCO/EBSCOhostSettings.php
@@ -81,16 +81,17 @@ class EBSCO_EBSCOhostSettings extends ObjectEditor {
 			/** @var EBSCOhostSetting $curObject */
 			$curObject = $this->getExistingObjectById($id);
 			$searchSettings = $curObject->getSearchSettings();
-			$connectionFailed = false;
+			$connectionErrors = [];
 			foreach ($searchSettings as $searchSetting) {
-				if (!$searchSetting->updateDatabasesFromEBSCOhost()) {
-					$connectionFailed = true;
+				$result = $searchSetting->updateDatabasesFromEBSCOhost();
+				if ($result !== true) {
+					$connectionErrors[] = $result;
 				}
 			}
-			if ($connectionFailed) {
+			if (!empty($connectionErrors)) {
 				global $interface;
-				$interface->assign('updateMessage', 'EBSCO connection failed. Credentials may be invalid or the EBSCO API is unreachable.');
-				$interface->assign('updateMessageIsError', $connectionFailed);
+				$interface->assign('updateMessage', htmlspecialchars('EBSCO connection failed: ' . implode('; ', $connectionErrors), ENT_QUOTES, 'UTF-8'));
+				$interface->assign('updateMessageIsError', true);
 			}
 		}
 		parent::viewIndividualObject($structure);

--- a/code/web/sys/Ebsco/EBSCOhostSearchSetting.php
+++ b/code/web/sys/Ebsco/EBSCOhostSearchSetting.php
@@ -187,7 +187,7 @@ class EBSCOhostSearchSetting extends DataObject {
 		return parent::delete($useWhere, $hardDelete);
 	}
 
-	public function updateDatabasesFromEBSCOhost() : bool {
+	public function updateDatabasesFromEBSCOhost() : string|true {
 		$currentDatabases = $this->getDatabases();
 		/** @var SearchObject_EbscohostSearcher $ebscohostSearch */
 		$ebscohostSearch = SearchObjectFactory::initSearchObject('Ebscohost');
@@ -200,7 +200,8 @@ class EBSCOhostSearchSetting extends DataObject {
 
 		$databaseList = $ebscohostSearch->getDatabases();
 		if (empty($databaseList)) {
-			return false;
+			$connectionError = SearchObject_EbscohostSearcher::getLastConnectionError();
+			return $connectionError ?: 'EBSCOhost returned no databases. Check credentials and profile ID.';
 		}
 		//Get a list of all databases that exist to check for things that have been removed.
 		$removedDatabases = [];

--- a/code/web/sys/SearchObject/EbscohostSearcher.php
+++ b/code/web/sys/SearchObject/EbscohostSearcher.php
@@ -13,6 +13,7 @@ class SearchObject_EbscohostSearcher extends SearchObject_BaseSearcher {
 	private $ebscohostBaseUrl = 'https://eit.ebscohost.com/Services/SearchService.asmx';
 	private $curl_connection;
 	private static $searchOptions;
+	private static string $lastConnectionError = '';
 
 	protected $queryStartTime = null;
 	protected $queryEndTime = null;
@@ -131,6 +132,10 @@ class SearchObject_EbscohostSearcher extends SearchObject_BaseSearcher {
 
 	public function setSettings($ebscohostSettings) {
 		$this->ebscohostSettings = $ebscohostSettings;
+	}
+
+	public static function getLastConnectionError(): string {
+		return self::$lastConnectionError;
 	}
 
 	public function getCurlConnection() {
@@ -320,13 +325,36 @@ class SearchObject_EbscohostSearcher extends SearchObject_BaseSearcher {
 				curl_setopt($curlConnection, CURLOPT_URL, $infoUrl);
 				$searchOptionsStr = curl_exec($curlConnection);
 
+				if ($searchOptionsStr === false) {
+					global $logger;
+					$curlError = curl_error($curlConnection);
+					$logger->log('EBSCOhost getSearchOptions: curl error — ' . $curlError, Logger::LOG_ERROR);
+					self::$lastConnectionError = 'Could not connect to EBSCOhost: ' . $curlError;
+					return null;
+				}
+
 				SearchObject_EbscohostSearcher::$searchOptions = simplexml_load_string($searchOptionsStr);
 				if (SearchObject_EbscohostSearcher::$searchOptions) {
+					if (!empty((string)SearchObject_EbscohostSearcher::$searchOptions->Message)) {
+						global $logger;
+						$ebscoMessage = (string)SearchObject_EbscohostSearcher::$searchOptions->Message;
+						$logger->log('EBSCOhost getSearchOptions: EBSCO error — ' . $ebscoMessage, Logger::LOG_ERROR);
+						self::$lastConnectionError = $ebscoMessage;
+						SearchObject_EbscohostSearcher::$searchOptions = null;
+						return null;
+					}
+					self::$lastConnectionError = '';
 					return SearchObject_EbscohostSearcher::$searchOptions;
 				} else {
+					global $logger;
+					$logger->log('EBSCOhost getSearchOptions: failed to parse XML response. Raw response: ' . $searchOptionsStr, Logger::LOG_ERROR);
+					self::$lastConnectionError = 'EBSCOhost returned an unexpected response.';
 					return null;
 				}
 			} else {
+				global $logger;
+				$logger->log('EBSCOhost getSearchOptions: no EBSCOhost settings configured for this library.', Logger::LOG_WARNING);
+				self::$lastConnectionError = 'No EBSCOhost settings configured for this library.';
 				return null;
 			}
 		} else {
@@ -605,15 +633,21 @@ class SearchObject_EbscohostSearcher extends SearchObject_BaseSearcher {
 			$infoUrl .= "&query=$uniqueIdTag%20$uniqueId&db=$dbId";
 			curl_setopt($curlConnection, CURLOPT_URL, $infoUrl);
 			$recordInfoStr = curl_exec($curlConnection);
-			if ($recordInfoStr == false) {
+			if ($recordInfoStr === false) {
+				global $logger;
+				$logger->log('EBSCOhost retrieveRecord: curl error — ' . curl_error($curlConnection), Logger::LOG_ERROR);
 				return null;
+			}
+			$recordData = simplexml_load_string($recordInfoStr);
+			if ($recordData === false) {
+				global $logger;
+				$logger->log('EBSCOhost retrieveRecord: failed to parse XML. Raw response: ' . $recordInfoStr, Logger::LOG_ERROR);
+				return null;
+			}
+			if ($recordData->Hits > 0) {
+				return reset($recordData->SearchResults->records);
 			} else {
-				$recordData = simplexml_load_string($recordInfoStr);
-				if ($recordData->Hits > 0) {
-					return reset($recordData->SearchResults->records);
-				} else {
-					return null;
-				}
+				return null;
 			}
 		} else {
 			return null;
@@ -722,15 +756,25 @@ class SearchObject_EbscohostSearcher extends SearchObject_BaseSearcher {
 			]);
 			curl_setopt($curlConnection, CURLOPT_URL, $searchUrl);
 			$result = curl_exec($curlConnection);
+
+			if ($result === false) {
+				global $logger;
+				$curlError = curl_error($curlConnection);
+				$logger->log('EBSCOhost processSearch: curl error — ' . $curlError, Logger::LOG_ERROR);
+				return new AspenError('EBSCOhost connection failed: ' . $curlError);
+			}
+
 			try {
 				$searchData = simplexml_load_string($result);
 				if ($searchData->Message) {
+					global $logger;
 					$message = (string)$searchData->Message;
 					if (strpos($message, 'name=')) {
 						if (preg_match('/name="(.*?)"/', $message, $matches)) {
 							$message = $matches[1];
 						}
 					}
+					$logger->log('EBSCOhost processSearch: EBSCO returned error message — ' . $message, Logger::LOG_ERROR);
 					return new AspenError("Error processing search in EBSCOhost: " . $message);
 				}
 				$this->stopQueryTimer();
@@ -740,12 +784,16 @@ class SearchObject_EbscohostSearcher extends SearchObject_BaseSearcher {
 
 					return $searchData->SearchResults->records;
 				} elseif ($searchData && !empty($searchData->ErrorNumber)) {
-					return new AspenError("Error processing search in EBSCOhost: " . (string)$searchData->ErrorNumber);
+					global $logger;
+					$errorNumber = (string)$searchData->ErrorNumber;
+					$logger->log('EBSCOhost processSearch: EBSCO ErrorNumber ' . $errorNumber, Logger::LOG_ERROR);
+					return new AspenError("Error processing search in EBSCOhost: " . $errorNumber);
 				} else {
 					global $logger;
+					$logger->log('EBSCOhost processSearch: failed to parse XML. Raw response: ' . $result, Logger::LOG_ERROR);
 					if (IPAddress::showDebuggingInformation()) {
 						$curlInfo = curl_getinfo($curlConnection);
-						$logger->log(print_r($curlInfo(true)), Logger::LOG_WARNING);
+						$logger->log('EBSCOhost processSearch: curl info — ' . print_r($curlInfo, true), Logger::LOG_WARNING);
 					}
 					$this->lastSearchResults = false;
 					return new AspenError("Error processing search in EBSCOhost, unknown error returned.");
@@ -767,6 +815,13 @@ class SearchObject_EbscohostSearcher extends SearchObject_BaseSearcher {
 		if ($searchOptions == null) {
 			global $logger;
 			$logger->log('EBSCOhost getDatabases: getSearchOptions() returned null — credentials may be invalid or the EBSCO API is unreachable', Logger::LOG_WARNING);
+			return $databases;
+		}
+		if (count($searchOptions->dbInfo->db) === 0) {
+			global $logger;
+			$rawXml = $searchOptions->asXML();
+			$logger->log('EBSCOhost getDatabases: response missing dbInfo. Raw response: ' . $rawXml, Logger::LOG_ERROR);
+			self::$lastConnectionError = 'EBSCOhost returned no database list. Communicate with the support team for details.';
 			return $databases;
 		}
 		/** @var SimpleXMLElement $dbInfo */


### PR DESCRIPTION
Previously, when an EBSCOhost connection failed, the reason returned by the EBSCO API was silently discarded — leaving administrators with only a generic "credentials may be invalid" message in the admin UI and no useful information in the error log.

This improvement ensures that:

- All EBSCOhost connection errors (curl failures, invalid credentials, malformed profile IDs, unexpected API responses) are now logged to error.log with full technical detail
- The admin UI displays the actual error message returned by EBSCO instead of a generic fallback, making it easier to diagnose misconfigured credentials or profile IDs without needing to inspect server logs
- A bug in processSearch() where curl_getinfo was incorrectly called as a function ($curlInfo(true)) has been fixed
- Silent failures in retrieveRecord() that previously returned null with no log entry are now properly logged

Test plan 

Before

1. Go to Administration > EBSCOhost Settings and open an existing setting
2. Enter an invalid profile ID (e.g. lalaland) and save
3. Observe the connection error message in the UI — only shows generic: "EBSCO connection failed. Credentials may be invalid or the EBSCO API is unreachable."
4. Check error.log — no useful information about the actual failure reason

After

1. Enter a profile ID in wrong format (e.g. lalaland) and save
 - UI: Error message shows the actual EBSCO response: "EBSCO connection failed: User profile "lalaland" is not in expected format <user>.<group>.<profile>"
 - error.log: Entry logged with full detail: [ERROR] EBSCOhost getSearchOptions: EBSCO error — User profile "lalaland" is not in expected format "<user>.<group>.<profile>"
2. Enter a valid format but wrong credentials (e.g. wrong.wrong.wrong) and save
 - UI: Shows the EBSCO authentication error message
 - error.log: Error logged with the raw EBSCO response
3. Simulate a network failure (e.g. block eit.ebscohost.com via hosts file or disconnect network)
 - UI: Shows "EBSCO connection failed: Could not connect to EBSCOhost: <curl error>"
 - error.log: Curl error logged
4. Enter valid credentials and save
 - UI: No error message, databases list updates normally
 - error.log: No error entries