### PR TITLE
DIS-2130: (follow-up) Add comments and use variables for series link

### DIFF
--- a/code/web/RecordDrivers/GroupedWorkDriver.php
+++ b/code/web/RecordDrivers/GroupedWorkDriver.php
@@ -2369,6 +2369,19 @@ class GroupedWorkDriver extends IndexRecordDriver {
 
 	private $seriesData;
 
+	/**
+	 * Fetch series data depending on the sources enabled
+	 * if 'Series Index' is enabled, primary and additionalSeries entries are from the index
+	 * else if 'Novelist' is enabled, primary series is from Novelist 
+	 *     and if showIndexedSeriesWithNoveList enabled, additionalSeries pulled from the MARC
+	 * else primary and additionalSeries from MARC
+	 *
+	 *
+	 * @access  public
+	 * @param boolean allowReload whether Novelist data can be fetched anew from Novelist
+	 * @param int $seriesId ID of the series that this work is contained on
+	 * @return  string              Name of Smarty template file to display.
+	 */
 	public function getSeries($allowReload = true, ?int $seriesId = null): ?array {
 		require_once ROOT_DIR . '/sys/Grouping/GroupedWorkDisplayInfo.php';
 

--- a/code/web/interface/themes/responsive/GroupedWork/series-shared.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/series-shared.tpl
@@ -1,21 +1,20 @@
 {if !empty($summSeries)}
 	{assign var=totalSeriesShown value=0}
+	{assign var=additionalSeriesLink value="/Search/Results?lookfor={$summSeries.seriesTitle|escape:url}&searchIndex=Series"}
 	{if !empty($summSeries.fromNovelist)}
 		{assign var=seriesClass value="series_from_novelist"}
+		{assign var=seriesLink value="/GroupedWork/{$summSeries.groupedWorkId}/Series"}
 	{elseif !empty($summSeries.fromSeriesIndex)}
 		{assign var=seriesClass value="series_from_series_index"}
+		{assign var=seriesLink value="/Series/{$summSeries.seriesId}"}
+		{assign var=additionalSeriesLink value="/Series/{$summSeries.seriesId}"}
 	{else}
 		{assign var=seriesClass value="series_from_marc"}
+		{assign var=seriesLink value="/Search/Results?lookfor={$summSeries.seriesTitle|escape:url}&searchIndex=Series"}
 	{/if}
 	{if empty($summSeries.hidden)}
 		{assign var=totalSeriesShown value=$totalSeriesShown+1}
-		{if $summSeries.fromSeriesIndex}
-			<a class="{$seriesClass}" href="/Series/{$summSeries.seriesId}">{$summSeries.seriesTitle}</a>{if !empty($summSeries.volume)}<strong> {translate text="volume %1%" 1=$summSeries.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}<br>
-		{elseif $summSeries.fromNovelist}
-			<a class="{$seriesClass}" href="/GroupedWork/{$summSeries.groupedWorkId}/Series">{$summSeries.seriesTitle}</a>{if !empty($summSeries.volume)}<strong> {translate text="volume %1%" 1=$summSeries.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}<br>
-		{else}
-			<a class="{$seriesClass}" href="/Search/Results?lookfor={$summSeries.seriesTitle|escape:url}&searchIndex=Series">{$summSeries.seriesTitle}</a>{if !empty($summSeries.volume)}<strong> {translate text="volume %1%" 1=$summSeries.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}<br>
-		{/if}
+		<a class="{$seriesClass}" href="{$seriesLink}">{$summSeries.seriesTitle}</a>{if !empty($summSeries.volume)}<strong> {translate text="volume %1%" 1=$summSeries.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}<br>
 	{/if}
 	{if !empty($summSeries.additionalSeries)}
 		{foreach from=$summSeries.additionalSeries item=additional}
@@ -25,13 +24,7 @@
 					<a onclick="$('#moreSeries_{$summId}').show();$('#moreSeriesLink_{$summId}').hide();" id="moreSeriesLink_{$summId}">{translate text='More Series...' isPublicFacing=true}</a>
 					<div id="moreSeries_{$summId}" style="display:none">
 				{/if}
-				{if $additional.fromSeriesIndex}
-					<a class="additional_series" href="/Series/{$additional.seriesId}">{$additional.seriesTitle}</a>{if !empty($additional.volume)}<strong> {translate text="volume %1%" 1=$additional.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}<br>
-				{elseif $additional.fromNovelist}
-					<a class="additional_series" href="/GroupedWork/{$additional.groupedWorkId}/Series">{$additional.seriesTitle}</a>{if !empty($additional.volume)}<strong> {translate text="volume %1%" 1=$additional.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}<br>
-				{else}
-					<a class="additional_series" href="/Search/Results?lookfor={$additional.seriesTitle|escape:url}&searchIndex=Series">{$additional.seriesTitle}</a>{if !empty($additional.volume)}<strong> {translate text="volume %1%" 1=$additional.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}<br>
-				{/if}
+				<a class="additional_series" href="{$additionalSeriesLink}">{$additional.seriesTitle}</a>{if !empty($additional.volume)}<strong> {translate text="volume %1%" 1=$additional.volume|format_float_with_min_decimals isPublicFacing=true}</strong>{/if}<br>
 			{/if}
 		{/foreach}
 		{if $totalSeriesShown >= $seriesLimit}


### PR DESCRIPTION
I used variables for the series links, to remove need for a second set of conditionals

Additional series as well, but I add comments to the function, if I followed, additional series either come from:
series index if enabled
MARC record if using novelist or not

Novelist can only return a single series