### PR TITLE
DIS-2227: Preserve accented letters in awards facet values

### DIFF
--- a/code/reindexer/src/org/aspen_discovery/reindexer/MarcRecordProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/MarcRecordProcessor.java
@@ -536,7 +536,7 @@ abstract class MarcRecordProcessor {
 				//Remove dates
 				award = award.replaceAll("\\d{2,4}", "");
 				//Remove punctuation
-				award = award.replaceAll("[^\\w\\s]", "");
+				award = award.replaceAll("[^\\p{L}\\p{N}\\s]", "");
 			}
 			awards.add(award.trim());
 		}

--- a/code/web/release_notes/26.05.00.MD
+++ b/code/web/release_notes/26.05.00.MD
@@ -31,6 +31,8 @@
 //stephen
 
 //yanjun
+### Indexing Updates
+- Allow the awards facet to retain accented and other Unicode letters when normalizing MARC 586 award field.  ([DIS-2227](https://aspen-discovery.atlassian.net/browse/DIS-2227)) (*YL*)
 
 //imani
 - add a strip tags to the format name inside of searchLite to avoid html added to formats from being displayed raw in LiDA ([DIS-2313](https://aspen-discovery.atlassian.net/browse/DIS-2313)) (*IT*)


### PR DESCRIPTION
The awards_facet indexed into Solr documents loses accented letters. (e.g. Américas” becomes “Amricas”). MARC field 586 $a is normalized with award.replaceAll("[^\\w\\s]", "")  so diacritics are removed along with punctuation. 

To test:
1. Set a record with field 586 $a "Américas" in ILS
2. In Aspen, find Grouped Works > Grouped Work Facets > Awards, enable "Show on Results Page" or	"Show on Advanced Search" or both
3. Force reindex the record in Aspen
4. Search this record and see Awards facet show "Amricas"
5. Apply PR
6. Force reindex the record and search the record
7. See Awads facet show "Américas" 