### PR TITLE
DIS-2262: Fix Advanced Search facet popup Apply button not responding

### DIFF
--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -20010,11 +20010,18 @@ AspenDiscovery.Searches = (function(){
 						return aspenJQ(this).attr('data-filter') === currentVal;
 					}).prop('checked', true);
 				}
-				// Enforce single-select: checking one unchecks all others
+				// Enforce single-select: checking one unchecks all others.
+				// If the user clicks the already-checked item, keep it checked so Apply always has a valid selection.
 				aspenJQ('#modalDialog').off('change.advFacet').on('change.advFacet', '.advFacetCheckbox', function () {
 					if (aspenJQ(this).prop('checked')) {
 						aspenJQ('.advFacetCheckbox').not(this).prop('checked', false);
+					} else {
+						aspenJQ(this).prop('checked', true);
 					}
+				});
+				// Bind Apply button via event delegation (avoids inline onclick issues)
+				aspenJQ('#modalDialog').off('click.advFacetApply').on('click.advFacetApply', '.adv-facet-apply-btn', function () {
+					AspenDiscovery.Searches.applyAdvancedFacetSelections();
 				});
 			};
 			if (cache[facetName]) {

--- a/code/web/interface/themes/responsive/js/aspen/searches.js
+++ b/code/web/interface/themes/responsive/js/aspen/searches.js
@@ -439,11 +439,18 @@ AspenDiscovery.Searches = (function(){
 						return aspenJQ(this).attr('data-filter') === currentVal;
 					}).prop('checked', true);
 				}
-				// Enforce single-select: checking one unchecks all others
+				// Enforce single-select: checking one unchecks all others.
+				// If the user clicks the already-checked item, keep it checked so Apply always has a valid selection.
 				aspenJQ('#modalDialog').off('change.advFacet').on('change.advFacet', '.advFacetCheckbox', function () {
 					if (aspenJQ(this).prop('checked')) {
 						aspenJQ('.advFacetCheckbox').not(this).prop('checked', false);
+					} else {
+						aspenJQ(this).prop('checked', true);
 					}
+				});
+				// Bind Apply button via event delegation (avoids inline onclick issues)
+				aspenJQ('#modalDialog').off('click.advFacetApply').on('click.advFacetApply', '.adv-facet-apply-btn', function () {
+					AspenDiscovery.Searches.applyAdvancedFacetSelections();
 				});
 			};
 			if (cache[facetName]) {

--- a/code/web/release_notes/26.04.00.MD
+++ b/code/web/release_notes/26.04.00.MD
@@ -8,6 +8,8 @@
 ### Advanced Search Updates
 - Add ability to browse and search all available facet values from the Advanced Search page via a popup modal, with dropdowns capped at 5 values and a "More options..." entry to open the browser. ([DIS-2128](https://aspen-discovery.atlassian.net/browse/DIS-2128)) (*LM*)
 - Update the modal dialog opened by the “More options…” sentinel in 'Advanced Search' for consistency ([DIS-2205](https://aspen-discovery.atlassian.net/browse/DIS-2205)) (*LM*)
+- Fix Apply button not responding and prevent deselecting the active facet value in the Advanced Search facet browser modal ([DIS-2262](https://aspen-discovery.atlassian.net/browse/DIS-2262)) (*LM*)
+- 
 
 ### API Updates
 - Added data in User API checkoutILSItem response for if the item was not found and the scanned barcode value to allow user to confirm. ([DIS-2177](https://aspen-discovery.atlassian.net/browse/DIS-2177)) (*KK*)

--- a/code/web/services/Search/AJAX.php
+++ b/code/web/services/Search/AJAX.php
@@ -834,7 +834,7 @@ class AJAX extends JSON_Action {
 			$searchObject->close();
 
 			$applyLabel = translate(['text' => 'Apply', 'isPublicFacing' => true]);
-			$buttons = "<button class='btn btn-primary' onclick='AspenDiscovery.Searches.applyAdvancedFacetSelections()'>$applyLabel</button>";
+			$buttons = "<button class='btn btn-primary adv-facet-apply-btn'>$applyLabel</button>";
 			return [
 				'success'   => true,
 				'title'     => translate([


### PR DESCRIPTION
The Apply button in the "More options…" facet popup on the Advanced Search page fails silently when clicked. The root cause is the button's inline onclick handler, which can be blocked by browser security policies (CSP). Additionally, clicking a pre-selected checkbox in the popup would uncheck it, leaving Apply with nothing to act on. This patch replaces the inline handler with jQuery event delegation and prevents accidental unchecking of the active selection.

Test plan

Before

1. Go to Advanced Search and open the facet browser modal via "More options…"
2. Select a facet value — confirm it gets checked
3. Click the same checked value — confirm it unchecks (broken behavior)
4. Click Apply — confirm nothing happens or an error occurs (broken behavior)

After

5. Open the facet browser modal via "More options…"
6. Select a facet value — confirm it gets checked
7. Click the same checked value — confirm it stays checked (cannot deselect)
8. Click Apply — confirm the search is filtered by the selected facet value