### PR TITLE
DIS-2355 ISBN Advanced Searches

### DIFF
--- a/code/web/release_notes/26.05.00.MD
+++ b/code/web/release_notes/26.05.00.MD
@@ -117,6 +117,7 @@
 //jonah
 - Fix typo in Solr schema for genealogy. ([DIS-2213](https://aspen-discovery.atlassian.net/browse/DIS-2213)) (*JW*)
 - Fix a bug pertaining to AmazonSesSettings sending emails + associated email validation. ([DIS-2247](https://aspen-discovery.atlassian.net/browse/DIS-2247)) (*JW*)
+- Fix bug affecting Advanced Search ISBN flow ([DIS-2355](https://aspen-discovery.atlassian.net/browse/DIS-2355)) (*JW*)
 
 //chloe & Jacob
 #### Event Registration

--- a/code/web/sys/ISBN.php
+++ b/code/web/sys/ISBN.php
@@ -117,10 +117,8 @@ class ISBN {
 	 * @return  string                  Normalized ISBN.
 	 */
 	public static function normalizeISBN(string $raw) : string {
-		if (strlen($raw) > 13 && str_starts_with($raw, '978')) {
-			$raw = substr($raw, 0, 13);
-		}
-		return preg_replace('/[^0-9X]/', '', strtoupper($raw));
+		$cleanIsbn = fn($isbn) => preg_replace('/[^0-9X]/', '', strtoupper($isbn));
+		return substr($cleanIsbn($raw), 0, 13);
 	}
 
 	/**

--- a/code/web/sys/SolrConnector/Solr.php
+++ b/code/web/sys/SolrConnector/Solr.php
@@ -991,8 +991,9 @@ abstract class Solr {
 						}
 					}
 
+					require_once ROOT_DIR . '/sys/Utils/GroupingUtils.php';
 					// Basic Search
-					if (isset($params['lookfor']) && $params['lookfor'] != '') {
+					if (issetNonEmpty($params, 'lookfor')) {
 						// Clean and validate input
 						$lookfor = $this->validateInput($params['lookfor']);
 
@@ -1002,8 +1003,10 @@ abstract class Solr {
 							$lookfor = SolrUtils::capitalizeBooleans($lookfor);
 						}
 
-						if (isset($params['field']) && ($params['field'] != '')) {
-							if ($this->isAdvanced($lookfor)) {
+						if (issetNonEmpty($params, "field")) {
+							if ($params["field"] === "ISN") {
+								$query .= $this->_buildQueryComponent("ISN", ISBN::normalizeISBN($lookfor));
+							} else if ($this->isAdvanced($lookfor)) {
 								$query .= $this->_buildAdvancedQuery($params['field'], $lookfor);
 							} else {
 								$query .= $this->_buildQueryComponent($params['field'], $lookfor);

--- a/code/web/sys/Utils/GroupingUtils.php
+++ b/code/web/sys/Utils/GroupingUtils.php
@@ -263,3 +263,7 @@ function getSortableDate(?string $str) : ?DateTime {
 	$sortableDateCache[$str] = null;
 	return null;
 }
+
+function issetNonEmpty(array $array, string $key): bool {
+	return isset($array[$key]) && $array[$key] !== '';
+}


### PR DESCRIPTION
Fixed a bug with Advanced Search returning a Solr Error whenever ISBN search is done with any a dash (or any other special character) provided in the search field.

Reproduction Instructions:
https://aspen-discovery.atlassian.net/browse/DIS-2355

@mdnoble73 Please review the two flows mentioned in the Jira, I'm not sure which, if either of these, is expected behavior.  Scenario 2 is definitely wrong, not sure about #1.