### PR TITLE
DIS-2367: Add visibility to possible failures in MARC files replacements during Sideload uploads

### DIFF
--- a/code/web/release_notes/26.06.00.MD
+++ b/code/web/release_notes/26.06.00.MD
@@ -22,6 +22,8 @@
 //jacob
 
 //lucas
+### Sideload Updates
+- Add error visibility to the 'Replace existing files?' operation in SideLoad uploads ([DIS-2367](https://aspen-discovery.atlassian.net/browse/DIS-2367)) (*LM*) 
 
 //tomas
 

--- a/code/web/services/SideLoads/UploadMarc.php
+++ b/code/web/services/SideLoads/UploadMarc.php
@@ -28,12 +28,34 @@ class SideLoads_UploadMarc extends Admin_Admin {
 					//File was uploaded, need to verify it was the correct type
 					$fileType = $uploadedFile["type"];
 					$uploadPath = $sideload->marcPath;
+					global $logger;
+					$logger->log("UploadMarc: file={$uploadedFile['name']}, type={$fileType}, replaceExisting=" . ($replaceExisting ? 'true' : 'false') . ", uploadPath={$uploadPath}", Logger::LOG_NOTICE, true);
 					if ($replaceExisting) {
-						$files = glob($uploadPath . '/*'); // get all file names
-						foreach ($files as $file) {
-							if (is_file($file)) {
-								unlink($file);
+						$files = glob($uploadPath . '/*');
+						if ($files === false) {
+							$logger->log("UploadMarc: glob() returned false for pattern: {$uploadPath}/*", Logger::LOG_ERROR, true);
+							$interface->assign('error', 'Could not read the upload directory to replace existing files.');
+						} else {
+							$logger->log("UploadMarc: replacing " . count($files) . " existing file(s): " . implode(', ', $files), Logger::LOG_NOTICE, true);
+							$deleteFailed = false;
+							foreach ($files as $file) {
+								if (is_file($file)) {
+									$unlinkResult = unlink($file);
+									$logger->log("UploadMarc: unlink({$file}): " . ($unlinkResult ? 'SUCCESS' : 'FAILED'), Logger::LOG_NOTICE, true);
+									if (!$unlinkResult) {
+										$deleteFailed = true;
+									}
+								}
 							}
+							if ($deleteFailed) {
+								$logger->log("UploadMarc: one or more files could not be deleted in {$uploadPath}", Logger::LOG_ERROR, true);
+								$interface->assign('error', 'One or more existing files could not be deleted. Check file permissions on the upload directory.');
+							}
+						}
+						if (!empty($interface->getVariable('error'))) {
+							$interface->assign('id', $_REQUEST['id']);
+							$this->display('uploadMarc.tpl', 'Upload MARC File');
+							return;
 						}
 					}
 					$destFileName = $uploadedFile["name"];


### PR DESCRIPTION
Currently, when uploading a MARC file with "Replace Existing Files" checked, any failure during the deletion of existing files is handled silently. The user receives no feedback and the upload may proceed with stale files still present. This change adds server-side logging for the replacement operation and surfaces a clear error message in the UI when a file cannot be deleted, allowing administrators to identify and resolve the underlying cause

Test plan

Before patching:
1 - Create or open an existing Side Load configuration
2 - Upload a MARC file (.mrc) to populate the sideload directory
3 - Go to Admin > Side Loads > Upload MARC File, check "Replace Existing Files?", and upload a new MARC file
4 - If the deletion of existing files fails for any reason (e.g. permission mismatch), no error is shown. The upload proceeds silently with no indication of what happened.

After patching:
5 - Repeat steps 1 through 3
6 - If file deletion succeeds, behavior is unchanged. Old files are removed and the new file is written normally.
7 - To test the error path: change ownership of the existing MARC file to a different OS user so the web process cannot delete it, then repeat step 3
8 - Observe a UI error message: "One or more existing files could not be deleted. Check file permissions on the upload directory." The upload is aborted and the form is redisplayed.
9 - Check /var/log/aspen-discovery/<serverName>/messages.log and confirm log entries show the upload attempt, the files targeted for deletion, and a FAILED result for the unlink call