### PR TITLE
DIS-2293: Fix inaccurate Koha reading history

### DIFF
--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -1663,7 +1663,7 @@ class Koha extends AbstractIlsDriver {
 			$hasMorePages = true;
 			while ($hasMorePages) {
 				$checkedInParam = $checkedIn ? 'true' : 'false';
-				$endpoint = "/api/v1/checkouts?patron_id=" . $patron->unique_ils_id . "&checked_in=" . $checkedInParam . "&_page=" . $page . "&_per_page=" . $perPage;
+				$endpoint = "/api/v1/checkouts?patron_id=" . $patron->unique_ils_id . "&checked_in=" . $checkedInParam . "&_page=" . $page . "&_per_page=" . $perPage . "&_match=exact";
 				$extraHeaders = [
 					'Accept-Encoding: gzip, deflate',
 					'Content-Type: application/json',

--- a/code/web/release_notes/26.03.04.MD
+++ b/code/web/release_notes/26.03.04.MD
@@ -1,0 +1,8 @@
+## Aspen Discovery Updates
+### Koha Updates
+- Fix the issue where reading history returned by the Koha API is not always accurate. ([DIS-2293](https://aspen-discovery.atlassian.net/browse/DIS-2293)) (*YL*)
+
+## This release includes code contributions from
+
+### Bywater Solutions
+- Yanjun Li (YL)


### PR DESCRIPTION
Koha reading history data returned in Aspen is not always accurate. We should include a required parameter in the endpoint. 

To Test:
1. Apply the PR
2. Confirm that reading history is more accurate 