### PR TITLE
DIS-2228: Add holiday and special hours to LiDA

### DIFF
--- a/code/web/release_notes/26.05.00.MD
+++ b/code/web/release_notes/26.05.00.MD
@@ -84,6 +84,7 @@
     - Update the Koha holiday import flow support the new holiday table structure.
     - Update the Sierra Batch Update Holidays flow support the new holiday table structure.
     - Move Holidays and Special Hours section after Events section in Libray Systems.
+- Add support for holiday closures and special hours in Aspen LiDA location hours displays.  ([DIS-2228](https://aspen-discovery.atlassian.net/browse/DIS-2228)) (*YL*)
 
 <div markdown="1" class="settings">
 

--- a/code/web/sys/LibraryLocation/Location.php
+++ b/code/web/sys/LibraryLocation/Location.php
@@ -3179,11 +3179,34 @@ class Location extends DataObject {
 		} else {
 			$apiInfo['email'] = $this->contactEmail;
 		}
+
+		require_once ROOT_DIR . '/sys/LibraryLocation/Holiday.php';
+
+		$today = (int)date('w');
+		$specialHours = new Holiday();
+		$specialHours->locationId = $this->locationId;
+		$specialHours->date = date('Y-m-d');
+		$isHoliday = $specialHours->find(true);
+		if ($isHoliday){
+			$apiInfo['hours'][] = [
+				'day' => $today,
+				'dayName' => $specialHours->name,
+				'isClosed' => (bool)$specialHours->closed,
+				'open' => $specialHours->open ?? '',
+				'close' => $specialHours->close ?? '',
+				'notes' => '',
+			];
+		}
+
 		unset($this->_hours);
 		$hours = $this->getHours();
 		foreach ($hours as $hour) {
+			$dayOfWeek = (int)$hour->day;
+			if ($isHoliday && $today === $dayOfWeek) {
+				continue;
+			}
 			$apiInfo['hours'][] = [
-				'day' => (int)$hour->day,
+				'day' => $dayOfWeek,
 				'dayName' => LocationHours::$dayNames[$hour->day],
 				'isClosed' => (bool)$hour->closed,
 				'open' => $hour->open,


### PR DESCRIPTION
Add support for holiday closures and special hours in Aspen LiDA location hours displays so that LiDA messaging is aligned with Discovery.

To Test:
1. Apply PR
2. Log in to LiDA and see the holiday closures and special hours message. 