### PR TITLE
DIS-2253: Group Same Title Materials Requests

### DIFF
--- a/code/web/services/Admin/ObjectEditor.php
+++ b/code/web/services/Admin/ObjectEditor.php
@@ -1352,7 +1352,9 @@ abstract class ObjectEditor extends Admin_Admin {
 		$filterFields = $this->getFilterFields($object::getObjectStructure($this->getContext()));
 		$appliedFilters = $this->getAppliedFilters($filterFields);
 		foreach ($appliedFilters as $fieldName => $filter) {
-			$this->applyFilter($object, $fieldName, $filter);
+			if ($filter['field']['type'] != "calculatedInteger" || !empty($filter->filterValue)) {
+				$this->applyFilter($object, $fieldName, $filter);
+			}
 		}
 	}
 

--- a/code/web/services/MaterialsRequest/AJAX.php
+++ b/code/web/services/MaterialsRequest/AJAX.php
@@ -597,8 +597,14 @@ class MaterialsRequest_AJAX extends JSON_Action {
 					}
 					if (!empty($newStatus)) {
 						if ($materialsRequest->status != $newStatus) {
-							$materialsRequest->status = $newStatus;
-							$sameStatus = false;
+							require_once ROOT_DIR . '/sys/MaterialsRequests/MaterialsRequestStatus.php';
+							$status = new MaterialsRequestStatus();
+							$status->id = $materialsRequest->status;
+							$status->find(true);
+							if (!$status->isPatronCancel) {
+								$materialsRequest->status = $newStatus;
+								$sameStatus = false;
+							}
 						}
 					}
 					if ($materialsRequest->update()){
@@ -619,6 +625,15 @@ class MaterialsRequest_AJAX extends JSON_Action {
 						'isPublicFacing' => true,
 					]),
 					'modalBody' => "Successfully updated " . $numAssigneeUpdates . " assignees and " . $numStatusUpdates . " statuses of " . $numRequestsToUpdate . " requests.",
+				];
+			} else {
+				return [
+					'success' => true,
+					'title' => translate([
+						'text' => 'No Changes Made',
+						'isPublicFacing' => true,
+					]),
+					'modalBody' => 'No requests required updating.'
 				];
 			}
 		}

--- a/code/web/services/MaterialsRequest/Submit.php
+++ b/code/web/services/MaterialsRequest/Submit.php
@@ -253,6 +253,11 @@ class MaterialsRequest_Submit extends Action {
 											$materialsRequestTitle->whereAdd("REGEXP_REPLACE(title, '[^a-zA-Z ]', '') REGEXP '" . $titlePattern . "'");
 											$materialsRequestTitle->whereAdd("REGEXP_REPLACE(author, '[^a-zA-Z ]', '') REGEXP '" . $authorPattern . "'");
 										}
+										//try title & format if no match
+										elseif (!empty($this->title) && !empty($this->format)) {
+											$materialsRequestTitle->whereAdd("REGEXP_REPLACE(title, '[^a-zA-Z ]', '') REGEXP '" . $titlePattern . "'");
+											$materialsRequestTitle->format = $this->format;
+										}
 										//try only title if still no match
 										elseif (!empty($materialsRequest->title)) {
 											$materialsRequestTitle->whereAdd("REGEXP_REPLACE(title, '[^a-zA-Z ]', '') REGEXP '" . $titlePattern . "'");

--- a/code/web/sys/MaterialsRequests/MaterialsRequest.php
+++ b/code/web/sys/MaterialsRequests/MaterialsRequest.php
@@ -1001,6 +1001,11 @@ class MaterialsRequest extends DataObject {
 					$materialsRequestTitle->whereAdd("REGEXP_REPLACE(title, '[^a-zA-Z ]', '') REGEXP '" . $titlePattern . "'");
 					$materialsRequestTitle->whereAdd("REGEXP_REPLACE(author, '[^a-zA-Z ]', '') REGEXP '" . $authorPattern . "'");
 				}
+				//try title & format if no match
+				elseif (!empty($this->title) && !empty($this->format)) {
+					$materialsRequestTitle->whereAdd("REGEXP_REPLACE(title, '[^a-zA-Z ]', '') REGEXP '" . $titlePattern . "'");
+					$materialsRequestTitle->format = $this->format;
+				}
 				//try only title if still no match
 				elseif (!empty($this->title)) {
 					$materialsRequestTitle->whereAdd("REGEXP_REPLACE(title, '[^a-zA-Z ]', '') REGEXP '" . $titlePattern . "'");


### PR DESCRIPTION
QA Updates:
- Add a check for title & format matches after title & author, before solely checking title match
- Update ObjectEditor.php applyFilters() to not try and query empty data sets for integers
- Update batch updating title requests so that "cancelled by patron" status does not get updated by bulk updates


Tested on my local instance of Aspen