### PR TITLE
DIS-2372: add pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Type of Change
+- [ ] Bug
+- [ ] Enhancement
+
+## Description
+Describe the changes
+
+## Testing
+- [ ] What testing has taken place?
+- [ ] Ensure testing notes exist in Jira
+- [ ] Include testing notes from Jira in PR
+
+## Jira
+- [ ] Created a Jira Issue for the change
+- [ ] Include a description in the Jira issue
+- [ ] Pull request title should follow the template DIS-### Description (Necessary for PR linkage)
+- [ ] Jira also needs to be updated with developer information and the ticket should be in Code Review status.
+
+## Release Notes
+- [ ] Pull Request contains updated release notes


### PR DESCRIPTION
## Type of Change
- [x] Enhancement

## Description
There are some community pain points when pushing new code to the repository. Testing instructions, non-compliant titles, Jira statuses, descriptions of work done, etc. are inconsistent across organizations and developers.

This is a one file change to add a Pull-Request template to remind developers across the Aspen Community of requirements when pushing code.

## Testing
- [X] Pushed to bywater repo and saw that the PR template was showing up
- [X] A comment has been made in Jira about testing. 
- [X] This is a github change, it does not affect Aspen, and no testing needs to occur.

## Jira
- [X] https://aspen-discovery.atlassian.net/browse/DIS-2372
- [X] Name is compliant
- [X] Jira is up-to-date
- [X] Same as Description above

## Release Notes
- [X] This is not a change to aspen and as such does not require release notes.
