### PR TITLE
DIS-2384 Line item receipt for Square payments

### DIFF
--- a/code/web/interface/themes/responsive/MyAccount/paymentDetails.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/paymentDetails.tpl
@@ -49,11 +49,11 @@
 						</div>
 					</div>
 				{/if}
-				{if $paymentDetails.paymentType == 'stripe' && !empty($paymentDetails.stripeReceiptUrl)}
+				{if $paymentDetails.paymentType == 'stripe' && !empty($paymentDetails.receiptUrl)}
 					<div class="row">
 						<div class="result-label col-sm-3 col-xs-12">{translate text="Receipt" isPublicFacing=true}</div>
 						<div class="result-value col-sm-9 col-xs-12">
-							<a href="{$paymentDetails.stripeReceiptUrl}" target="_blank" rel="noopener noreferrer" class="btn btn-sm btn-primary">
+							<a href="{$paymentDetails.receiptUrl}" target="_blank" rel="noopener noreferrer" class="btn btn-sm btn-primary">
 								<i class="fas fa-receipt"></i> {translate text="View Stripe Receipt" isPublicFacing=true}
 							</a>
 						</div>

--- a/code/web/interface/themes/responsive/MyAccount/paymentDetails.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/paymentDetails.tpl
@@ -49,7 +49,7 @@
 						</div>
 					</div>
 				{/if}
-				{if $paymentDetails.paymentType == 'stripe' && !empty($paymentDetails.receiptUrl)}
+				{if ($paymentDetails.paymentType == 'stripe' || $paymentDetails.paymentType == 'square') && !empty($paymentDetails.receiptUrl)}
 					<div class="row">
 						<div class="result-label col-sm-3 col-xs-12">{translate text="Receipt" isPublicFacing=true}</div>
 						<div class="result-value col-sm-9 col-xs-12">

--- a/code/web/interface/themes/responsive/MyAccount/paymentHistory.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/paymentHistory.tpl
@@ -51,8 +51,8 @@
 							<td>{$payment.completed}</td>
 							{if $hasStripePayments}
 								<td>
