### PR TITLE
DIS-2300: Remove data-container for curbside pickup

### DIFF
--- a/code/web/interface/themes/responsive/MyAccount/curbsidePickupsSchedule.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/curbsidePickupsSchedule.tpl
@@ -34,7 +34,7 @@
 					{else}
 						{* Display custom instructions popover when in instruction lead window or ready. *}
 						{if $pickup['isReady'] || $pickup['withinTime'] || $timeAllowedBeforeCheckIn == -1}
-							<a role="button" tabindex="0" class="btn btn-primary btn-sm curbside-checkin-btn mb-1" data-toggle="popover" data-trigger="focus" data-placement="left" data-title="{translate text='Check-In Instructions' isPublicFacing=true}" data-content="{translate text=$pickupInstructions isPublicFacing=true isAdminEnteredData=true}" data-html="true" data-container="body">
+							<a role="button" tabindex="0" class="btn btn-primary btn-sm curbside-checkin-btn mb-1" data-toggle="popover" data-trigger="focus" data-placement="left" data-title="{translate text='Check-In Instructions' isPublicFacing=true}" data-content="{translate text=$pickupInstructions isPublicFacing=true isAdminEnteredData=true}" data-html="true">
 								<i class="fas fa-info-circle mr-1"></i> {translate text="View Instructions" isPublicFacing=true inAttribute=true}
 							</a>
 						{else}

--- a/code/web/release_notes/26.04.00.MD
+++ b/code/web/release_notes/26.04.00.MD
@@ -183,6 +183,7 @@
 - Correct indicating titles that are On Hold for You with action button. ([DIS-2238](https://aspen-discovery.atlassian.net/browse/DIS-2238)) (*MDN*)
 - Add tracking of number of skipped pages and update website indexing log more frequently to prevent timeouts. ([DIS-2207](https://aspen-discovery.atlassian.net/browse/DIS-2207)) (*MDN*)
 - Correct saving "Always place holds on suggested edition" option after placing a hold. ([DIS-2275](https://aspen-discovery.atlassian.net/browse/DIS-2275)) (*MDN*)
+- Remove the extra data-container attribute from the curbside pickup instructions popover. ([DIS-2300](https://aspen-discovery.atlassian.net/browse/DIS-2300)) (*YL*)
 
 
 ## This release includes code contributions from


### PR DESCRIPTION
Remove data-container attribute from the curbside pickup instructions popover. 

To Test:
1. Apply PR
2. Create a hold that is ready to pick up 
3. Schedule a curbside pickup and view instructions
4. Confirm the instructions popover displays correctly
5. Confirm the popover can be dismissed normally.