### PR TITLE
DIS-2283: Fix backend startup race condition against MariaDB and clean up Docker Compose env vars

### DIFF
--- a/code/web/release_notes/26.05.00.MD
+++ b/code/web/release_notes/26.05.00.MD
@@ -21,6 +21,10 @@
 ### EBSCO Updates
 - Fix fatal error in EBSCOhost settings when API is unreachable or EBSCO credentials are not yet configured. ([DIS-2215](https://aspen-discovery.atlassian.net/browse/DIS-2215)) (*LM*)
 
+### Docker Updates
+- Fix backend startup race condition by adding a MariaDB healthcheck and waiting for a healthy db status before starting the backend service. ([DIS-2283](https://aspen-discovery.atlassian.net/browse/DIS-2283)) (*LM*)
+- Replace outdated `ASPEN_DATA_DIR` environment variable with `ASPEN_HOME` and remove the default `my.cnf` bind mount from the db service. ([DIS-2283](https://aspen-discovery.atlassian.net/browse/DIS-2283)) (*LM*)
+
 //pedro
 
 //galen

--- a/docker/README.md
+++ b/docker/README.md
@@ -3,9 +3,14 @@
 ## Quick Start
 
 ```bash
-git clone https://github.com/Aspen-Discovery/aspen-discovery.git
-cd aspen-discovery/docker
-cp files/env/default.env .env
+curl -O https://raw.githubusercontent.com/Aspen-Discovery/aspen-discovery/26.05.00/docker/docker-compose.yml
+curl -O https://raw.githubusercontent.com/Aspen-Discovery/aspen-discovery/26.05.00/docker/files/env/default.env
+cp default.env .env
+```
+
+Edit `.env` to set your site name, URL, and admin password, then start:
+
+```bash
 docker compose up -d
 ```
 
@@ -28,7 +33,8 @@ Access Aspen at http://localhost:85 (default credentials: `aspen_admin` / `secre
 | `TITLE` | `Aspen Discovery` | Library title |
 | `LIBRARY` | `Test Library` | Library name |
 | `TIMEZONE` | `America/Argentina/Cordoba` | PHP timezone |
-| `ASPEN_ADMIN_PASSWORD` | `secretPass123` | Admin password |
+| `ASPEN_ADMIN_PASSWORD` | `secretPass123` | Admin password — **change before going live** |
+| `ASPEN_HOME` | `./aspen` | Directory where instance files are stored (conf, data, logs) |
 | `SUPPORTING_COMPANY` | `ByWater Solutions` | Support company name |
 
 ### Database

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,8 @@ services:
       - ${ASPEN_DATA_DIR}/data:/data/aspen-discovery/${SITE_NAME}
       - ${ASPEN_DATA_DIR}/logs:/var/log/aspen-discovery/${SITE_NAME}
     depends_on:
-      - db
+      db:
+        condition: service_healthy
 
   apache:
     image: ${BACKEND_IMAGE_TAG:-aspendiscovery/aspen}
@@ -72,6 +73,10 @@ services:
       - ${ASPEN_DATA_DIR}/my.cnf:/etc/mysql/my.cnf
     networks:
       - net-aspen
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--su-mysql", "--connect", "--innodb_initialized"]
+      interval: 5s
+      retries: 10
 
   solr:
     image: ${SOLR_IMAGE_TAG:-aspendiscovery/solr}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,9 +13,9 @@ services:
       - net-aspen
     tty: true
     volumes:
-      - ${ASPEN_DATA_DIR}/conf:/usr/local/aspen-discovery/sites/${SITE_NAME}
-      - ${ASPEN_DATA_DIR}/data:/data/aspen-discovery/${SITE_NAME}
-      - ${ASPEN_DATA_DIR}/logs:/var/log/aspen-discovery/${SITE_NAME}
+      - ${ASPEN_HOME:-./aspen}/conf:/usr/local/aspen-discovery/sites/${SITE_NAME}
+      - ${ASPEN_HOME:-./aspen}/data:/data/aspen-discovery/${SITE_NAME}
+      - ${ASPEN_HOME:-./aspen}/logs:/var/log/aspen-discovery/${SITE_NAME}
     depends_on:
       db:
         condition: service_healthy
@@ -29,9 +29,9 @@ services:
     networks:
       - net-aspen
     volumes:
-      - ${ASPEN_DATA_DIR}/conf:/usr/local/aspen-discovery/sites/${SITE_NAME}
-      - ${ASPEN_DATA_DIR}/data:/data/aspen-discovery/${SITE_NAME}
-      - ${ASPEN_DATA_DIR}/logs:/var/log/aspen-discovery/${SITE_NAME}
+      - ${ASPEN_HOME:-./aspen}/conf:/usr/local/aspen-discovery/sites/${SITE_NAME}
+      - ${ASPEN_HOME:-./aspen}/data:/data/aspen-discovery/${SITE_NAME}
+      - ${ASPEN_HOME:-./aspen}/logs:/var/log/aspen-discovery/${SITE_NAME}
     command:
       - apache
     depends_on:
@@ -48,9 +48,9 @@ services:
           - ${SITE_NAME}
     tty: true
     volumes:
-      - ${ASPEN_DATA_DIR}/conf:/usr/local/aspen-discovery/sites/${SITE_NAME}
-      - ${ASPEN_DATA_DIR}/data:/data/aspen-discovery/${SITE_NAME}
-      - ${ASPEN_DATA_DIR}/logs:/var/log/aspen-discovery/${SITE_NAME}
+      - ${ASPEN_HOME:-./aspen}/conf:/usr/local/aspen-discovery/sites/${SITE_NAME}
+      - ${ASPEN_HOME:-./aspen}/data:/data/aspen-discovery/${SITE_NAME}
+      - ${ASPEN_HOME:-./aspen}/logs:/var/log/aspen-discovery/${SITE_NAME}
     command:
       - cron
     depends_on:
@@ -69,8 +69,7 @@ services:
       - MARIADB_PASSWORD=${DATABASE_PASSWORD:-passwd}
       - MARIADB_DATABASE=${DATABASE_NAME:-aspen}
     volumes:
-      - ${ASPEN_DATA_DIR}/database:/var/lib/mysql
-      - ${ASPEN_DATA_DIR}/my.cnf:/etc/mysql/my.cnf
+      - ${ASPEN_HOME:-./aspen}/database:/var/lib/mysql
     networks:
       - net-aspen
     healthcheck:
@@ -90,8 +89,6 @@ services:
       - solr:/var/solr
     networks:
       - net-aspen
-    depends_on:
-      - backend
     entrypoint:
     - /bin/bash
     - '-c'

--- a/docker/files/env/default.env
+++ b/docker/files/env/default.env
@@ -15,6 +15,7 @@ SOLR_PORT=8983
 PHP_FPM_HOST=backend
 PHP_FPM_PORT=9000
 ASPEN_ADMIN_PASSWORD=secretPass123
+ASPEN_HOME=./aspen
 
 # =============================================================================
 # DATABASE SETTINGS


### PR DESCRIPTION
This patch fixes a backend startup race condition by adding a MariaDB healthcheck so the backend waits for the database to be ready before starting. Also replaces the outdated ASPEN_DATA_DIR environment variable with ASPEN_HOME and removes the default my.cnf bind mount from the db service.