### PR TITLE
DIS-2282 Load Syndetics Unbound initiator script async:

### DIFF
--- a/code/web/interface/themes/responsive/GroupedWork/syndeticsUnbound.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/syndeticsUnbound.tpl
@@ -1,22 +1,29 @@
 {strip}
 	<div id="syndetics_unbound"></div>
-	<script src="https://unbound.syndetics.com/syndeticsunbound/connector/initiator.php?a_id={$unboundAccountNumber}{if !empty($unboundInstanceNumber)}&i_id={$unboundInstanceNumber}{/if}" type="text/javascript"></script>
+	<script async id="syndetics_initiator" src="https://unbound.syndetics.com/syndeticsunbound/connector/initiator.php?a_id={$unboundAccountNumber}{if !empty($unboundInstanceNumber)}&i_id={$unboundInstanceNumber}{/if}" type="text/javascript"></script>
 	<script type="text/javascript">
-		var su_session = LibraryThingConnector.runUnboundWithMetadata({ldelim}
-			"title":"{$recordDriver->getTitle()|escape:'javascript'}",
-			"author":"{$recordDriver->getPrimaryAuthor()|escape:'javascript'}",
-			"isbn":"{$recordDriver->getCleanISBN()}",
-			"upc":"{$recordDriver->getCleanUPC()}",
-			"id":"{$recordDriver->getPermanentId()}",
-			"unbound_container_id":"#syndetics_unbound",
-			"sectionTitle":"{translate text="See More from Syndetics Unbound" inAttribute=true isPublicFacing=true}",
-			"buttonTitle":"{translate text="Explore" inAttribute=true isPublicFacing=true}"
-		{rdelim});
-		unboundLoaded = function() {ldelim}
-			var numEnrichments = LibraryThingConnector.numberOfEnhancementsShown();
-			if( numEnrichments === 0 ) {ldelim}
-				$("#syndeticsUnboundPanel").hide();
+		function syndeticsUnboundInit() {ldelim}
+			var su_session = LibraryThingConnector.runUnboundWithMetadata({ldelim}
+				"title":"{$recordDriver->getTitle()|escape:'javascript'}",
+				"author":"{$recordDriver->getPrimaryAuthor()|escape:'javascript'}",
+				"isbn":"{$recordDriver->getCleanISBN()}",
+				"upc":"{$recordDriver->getCleanUPC()}",
+				"id":"{$recordDriver->getPermanentId()}",
+				"unbound_container_id":"#syndetics_unbound",
+				"sectionTitle":"{translate text="See More from Syndetics Unbound" inAttribute=true isPublicFacing=true}",
+				"buttonTitle":"{translate text="Explore" inAttribute=true isPublicFacing=true}"
+			{rdelim});
+			unboundLoaded = function() {ldelim}
+				var numEnrichments = LibraryThingConnector.numberOfEnhancementsShown();
+				if( numEnrichments === 0 ) {ldelim}
+					$("#syndeticsUnboundPanel").hide();
+				{rdelim}
 			{rdelim}
+		{rdelim}
+		if (typeof LibraryThingConnector !== 'undefined') {ldelim}
+			syndeticsUnboundInit();
+		{rdelim} else {ldelim}
+			document.getElementById('syndetics_initiator').addEventListener('load', syndeticsUnboundInit);
 		{rdelim}
 	</script>
 {/strip}

--- a/code/web/release_notes/26.04.00.MD
+++ b/code/web/release_notes/26.04.00.MD
@@ -183,6 +183,7 @@
 - Correct indicating titles that are On Hold for You with action button. ([DIS-2238](https://aspen-discovery.atlassian.net/browse/DIS-2238)) (*MDN*)
 - Add tracking of number of skipped pages and update website indexing log more frequently to prevent timeouts. ([DIS-2207](https://aspen-discovery.atlassian.net/browse/DIS-2207)) (*MDN*)
 - Correct saving "Always place holds on suggested edition" option after placing a hold. ([DIS-2275](https://aspen-discovery.atlassian.net/browse/DIS-2275)) (*MDN*)
+- Load Syndetics Unbound initiator script asynchronously so slow responses from the Syndetics server no longer block catalog record page rendering. ([DIS-2282](https://aspen-discovery.atlassian.net/browse/DIS-2282)) (*LP*)
 
 
 ## This release includes code contributions from
@@ -197,6 +198,9 @@
 - Kirstien Kroeger (KK)
 - Kodi Lein (KL)
 - Stephen Wicks (SW)
+
+### LibraryThing
+- Lauren Przywara (LP)
 
 ### Nashville Public Library
 - Bryan Jones (*BJ*)


### PR DESCRIPTION
Add async attribute to the Syndetics Unbound initiator script tag so slow responses from unbound.syndetics.com no longer block page rendering. Defer the runUnboundWithMetadata call until the initiator has loaded to avoid a race on LibraryThingConnector.

One way to test this fix is using dev tools; in the network tab (chrome), find` initiator.php`, right-click > Throttle requests > Throttle request URL. The catalog page now loads quickly despite the simulated slow load times for Syndetics Unbound. 

<img width="2078" height="970" alt="image" src="https://github.com/user-attachments/assets/6ec84d36-820d-48df-ad53-c9c4de524d8a" />
