### PR TITLE
DIS-2411: Improve mechanism for detecting and setting a language

### DIFF
--- a/code/web/index.php
+++ b/code/web/index.php
@@ -56,9 +56,17 @@ $interface->assign('cssJsCacheCounter', 47);
 global $language;
 global $serverName;
 //Get the active language
+require_once ROOT_DIR . '/sys/Translation/Language.php';
 $userLanguage = UserAccount::getUserInterfaceLanguage();
 if ($userLanguage == '') {
-	$language = strip_tags((isset($_SESSION['language'])) ? $_SESSION['language'] : 'en');
+	if (!empty($_COOKIE['aspenInterfaceLanguage'])) {
+		$language = strip_tags($_COOKIE['aspenInterfaceLanguage']);
+	} elseif (!empty($_SESSION['language'])) {
+		$language = strip_tags($_SESSION['language']);
+	} else {
+		$browserLanguage = Language::getLanguageFromBrowser();
+		$language = $browserLanguage ?: Language::getDefaultLanguageCode();
+	}
 } else {
 	$language = $userLanguage;
 }
@@ -71,7 +79,8 @@ if (isset($_REQUEST['myLang'])) {
 	}
 	if ($language != $newLanguage) {
 		$language = $newLanguage;
-		$_SESSION['language'] = $language;
+		setcookie('aspenInterfaceLanguage', $language, time() + (3 * 365 * 24 * 3600), '/');
+		$_COOKIE['aspenInterfaceLanguage'] = $language;
 		//Clear the preference cookie
 		if (isset($_COOKIE['searchPreferenceLanguage'])) {
 			//Clear the cookie when we change languages
@@ -94,11 +103,10 @@ if (!UserAccount::isLoggedIn() && isset($_COOKIE['searchPreferenceLanguage'])) {
 $interface->assign('showLanguagePreferencesBar', $showLanguagePreferencesBar);
 
 // Make sure language code is valid, reset to default if bad:
-require_once ROOT_DIR . '/sys/Translation/Language.php';
 $validLanguages = Language::getValidLanguages();
 
 if (!array_key_exists($language, $validLanguages)) {
-	$language = 'en';
+	$language = Language::getDefaultLanguageCode();
 }
 global $activeLanguage;
 global $translator;

--- a/code/web/release_notes/26.06.00.MD
+++ b/code/web/release_notes/26.06.00.MD
@@ -27,6 +27,10 @@
 //lucas
 ### Sideload Updates
 - Add error visibility to the 'Replace existing files?' operation in SideLoad uploads ([DIS-2367](https://aspen-discovery.atlassian.net/browse/DIS-2367)) (*LM*) 
+### Language Updates
+- Added a "Default Language" option to the Languages admin page, allowing administrators to designate any language as the system default for unauthenticated users, replacing the hardcoded English fallback. ([DIS-2411](https://aspen-discovery.atlassian.net/browse/DIS-2411)) (*LM*)
+- On first visit, the interface now automatically detects the user's browser language preference (via the `Accept-Language` header) and applies it if the language is available in the catalog. ([DIS-2411](https://aspen-discovery.atlassian.net/browse/DIS-2411)) (*LM*)
+- Language selection is now persisted in a long-lived cookie, preserving the user's preference across browser sessions without requiring a login. ([DIS-2411](https://aspen-discovery.atlassian.net/browse/DIS-2411)) (*LM*)
 
 //tomas
 

--- a/code/web/services/AJAX/JSON.php
+++ b/code/web/services/AJAX/JSON.php
@@ -604,7 +604,7 @@ class AJAX_JSON extends Action {
 		global $interface;
 		$userLanguage = UserAccount::getUserInterfaceLanguage();
 		if ($userLanguage == '') {
-			$language = strip_tags((isset($_SESSION['language'])) ? $_SESSION['language'] : 'en');
+			$language = strip_tags(!empty($_SESSION['language']) ? $_SESSION['language'] : 'en');
 		} else {
 			$language = $userLanguage;
 		}
@@ -613,6 +613,8 @@ class AJAX_JSON extends Action {
 		if ($language != $preferredLanguage) {
 			$language = $preferredLanguage;
 			$_SESSION['language'] = $language;
+			setcookie('aspenInterfaceLanguage', $language, time() + (3 * 365 * 24 * 3600), '/');
+			$_COOKIE['aspenInterfaceLanguage'] = $language;
 			//Clear the preference cookie
 			if (isset($_COOKIE['searchPreferenceLanguage'])) {
 				//Clear the cookie when we change languages

--- a/code/web/sys/DBMaintenance/version_updates/26.06.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/26.06.00.php
@@ -34,6 +34,14 @@ function getUpdates26_06_00(): array {
 		//mark j
 
 		//lucas
+		'language_add_is_default' => [
+			'title' => 'Add Default Language Flag',
+			'description' => 'Adds an isDefault column to the languages table to allow admins to designate a default language for unauthenticated users. English is set as the initial default to preserve existing behavior.',
+			'sql' => [
+				'ALTER TABLE languages ADD COLUMN isDefault TINYINT(1) NOT NULL DEFAULT 0',
+				"UPDATE languages SET isDefault = 1 WHERE code = 'en' LIMIT 1",
+			],
+		], //language_add_is_default
 
 		//tomas
 

--- a/code/web/sys/Translation/Language.php
+++ b/code/web/sys/Translation/Language.php
@@ -10,6 +10,7 @@ class Language extends DataObject {
 	public $locale;
 	public $facetValue;
 	public $displayToTranslatorsOnly;
+	public $isDefault;
 
 	static $_objectStructure = [];
 	static function getObjectStructure(string $context = ''): array {
@@ -75,6 +76,13 @@ class Language extends DataObject {
 				'type' => 'checkbox',
 				'label' => 'Display To Translators Only',
 				'description' => 'Whether or not only translators should see the translation (good practice before the translation is completed)',
+				'default' => 0,
+			],
+			'isDefault' => [
+				'property' => 'isDefault',
+				'type' => 'checkbox',
+				'label' => 'Default Language',
+				'description' => 'Whether this is the default language for unauthenticated users. Only one language can be set as default.',
 				'default' => 0,
 			],
 		];
@@ -145,10 +153,68 @@ class Language extends DataObject {
 		return  self::$_validLanguages;
 	}
 
+	public function update($context = ''): bool|int {
+		if ($this->isDefault) {
+			$other = new Language();
+			$other->whereAdd('id != ' . (int)$this->id);
+			$other->find();
+			while ($other->fetch()) {
+				if ($other->isDefault) {
+					$other->isDefault = 0;
+					$other->update();
+				}
+			}
+		}
+		self::$_validLanguages = null;
+		return parent::update($context);
+	}
+
+	public static function getDefaultLanguageCode(): string {
+		$validLanguages = self::getValidLanguages();
+		$language = new Language();
+		$language->isDefault = 1;
+		if ($language->find(true) && isset($validLanguages[$language->code])) {
+			return $language->code;
+		}
+		return array_key_first($validLanguages) ?? 'en';
+	}
+
+	public static function getLanguageFromBrowser(): string {
+		if (empty($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
+			return '';
+		}
+		$validLanguages = self::getValidLanguages();
+		$accepted = [];
+		foreach (explode(',', $_SERVER['HTTP_ACCEPT_LANGUAGE']) as $part) {
+			$part = trim($part);
+			if (preg_match('/^([a-zA-Z]{1,8}(?:-[a-zA-Z0-9]{1,8})*)(?:;q=([0-9.]+))?$/', $part, $m)) {
+				$accepted[strtolower($m[1])] = isset($m[2]) ? (float)$m[2] : 1.0;
+			}
+		}
+		arsort($accepted);
+		// Exact match first (e.g. "es" matches language code "es")
+		foreach ($accepted as $tag => $q) {
+			if (isset($validLanguages[$tag])) {
+				return $tag;
+			}
+		}
+		// Primary subtag match (e.g. "es-419" or "es-US" matches code "es")
+		foreach ($accepted as $tag => $q) {
+			$primary = explode('-', $tag)[0];
+			foreach (array_keys($validLanguages) as $code) {
+				if (strtolower(explode('-', $code)[0]) === $primary) {
+					return $code;
+				}
+			}
+		}
+		return '';
+	}
+
 	public function getNumericColumnNames(): array {
 		return [
 			'id',
 			'weight',
+			'isDefault',
 		];
 	}
 


### PR DESCRIPTION
Aspen Discovery had no way to configure a default language for unauthenticated users. The fallback was hardcoded to 'en' in index.php.

Three improvements were implemented:

1. Admin-configurable default language:
Added an isDefault column to the languages table. The Languages admin page now shows a "Default Language" checkbox. Language::update() enforces single-default by clearing other rows when a new default is saved. Language::getDefaultLanguageCode() reads this flag and validates the result against active languages before returning it.

2. Browser language auto-detection
Added Language::getLanguageFromBrowser(), which parses the Accept-Language HTTP header on the user's first visit. It tries an exact tag match first, then falls back to primary subtag matching (e.g., es-AR matches es).

3. Persistent language cookie
Language selection is now stored in an aspenInterfaceLanguage cookie with a 3-year expiry. Both switch paths write to it: the navbar myLang param (in index.php) and the display settings modal AJAX call (JSON.php:updateDisplaySettings()).

Test plan

1. Admin default is respected on first visit
   - Set Spanish as default in Languages admin.
   - Open a new incognito window with `Accept-Language` set to a language not installed (e.g. French).
   - Navigate to the catalog as an unauthenticated user.
   - Expected: interface displays in Spanish.

2. Browser language auto-detection
   - Set English as default. Keep both English and Spanish installed.
   - Open a new incognito window with browser language set to Spanish (`es` or `es-AR`).
   - Navigate to the catalog.
   - Expected: interface displays in Spanish (browser preference matched an installed language).

3. Navbar language switch persists across page navigation
   - From the catalog, switch language via the navbar link (appends `?myLang=es`).
   - Navigate to another page without using `myLang`.
   - Expected: language is still Spanish (cookie was set).

4. Display settings modal language switch
   - Open the display settings modal and change the language, then click Update Settings.
   - Navigate to another page.
   - Expected: language selection is retained (AJAX handler wrote the cookie).

5. Cookie survives browser restart
   - Select a non-default language via either switch method.
   - Close and reopen the browser.
   - Navigate to the catalog.
   - Expected: previously selected language is still active.

6. Admin default change takes effect for new visitors
   - Change the default language in admin from Spanish to English.
   - Open a new incognito window with no matching `Accept-Language`.
   - Expected: interface displays in English.

7. Authenticated users are unaffected
   - Log in as a user with a saved language preference (e.g. French).
   - Expected: interface displays in French regardless of cookie or DB default.