### PR TITLE
DIS-2406 Query on ils_username instead of displayName

### DIFF
--- a/code/web/release_notes/26.06.00.MD
+++ b/code/web/release_notes/26.06.00.MD
@@ -24,6 +24,9 @@
 
 //chloe
 
+//pedro
+- Bugfix for searching patrons on ils_username instead of displayName in Community Engagement's Admin View
+
 //jacob
 
 //lucas

--- a/code/web/services/CommunityEngagement/AJAX.php
+++ b/code/web/services/CommunityEngagement/AJAX.php
@@ -1289,8 +1289,7 @@ class CommunityEngagement_AJAX extends JSON_Action {
 
 		$escapedQuery = addslashes($query);
 
-		# FIXME: This will never work if displayName is encrypted. Only barcode matching will work.
-		$user->whereAdd("displayName LIKE '%$escapedQuery%' OR ils_barcode LIKE '%$escapedQuery%'");
+		$user->whereAdd("ils_username LIKE '%$escapedQuery%' OR ils_barcode LIKE '%$escapedQuery%'");
 
 		$user->limit(0, 25);
 


### PR DESCRIPTION
displayName is an encrypted field, a LIKE search will never work. ils_username should be used instead.