### PR TITLE
DIS-2174: Minimize reading history sent back to Koha.

### DIFF
--- a/code/web/CatalogConnection.php
+++ b/code/web/CatalogConnection.php
@@ -1250,7 +1250,7 @@ class CatalogConnection {
 			}
 		}
 
-		$checkouts = $patron->getCheckouts(false);
+		$checkouts = $patron->getCheckouts(false, isNightlyUpdate: $isNightlyUpdate);
 		foreach ($checkouts as $checkout) {
 			$source = $checkout->source;
 			$sourceId = $checkout->sourceId;

--- a/code/web/Drivers/AbstractDriver.php
+++ b/code/web/Drivers/AbstractDriver.php
@@ -2,6 +2,8 @@
 
 
 abstract class AbstractDriver {
+	protected bool $isNightlyUpdate = false;
+
 	public abstract function hasNativeReadingHistory(): bool;
 
 	public function canLoadReadingHistoryInMasqueradeMode() : bool {
@@ -245,5 +247,9 @@ abstract class AbstractDriver {
 
 		$accountSummary->clearCheckoutsStale();
 		return $activeCheckouts;
+	}
+
+	public function setNightlyUpdateStatus(bool $nightly): void {
+		$this->isNightlyUpdate = $nightly;
 	}
 }

--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -567,6 +567,12 @@ class Koha extends AbstractIlsDriver {
 			}
 			$curCheckout->dueDate = $dueTime;
 			$curCheckout->itemId = $itemNumber;
+
+			if(!$this->isNightlyUpdate) {
+				$checkouts[$curCheckout->source . $curCheckout->sourceId . $curCheckout->userId] = $curCheckout;
+				continue;
+			}
+			
 			$curCheckout->renewIndicator = $curRow['itemnumber'];
 			if ($kohaVersion >= 22.11) {
 				$curCheckout->renewCount = $curRow['renewals_count'];

--- a/code/web/release_notes/26.05.00.MD
+++ b/code/web/release_notes/26.05.00.MD
@@ -59,6 +59,7 @@
 - Fix typo in Solr schema for genealogy. ([DIS-2213](https://aspen-discovery.atlassian.net/browse/DIS-2213)) (*JW*)
 //chloe
 - Fix a bug pertaining to AmazonSesSettings sending emails + associated email validation. ([DIS-2247](https://aspen-discovery.atlassian.net/browse/DIS-2247)) (*JW*)
+- Code changes relating to fetching unnecessary reading history for Koha ([DIS-2174](https://aspen-discovery.atlassian.net/browse/DIS-2174)) (*JW*)
 
 //lucas
 ### EBSCO Updates

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -1857,9 +1857,10 @@ class User extends DataObject {
 	 *
 	 * @param bool $includeLinkedUsers
 	 * @param string $source
+	 * @param bool $isNightlyUpdate
 	 * @return Checkout[]
 	 */
-	public function getCheckouts(bool $includeLinkedUsers = true, string $source = 'all'): array {
+	public function getCheckouts(bool $includeLinkedUsers = true, string $source = 'all', bool $isNightlyUpdate): array {
 		require_once ROOT_DIR . '/sys/User/Checkout.php';
 
 		$checkoutsToReturn = [];
@@ -1868,6 +1869,7 @@ class User extends DataObject {
 		global $offlineMode;
 		if ($this->hasIlsConnection() && !$offlineMode) {
 			if ($source == 'all' || $source == 'ils') {
+				$this->getCatalogDriver()->driver->setNightlyUpdateStatus($isNightlyUpdate);
 				$ilsCheckouts = $this->getCatalogDriver()->getCheckouts($this);
 				$checkoutsToReturn = $ilsCheckouts;
 				$timer->logTime("Loaded transactions from catalog. $this->id");


### PR DESCRIPTION
Right now, when Koha is getting all checkouts, it returns a bunch of extra data which isn't always needed.  Moved that behind an "isNightlyUpdate" flag so that this information is sent less frequently.

@kidclamp Feel free to add anything you see fit.