### PR TITLE
DIS-2465: Sierra ILL item renewals 

### DIFF
--- a/code/web/Drivers/Sierra.php
+++ b/code/web/Drivers/Sierra.php
@@ -846,9 +846,7 @@ class Sierra extends AbstractIlsDriver {
 					}
 					$curCheckout->formats = ['Unknown'];
 					$homeLibrary = $patron->getHomeLibrary();
-					if ($homeLibrary !== null && !$homeLibrary->allowToRenewILL) {
-						$curCheckout->canRenew = false;
-					}
+					$curCheckout->canRenew = !($homeLibrary && !$homeLibrary->allowToRenewILL);
 				} else {
 					preg_match($this->urlIdRegExp, $entry->item, $m);
 					$itemIdShort = $m[1];

--- a/code/web/Drivers/Sierra.php
+++ b/code/web/Drivers/Sierra.php
@@ -845,6 +845,10 @@ class Sierra extends AbstractIlsDriver {
 						$curCheckout->author = 'Unknown';
 					}
 					$curCheckout->formats = ['Unknown'];
+					$homeLibrary = $patron->getHomeLibrary();
+					if ($homeLibrary !== null && !$homeLibrary->allowToRenewILL) {
+						$curCheckout->canRenew = false;
+					}
 				} else {
 					preg_match($this->urlIdRegExp, $entry->item, $m);
 					$itemIdShort = $m[1];

--- a/code/web/release_notes/26.06.00.MD
+++ b/code/web/release_notes/26.06.00.MD
@@ -13,6 +13,15 @@
 //stephen
 
 //yanjun
+### Sierra Updates
+- Add a library setting to control whether ILL items are renewable. ([DIS-2465](https://aspen-discovery.atlassian.net/browse/DIS-2465)) (*YL*)
+
+<div markdown="1" class="settings">
+
+#### New Settings
+- Library Systems > Interlibrary loans > Allow ILL Renewals
+
+</div>
 
 //imani
 

--- a/code/web/sys/DBMaintenance/version_updates/26.06.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/26.06.00.php
@@ -22,6 +22,16 @@ function getUpdates26_06_00(): array {
 		//kodi
 
 		//yanjun
+		'allow_to_renew_ill_items' => [
+			'title' => 'Allow Renewing ILL Items',
+			'description' => 'Add allowToRenewILL to the library table to control whether patrons can renew ILL items.',
+			'continueOnError' => false,
+			'sql' => [
+				'ALTER TABLE library ADD COLUMN allowToRenewILL TINYINT(1) DEFAULT 1'
+			]
+		], //allow_to_renew_ill_items
+
+
 
 		//imani
 

--- a/code/web/sys/LibraryLocation/Library.php
+++ b/code/web/sys/LibraryLocation/Library.php
@@ -418,6 +418,7 @@ class Library extends DataObject {
 	public $localIllRequestType;
 	public $maximumLocalIllRequests;
 	public $includeRemoteCheckoutsInMaxLocalIllRequests;
+	public $allowToRenewILL;
 	public $localIllEmail;
 	/** @noinspection PhpUnused */
 	public $_localIllEmailSuccessMessage;
@@ -4212,6 +4213,15 @@ class Library extends DataObject {
 						'description' => 'Include Remote Checkouts in Max Local ILL requests',
 						'note' => "Remote checkouts are checkouts that were picked up from the item's owning home group (but that are not owned by the patron's home group)",
 						'default' => 1
+					],
+					'allowToRenewILL' => [
+						'property' => 'allowToRenewILL',
+						'type' => 'checkbox',
+						'label' => 'Allow ILL Renewals',
+						'description' => 'Whether or not patrons can renew ILL items.',
+						'note' => 'Applies to Sierra Only',
+						'default' => 1,
+						'relatedIls' => ['sierra'],
 					],
 					'ILLSystem' => [
 						'property' => 'ILLSystem',


### PR DESCRIPTION
For Sierra libraries, ILL items are currently treated as renewable by default. Add a library setting that allows libraries to control whether ILL items should be renewable.

To Test:
1. Apply PR to a Sierra Library and run db update
2. Log in as a patron who has an ILL item checked out 
3. Confirm that the ILL item is renewable
4. Deselect Library Systems > Interlibrary loans > Allow ILL Renewals
5. Confirm that the ILL item is not renewable