### PR TITLE
DIS-2257: Add To List modal: stack "or" and "Create a New List" button vertically

### DIFF
--- a/code/web/interface/themes/responsive/MyAccount/saveToList.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/saveToList.tpl
@@ -40,8 +40,12 @@
 										<option value="">{translate text='My Favorites' isPublicFacing=true}</option>
 									{/foreach}
 								</select>
-								&nbsp;or&nbsp;
-								<button class="btn btn-sm btn-default" onclick="return AspenDiscovery.Account.showCreateListForm('{$source|escape:"url"}', '{$sourceId|escape:"url"}')">{translate text="Create a New List" isPublicFacing=true}</button>
+								<div style="margin-top: 6px; text-align: center;">
+									<div>{translate text='or' isPublicFacing=true}</div>
+									<div style="margin-top: 6px;">
+										<button class="btn btn-sm btn-default" onclick="return AspenDiscovery.Account.showCreateListForm('{$source|escape:"url"}', '{$sourceId|escape:"url"}')">{translate text="Create a New List" isPublicFacing=true}</button>
+									</div>
+								</div>
 							</div>
 						</div>
 					{else}

--- a/code/web/release_notes/26.05.00.MD
+++ b/code/web/release_notes/26.05.00.MD
@@ -18,6 +18,9 @@
 //chloe
 
 //lucas
+### Other Updates
+- Improve layout of the "Add To List" modal: stack the "or" separator and "Create a New List" button vertically, centered below the list dropdown. ([DIS-2257](https://aspen-discovery.atlassian.net/browse/DIS-2257)) (*LM*)
+
 ### EBSCO Updates
 - Fix fatal error in EBSCOhost settings when API is unreachable or EBSCO credentials are not yet configured. ([DIS-2215](https://aspen-discovery.atlassian.net/browse/DIS-2215)) (*LM*)
 


### PR DESCRIPTION
In the "Add To List" modal, the "or" text and "Create a New List" button are displayed inline on the same row, which looks unbalanced relative to the dropdown above it.

Test plan

Before:
1. Log in and open any title's detail page
2. Click "Add to List"
3. Observe the "or" and "Create a New List" button — they appear inline on the same row, left-aligned below the dropdown

After:
1. Log in and open any title's detail page
2. Click "Add to List"
3. Observe the "or" text appears centered on its own line below the dropdown
4. The "Create a New List" button appears centered below the "or"
5. The "Add a Note" textarea follows below as usual
6. Click "Create a New List" — verify it still opens the create list form correctly
7. Select an existing list from the dropdown and click "Save To List" — verify saving still works