### PR TITLE
DIS-2249: Fix permissions for editing 'Layout Settings'

### DIFF
--- a/code/web/release_notes/26.05.00.MD
+++ b/code/web/release_notes/26.05.00.MD
@@ -253,6 +253,8 @@ This is the first submission in a serie of enhancements adding a registation sys
 ### Docker Updates
 - Fix backend startup race condition by adding a MariaDB healthcheck and waiting for a healthy db status before starting the backend service. ([DIS-2283](https://aspen-discovery.atlassian.net/browse/DIS-2283)) (*LM*)
 - Replace outdated `ASPEN_DATA_DIR` environment variable with `ASPEN_HOME` and remove the default `my.cnf` bind mount from the db service. ([DIS-2283](https://aspen-discovery.atlassian.net/browse/DIS-2283)) (*LM*)
+### Administration Updates
+- Fix permission issue where users with 'Administer All Themes' or 'Administer Library Themes' have access to 'Layout Settings'. ([DIS-2249](https://aspen-discovery.atlassian.net/browse/DIS-2249)) (*LM*)
 
 //pedro
 

--- a/code/web/sys/LibraryLocation/Library.php
+++ b/code/web/sys/LibraryLocation/Library.php
@@ -1293,7 +1293,7 @@ class Library extends DataObject {
 						'values' => $layoutSettings,
 						'label' => 'Layout Settings',
 						'description' => 'Layout Settings to apply to this interface',
-						'permissions' => ['Library Theme Configuration'],
+						'permissions' => ['Administer Library Layout Settings','Administer All Layout Settings'],
 					],
 					'homeLink' => [
 						'property' => 'homeLink',


### PR DESCRIPTION
This patch fix an issue where users with either "Administer All Themes" or "Administer Library Themes" were able to edit 'Layout Settings'

Test plan (KTD & ADB setup)

Before

Log in to Aspen with a user who has either 'Administer All Themes' or 'Administer Library Themes'.
Go to Aspen Administration → Themes and Layout.
The user can edit 'Layout Settings' (this is incorrect).

After
4. Repeat steps 1–2.
5. 'Layout Settings' is no longer visible if the user does not have the appropriate permissions.
  