### PR TITLE
DIS-2100: Add check for allowAppRequestLogging in API requests for LiDA

### DIFF
--- a/code/web/release_notes/26.06.00.MD
+++ b/code/web/release_notes/26.06.00.MD
@@ -2,6 +2,8 @@
 //mark n
 
 //kirstien
+### API Updates
+- Add logPatronRequestExternal in Abstract API to include `debug` key if allowAppRequestLogging in API returns (only for LiDA requests) to force logging in Aspen LiDA. ([DIS-2100](https://aspen-discovery.atlassian.net/browse/DIS-2100)) (*KK*)
 
 //kodi
 

--- a/code/web/services/API/AbstractAPI.php
+++ b/code/web/services/API/AbstractAPI.php
@@ -101,6 +101,24 @@ abstract class AbstractAPI extends Action{
 		}
 	}
 
+	/**
+	 * Add debug output if user has enabled App Request Logging in Discovery
+	 * This forces responses to be logged into Aspen LiDA instead of just errors
+	 * @param mixed $result
+	 * @return mixed
+	 */
+	protected function logPatronRequestExternal(mixed $result): mixed {
+		$user = $this->getUserForApiCall();
+		if ($user !== false && $user->allowAppRequestLogging) {
+			if (is_array($result)) {
+				$result['debug'] = true;
+			} elseif (is_object($result)) {
+				$result->debug = true;
+			}
+		}
+		return $result;
+	}
+
 	private $_userForAPICall = null;
 	/**
 	 * @return bool|User

--- a/code/web/services/API/EventAPI.php
+++ b/code/web/services/API/EventAPI.php
@@ -29,7 +29,7 @@ class EventAPI extends AbstractAPI {
 					header('Cache-Control: max-age=10800');
 					require_once ROOT_DIR . '/sys/SystemLogging/APIUsage.php';
 					APIUsage::incrementStat('EventAPI', $method);
-					$output = json_encode($this->$method());
+					$output = json_encode($this->logPatronRequestExternal($this->$method()));
 				} else {
 					header('Cache-Control: no-cache, must-revalidate'); // HTTP/1.1
 					$output = json_encode(['error' => 'invalid_method']);

--- a/code/web/services/API/ItemAPI.php
+++ b/code/web/services/API/ItemAPI.php
@@ -58,7 +58,7 @@ class ItemAPI extends AbstractAPI {
 					header("Cache-Control: max-age=10800");
 					require_once ROOT_DIR . '/sys/SystemLogging/APIUsage.php';
 					APIUsage::incrementStat('ItemAPI', $method);
-					$output = json_encode($this->$method());
+					$output = json_encode($this->logPatronRequestExternal($this->$method()));
 				} else {
 					header('Cache-Control: no-cache, must-revalidate'); // HTTP/1.1
 					$output = json_encode(['error' => 'invalid_method']);

--- a/code/web/services/API/ListAPI.php
+++ b/code/web/services/API/ListAPI.php
@@ -40,7 +40,7 @@ class ListAPI extends AbstractAPI {
 					'editListGroup',
 					'editListGroupParent'
 				])) {
-					$result = ['result' => $this->$method()];
+					$result = ['result' => $this->logPatronRequestExternal($this->$method())];
 					$output = json_encode($result);
 					header('Content-type: application/json');
 					header("Cache-Control: max-age=300");

--- a/code/web/services/API/RegistrationAPI.php
+++ b/code/web/services/API/RegistrationAPI.php
@@ -46,7 +46,7 @@ class API_RegistrationAPI extends AbstractAPI {
 					header("Cache-Control: max-age=10800");
 					require_once ROOT_DIR . '/sys/SystemLogging/APIUsage.php';
 					APIUsage::incrementStat('RegistrationAPI', $method);
-					$output = json_encode(['result' => $this->$method()]);
+					$output = json_encode(['result' => $this->logPatronRequestExternal($this->$method())]);
 				} else {
 					header('Cache-Control: no-cache, must-revalidate'); // HTTP/1.1
 					$output = json_encode(['error' => 'invalid_method']);

--- a/code/web/services/API/SearchAPI.php
+++ b/code/web/services/API/SearchAPI.php
@@ -50,7 +50,7 @@ class SearchAPI extends AbstractAPI {
 					header("Cache-Control: max-age=10800");
 					require_once ROOT_DIR . '/sys/SystemLogging/APIUsage.php';
 					APIUsage::incrementStat('SearchAPI', $method);
-					$jsonOutput = json_encode(['result' => $this->$method()]);
+					$jsonOutput = json_encode(['result' => $this->logPatronRequestExternal($this->$method())]);
 				} else {
 					$output = json_encode(['error' => 'invalid_method']);
 				}

--- a/code/web/services/API/SystemAPI.php
+++ b/code/web/services/API/SystemAPI.php
@@ -56,7 +56,7 @@ class SystemAPI extends AbstractAPI {
 					'getHomeScreenLinks',
 				])) {
 					$result = [
-						'result' => $this->$method(),
+						'result' => $this->logPatronRequestExternal($this->$method()),
 					];
 					$output = json_encode($result);
 					header("Cache-Control: max-age=10800");

--- a/code/web/services/API/UserAPI.php
+++ b/code/web/services/API/UserAPI.php
@@ -119,7 +119,7 @@ class UserAPI extends AbstractAPI {
 					header("Cache-Control: max-age=10800");
 					require_once ROOT_DIR . '/sys/SystemLogging/APIUsage.php';
 					APIUsage::incrementStat('UserAPI', $method);
-					$output = json_encode(['result' => $this->$method()]);
+					$output = json_encode(['result' => $this->logPatronRequestExternal($this->$method())]);
 				} else {
 					header('Cache-Control: no-cache, must-revalidate'); // HTTP/1.1
 					$output = json_encode(['error' => 'invalid_method']);

--- a/code/web/services/API/WorkAPI.php
+++ b/code/web/services/API/WorkAPI.php
@@ -47,7 +47,7 @@ class WorkAPI extends AbstractAPI {
 					header('Cache-Control: max-age=10800');
 					require_once ROOT_DIR . '/sys/SystemLogging/APIUsage.php';
 					APIUsage::incrementStat('WorkAPI', $method);
-					$output = json_encode($this->$method());
+					$output = json_encode($this->logPatronRequestExternal($this->$method()));
 				} else {
 					header('Cache-Control: no-cache, must-revalidate'); // HTTP/1.1
 					$output = json_encode(['error' => 'invalid_method']);


### PR DESCRIPTION
- Adds logPatronRequestExternal function to Abstract API that is used when returning $output from LiDA requests for each API
- Adds `debug` true if user has allowAppRequestLogging enabled (set in MyAccount/AppRequests/) which forces logging of the API request in Aspen LiDA's new API Error Log (as part of DIS-2100), which by default only logs requests with errors or malformed data