### PR TITLE
DIS-2422 Update script should check if db is remote

### DIFF
--- a/code/web/release_notes/26.06.00.MD
+++ b/code/web/release_notes/26.06.00.MD
@@ -25,6 +25,9 @@
 
 //tomas
 
+### Other Updates
+- Let update script to check if db is remote. ([DIS-2422](https://aspen-discovery.atlassian.net/browse/DIS-2422)) (*BNJ*)
+
 ## This release includes code contributions from
 ### ByWater Solutions
 - Yanjun Li (YL)
@@ -38,6 +41,9 @@
 - Kodi Lein (KL)
 - Myranda Fuentes (MAF)
 - Stephen Wicks (SW)
+
+### Nashville Public Libraries  
+- Bryan Neil Jones (BNJ)  
 
 ### Open Fifth
 - Alexander Blanchard (AB)

--- a/code/web/release_notes/26.06.00.MD
+++ b/code/web/release_notes/26.06.00.MD
@@ -26,7 +26,7 @@
 //tomas
 
 ### Other Updates
-- Let update script to check if db is remote. ([DIS-2422](https://aspen-discovery.atlassian.net/browse/DIS-2422)) (*BNJ*)
+- Let update script check if db is remote. ([DIS-2422](https://aspen-discovery.atlassian.net/browse/DIS-2422)) (*BNJ*)
 
 ## This release includes code contributions from
 ### ByWater Solutions

--- a/install/upgrade.sh
+++ b/install/upgrade.sh
@@ -41,8 +41,15 @@ read waitOver
 cd /usr/local/aspen-discovery/data_dir_setup
 /usr/local/aspen-discovery/data_dir_setup/update_solr_files.sh $1
 
-systemctl restart mariadb 
-sleep 10
+if systemctl is-active --quiet mysqld || systemctl is-active --quiet mariadb; then
+  systemctl restart mariadb
+  sleep 10
+else
+  echo "Restart MariaDB, and then press return when done"
+  # shellcheck disable=SC2034
+  read waitOver
+fi
+
 apachectl graceful
 sleep 5
 


### PR DESCRIPTION
Checks if MariaDB is running. If not, it prompts you manually restart it. 

This fixes are error that gets thrown since we moved our databases to separate servers.