### PR TITLE
DIS-2352: Translate 041a language code 

### DIFF
--- a/code/reindexer/src/org/aspen_discovery/grouping/BaseMarcRecordGrouper.java
+++ b/code/reindexer/src/org/aspen_discovery/grouping/BaseMarcRecordGrouper.java
@@ -301,6 +301,10 @@ public abstract class BaseMarcRecordGrouper extends RecordGroupingProcessor {
 			languages = MarcUtil.getFieldList(marcRecord, secondaryLanguageField);
 			for (String language : languages){
 				language = language.replaceAll("^[^a-zA-Z]+|[^a-zA-Z]+$|\\p{Punct}", "");
+				language = translateValue("language_to_three_letter_code", language);
+				if (language == null || language.length() != 3 || language.contains(" ")) {
+					continue;
+				}
 				if (activeLanguage == null){
 					activeLanguage = language;
 				}else{

--- a/code/reindexer/src/org/aspen_discovery/grouping/RecordGroupingProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/grouping/RecordGroupingProcessor.java
@@ -913,6 +913,10 @@ public class RecordGroupingProcessor {
 			languages = MarcUtil.getFieldList(marcRecord, secondaryLanguageField);
 			for (String language : languages){
 				language = language.replaceAll("^[^a-zA-Z]+|[^a-zA-Z]+$|\\p{Punct}", "");
+				language = translateValue("language_to_three_letter_code", language);
+				if (language == null || language.length() != 3 || language.contains(" ")) {
+					continue;
+				}
 				if (activeLanguage == null){
 					activeLanguage = language;
 				}else{

--- a/code/web/release_notes/26.05.00.MD
+++ b/code/web/release_notes/26.05.00.MD
@@ -139,6 +139,7 @@
 
 ### Indexing Updates
 - Allow the awards facet to retain accented and other Unicode letters when normalizing MARC 586 award field.  ([DIS-2227](https://aspen-discovery.atlassian.net/browse/DIS-2227)) (*YL*)
+- Fix a grouped work indexing issue where fallback language values from 041a are not translated to a 3-letter language code before generating grouped work IDs. ([DIS-2352](https://aspen-discovery.atlassian.net/browse/DIS-2352)) (*YL*)
 
 ### Koha Updates
 - Fix Koha password recovery error mapping to display resetPin error messages. ([DIS-2339](https://aspen-discovery.atlassian.net/browse/DIS-2339)) (*YL*)


### PR DESCRIPTION
When a MARC record doesn’t contain 008[35-37], language falls back to 041a. If the 041a value is not a 3-letter code, such as “english” instead of “eng”, the grouped work ID can be generated with “-english” instead of “-eng”, which causes indexing failures. 

Example error
ERROR: Error adding grouped record ils:3445 to grouped work a0b4f8c8-781e-6514-ba42-cacdd70909fc-english com.mysql.cj.jdbc.exceptions.MysqlDataTruncation: Data truncation: Data too long for column 'permanent_id' at row 1

To Test:
1. Create a MARC record with an empty 008[35-37] and set "english" as 041a value
2. Index this record and see the error 
3. Apply pr
4. Index this record again and see no error