-									{if !empty($payment.stripeReceiptUrl)}
-										<a href="{$payment.stripeReceiptUrl}" target="_blank" rel="noopener noreferrer" class="btn btn-xs btn-default" title="{translate text='View Stripe Receipt' isPublicFacing=true inAttribute=true}">
+									{if !empty($payment.receiptUrl)}
+										<a href="{$payment.receiptUrl}" target="_blank" rel="noopener noreferrer" class="btn btn-xs btn-default" title="{translate text='View Stripe Receipt' isPublicFacing=true inAttribute=true}">
 											<i class="fas fa-receipt"></i> {translate text="View" isPublicFacing=true}
 										</a>
 									{/if}

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -4234,7 +4234,6 @@ AspenDiscovery.Account = (function () {
 			};
 			// noinspection JSUnresolvedFunction
 			$.getJSON(url, params, function (data) {
-				console.log(data);
 				if (data.success) {
 					let buttons = '';
 					// noinspection JSUnresolvedReference

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -4234,12 +4234,16 @@ AspenDiscovery.Account = (function () {
 			};
 			// noinspection JSUnresolvedFunction
 			$.getJSON(url, params, function (data) {
+				console.log(data);
 				if (data.success) {
-					if (data.isDonation) {
-						window.location.href = Globals.path + '/Donations/DonationCompleted?id=' + data.paymentId;
-					} else {
-						AspenDiscovery.showMessage('Thank you', data.message, false, true);
+					let buttons = '';
+					// noinspection JSUnresolvedReference
+					if (data.receiptUrl) {
+						const safeReceiptUrl = encodeURI(data.receiptUrl);
+						buttons = '<a href="' + safeReceiptUrl + '" target="_blank" rel="noopener noreferrer" class="btn btn-primary">' +
+							'<i class="fas fa-receipt"></i> View Receipt</a>';
 					}
+					AspenDiscovery.showMessageWithButtons('Thank You', data.message, buttons, true);
 				} else {
 					if (data.isDonation) {
 						window.location.href = Globals.path + '/Donations/DonationCancelled?id=' + data.paymentId;

--- a/code/web/interface/themes/responsive/js/aspen/account.js
+++ b/code/web/interface/themes/responsive/js/aspen/account.js
@@ -2061,11 +2061,14 @@ AspenDiscovery.Account = (function () {
 			// noinspection JSUnresolvedFunction
 			$.getJSON(url, params, function (data) {
 				if (data.success) {
-					if (data.isDonation) {
-						window.location.href = Globals.path + '/Donations/DonationCompleted?id=' + data.paymentId;
-					} else {
-						AspenDiscovery.showMessage('Thank you', data.message, false, true);
+					let buttons = '';
+					// noinspection JSUnresolvedReference
+					if (data.receiptUrl) {
+						const safeReceiptUrl = encodeURI(data.receiptUrl);
+						buttons = '<a href="' + safeReceiptUrl + '" target="_blank" rel="noopener noreferrer" class="btn btn-primary">' +
+							'<i class="fas fa-receipt"></i> View Receipt</a>';
 					}
+					AspenDiscovery.showMessageWithButtons('Thank You', data.message, buttons, true);
 				} else {
 					if (data.isDonation) {
 						window.location.href = Globals.path + '/Donations/DonationCancelled?id=' + data.paymentId;

--- a/code/web/release_notes/26.06.00.MD
+++ b/code/web/release_notes/26.06.00.MD
@@ -9,6 +9,8 @@
 
 //stephen
 
+- Itemized receipt for Square payments ([DIS-2384](https://aspen-discovery.atlassian.net/browse/DIS-2384)) (*SW*)
+
 //yanjun
 
 //imani

--- a/code/web/release_notes/26.06.00.MD
+++ b/code/web/release_notes/26.06.00.MD
@@ -8,8 +8,8 @@
 //mark j
 
 //stephen
-
-- Itemized receipt for Square payments ([DIS-2384](https://aspen-discovery.atlassian.net/browse/DIS-2384)) (*SW*)
+### eCommerce Updates
+- Add display of an itemized receipt for Square payments. ([DIS-2384](https://aspen-discovery.atlassian.net/browse/DIS-2384)) (*SW*)
 
 //yanjun
 

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -6011,10 +6011,13 @@ class MyAccount_AJAX extends JSON_Action {
 				$paymentResults = $decodedPaymentRequestResults->payment;
 
 				if ($paymentResults->status == 'COMPLETED' || $paymentResults->status == 'APPROVED') {
+
+					$payment->transactionId = $paymentResults->id;
+					$payment->receiptUrl = $paymentResults->receipt_url;
+					$payment->orderId = $paymentResults->order_id;
+
 					if ($transactionType == 'donation') {
 						$payment->completed = 1;
-						$payment->transactionId = $paymentResults->id;
-						$payment->orderId = $paymentResults->order_id;
 						$payment->update();
 
 						$donation = new Donation();
@@ -6028,6 +6031,8 @@ class MyAccount_AJAX extends JSON_Action {
 								'isDonation' => true,
 								'paymentId' => $payment->id,
 								'donationId' => $donation->id,
+								'message' => 'Your payment has been completed.',
+								'receiptUrl' => $payment->receiptUrl
 							];
 						} else {
 							return [
@@ -6042,24 +6047,21 @@ class MyAccount_AJAX extends JSON_Action {
 						if ($payment->completed) {
 							return $this->failureResult(null, 'This payment has already been processed');
 						} else {
-							$payment->transactionId = $paymentResults->id;
-							$payment->orderId = $paymentResults->order_id;
-							$payment->receiptUrl = $paymentResults->receipt_url;
-							$payment->update();
 
+							$payment->update();
 							$user = UserAccount::getActiveUserObj();
 							$patron = $user->getUserReferredTo($patronId);
 
 							$result = $patron->completeFinePayment($payment);
 
+
 							if (!$result['success']) {
 								$payment->message .= 'Your payment was received, but was not cleared in our library software. Your account will be updated within the next business day. If you need more immediate assistance, please visit the library with your receipt. ' . $result['message'];
 
 								$payment->update();
-								$result['message'] = $payment->message;
 							}
 
-							$result['message'] = $payment->receiptUrl;
+							$result['receiptUrl'] = $payment->receiptUrl;
 
 							return $result;
 						}

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -5859,14 +5859,17 @@ class MyAccount_AJAX extends JSON_Action {
 		require_once ROOT_DIR . '/sys/Account/UserPayment.php';
 		$payment = new UserPayment();
 		$payment->squareToken = $paymentToken;
+
 		if ($transactionType == 'donation') {
 			//Get the order information
 			$payment->transactionType = 'donation';
 			if ($payment->find(true)) {
 				$paymentId = $payment->id;
+
 				require_once ROOT_DIR . '/sys/Donations/Donation.php';
 				$donation = new Donation();
 				$donation->paymentId = $payment->id;
+
 				if (!$donation->find(true)) {
 					header('Location: ' . $configArray['Site']['url'] . '/Donations/DonationCancelled?id=' . $payment->id);
 				}
@@ -5876,14 +5879,18 @@ class MyAccount_AJAX extends JSON_Action {
 		} else {
 			//Get the order information
 			$payment->userId = $patronId;
+
 			if ($payment->find(true)) {
 				$paymentId = $payment->id;
+
 				$user = UserAccount::getLoggedInUser();
 				$patronId = $_REQUEST['patronId'];
 				$patron = $user->getUserReferredTo($patronId);
 				$userLibrary = $patron->getHomeLibrary();
+
 				global $library;
 				$paymentLibrary = $library;
+
 				$systemVariables = SystemVariables::getSystemVariables();
 				if ($systemVariables->libraryToUseForPayments == 0) {
 					$paymentLibrary = $userLibrary;
@@ -5894,9 +5901,11 @@ class MyAccount_AJAX extends JSON_Action {
 		require_once ROOT_DIR . '/sys/ECommerce/SquareSetting.php';
 		$squareSettings = new SquareSetting();
 		$squareSettings->id = $paymentLibrary->squareSettingId;
+
 		if ($squareSettings->find(true)) {
 			require_once ROOT_DIR . '/sys/CurlWrapper.php';
 			$paymentRequest = new CurlWrapper();
+
 			$baseUrl = 'https://connect.squareup.com';
 			if ($squareSettings->sandboxMode == 1) {
 				$baseUrl = 'https://connect.squareupsandbox.com';
@@ -5908,129 +5917,178 @@ class MyAccount_AJAX extends JSON_Action {
 				"Authorization: Bearer $squareSettings->accessToken",
 			], true);
 
-			$paymentId = null;
-			$paymentAmount = null;
-			require_once ROOT_DIR . '/sys/Account/UserPayment.php';
 			require_once ROOT_DIR . '/sys/Account/UserPaymentLine.php';
 
-			$payment = new UserPayment();
-			$payment->squareToken = $paymentToken;
-			if ($payment->find(true)) {
-				$paymentId = $payment->id;
+			$userPaymentLine = new UserPaymentLine();
+			$userPaymentLine->paymentId = $payment->id;
 
-				$lines = new UserPaymentLine();
-				$lines->paymentId = $payment->id;
+			$lineItems = [];
 
-				$lineItems = [];
-
-				if ($lines->find()) {
-					while ($lines->fetch()) {
-						$lineItems[] = [
-							'name' => $lines->description,
-							'quantity' => '1',
-							'base_price_money' => [
-								'amount' => (int)round($lines->amountPaid * 100),
-								'currency' => 'USD'
-							]
-						];
-					}
-				}
-
-				$orderBody = [
-					'idempotency_key' => strval($paymentId) . '-order',
-					'order' => [
-						'location_id' => strval($squareSettings->locationId),
-						'line_items' => $lineItems
-					]
-				];
-
-				$orderUrl = $baseUrl . '/v2/orders';
-
-				$orderResponse = $paymentRequest->curlPostBodyData($orderUrl, $orderBody);
-				$decodedOrder = json_decode($orderResponse);
-
-				$squareOrderId = $decodedOrder->order->id ?? null;
-
-				$body = [
-					'idempotency_key' => strval($paymentId),
-					'amount_money' => [
-						'amount' => (int)round($payment->totalPaid * 100),
-						'currency' => 'USD'
-					],
-					'source_id' => $paymentToken,
-					'order_id' => $squareOrderId
-				];
-
-				$paymentUrl = $baseUrl . '/v2/payments';
-				$paymentRequestResults = $paymentRequest->curlPostBodyData($paymentUrl, $body);
-				$decodedPaymentRequestResults = json_decode($paymentRequestResults);
-
-				ExternalRequestLogEntry::logRequest('fine_payment.completeSquareOrder', 'POST', $paymentUrl, $paymentRequest->getHeaders(), json_encode($body), $paymentRequest->getResponseCode(), $paymentRequestResults, []);
-
-				if ($decodedPaymentRequestResults->payment) {
-					$paymentResults = $decodedPaymentRequestResults->payment;
-					if ($paymentResults->status == 'COMPLETED' || $paymentResults->status == 'APPROVED') {
-						if ($transactionType == 'donation') {
-							$payment->completed = 1;
-							$payment->transactionId = $paymentResults->id;
-							$payment->orderId = $paymentResults->order_id;
-							$payment->update();
-							$donation = new Donation();
-							$donation->paymentId = $payment->id;
-
-							if ($donation->find(true)) {
-								$donation->sendReceiptEmail();
-								return [
-									'success' => true,
-									'isDonation' => true,
-									'paymentId' => $payment->id,
-									'donationId' => $donation->id,
-								];
-							} else {
-								return [
-									'success' => false,
-									'message' => 'Unable to find donation with provided id',
-									'isDonation' => true,
-									'paymentId' => $payment->id,
-									'donationId' => '',
-								];
-							}
-						} else {
-							if ($payment->completed) {
-								return $this->failureResult(null, 'This payment has already been processed');
-							} else {
-								$payment->transactionId = $paymentResults->id;
-								$payment->orderId = $paymentResults->order_id;
-								$payment->receiptUrl = $paymentResults->receipt_url;
-								$payment->update();
-								$user = UserAccount::getActiveUserObj();
-								$patron = $user->getUserReferredTo($patronId);
-								$result = $patron->completeFinePayment($payment);
-								if (!$result['success']) {
-									$payment->message .= 'Your payment was received, but was not cleared in our library software. Your account will be updated within the next business day. If you need more immediate assistance, please visit the library with your receipt. ' . $result['message'];
-									$payment->update();
-									$result['message'] = $payment->message;
-								}
-								$result['message'] = $payment->receiptUrl;
-								return $result;
-							}
-						}
-					} else {
-						return $this->failureResult(null, 'Payment status is ' . ($paymentResults->status ?? 'NO STATUS RECEIVED') . '. Please make sure the information you entered is correct.');
-					}
-				} else {
-					$error = $decodedPaymentRequestResults->error;
-					$payment->error = 1;
-					$payment->message = $error->detail;
-					$payment->update();
-					return [
-						'success' => false,
-						'message' => $error->detail,
+			if ($userPaymentLine->find()) {
+				while ($userPaymentLine->fetch()) {
+					$lineItems[] = [
+						'name' => $userPaymentLine->description,
+						'quantity' => '1',
+						'base_price_money' => [
+							'amount' => (int)round($userPaymentLine->amountPaid * 100),
+							'currency' => 'USD'
+						]
 					];
 				}
 			}
+
+			if (empty($lineItems)) {
+				return [
+					'success' => false,
+					'message' => 'No payment line items were found.',
+				];
+			}
+
+			// Hit the Orders API first. This creates an itemized payment
+			$orderUrl = $baseUrl . '/v2/orders';
+
+			$orderBody = [
+				'idempotency_key' => strval($payment->id) . '-order',
+				'order' => [
+					'location_id' => strval($squareSettings->locationId),
+					'line_items' => $lineItems
+				]
+			];
+
+			$orderResponse = $paymentRequest->curlPostBodyData($orderUrl, $orderBody);
+
+			ExternalRequestLogEntry::logRequest(
+				'fine_payment.createSquareOrder',
+				'POST',
+				$orderUrl,
+				$paymentRequest->getHeaders(),
+				json_encode($orderBody),
+				$paymentRequest->getResponseCode(),
+				$orderResponse,
+				[]
+			);
+
+			$decodedOrder = json_decode($orderResponse);
+			$squareOrderId = $decodedOrder->order->id ?? null;
+
+			if ($squareOrderId === null) {
+				$error = $decodedOrder->errors[0]->detail ?? 'Unknown Square order error';
+
+				return [
+					'success' => false,
+					'message' => $error,
+				];
+			}
+
+			$body = [
+				'idempotency_key' => strval($payment->id),
+				'amount_money' => [
+					// Use the total and currency returned from the Order API call to prevent conflicts
+					'amount' => $decodedOrder->order->total_money->amount,
+					'currency' => $decodedOrder->order->total_money->currency
+				],
+				'source_id' => $paymentToken,
+				'order_id' => $squareOrderId
+			];
+
+			$paymentUrl = $baseUrl . '/v2/payments';
+
+			$paymentRequestResults = $paymentRequest->curlPostBodyData($paymentUrl, $body);
+			$decodedPaymentRequestResults = json_decode($paymentRequestResults);
+
+			ExternalRequestLogEntry::logRequest(
+				'fine_payment.completeSquareOrder',
+				'POST',
+				$paymentUrl,
+				$paymentRequest->getHeaders(),
+				json_encode($body),
+				$paymentRequest->getResponseCode(),
+				$paymentRequestResults,
+				[]
+			);
+
+			if ($decodedPaymentRequestResults->payment) {
+				$paymentResults = $decodedPaymentRequestResults->payment;
+
+				if ($paymentResults->status == 'COMPLETED' || $paymentResults->status == 'APPROVED') {
+					if ($transactionType == 'donation') {
+						$payment->completed = 1;
+						$payment->transactionId = $paymentResults->id;
+						$payment->orderId = $paymentResults->order_id;
+						$payment->update();
+
+						$donation = new Donation();
+						$donation->paymentId = $payment->id;
+
+						if ($donation->find(true)) {
+							$donation->sendReceiptEmail();
+
+							return [
+								'success' => true,
+								'isDonation' => true,
+								'paymentId' => $payment->id,
+								'donationId' => $donation->id,
+							];
+						} else {
+							return [
+								'success' => false,
+								'message' => 'Unable to find donation with provided id',
+								'isDonation' => true,
+								'paymentId' => $payment->id,
+								'donationId' => '',
+							];
+						}
+					} else {
+						if ($payment->completed) {
+							return $this->failureResult(null, 'This payment has already been processed');
+						} else {
+							$payment->transactionId = $paymentResults->id;
+							$payment->orderId = $paymentResults->order_id;
+							$payment->receiptUrl = $paymentResults->receipt_url;
+							$payment->update();
+
+							$user = UserAccount::getActiveUserObj();
+							$patron = $user->getUserReferredTo($patronId);
+
+							$result = $patron->completeFinePayment($payment);
+
+							if (!$result['success']) {
+								$payment->message .= 'Your payment was received, but was not cleared in our library software. Your account will be updated within the next business day. If you need more immediate assistance, please visit the library with your receipt. ' . $result['message'];
+
+								$payment->update();
+								$result['message'] = $payment->message;
+							}
+
+							$result['message'] = $payment->receiptUrl;
+
+							return $result;
+						}
+					}
+				} else {
+					return $this->failureResult(
+						null,
+						'Payment status is ' . ($paymentResults->status ?? 'NO STATUS RECEIVED') . '. Please make sure the information you entered is correct.'
+					);
+				}
+			} else {
+				$error = $decodedPaymentRequestResults->errors[0] ?? null;
+				$errorMessage = $error->detail ?? $error->code ?? 'Unknown Square payment error';
+
+				$payment->error = 1;
+				$payment->message = $errorMessage;
+				$payment->update();
+
+				return [
+					'success' => false,
+					'message' => $errorMessage,
+				];
+			}
 		}
-		return $this->failureResult(null, 'Your payment with Square could not be completed. Please contact library staff for assistance.');
+
+		return $this->failureResult(
+			null,
+			'Your payment with Square could not be completed. Please contact library staff for assistance.'
+		);
 	}
 
 	/** @noinspection PhpUnused */

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -5845,252 +5845,154 @@ class MyAccount_AJAX extends JSON_Action {
 		}
 	}
 
-	/** @noinspection PhpUnused */
+/** @noinspection PhpUnused */
 	function completeSquareOrder(): array {
 		global $configArray;
+		global $library;
 
 		$patronId = $_REQUEST['patronId'];
 		$transactionType = $_REQUEST['type'];
 		$paymentToken = $_REQUEST['token'];
 
-		global $library;
 		$paymentLibrary = $library;
 
 		require_once ROOT_DIR . '/sys/Account/UserPayment.php';
+
 		$payment = new UserPayment();
 		$payment->squareToken = $paymentToken;
+		$payment->userId = $patronId;
 
 		if ($transactionType == 'donation') {
-			//Get the order information
 			$payment->transactionType = 'donation';
-			if ($payment->find(true)) {
-				$paymentId = $payment->id;
+		}
 
-				require_once ROOT_DIR . '/sys/Donations/Donation.php';
-				$donation = new Donation();
-				$donation->paymentId = $payment->id;
-
-				if (!$donation->find(true)) {
-					header('Location: ' . $configArray['Site']['url'] . '/Donations/DonationCancelled?id=' . $payment->id);
-				}
-			} else {
+		if (!$payment->find(true)) {
+			if ($transactionType == 'donation') {
 				header('Location: ' . $configArray['Site']['url'] . '/Donations/DonationCancelled?id=' . $payment->id);
 			}
+
+			return $this->failureResult(
+				null,
+				'Your payment with Square could not be completed. Please contact library staff for assistance.'
+			);
+		}
+
+		if ($transactionType == 'donation') {
+			require_once ROOT_DIR . '/sys/Donations/Donation.php';
+
+			$donation = new Donation();
+			$donation->paymentId = $payment->id;
+
+			if (!$donation->find(true)) {
+				header('Location: ' . $configArray['Site']['url'] . '/Donations/DonationCancelled?id=' . $payment->id);
+				return $this->failureResult( null, 'Your payment with Square could not be completed. Please contact library staff for assistance.');
+			}
+
 		} else {
-			//Get the order information
-			$payment->userId = $patronId;
+			$user = UserAccount::getLoggedInUser();
+			$patron = $user->getUserReferredTo($patronId);
+			$userLibrary = $patron->getHomeLibrary();
 
-			if ($payment->find(true)) {
-				$paymentId = $payment->id;
+			$systemVariables = SystemVariables::getSystemVariables();
 
-				$user = UserAccount::getLoggedInUser();
-				$patronId = $_REQUEST['patronId'];
-				$patron = $user->getUserReferredTo($patronId);
-				$userLibrary = $patron->getHomeLibrary();
+			if ($systemVariables->libraryToUseForPayments == 0) {
+				$paymentLibrary = $userLibrary;
+			}
 
-				global $library;
-				$paymentLibrary = $library;
-
-				$systemVariables = SystemVariables::getSystemVariables();
-				if ($systemVariables->libraryToUseForPayments == 0) {
-					$paymentLibrary = $userLibrary;
-				}
+			if ($payment->completed) {
+				return $this->failureResult(null, 'This payment has already been processed');
 			}
 		}
 
 		require_once ROOT_DIR . '/sys/ECommerce/SquareSetting.php';
+
 		$squareSettings = new SquareSetting();
 		$squareSettings->id = $paymentLibrary->squareSettingId;
 
-		if ($squareSettings->find(true)) {
-			require_once ROOT_DIR . '/sys/CurlWrapper.php';
-			$paymentRequest = new CurlWrapper();
-
-			$baseUrl = 'https://connect.squareup.com';
-			if ($squareSettings->sandboxMode == 1) {
-				$baseUrl = 'https://connect.squareupsandbox.com';
-			}
-
-			$paymentRequest->addCustomHeaders([
-				'Content-Type: application/json',
-				'Square-Version: 2023-06-08',
-				"Authorization: Bearer $squareSettings->accessToken",
-			], true);
-
-			require_once ROOT_DIR . '/sys/Account/UserPaymentLine.php';
-
-			$userPaymentLine = new UserPaymentLine();
-			$userPaymentLine->paymentId = $payment->id;
-
-			$lineItems = [];
-
-			if ($userPaymentLine->find()) {
-				while ($userPaymentLine->fetch()) {
-					$lineItems[] = [
-						'name' => $userPaymentLine->description,
-						'quantity' => '1',
-						'base_price_money' => [
-							'amount' => (int)round($userPaymentLine->amountPaid * 100),
-							'currency' => 'USD'
-						]
-					];
-				}
-			}
-
-			if (empty($lineItems)) {
-				return [
-					'success' => false,
-					'message' => 'No payment line items were found.',
-				];
-			}
-
-			// Hit the Orders API first. This creates an itemized payment
-			$orderUrl = $baseUrl . '/v2/orders';
-
-			$orderBody = [
-				'idempotency_key' => strval($payment->id) . '-order',
-				'order' => [
-					'location_id' => strval($squareSettings->locationId),
-					'line_items' => $lineItems
-				]
-			];
-
-			$orderResponse = $paymentRequest->curlPostBodyData($orderUrl, $orderBody);
-
-			ExternalRequestLogEntry::logRequest(
-				'fine_payment.createSquareOrder',
-				'POST',
-				$orderUrl,
-				$paymentRequest->getHeaders(),
-				json_encode($orderBody),
-				$paymentRequest->getResponseCode(),
-				$orderResponse,
-				[]
+		if (!$squareSettings->find(true)) {
+			return $this->failureResult(
+				null,
+				'Your payment with Square could not be completed. Please contact library staff for assistance.'
 			);
-
-			$decodedOrder = json_decode($orderResponse);
-			$squareOrderId = $decodedOrder->order->id ?? null;
-
-			if ($squareOrderId === null) {
-				$error = $decodedOrder->errors[0]->detail ?? 'Unknown Square order error';
-
-				return [
-					'success' => false,
-					'message' => $error,
-				];
-			}
-
-			$body = [
-				'idempotency_key' => strval($payment->id),
-				'amount_money' => [
-					// Use the total and currency returned from the Order API call to prevent conflicts
-					'amount' => $decodedOrder->order->total_money->amount,
-					'currency' => $decodedOrder->order->total_money->currency
-				],
-				'source_id' => $paymentToken,
-				'order_id' => $squareOrderId
-			];
-
-			$paymentUrl = $baseUrl . '/v2/payments';
-
-			$paymentRequestResults = $paymentRequest->curlPostBodyData($paymentUrl, $body);
-			$decodedPaymentRequestResults = json_decode($paymentRequestResults);
-
-			ExternalRequestLogEntry::logRequest(
-				'fine_payment.completeSquareOrder',
-				'POST',
-				$paymentUrl,
-				$paymentRequest->getHeaders(),
-				json_encode($body),
-				$paymentRequest->getResponseCode(),
-				$paymentRequestResults,
-				[]
-			);
-
-			if ($decodedPaymentRequestResults->payment) {
-				$paymentResults = $decodedPaymentRequestResults->payment;
-
-				if ($paymentResults->status == 'COMPLETED' || $paymentResults->status == 'APPROVED') {
-
-					$payment->transactionId = $paymentResults->id;
-					$payment->receiptUrl = $paymentResults->receipt_url;
-					$payment->orderId = $paymentResults->order_id;
-
-					if ($transactionType == 'donation') {
-						$payment->completed = 1;
-						$payment->update();
-
-						$donation = new Donation();
-						$donation->paymentId = $payment->id;
-
-						if ($donation->find(true)) {
-							$donation->sendReceiptEmail();
-
-							return [
-								'success' => true,
-								'isDonation' => true,
-								'paymentId' => $payment->id,
-								'donationId' => $donation->id,
-								'message' => 'Your payment has been completed.',
-								'receiptUrl' => $payment->receiptUrl
-							];
-						} else {
-							return [
-								'success' => false,
-								'message' => 'Unable to find donation with provided id',
-								'isDonation' => true,
-								'paymentId' => $payment->id,
-								'donationId' => '',
-							];
-						}
-					} else {
-						if ($payment->completed) {
-							return $this->failureResult(null, 'This payment has already been processed');
-						} else {
-
-							$payment->update();
-							$user = UserAccount::getActiveUserObj();
-							$patron = $user->getUserReferredTo($patronId);
-
-							$result = $patron->completeFinePayment($payment);
-
-
-							if (!$result['success']) {
-								$payment->message .= 'Your payment was received, but was not cleared in our library software. Your account will be updated within the next business day. If you need more immediate assistance, please visit the library with your receipt. ' . $result['message'];
-
-								$payment->update();
-							}
-
-							$result['receiptUrl'] = $payment->receiptUrl;
-
-							return $result;
-						}
-					}
-				} else {
-					return $this->failureResult(
-						null,
-						'Payment status is ' . ($paymentResults->status ?? 'NO STATUS RECEIVED') . '. Please make sure the information you entered is correct.'
-					);
-				}
-			} else {
-				$error = $decodedPaymentRequestResults->errors[0] ?? null;
-				$errorMessage = $error->detail ?? $error->code ?? 'Unknown Square payment error';
-
-				$payment->error = 1;
-				$payment->message = $errorMessage;
-				$payment->update();
-
-				return [
-					'success' => false,
-					'message' => $errorMessage,
-				];
-			}
 		}
 
-		return $this->failureResult(
-			null,
-			'Your payment with Square could not be completed. Please contact library staff for assistance.'
+		$lineItemResult = $squareSettings->createLineItems($payment);
+
+		if (!$lineItemResult['success']) {
+			return $lineItemResult;
+		}
+
+		$paymentResult = $squareSettings->submitTransaction(
+			$payment,
+			$paymentToken,
+			$lineItemResult['orderId'],
+			$lineItemResult['amountMoney']
 		);
+
+		if (!$paymentResult['success']) {
+			$payment->error = 1;
+			$payment->message = $paymentResult['message'];
+			$payment->update();
+
+			return $paymentResult;
+		}
+
+		if ($paymentResult['payment']->status != 'COMPLETED' && $paymentResult['payment']->status != 'APPROVED') {
+			return $this->failureResult(
+				null,
+				'Payment status is ' . ($paymentResult['payment']->status ?? 'NO STATUS RECEIVED') . '. Please make sure the information you entered is correct.'
+			);
+		}
+
+		$payment->transactionId = $paymentResult['payment']->id;
+		$payment->receiptUrl = $paymentResult['payment']->receipt_url;
+		$payment->orderId = $paymentResult['payment']->order_id;
+
+		if ($transactionType == 'donation') {
+			$payment->completed = 1;
+			$payment->update();
+
+			$donation = new Donation();
+			$donation->paymentId = $payment->id;
+
+			if (!$donation->find(true)) {
+				return [
+					'success' => false,
+					'message' => 'Unable to find donation with provided id',
+					'isDonation' => true,
+					'paymentId' => $payment->id,
+					'donationId' => '',
+				];
+			}
+
+			$donation->sendReceiptEmail();
+
+			return [
+				'success' => true,
+				'isDonation' => true,
+				'paymentId' => $payment->id,
+				'donationId' => $donation->id,
+				'message' => 'Your payment has been completed.',
+				'receiptUrl' => $payment->receiptUrl,
+			];
+		}
+
+		$payment->update();
+
+		$user = UserAccount::getActiveUserObj();
+		$patron = $user->getUserReferredTo($patronId);
+
+		$result = $patron->completeFinePayment($payment);
+
+		if (!$result['success']) {
+			$payment->message .= 'Your payment was received, but was not cleared in our library software. Your account will be updated within the next business day. If you need more immediate assistance, please visit the library with your receipt. ' . $result['message'];
+
+			$payment->update();
+		}
+
+		$result['receiptUrl'] = $payment->receiptUrl;
+
+		return $result;
 	}
 
 	/** @noinspection PhpUnused */

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -5911,18 +5911,54 @@ class MyAccount_AJAX extends JSON_Action {
 			$paymentId = null;
 			$paymentAmount = null;
 			require_once ROOT_DIR . '/sys/Account/UserPayment.php';
+			require_once ROOT_DIR . '/sys/Account/UserPaymentLine.php';
+
 			$payment = new UserPayment();
 			$payment->squareToken = $paymentToken;
 			if ($payment->find(true)) {
 				$paymentId = $payment->id;
+
+				$lines = new UserPaymentLine();
+				$lines->paymentId = $payment->id;
+
+				$lineItems = [];
+
+				if ($lines->find()) {
+					while ($lines->fetch()) {
+						$lineItems[] = [
+							'name' => $lines->description,
+							'quantity' => '1',
+							'base_price_money' => [
+								'amount' => (int)round($lines->amountPaid * 100),
+								'currency' => 'USD'
+							]
+						];
+					}
+				}
+
+				$orderBody = [
+					'idempotency_key' => strval($paymentId) . '-order',
+					'order' => [
+						'location_id' => strval($squareSettings->locationId),
+						'line_items' => $lineItems
+					]
+				];
+
+				$orderUrl = $baseUrl . '/v2/orders';
+
+				$orderResponse = $paymentRequest->curlPostBodyData($orderUrl, $orderBody);
+				$decodedOrder = json_decode($orderResponse);
+
+				$squareOrderId = $decodedOrder->order->id ?? null;
+
 				$body = [
 					'idempotency_key' => strval($paymentId),
-					// Square needs this to be a string, so guarantee it
 					'amount_money' => [
 						'amount' => (int)round($payment->totalPaid * 100),
 						'currency' => 'USD'
 					],
-					'source_id' => $paymentToken
+					'source_id' => $paymentToken,
+					'order_id' => $squareOrderId
 				];
 
 				$paymentUrl = $baseUrl . '/v2/payments';
@@ -5965,6 +6001,7 @@ class MyAccount_AJAX extends JSON_Action {
 							} else {
 								$payment->transactionId = $paymentResults->id;
 								$payment->orderId = $paymentResults->order_id;
+								$payment->receiptUrl = $paymentResults->receipt_url;
 								$payment->update();
 								$user = UserAccount::getActiveUserObj();
 								$patron = $user->getUserReferredTo($patronId);
@@ -5974,7 +6011,7 @@ class MyAccount_AJAX extends JSON_Action {
 									$payment->update();
 									$result['message'] = $payment->message;
 								}
-
+								$result['message'] = $payment->receiptUrl;
 								return $result;
 							}
 						}

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -3139,7 +3139,7 @@ class User extends DataObject {
 				]),
 				'totalPaid' => StringUtils::formatCurrency($userPayment->totalPaid),
 				'paymentType' => $userPayment->paymentType,
-				'stripeReceiptUrl' => $userPayment->stripeReceiptUrl,
+				'receiptUrl' => $userPayment->receiptUrl,
 			];
 		}
 

--- a/code/web/sys/Account/UserPayment.php
+++ b/code/web/sys/Account/UserPayment.php
@@ -28,7 +28,7 @@ class UserPayment extends DataObject {
 	public $pay360TransactionStateMessage;
 	public $pay360Timestamp;
 	public $requestingUrl;
-	public $stripeReceiptUrl;
+	public $receiptUrl;
 
 	static $_objectStructure = [];
 	static function getObjectStructure(string $context = ''): array {
@@ -155,11 +155,11 @@ class UserPayment extends DataObject {
 				'description' => 'Where the payment was requested from',
 				'readOnly' => true,
 			],
-			'stripeReceiptUrl' => [
-				'property' => 'stripeReceiptUrl',
+			'receiptUrl' => [
+				'property' => 'receiptUrl',
 				'type' => 'url',
-				'label' => 'Stripe Receipt URL',
-				'description' => 'The URL to the Stripe payment receipt.',
+				'label' => 'Receipt URL',
+				'description' => 'The URL to the payment receipt.',
 				'readOnly' => true,
 			]
 		];

--- a/code/web/sys/DBMaintenance/version_updates/26.06.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/26.06.00.php
@@ -39,6 +39,15 @@ function getUpdates26_06_00(): array {
 
 		// stephen
 
+		'user_payments_receipt_url_rename' => [
+		'title' => 'Rename Receipt URL Column',
+		'description' => 'Rename column from stripeReceiptUrl to receiptUrl.',
+		'continueOnError' => false,
+		'sql' => [
+			'ALTER TABLE user_payments CHANGE stripeReceiptUrl receiptUrl VARCHAR(255) DEFAULT NULL'
+		]
+	], //user_payments_receipt_url_rename
+
 		//other
 
 	];

--- a/code/web/sys/ECommerce/SquareSetting.php
+++ b/code/web/sys/ECommerce/SquareSetting.php
@@ -166,4 +166,159 @@ class SquareSetting extends DataObject {
 			unset($this->_libraries);
 		}
 	}
+
+	public function submitTransaction(UserPayment $payment, string $paymentToken, string $squareOrderId, array $amountMoney): array {
+		require_once ROOT_DIR . '/sys/CurlWrapper.php';
+
+		$paymentRequest = new CurlWrapper();
+
+		$paymentRequest->addCustomHeaders([
+			'Content-Type: application/json',
+			'Square-Version: 2023-06-08',
+			"Authorization: Bearer $this->accessToken",
+		], true);
+
+		$baseUrl = 'https://connect.squareup.com';
+
+		if ($this->sandboxMode == 1) {
+			$baseUrl = 'https://connect.squareupsandbox.com';
+		}
+
+		$body = [
+			'idempotency_key' => strval($payment->id),
+			'amount_money' => $amountMoney,
+			'source_id' => $paymentToken,
+			'order_id' => $squareOrderId
+		];
+
+		$paymentUrl = $baseUrl . '/v2/payments';
+
+		$paymentRequestResults = $paymentRequest->curlPostBodyData($paymentUrl, $body);
+
+		ExternalRequestLogEntry::logRequest(
+			'fine_payment.completeSquareOrder',
+			'POST',
+			$paymentUrl,
+			$paymentRequest->getHeaders(),
+			json_encode($body),
+			$paymentRequest->getResponseCode(),
+			$paymentRequestResults,
+			[]
+		);
+
+		$decodedPaymentRequestResults = json_decode($paymentRequestResults);
+
+		if (!isset($decodedPaymentRequestResults->payment)) {
+			$error = $decodedPaymentRequestResults->errors[0] ?? null;
+
+			$errorMessage =
+				$error->detail ??
+				$error->code ??
+				'Unknown Square payment error';
+
+			return [
+				'success' => false,
+				'message' => $errorMessage,
+			];
+		}
+
+		return [
+			'success' => true,
+			'payment' => $decodedPaymentRequestResults->payment,
+		];
+	}
+
+	public function createLineItems(UserPayment $payment): array {
+		require_once ROOT_DIR . '/sys/CurlWrapper.php';
+		require_once ROOT_DIR . '/sys/Account/UserPaymentLine.php';
+
+		$paymentRequest = new CurlWrapper();
+
+		$paymentRequest->addCustomHeaders([
+			'Content-Type: application/json',
+			'Square-Version: 2023-06-08',
+			"Authorization: Bearer $this->accessToken",
+		], true);
+
+		$baseUrl = 'https://connect.squareup.com';
+
+		if ($this->sandboxMode == 1) {
+			$baseUrl = 'https://connect.squareupsandbox.com';
+		}
+
+		$userPaymentLine = new UserPaymentLine();
+		$userPaymentLine->paymentId = $payment->id;
+
+		$lineItems = [];
+
+		if ($userPaymentLine->find()) {
+			while ($userPaymentLine->fetch()) {
+				$lineItems[] = [
+					'name' => $userPaymentLine->description,
+					'quantity' => '1',
+					'base_price_money' => [
+						'amount' => (int)round($userPaymentLine->amountPaid * 100),
+						'currency' => 'USD'
+					]
+				];
+			}
+		}
+
+		if (empty($lineItems)) {
+			return [
+				'success' => false,
+				'message' => 'No payment line items were found.',
+			];
+		}
+
+		$orderUrl = $baseUrl . '/v2/orders';
+
+		$orderBody = [
+			'idempotency_key' => strval($payment->id) . '-order',
+			'order' => [
+				'location_id' => strval($this->locationId),
+				'line_items' => $lineItems
+			]
+		];
+
+		$orderResponse = $paymentRequest->curlPostBodyData($orderUrl, $orderBody);
+
+		ExternalRequestLogEntry::logRequest(
+			'fine_payment.createSquareOrder',
+			'POST',
+			$orderUrl,
+			$paymentRequest->getHeaders(),
+			json_encode($orderBody),
+			$paymentRequest->getResponseCode(),
+			$orderResponse,
+			[]
+		);
+
+		$decodedOrder = json_decode($orderResponse);
+
+		$squareOrderId = $decodedOrder->order->id ?? null;
+
+		if ($squareOrderId === null) {
+			$error = $decodedOrder->errors[0] ?? null;
+
+			$errorMessage =
+				$error->detail ??
+				$error->code ??
+				'Unknown Square order error';
+
+			return [
+				'success' => false,
+				'message' => $errorMessage,
+			];
+		}
+
+		return [
+			'success' => true,
+			'orderId' => $squareOrderId,
+			'amountMoney' => [
+				'amount' => $decodedOrder->order->total_money->amount,
+				'currency' => $decodedOrder->order->total_money->currency
+			],
+		];
+	}
 }

--- a/code/web/sys/ECommerce/StripeSetting.php
+++ b/code/web/sys/ECommerce/StripeSetting.php
@@ -288,7 +288,7 @@ class StripeSetting extends DataObject {
 						if ($chargeRequest->getResponseCode() == 200) {
 							$chargeData = json_decode($chargeResponse, true);
 							if (!empty($chargeData['receipt_url'])) {
-								$payment->stripeReceiptUrl = $chargeData['receipt_url'];
+								$payment->receiptUrl = $chargeData['receipt_url'];
 							}
 						}
 					}
@@ -303,8 +303,8 @@ class StripeSetting extends DataObject {
 								'isPublicFacing' => true,
 							]),
 						];
-						if (!empty($payment->stripeReceiptUrl)) {
-							$result['receiptUrl'] = $payment->stripeReceiptUrl;
+						if (!empty($payment->receiptUrl)) {
+							$result['receiptUrl'] = $payment->receiptUrl;
 						}
 						return $result;
 					} else {
@@ -322,8 +322,8 @@ class StripeSetting extends DataObject {
 										'isPublicFacing' => true,
 									]),
 								];
-								if (!empty($payment->stripeReceiptUrl)) {
-									$result['receiptUrl'] = $payment->stripeReceiptUrl;
+								if (!empty($payment->receiptUrl)) {
+									$result['receiptUrl'] = $payment->receiptUrl;
 								}
 								return $result;
 							} else {


### PR DESCRIPTION
https://aspen-discovery.atlassian.net/browse/DIS-2384

Creates an itemized receipt for Square, modeled after the Stripe receipt link.

**Note:** Receipts for Square apparently don't work in Sandbox/Dev mode. The link is provided but returns a 404. **I was unable to see a real receipt besides a link.** So this will require some other type of testing. https://developer.squareup.com/forums/t/receipt-preview/15135

- Puts a "View Receipt" button in the completed fine modal and completed donation modal when Square is used.

- Modifies MyAccount.AJAX.php completeSquareOrder() so that it hits the Orders API with a list of line items. developer.squareup.com/reference/square/orders-api/create-order

Once an Order is created, we use the order id and put it in the Payments ('/v2/payments') object, and complete the request the same as before. This should link the list of line items to the payment and create an itemized receipt. It does this for fines and donations. (A donation will always have one line item.)

- Renames user_payments.stripeReceiptUrl to just receiptUrl and records the url there.

- Breaks down and flattens the logic in completeSquareOrder() a bit and puts some of the implementation in SquareSetting.php (modeling it basically after StripeSetting.php). Creates a separate method for building up the line items. This was getting a little confusing once line items were added so I thought this was appropriate.

- Fixes some error message handling. It looks like we were checking for ->error->detail but Square returns errors as an array.

- I noticed ecommerce/Donations Report records every donation twice for me. This is worth looking into.