### PR TITLE
DIS-2285: Restore My Account Renew All functionality

### DIFF
--- a/code/web/release_notes/26.04.00.MD
+++ b/code/web/release_notes/26.04.00.MD
@@ -183,6 +183,7 @@
 - Correct indicating titles that are On Hold for You with action button. ([DIS-2238](https://aspen-discovery.atlassian.net/browse/DIS-2238)) (*MDN*)
 - Add tracking of number of skipped pages and update website indexing log more frequently to prevent timeouts. ([DIS-2207](https://aspen-discovery.atlassian.net/browse/DIS-2207)) (*MDN*)
 - Correct saving "Always place holds on suggested edition" option after placing a hold. ([DIS-2275](https://aspen-discovery.atlassian.net/browse/DIS-2275)) (*MDN*)
+- Restore "Renew All" on checked out titles functionality and fix AJAX error. ([DIS-2285](https://aspen-discovery.atlassian.net/browse/DIS-2285)) (*YL*)
 
 
 ## This release includes code contributions from

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -2390,14 +2390,9 @@ class MyAccount_AJAX extends JSON_Action {
 			'message' => ['Unable to renew all titles'],
 		];
 		$user = UserAccount::getLoggedInUser();
-		if ($user) {
-			if (!method_exists($user, 'renewAll')) {
-				AspenError::raiseError(new AspenError('Cannot Renew Item - ILS Not Supported'));
-				$renewResults = $this->failureResult(null, 'Cannot Renew Items - ILS Not Supported.');
-			} else {
-				// Renew linked accounts as well if applicable
-				$renewResults = $user->renewAll(true);
-			}
+		if ($user){
+			// Renew linked accounts as well if applicable
+			$renewResults = $user->renewAll(true);
 		} else {
 			$renewResults = $this->failureResult(null, 'Sorry, it looks like you don\'t have access to that patron.');
 		}

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -2389,6 +2389,18 @@ class MyAccount_AJAX extends JSON_Action {
 			'success' => false,
 			'message' => ['Unable to renew all titles'],
 		];
+		$user = UserAccount::getLoggedInUser();
+		if ($user) {
+			if (!method_exists($user, 'renewAll')) {
+				AspenError::raiseError(new AspenError('Cannot Renew Item - ILS Not Supported'));
+				$renewResults = $this->failureResult(null, 'Cannot Renew Items - ILS Not Supported.');
+			} else {
+				// Renew linked accounts as well if applicable
+				$renewResults = $user->renewAll(true);
+			}
+		} else {
+			$renewResults = $this->failureResult(null, 'Sorry, it looks like you don\'t have access to that patron.');
+		}
 
 		global $interface;
 		$interface->assign('renew_message_data', $renewResults);
@@ -2414,7 +2426,7 @@ class MyAccount_AJAX extends JSON_Action {
 			]),
 			'modalBody' => $interface->fetch('Record/renew-results.tpl'),
 			'success' => $renewResults['success'],
-			'renewed' => $renewResults['Renewed'],
+			'renewed' => $renewResults['Renewed'] ?? 0,
 		];
 	}
 


### PR DESCRIPTION
When patrons attempt to renew all physical materials by “Renew All”, the request fails and throws an AJAX error
<br/><b>Warning</b>:  Undefined array key "Renewed" in <b>/usr/local/aspen-discovery/code/web/services/MyAccount/AJAX.php</b> on line <b>2398</b><br/>{
    "title": "Renew All",
    "modalBody": "<div class=\"content\">\n\t\t\t\t\t\t\t\t\t\t<div class=\"alert alert-danger\">Unable to renew all titles<\/div>\n\t\t\t\t\t\t\t<\/div>\n",
    "success": false,
    "renewed": null
}

To test:
1. Apply PR
2. Log in as a patron who has at least one renewable ILS checkout 
3. Click Renew All and see no AJAX error
4. Confirm that every checkout that was renewable is renewed