### PR TITLE
DIS-2338: Create an audiobook duration facet

### DIFF
--- a/code/java_shared_libraries/src/com/turning_leaf_technologies/strings/AspenStringUtils.java
+++ b/code/java_shared_libraries/src/com/turning_leaf_technologies/strings/AspenStringUtils.java
@@ -109,6 +109,34 @@ public class AspenStringUtils {
 		return subfield;
 	}
 
+	public static int extractTotalMinutes(String input) {
+		// Handle HH:mm:ss format (e.g., "06:02:00")
+		Pattern timeColonPattern = Pattern.compile("(\\d+):(\\d{2}):(\\d{2})");
+		Matcher timeColonMatcher = timeColonPattern.matcher(input);
+		if (timeColonMatcher.find()) {
+			int hours = Integer.parseInt(timeColonMatcher.group(1));
+			int minutes = Integer.parseInt(timeColonMatcher.group(2));
+			// group(3) is seconds — ignored, but matched to confirm HH:mm:ss format
+			return hours * 60 + minutes;
+		}
+
+		// Handle "6 hr. 2 min." / "6h 2m 0s" formats
+		Pattern hrPattern = Pattern.compile("(\\d+)\\s*(?:hr\\.|h\\b)");
+		Pattern minPattern = Pattern.compile("(\\d+)\\s*(?:min\\.|m(?!s))");
+
+		Matcher hrMatcher = hrPattern.matcher(input);
+		Matcher minMatcher = minPattern.matcher(input);
+
+		int hours = hrMatcher.find() ? Integer.parseInt(hrMatcher.group(1)) : 0;
+		int minutes = minMatcher.find() ? Integer.parseInt(minMatcher.group(1)) : 0;
+
+		if (hours == 0 && minutes == 0) {
+			return 0;
+		}
+
+		return hours * 60 + minutes;
+	}
+
 	public static String stripNonValidXMLCharacters(String in) {
 		StringBuilder out = new StringBuilder(); // Used to hold the output.
 		char current; // Used to reference the current character.

--- a/code/reindexer/src/org/aspen_discovery/reindexer/AbstractGroupedWorkSolr.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/AbstractGroupedWorkSolr.java
@@ -78,6 +78,7 @@ public abstract class AbstractGroupedWorkSolr implements DebugLogger {
 	protected Long numHoldings = 0L;
 	protected HashSet<String> oclcs = new HashSet<>();
 	protected HashSet<String> physicals = new HashSet<>();
+	protected HashSet<Integer> durations = new HashSet<>();
 	protected double popularity;
 	protected long totalHolds;
 
@@ -990,6 +991,10 @@ public abstract class AbstractGroupedWorkSolr implements DebugLogger {
 
 	void addPhysical(Set<String> fieldList) {
 		this.physicals.addAll(fieldList);
+	}
+
+	void addDuration(Set<Integer> fieldList) {
+		this.durations.addAll(fieldList);
 	}
 
 	void addPhysical(String field) {

--- a/code/reindexer/src/org/aspen_discovery/reindexer/CloudLibraryProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/CloudLibraryProcessor.java
@@ -142,6 +142,7 @@ class CloudLibraryProcessor extends MarcRecordProcessor {
 				allRelatedRecords.add(cloudLibraryRecord);
 				loadEditions(groupedWork, marcRecord, allRelatedRecords);
 				loadPhysicalDescription(groupedWork, marcRecord, allRelatedRecords);
+				loadDuration(groupedWork, marcRecord, allRelatedRecords);
 				loadLanguageDetails(groupedWork, marcRecord, allRelatedRecords, identifier);
 				loadPublicationDetails(groupedWork, marcRecord, allRelatedRecords);
 

--- a/code/reindexer/src/org/aspen_discovery/reindexer/GroupedWorkIndexer.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/GroupedWorkIndexer.java
@@ -141,6 +141,8 @@ public class GroupedWorkIndexer {
 	private PreparedStatement addPlaceOfPublicationStmt;
 	private PreparedStatement getPhysicalDescriptionStmt;
 	private PreparedStatement addPhysicalDescriptionStmt;
+	private PreparedStatement getDurationStmt;
+	private PreparedStatement addDurationStmt;
 	private PreparedStatement getEContentSourceStmt;
 	private PreparedStatement addEContentSourceStmt;
 	private PreparedStatement getShelfLocationStmt;
@@ -285,10 +287,10 @@ public class GroupedWorkIndexer {
 			addScopeStmt = dbConn.prepareStatement("INSERT INTO scope (name, isLibraryScope, isLocationScope) VALUES (?, ?, ?)", Statement.RETURN_GENERATED_KEYS);
 			updateScopeStmt = dbConn.prepareStatement("UPDATE scope set isLibraryScope = ?, isLocationScope = ? WHERE id = ?");
 			removeScopeStmt = dbConn.prepareStatement("DELETE FROM scope where id = ?");
-			getExistingRecordsForWorkStmt = dbConn.prepareStatement("SELECT id, sourceId, recordIdentifier, groupedWorkId, editionId, publisherId, publicationDateId, placeOfPublicationId, physicalDescriptionId, formatId, formatCategoryId, languageId, isClosedCaptioned, hasParentRecord, audienceId, hasChildRecord from grouped_work_records where groupedWorkId = ?", ResultSet.TYPE_FORWARD_ONLY,  ResultSet.CONCUR_READ_ONLY);
-			addRecordForWorkStmt = dbConn.prepareStatement("INSERT INTO grouped_work_records (groupedWorkId, sourceId, recordIdentifier, editionId, publisherId, publicationDateId, placeOfPublicationId, physicalDescriptionId, formatId, formatCategoryId, languageId, isClosedCaptioned, hasParentRecord, hasChildRecord, audienceId) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) " +
-					"ON DUPLICATE KEY UPDATE groupedWorkId = VALUES(groupedWorkId), editionId = VALUES(editionId), publisherId = VALUES(publisherId), publicationDateId = VALUES(publicationDateId), placeOfPublicationId = VALUES(placeOfPublicationId), physicalDescriptionId = VALUES(physicalDescriptionId), formatId = VALUES(formatId), formatCategoryId = VALUES(formatCategoryId), languageId = VALUES(languageId), isClosedCaptioned = VALUES(isClosedCaptioned), hasParentRecord = VALUES(hasParentRecord), hasChildRecord = VALUES(hasChildRecord), audienceId = VALUES(audienceId)", PreparedStatement.RETURN_GENERATED_KEYS);
-			updateRecordForWorkStmt = dbConn.prepareStatement("UPDATE grouped_work_records SET groupedWorkId = ?, editionId = ?, publisherId = ?, publicationDateId = ?, placeOfPublicationId = ?, physicalDescriptionId = ?, formatId = ?, formatCategoryId = ?, languageId = ?, isClosedCaptioned = ?, hasParentRecord = ?, hasChildRecord = ?, audienceId = ? where id = ?");
+			getExistingRecordsForWorkStmt = dbConn.prepareStatement("SELECT id, sourceId, recordIdentifier, groupedWorkId, editionId, publisherId, publicationDateId, placeOfPublicationId, physicalDescriptionId, formatId, formatCategoryId, languageId, isClosedCaptioned, hasParentRecord, audienceId, hasChildRecord, durationId from grouped_work_records where groupedWorkId = ?", ResultSet.TYPE_FORWARD_ONLY,  ResultSet.CONCUR_READ_ONLY);
+			addRecordForWorkStmt = dbConn.prepareStatement("INSERT INTO grouped_work_records (groupedWorkId, sourceId, recordIdentifier, editionId, publisherId, publicationDateId, placeOfPublicationId, physicalDescriptionId, formatId, formatCategoryId, languageId, isClosedCaptioned, hasParentRecord, hasChildRecord, audienceId, durationId) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) " +
+					"ON DUPLICATE KEY UPDATE groupedWorkId = VALUES(groupedWorkId), editionId = VALUES(editionId), publisherId = VALUES(publisherId), publicationDateId = VALUES(publicationDateId), placeOfPublicationId = VALUES(placeOfPublicationId), physicalDescriptionId = VALUES(physicalDescriptionId), formatId = VALUES(formatId), formatCategoryId = VALUES(formatCategoryId), languageId = VALUES(languageId), isClosedCaptioned = VALUES(isClosedCaptioned), hasParentRecord = VALUES(hasParentRecord), hasChildRecord = VALUES(hasChildRecord), audienceId = VALUES(audienceId), durationId = VALUES(durationId)", PreparedStatement.RETURN_GENERATED_KEYS);
+			updateRecordForWorkStmt = dbConn.prepareStatement("UPDATE grouped_work_records SET groupedWorkId = ?, editionId = ?, publisherId = ?, publicationDateId = ?, placeOfPublicationId = ?, physicalDescriptionId = ?, formatId = ?, formatCategoryId = ?, languageId = ?, isClosedCaptioned = ?, hasParentRecord = ?, hasChildRecord = ?, audienceId = ?, durationId = ? where id = ?");
 			removeRecordForWorkStmt = dbConn.prepareStatement("DELETE FROM grouped_work_records where id = ?");
 			getIdForRecordStmt = dbConn.prepareStatement("SELECT id from grouped_work_records where sourceId = ? and recordIdentifier = ?", ResultSet.TYPE_FORWARD_ONLY,  ResultSet.CONCUR_READ_ONLY);
 			getExistingVariationsForWorkStmt = dbConn.prepareStatement("SELECT * from grouped_work_variation where groupedWorkId = ?", ResultSet.TYPE_FORWARD_ONLY,  ResultSet.CONCUR_READ_ONLY);
@@ -328,6 +330,8 @@ public class GroupedWorkIndexer {
 			addPlaceOfPublicationStmt = dbConn.prepareStatement("INSERT INTO indexed_place_of_publication (placeOfPublication) VALUES (?)", Statement.RETURN_GENERATED_KEYS);
 			getPhysicalDescriptionStmt = dbConn.prepareStatement("SELECT id from indexed_physical_description where physicalDescription = ?", ResultSet.TYPE_FORWARD_ONLY,  ResultSet.CONCUR_READ_ONLY);
 			addPhysicalDescriptionStmt = dbConn.prepareStatement("INSERT INTO indexed_physical_description (physicalDescription) VALUES (?)", Statement.RETURN_GENERATED_KEYS);
+			getDurationStmt = dbConn.prepareStatement("SELECT id from indexed_duration where duration = ?", ResultSet.TYPE_FORWARD_ONLY,  ResultSet.CONCUR_READ_ONLY);
+			addDurationStmt = dbConn.prepareStatement("INSERT INTO indexed_duration (duration) VALUES (?)", Statement.RETURN_GENERATED_KEYS);
 			getEContentSourceStmt = dbConn.prepareStatement("SELECT id from indexed_econtent_source where eContentSource = ?", ResultSet.TYPE_FORWARD_ONLY,  ResultSet.CONCUR_READ_ONLY);
 			addEContentSourceStmt = dbConn.prepareStatement("INSERT INTO indexed_econtent_source (eContentSource) VALUES (?)", Statement.RETURN_GENERATED_KEYS);
 			getShelfLocationStmt = dbConn.prepareStatement("SELECT id from indexed_shelf_location where shelfLocation = ?", ResultSet.TYPE_FORWARD_ONLY,  ResultSet.CONCUR_READ_ONLY);
@@ -1937,6 +1941,7 @@ public class GroupedWorkIndexer {
 				addRecordForWorkStmt.setBoolean(13, recordInfo.hasParentRecord());
 				addRecordForWorkStmt.setBoolean(14, recordInfo.hasChildRecord());
 				addRecordForWorkStmt.setLong(15, getAudienceId(recordInfo.getAudience(), 1));
+				addRecordForWorkStmt.setLong(16, getDurationId(recordInfo.getDuration(), 1));
 				addRecordForWorkStmt.executeUpdate();
 				ResultSet addRecordForWorkRS = addRecordForWorkStmt.getGeneratedKeys();
 				if (addRecordForWorkRS.next()) {
@@ -1959,6 +1964,7 @@ public class GroupedWorkIndexer {
 				long publisherId = getPublisherId(recordInfo.getPublisher(), recordInfo.getRecordIdentifier(), 1);
 				long publicationDateId = getPublicationDateId(recordInfo.getPublicationDate(), 1);
 				long physicalDescriptionId = getPhysicalDescriptionId(recordInfo.getPhysicalDescription(), 1);
+				long durationId = getDurationId(recordInfo.getDuration(), 1);
 				long placeOfPublicationId = getPlaceOfPublicationId(recordInfo.getPlaceOfPublication(), 1);
 				long formatId = getFormatId(recordInfo.getPrimaryFormat(), 1);
 				long formatCategoryId = getFormatCategoryId(recordInfo.getPrimaryFormatCategory(), 1);
@@ -1973,6 +1979,7 @@ public class GroupedWorkIndexer {
 				if (publicationDateId != existingRecord.publicationDateId) { hasChanges = true; }
 				if (placeOfPublicationId != existingRecord.placeOfPublicationId) {hasChanges = true; }
 				if (physicalDescriptionId != existingRecord.physicalDescriptionId) { hasChanges = true; }
+				if (durationId != existingRecord.durationId) {hasChanges = true; }
 				if (formatId != existingRecord.formatId) { hasChanges = true; }
 				if (formatCategoryId != existingRecord.formatCategoryId) { hasChanges = true; }
 				if (languageId != existingRecord.languageId) { hasChanges = true; }
@@ -1994,7 +2001,8 @@ public class GroupedWorkIndexer {
 					updateRecordForWorkStmt.setBoolean(11, hasParentRecord);
 					updateRecordForWorkStmt.setBoolean(12, hasChildRecord);
 					updateRecordForWorkStmt.setLong(13, audienceId);
-					updateRecordForWorkStmt.setLong(14, existingRecord.id);
+					updateRecordForWorkStmt.setLong(14, durationId);
+					updateRecordForWorkStmt.setLong(15, existingRecord.id);
 					updateRecordForWorkStmt.executeUpdate();
 				}
 			}
@@ -2418,6 +2426,45 @@ public class GroupedWorkIndexer {
 				}
 			}
 			physicalDescriptionIds.put(physicalDescription, id);
+		}
+		return id;
+	}
+
+	private final MaxSizeHashMap<Integer, Long> durationIds = new MaxSizeHashMap<>(1000);
+	private long getDurationId(int duration, int numTries) {
+		if (duration == 0){
+			return 0;
+		}
+		Long id = durationIds.get(duration);
+		if (id == null){
+			try {
+				getDurationStmt.setInt(1, duration);
+				ResultSet getPhysicalDescriptionRS = getDurationStmt.executeQuery();
+				if (getPhysicalDescriptionRS.next()){
+					id = getPhysicalDescriptionRS.getLong("id");
+				}else {
+					addDurationStmt.setInt(1, duration);
+					addDurationStmt.executeUpdate();
+					ResultSet addDurationRS = addDurationStmt.getGeneratedKeys();
+					if (addDurationRS.next()) {
+						id = addDurationRS.getLong(1);
+					} else {
+						logEntry.incErrors("Could not add duration");
+						id = -1L;
+					}
+					addDurationRS.close();
+				}
+				getPhysicalDescriptionRS.close();
+			} catch (SQLException e) {
+				//Another thread already created it, call it again
+				if (numTries == 1) {
+					return getDurationId(duration, numTries + 1);
+				}else {
+					logEntry.incErrors("Error getting physicalDescription id (" + duration + "):" + duration, e);
+					id = -1L;
+				}
+			}
+			durationIds.put(duration, id);
 		}
 		return id;
 	}

--- a/code/reindexer/src/org/aspen_discovery/reindexer/GroupedWorkSolr2.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/GroupedWorkSolr2.java
@@ -100,6 +100,7 @@ public class GroupedWorkSolr2 extends AbstractGroupedWorkSolr implements Cloneab
 
 			//faceting and refined searching
 			doc.addField("physical", physicals);
+			doc.addField("duration", durations);
 			doc.addField("edition", editions);
 			doc.addField("dateSpan", dateSpans);
 			//series.values().removeAll(GroupedWorkIndexer.hideSeries);

--- a/code/reindexer/src/org/aspen_discovery/reindexer/HooplaProcessor2.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/HooplaProcessor2.java
@@ -18,6 +18,9 @@ import java.sql.SQLException;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 class HooplaProcessor2 {
 	private final GroupedWorkIndexer indexer;
@@ -444,8 +447,12 @@ class HooplaProcessor2 {
 
 				groupedWork.addPublicationDate(releaseYear);
 				//physical description
-				if (rawResponse.has("duration")){
-					groupedWork.addPhysical(rawResponse.getString("duration"));
+				if (primaryFormat.equals("eAudiobook") && rawResponse.has("duration")) {
+					int duration = AspenStringUtils.extractTotalMinutes(rawResponse.getString("duration"));
+					hooplaRecord.setDuration(duration);
+					Set<Integer> durationSet = new HashSet<>();
+					durationSet.add(duration);
+					groupedWork.addDuration(durationSet);
 				}
 
 				//Description

--- a/code/reindexer/src/org/aspen_discovery/reindexer/IlsRecordProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/IlsRecordProcessor.java
@@ -336,6 +336,7 @@ abstract class IlsRecordProcessor extends MarcRecordProcessor {
 			loadEditions(groupedWork, record, allRelatedRecords);
 			loadAudiences(groupedWork, record, allRelatedRecords);
 			loadPhysicalDescription(groupedWork, record, allRelatedRecords);
+			loadDuration(groupedWork, record, allRelatedRecords);
 			loadLanguageDetails(groupedWork, record, allRelatedRecords, identifier);
 			loadPublicationDetails(groupedWork, record, allRelatedRecords);
 			loadClosedCaptioning(record, allRelatedRecords);

--- a/code/reindexer/src/org/aspen_discovery/reindexer/MarcRecordProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/MarcRecordProcessor.java
@@ -580,6 +580,25 @@ abstract class MarcRecordProcessor {
 		groupedWork.addPhysical(physicalDescriptions);
 	}
 
+	void loadDuration(AbstractGroupedWorkSolr groupedWork, org.marc4j.marc.Record record, HashSet<RecordInfo> ilsRecords) {
+		Set<String> durations = MarcUtil.getFieldList(record, "300a");
+		Set<Integer> durationSet = new HashSet<>();
+		if (!durations.isEmpty()){
+			String duration = durations.iterator().next();
+			for(RecordInfo ilsRecord : ilsRecords){
+				if (primaryFormatCategory.equals("Audio Books")) {
+					//try to get total minutes and save as duration if not zero
+					int durationMinutes = AspenStringUtils.extractTotalMinutes(duration);
+					if (durationMinutes != 0){
+						ilsRecord.setDuration(durationMinutes);
+						durationSet.add(durationMinutes);
+					}
+				}
+			}
+		}
+		groupedWork.addDuration(durationSet);
+	}
+
 	private String getCallNumberSubject(org.marc4j.marc.Record record) {
 		String val = MarcUtil.getFirstFieldVal(record, "090a:050a");
 

--- a/code/reindexer/src/org/aspen_discovery/reindexer/MarcRecordProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/MarcRecordProcessor.java
@@ -586,7 +586,7 @@ abstract class MarcRecordProcessor {
 		if (!durations.isEmpty()){
 			String duration = durations.iterator().next();
 			for(RecordInfo ilsRecord : ilsRecords){
-				if (primaryFormatCategory.equals("Audio Books")) {
+				if (ilsRecord.getPrimaryFormatCategory().equals("Audio Books")) {
 					//try to get total minutes and save as duration if not zero
 					int durationMinutes = AspenStringUtils.extractTotalMinutes(duration);
 					if (durationMinutes != 0){

--- a/code/reindexer/src/org/aspen_discovery/reindexer/OverDriveProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/OverDriveProcessor.java
@@ -221,6 +221,18 @@ class OverDriveProcessor {
 							}
 							groupedWork.addAuthor2(authors);
 							groupedWork.addAuthor2Role(authorsWithRole);
+							//Get format durations
+							JSONArray formats = rawMetadataDecoded.getJSONArray("formats");
+							for (int i = 0; i < formats.length(); i++) {
+								JSONObject format = formats.getJSONObject(i);
+								if (mediaType.equals("Audiobook") && format.has("duration")) {
+									int duration = AspenStringUtils.extractTotalMinutes(format.getString("duration"));
+									overDriveRecord.setDuration(duration);
+									Set<Integer> durationSet = new HashSet<>();
+									durationSet.add(duration);
+									groupedWork.addDuration(durationSet);
+								}
+							}
 						}
 
 						Date dateAdded = new Date(productRS.getLong("dateAdded") * 1000);

--- a/code/reindexer/src/org/aspen_discovery/reindexer/RecordInfo.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/RecordInfo.java
@@ -23,6 +23,7 @@ public class RecordInfo {
 	private String publicationDate;
 	private String placeOfPublication;
 	private String physicalDescription;
+	private Integer duration;
 	private boolean isClosedCaptioned;
 
 	private boolean hasParentRecord;
@@ -108,6 +109,10 @@ public class RecordInfo {
 
 	void setPhysicalDescription(String physicalDescription) {
 		this.physicalDescription = physicalDescription;
+	}
+
+	void setDuration(Integer duration) {
+		this.duration = duration;
 	}
 
 	ArrayList<ItemInfo> getRelatedItems() {
@@ -360,6 +365,7 @@ public class RecordInfo {
 		this.placeOfPublication = recordInfo.placeOfPublication;
 		this.publicationDate = recordInfo.publicationDate;
 		this.physicalDescription = recordInfo.physicalDescription;
+		this.duration = recordInfo.duration;
 		this.isClosedCaptioned = recordInfo.isClosedCaptioned;
 		for (ItemInfo itemInfo : recordInfo.relatedItems) {
 			ItemInfo clonedItem = new ItemInfo();
@@ -370,6 +376,13 @@ public class RecordInfo {
 
 	public String getPhysicalDescription() {
 		return physicalDescription;
+	}
+
+	public Integer getDuration() {
+		if (duration != null) {
+			return duration;
+		}
+		return 0;
 	}
 
 	public boolean isClosedCaptioned() {

--- a/code/reindexer/src/org/aspen_discovery/reindexer/SavedRecordInfo.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/SavedRecordInfo.java
@@ -14,6 +14,7 @@ public class SavedRecordInfo {
 	public long publicationDateId;
 	public long placeOfPublicationId;
 	public long physicalDescriptionId;
+	public long durationId;
 	public long formatId;
 	public long formatCategoryId;
 	public long languageId;

--- a/code/reindexer/src/org/aspen_discovery/reindexer/SideLoadedEContentProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/SideLoadedEContentProcessor.java
@@ -54,6 +54,7 @@ class SideLoadedEContentProcessor extends MarcRecordProcessor{
 
 			loadEditions(groupedWork, record, allRelatedRecords);
 			loadPhysicalDescription(groupedWork, record, allRelatedRecords);
+			loadDuration(groupedWork, record, allRelatedRecords);
 			loadLanguageDetails(groupedWork, record, allRelatedRecords, identifier);
 			loadPublicationDetails(groupedWork, record, allRelatedRecords);
 

--- a/code/web/RecordDrivers/GroupedWorkDriver.php
+++ b/code/web/RecordDrivers/GroupedWorkDriver.php
@@ -3484,13 +3484,14 @@ class GroupedWorkDriver extends IndexRecordDriver {
 			$records = [];
 		} else {
 			$uniqueRecordIdsString = implode(',', $uniqueRecordIds);
-			$recordQuery = "SELECT grouped_work_records.id, recordIdentifier, isClosedCaptioned, indexed_record_source.source, indexed_record_source.subSource, indexed_edition.edition, indexed_publisher.publisher, indexed_publication_date.publicationDate, indexed_place_of_publication.placeOfPublication, indexed_physical_description.physicalDescription, indexed_format.format, indexed_format_category.formatCategory, indexed_language.language, indexed_audience.audience, hasParentRecord, hasChildRecord FROM grouped_work_records
+			$recordQuery = "SELECT grouped_work_records.id, recordIdentifier, isClosedCaptioned, indexed_record_source.source, indexed_record_source.subSource, indexed_edition.edition, indexed_publisher.publisher, indexed_publication_date.publicationDate, indexed_place_of_publication.placeOfPublication, indexed_physical_description.physicalDescription, indexed_format.format, indexed_format_category.formatCategory, indexed_language.language, indexed_audience.audience, indexed_duration.duration, hasParentRecord, hasChildRecord FROM grouped_work_records
 								  LEFT JOIN indexed_record_source ON sourceId = indexed_record_source.id
 								  LEFT JOIN indexed_edition ON editionId = indexed_edition.id
 								  LEFT JOIN indexed_publisher ON publisherId = indexed_publisher.id
 								  LEFT JOIN indexed_publication_date ON publicationDateId = indexed_publication_date.id
 								  LEFT JOIN indexed_place_of_publication ON placeOfPublicationId = indexed_place_of_publication.id
 								  LEFT JOIN indexed_physical_description ON physicalDescriptionId = indexed_physical_description.id
+								  LEFT JOIN indexed_duration ON durationId = indexed_duration.id
 								  LEFT JOIN indexed_format on formatId = indexed_format.id
 								  LEFT JOIN indexed_format_category on formatCategoryId = indexed_format_category.id
 								  LEFT JOIN indexed_language on languageId = indexed_language.id

--- a/code/web/interface/themes/responsive/GroupedWork/relatedRecords.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/relatedRecords.tpl
@@ -18,8 +18,14 @@
 					{if !empty($relatedRecord->edition)}
 						<div class="row"><div class="result-label col-lg-5 col-tn-12">{translate text="Edition" isPublicFacing=true}</div><div class="result-value col-lg-7 col-tn-12"> {$relatedRecord->edition}</div></div>
 					{/if}
-					{if !empty($relatedRecord->physical)}
+					{if !empty($relatedRecord->physical) && empty($relatedRecord->duration)}
 						<div class="row"><div class="result-label col-lg-5 col-tn-12">{translate text="Physical Description" isPublicFacing=true}</div><div class="result-value col-lg-7 col-tn-12"> <a href="{$relatedRecord->getUrl()}">{$relatedRecord->physical} {if $relatedRecord->closedCaptioned}<i class="fas fa-closed-captioning"></i> {/if}</a></div></div>
+					{/if}
+					{if !empty($relatedRecord->duration)}
+						{math equation="floor(x/60)" x=$relatedRecord->duration assign="hours"}
+						{math equation="x%60" x=$relatedRecord->duration assign="minutes"}
+
+						<div class="row"><div class="result-label col-lg-5 col-tn-12">{translate text="Duration" isPublicFacing=true}</div><div class="result-value col-lg-7 col-tn-12"> <a href="{$relatedRecord->getUrl()}">{$hours} hours {$minutes} minutes</a></div></div>
 					{/if}
 					{if !empty($relatedRecord->languageNote)}
 						<div class="row"><div class="result-label col-lg-5 col-tn-12">{translate text="Language" isPublicFacing=true}</div><div class="result-value col-lg-7 col-tn-12"> <a href="{$relatedRecord->getUrl()}">{$relatedRecord->physical}</a></div></div>

--- a/code/web/interface/themes/responsive/Search/Recommend/SideFacets.tpl
+++ b/code/web/interface/themes/responsive/Search/Recommend/SideFacets.tpl
@@ -51,7 +51,7 @@
 									{include file="Search/Recommend/yearFacetFilter.tpl" cluster=$cluster title=$title}
 								{elseif $title == 'rating_facet'}
 									{include file="Search/Recommend/ratingFacet.tpl" cluster=$cluster title=$title}
-								{elseif $title == 'lexile_score' || $title == 'accelerated_reader_reading_level' || $title == 'accelerated_reader_point_value'}
+								{elseif $title == 'lexile_score' || $title == 'accelerated_reader_reading_level' || $title == 'accelerated_reader_point_value' || $title == 'duration'}
 									{include file="Search/Recommend/sliderFacet.tpl" cluster=$cluster title=$title}
 								{elseif $title == 'start_date'}
 									{include file="Search/Recommend/calendarFacet.tpl" cluster=$cluster title=$title}

--- a/code/web/interface/themes/responsive/Search/Recommend/sliderFacet.tpl
+++ b/code/web/interface/themes/responsive/Search/Recommend/sliderFacet.tpl
@@ -5,11 +5,11 @@
 		{/if}
 		<div class="form-group">
 			<label for="{$title}from" class="yearboxlabel sr-only control-label">{$cluster.label} from</label>
-			<input type="text" size="4" maxlength="4" class="yearbox form-control" placeholder="from" name="{$title}from" id="{$title}from" value="">
+			<input type="text" size="5" maxlength="5" class="yearbox form-control" placeholder="from" name="{$title}from" id="{$title}from" value="" oninput="this.value = this.value.replace(/[^0-9.]/g, '')">
 		</div>
 		<div class="form-group">
 			<label for="{$title}to" class="yearboxlabel sr-only control-label">{$cluster.label} to</label>
-			<input type="text" size="4" maxlength="4" class="yearbox form-control" placeholder="to" name="{$title}to" id="{$title}to" value="">
+			<input type="text" size="5" maxlength="5" class="yearbox form-control" placeholder="to" name="{$title}to" id="{$title}to" value="" oninput="this.value = this.value.replace(/[^0-9.]/g, '')">
 		</div>
 		{* To make sure that applying this filter does not remove existing filters we need to copy the get variables as hidden variables *}
 		{foreach from=$smarty.get item=parmValue key=paramName}

--- a/code/web/release_notes/26.05.00.MD
+++ b/code/web/release_notes/26.05.00.MD
@@ -64,6 +64,12 @@
 ### Other Updates
 - Fix issue where search results were not showing all formats of a grouped work if a language filter was specified ([DIS-1905](https://aspen-discovery.atlassian.net/browse/DIS-1905)) (*KL*)
 
+### Facet Updates
+- Create an audiobook duration facet ([DIS-2338](https://aspen-discovery.atlassian.net/browse/DIS-2338)) (*KL*)
+  - Add new solr schema field for duration
+  - Add new facet for Audiobook Duration that can handle ranges with decimals
+
+
 //mark j
 
 //myranda

--- a/code/web/services/Search/Results.php
+++ b/code/web/services/Search/Results.php
@@ -172,12 +172,18 @@ class Search_Results extends ResultsAction {
 			'lexile_score',
 			'accelerated_reader_reading_level',
 			'accelerated_reader_point_value',
+			'duration',
 		];
 		foreach ($rangeFilters as $filter) {
 			if ((isset($_REQUEST[$filter . 'from']) && strlen($_REQUEST[$filter . 'from']) > 0) || (isset($_REQUEST[$filter . 'to']) && strlen($_REQUEST[$filter . 'to']) > 0)) {
 				$queryParams = $_GET;
 				$from = (isset($_REQUEST[$filter . 'from']) && preg_match('/^\d+(\.\d*)?$/', $_REQUEST[$filter . 'from'])) ? $_REQUEST[$filter . 'from'] : '*';
 				$to = (isset($_REQUEST[$filter . 'to']) && preg_match('/^\d+(\.\d*)?$/', $_REQUEST[$filter . 'to'])) ? $_REQUEST[$filter . 'to'] : '*';
+
+				if ($filter = 'duration') {
+					$from = $from === '*' ? '*' : $from * 60;
+					$to = $to === '*' ? '*' : $to * 60;
+				}
 
 				if ($to != '*' && $from != '*' && $to < $from) {
 					$tmpFilter = $to;

--- a/code/web/sys/DBMaintenance/version_updates/26.05.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/26.05.00.php
@@ -73,11 +73,28 @@ function getUpdates26_05_00(): array {
 			'sql' => [
 				"ALTER TABLE self_check_completion_message ADD COLUMN name TEXT"
 			]
-		]
+		], //self_check_completion_message_name
 
 		//kirstien
 
 		//kodi
+		'indexed_duration' => [
+			'title' => 'Add indexed_duration Table',
+			'description' => 'Add table for indexing duration of grouped work variations (audiobooks).',
+			'sql' => [
+				'CREATE TABLE IF NOT EXISTS indexed_duration  (
+					id INT NOT NULL AUTO_INCREMENT PRIMARY KEY, 
+					duration int(11)
+				) ENGINE = InnoDB',
+			]
+		], //indexed_duration
+		'indexed_duration_id' => [
+			'title' => 'Add durationId Column',
+			'description' => 'Add durationId column to grouped_work_records.',
+			'sql' => [
+				'ALTER TABLE grouped_work_records ADD COLUMN durationId int(11)'
+			]
+		], // indexed_duration_id
 
 		//yanjun
 

--- a/code/web/sys/Grouping/GroupedWorkFacet.php
+++ b/code/web/sys/Grouping/GroupedWorkFacet.php
@@ -56,6 +56,7 @@ class GroupedWorkFacet extends FacetSetting {
 			"accelerated_reader_interest_level" => "AR Interest Level",
 			"accelerated_reader_reading_level" => "AR Reading Level",
 			"accelerated_reader_point_value" => "AR Point Value",
+			"duration" => "Audiobook Duration",
 			"fountas_pinnell" => "Fountas &amp; Pinnell",
 			"series_facet" => "Series",
 			"publisherStr" => "Publisher",

--- a/code/web/sys/Grouping/GroupedWorkRecord.php
+++ b/code/web/sys/Grouping/GroupedWorkRecord.php
@@ -14,6 +14,7 @@ class GroupedWorkRecord extends DataObject {
 	public $publicationDateId;
 	public $placeOfPublicationId;
 	public $physicalDescriptionId;
+	public $durationId;
 	public $languageId;
 	public $isClosedCaptioned;
 }

--- a/code/web/sys/Grouping/Record.php
+++ b/code/web/sys/Grouping/Record.php
@@ -17,6 +17,7 @@ class Grouping_Record {
 	private null|int|string $sortablePublicationDate = null;
 	public ?string $placeOfPublication;
 	public ?string $physical;
+	public ?int $duration;
 	public bool|string $closedCaptioned;
 	public string $variationFormat;
 	public string|int $variationId;
@@ -81,6 +82,7 @@ class Grouping_Record {
 			$this->publicationDate = $recordDetails['publicationDate'];
 			$this->placeOfPublication = $recordDetails['placeOfPublication'];
 			$this->physical = $recordDetails['physicalDescription'];
+			$this->duration = $recordDetails['duration'];
 			$this->language = $recordDetails['language'];
 			if (isset($recordDetails['isClosedCaptioned'])) {
 				$this->closedCaptioned = $recordDetails['isClosedCaptioned'];

--- a/data_dir_setup/solr7/grouped_works_v2/conf/schema.xml
+++ b/data_dir_setup/solr7/grouped_works_v2/conf/schema.xml
@@ -7,6 +7,7 @@
 		<fieldType name="float" class="FloatPointField"/>
 		<fieldType name="date" class="DatePointField"/>
 		<fieldType name="random" class="RandomSortField"/>
+		<fieldType name="pints" class="solr.IntPointField" docValues="true" multiValued="true"/>
 		<fieldType name="text_general" class="solr.TextField" positionIncrementGap="100">
 			<analyzer type="index">
 				<tokenizer class="solr.StandardTokenizerFactory"/>
@@ -287,6 +288,7 @@
 
 		<!-- Facets -->
 		<field name="physical" type="unchanged_string" indexed="true" stored="true" multiValued="true"/>
+		<field name="duration" type="pints" indexed="true" stored="true" multiValued="true" default="0" docValues="true"/>
 		<field name="edition" type="unchanged_string" indexed="true" stored="true" multiValued="true"/>
 		<field name="dateSpan" type="unchanged_string" indexed="true" stored="true" multiValued="true"/>
 		<field name="econtent_source" type="unchanged_string" indexed="true" stored="true" multiValued="true"/>


### PR DESCRIPTION
- Index duration for individual records and grouped works for marc records, hoopla records, and libby records
- Only audiobooks or eaudiobooks will have their duration indexed
- New facet can be added via the Grouped Work Facets settings but is not added automatically
- Full reindex of all works must be run before adding facet in facet settings
- The Audiobook Duration facet is a ranged facet, similar to AR reading level
- Users can input decimal values for number of hours

Update release notes

Tested on my local instance of Aspen