### PR TITLE
DIS-2363: CloudSource OA Direct Linking

### DIFF
--- a/code/web/RecordDrivers/CloudSourceRecordDriver.php
+++ b/code/web/RecordDrivers/CloudSourceRecordDriver.php
@@ -54,9 +54,9 @@ class CloudSourceRecordDriver extends RecordInterface {
 	 * @param bool $unscoped
 	 * @return string
 	 */
-	public function getLinkUrl($unscoped = false) {
+	public function getLinkUrl($unscoped = false, $redirectUrl = '') {
 		if ($this->bypassAspenCloudSourcePageSetting()){
-			return $this->getRecordUrl();
+			return $this->getRecordUrl($redirectUrl);
 		}
 		return '/CloudSource/Record?id=' . $this->getId();
 	}
@@ -82,9 +82,12 @@ class CloudSourceRecordDriver extends RecordInterface {
 		return $this->getRecordUrl();
 	}
 
-	public function getRecordUrl()
-	{
-		if (isset($this->record->webUrl)) {
+	public function getRecordUrl($redirectUrl = ''): null|string {
+		if ($redirectUrl != '') {
+			$doi = $this->record->doi;
+			return preg_replace('/(?<=qu=)[^&]+/', $doi, $redirectUrl);
+		}
+		elseif (isset($this->record->webUrl)) {
 			return $this->record->webUrl;
 		} else {
 			return null;
@@ -105,6 +108,49 @@ class CloudSourceRecordDriver extends RecordInterface {
 		return 'CloudSource';
 	}
 
+	public function getDoi() {
+		return $this->record->doi;
+	}
+
+	public function getPatronUrl($recordView = false): string {
+		require_once ROOT_DIR . '/sys/CloudSource/CloudSourceSetting.php';
+
+		global $library;
+		$patronUrl = '';
+		require_once ROOT_DIR . '/sys/CloudSource/LibraryCloudSourceSetting.php';
+		$libraryCloudSourceSetting = new LibraryCloudSourceSetting();
+		$libraryCloudSourceSetting->libraryId = $library->libraryId;
+		if ($libraryCloudSourceSetting->find(true)){
+			require_once ROOT_DIR . '/sys/CloudSource/CloudSourceSetting.php';
+			$cloudSourceSetting = new CloudSourceSetting();
+			$cloudSourceSetting->id = $libraryCloudSourceSetting->cloudsourceSettingId;
+			if ($cloudSourceSetting->find(true)){
+				if ($recordView) {
+					$patronUrl = $cloudSourceSetting->patronUrl . "/search/results?qu=" . $this->getDoi();
+				} else {
+					$patronUrl = $cloudSourceSetting->patronUrl . "/search/results?qu=" . $_REQUEST["lookfor"];
+				}
+			}
+		}
+
+		$ch = curl_init();
+		curl_setopt($ch, CURLOPT_URL, $patronUrl);
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+		curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
+		$html = curl_exec($ch);
+		curl_close($ch);
+
+		$searchToken = '';
+		// First grab the full input tag with id="targetValue"
+		if ($html && preg_match('/<input[^>]*id="targetValue"[^>]*>/', $html, $tag)) {
+			// Then extract the number from its value attribute
+			if (preg_match('/value="(-\d+):/', $tag[0], $matches)) {
+				$searchToken = $matches[1]; // e.g. "-261243320"
+			}
+		}
+
+		return $patronUrl . "&te=" . $searchToken;
+	}
 	public function getSearchResult($view = 'list', $showListsAppearingOn = true)
 	{
 		if ($view == 'covers') {
@@ -113,13 +159,15 @@ class CloudSourceRecordDriver extends RecordInterface {
 
 		global $interface;
 
+		$redirectUrl = $this->getPatronUrl();
+
 		$id = $this->getUniqueID();
 		$formats = $this->getFormats();
 		$interface->assign('summId', $id);
 		$interface->assign('summShortId', $id);
 		$interface->assign('module', $this->getModule());
 		$interface->assign('summFormats', $formats);
-		$interface->assign('summUrl', $this->getLinkUrl());
+		$interface->assign('summUrl', $this->getLinkUrl(false, $redirectUrl));
 		$interface->assign('externalUrl', $this->getRecordUrl());
 		$interface->assign('summTitle', $this->getTitle());
 		$interface->assign('summAuthor', $this->getAuthor());
@@ -158,8 +206,10 @@ class CloudSourceRecordDriver extends RecordInterface {
 	public function getBrowseResult() {
 		global $interface;
 
+		$redirectUrl = $this->getPatronUrl();
+
 		$interface->assign('summId', $this->getUniqueID());
-		$interface->assign('summUrl', $this->getLinkUrl());
+		$interface->assign('summUrl', $this->getLinkUrl(false, $redirectUrl));
 		$interface->assign('summTitle', $this->getTitle());
 
 		//Get cover image size
@@ -201,11 +251,12 @@ class CloudSourceRecordDriver extends RecordInterface {
 		$formats = $this->getFormats();
 		$id = $this->getUniqueID();
 
+		$redirectUrl = $this->getPatronUrl();
 		$interface->assign('summId', $id);
 		$interface->assign('summShortId', $id);
 		$interface->assign('module', $this->getModule());
 		$interface->assign('summFormats', $formats);
-		$interface->assign('summUrl', $this->getLinkUrl());
+		$interface->assign('summUrl', $this->getLinkUrl(false, $redirectUrl));
 		$interface->assign('summTitle', $this->getTitle());
 		$interface->assign('summAuthor', $this->getAuthor());
 		$interface->assign('summDescription', $this->getDescription());
@@ -221,6 +272,8 @@ class CloudSourceRecordDriver extends RecordInterface {
 	{
 		global $interface;
 
+		$redirectUrl = $this->getPatronUrl();
+
 		$interface->assign('showRatings', $collectionSpotlight->showRatings);
 		$interface->assign('key', $index);
 		$interface->assign('title', $this->getTitle());
@@ -228,7 +281,7 @@ class CloudSourceRecordDriver extends RecordInterface {
 		$interface->assign('description', $this->getDescription());
 		$interface->assign('shortId', $this->getUniqueID());
 		$interface->assign('id', $this->getUniqueID());
-		$interface->assign('titleURL', $this->getLinkUrl());
+		$interface->assign('titleURL', $this->getLinkUrl(false, $redirectUrl));
 
 		if ($collectionSpotlight->coverSize == 'small') {
 			$imageUrl = $this->getBookcoverUrl('small');

--- a/code/web/interface/themes/responsive/CloudSource/record-view.tpl
+++ b/code/web/interface/themes/responsive/CloudSource/record-view.tpl
@@ -12,7 +12,7 @@
 	<div class="col-tn-12 col-xs-12 col-sm-4 col-md-3 col-lg-3">
 		<div class="panel active">
 			<div class="panel-body" style="display:flex; justify-content:center">
-				<a href="{$recordDriver->getLinkUrl()}"><img class="img-responsive img-thumbnail {$coverStyle}" src="{$image}" alt="{$recordDriver->getTitle()|escape}" style="max-height: 280px; width: auto"></a>
+				<a href="{$patronUrl}"><img class="img-responsive img-thumbnail {$coverStyle}" src="{$image}" alt="{$recordDriver->getTitle()|escape}" style="max-height: 280px; width: auto"></a>
 			</div>
 		</div>
 		{if !empty($record->format)}
@@ -156,7 +156,7 @@
 		{*column for tool buttons & event description*}
 		<div class="col-sm-9">
 			<div class="btn-group btn-group-sm">
-				<a href="{$recordDriver->getRecordUrl()}" class="btn btn-sm btn-tools" target="_blank" aria-label="{translate text="More Info" isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})"><i class="fas fa-external-link-alt" role="presentation"></i> {translate text="More Info" isPublicFacing=true}</a>
+				<a href="{$patronUrl}" class="btn btn-sm btn-tools" target="_blank" aria-label="{translate text="More Info" isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})"><i class="fas fa-external-link-alt" role="presentation"></i> {translate text="More Info" isPublicFacing=true}</a>
 				<button onclick="return AspenDiscovery.Account.showSaveToListForm(this, 'CloudSource', '{$recordDriver->getUniqueID()|escape}');" class="btn btn-sm btn-tools addToListBtn">{translate text="Add to List" isPublicFacing=true}</button>
 			</div>
 			<div class="btn-group btn-group-sm">

--- a/code/web/release_notes/26.05.00.MD
+++ b/code/web/release_notes/26.05.00.MD
@@ -94,7 +94,7 @@
 <div markdown="1" class="settings">
 
 #### New Settings
-- Materials Requests > Manage Requests by Title
+- CloudSource OA Settings > Patron URL
 
 </div>
 
@@ -114,7 +114,7 @@
 <div markdown="1" class="settings">
 
 #### New Settings
-- CloudSource OA Settings > Patron URL
+- Materials Requests > Manage Requests by Title
 
 </div>
 

--- a/code/web/release_notes/26.05.00.MD
+++ b/code/web/release_notes/26.05.00.MD
@@ -88,6 +88,16 @@
 ### Search Updates
 - Make author sort case insensitive and sort missing values to the end ([DIS-2014](https://aspen-discovery.atlassian.net/browse/DIS-2014)) (*KL*)
 
+### CloudSource OA Updates
+- Update external link behavior for CloudSource OA to link to the library's CloudSource OA page ([DIS-2363](https://aspen-discovery.atlassian.net/browse/DIS-2363)) (*KL*)
+
+<div markdown="1" class="settings">
+
+#### New Settings
+- Materials Requests > Manage Requests by Title
+
+</div>
+
 ### Other Updates
 - Fix issue where search results were not showing all formats of a grouped work if a language filter was specified ([DIS-1905](https://aspen-discovery.atlassian.net/browse/DIS-1905)) (*KL*)
 
@@ -104,9 +114,10 @@
 <div markdown="1" class="settings">
 
 #### New Settings
-- Materials Requests > Manage Requests by Title
+- CloudSource OA Settings > Patron URL
 
 </div>
+
 ### Facet Updates
 - Create an audiobook duration facet ([DIS-2338](https://aspen-discovery.atlassian.net/browse/DIS-2338)) (*KL*)
   - Add new solr schema field for duration

--- a/code/web/services/CloudSource/Record.php
+++ b/code/web/services/CloudSource/Record.php
@@ -31,6 +31,10 @@ class CloudSource_Record extends Action {
 
 		$interface->assign('record', $record);
 
+		$patronUrl = (new CloudSourceRecordDriver($id))->getPatronURL(true);
+
+		$interface->assign('patronUrl', $patronUrl);
+
 		$interface->assign('recordDriver', $this->recordDriver);
 
 		$interface->assign('isStaff', UserAccount::isStaff());

--- a/code/web/sys/CloudSource/CloudSourceSetting.php
+++ b/code/web/sys/CloudSource/CloudSourceSetting.php
@@ -8,7 +8,8 @@ class CloudSourceSetting extends DataObject
 	public $__table = 'cloudsource_setting';
 	public $id;
 	public $name;
-	public $baseUrl;
+	public $apiUrl;
+	public $patronUrl;
 	public $accessToken;
 	public $profileKey;
 	public $showInExploreMore;
@@ -48,11 +49,18 @@ class CloudSourceSetting extends DataObject
 				'description' => 'A name to identify the open archives collection in the system',
 				'size' => '100',
 			],
-			'baseURL' => [
-				'property' => 'baseUrl',
+			'apiUrl' => [
+				'property' => 'apiUrl',
 				'type' => 'url',
-				'label' => 'Base URL',
-				'description' => 'The base url for CloudSource OA',
+				'label' => 'API URL',
+				'description' => 'Typically: https://na3.bc.sirsidynix.net/bcws',
+				'size' => '255',
+			],
+			'patronUrl' => [
+				'property' => 'patronUrl',
+				'type' => 'url',
+				'label' => 'Patron URL',
+				'description' => 'i.e. https://{host}/client/en_US/{profile}',
 				'size' => '255',
 			],
 			'accessToken' => [

--- a/code/web/sys/DBMaintenance/version_updates/26.05.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/26.05.00.php
@@ -141,6 +141,15 @@ function getUpdates26_05_00(): array {
 			]
 		], // indexed_duration_id
 
+		'update_cloudsource_urls' => [
+			'title' => 'Update Cloud Source URLs',
+			'description' => 'Update Cloud Source URL variable names for API vs Patron url.',
+			'sql' => [
+				'ALTER TABLE cloudsource_setting CHANGE baseUrl apiUrl VARCHAR(255)',
+				'ALTER TABLE cloudsource_setting ADD COLUMN patronUrl VARCHAR(255)',
+			]
+		], //update_cloudsource_urls
+
 		//yanjun
 		'add_hoopla_flex_batch_size' => [
 			'title' => 'Add Hoopla Flex Batch Size',

--- a/code/web/sys/SearchObject/CloudSourceSearcher.php
+++ b/code/web/sys/SearchObject/CloudSourceSearcher.php
@@ -159,7 +159,7 @@ class SearchObject_CloudSourceSearcher extends SearchObject_BaseSearcher{
 	public function processSearch($returnIndexErrors = false, $recommendations = false, $preventQueryModification = false) : AspenError|stdClass|array|null {
 		$settings = $this->getSettings();
 		$curlConnection = $this->getCurlConnection();
-		$url = $settings->baseUrl . '/api/cloudsourcesearch/search';
+		$url = $settings->apiUrl . '/api/cloudsourcesearch/search';
 		if (!empty($this->searchTerms) && is_array($this->searchTerms)) {
 			$searchTerm = $this->searchTerms[0]['lookfor'];
 		} else {
@@ -192,7 +192,7 @@ class SearchObject_CloudSourceSearcher extends SearchObject_BaseSearcher{
 			'term' => $searchTerm,
 			'start' => $start,
 			'pageSize' => 20,
-			'includeFields' => 'title,author{name},format{name},webUrl,publishDate,abstrakt,index,isbn,publication',
+			'includeFields' => 'title,author{name},format{name},webUrl,publishDate,abstrakt,index,isbn,publication,doi',
 			'includeFacets' => true,
 			'profileKey' => $settings->profileKey,
 			'facetSelections' => $facets
@@ -251,7 +251,7 @@ class SearchObject_CloudSourceSearcher extends SearchObject_BaseSearcher{
 			'SD-Stats-Session-ID: ' . $_COOKIE['aspen_session']
 		];
 
-		$baseUrl = $settings->baseUrl . '/api/cloudsourcesearch/search/id/' . $index . '/' . $id;
+		$baseUrl = $settings->apiUrl . '/api/cloudsourcesearch/search/id/' . $index . '/' . $id;
 
 
 		$recordData = $this->httpRequest($baseUrl, $headers);


### PR DESCRIPTION
Update linking for CloudSource OA records to link to the library's CloudSource OA page instead of the publisher page

Update release notes

Tested on my local instance of Aspen