### PR TITLE
DIS-2286: Size-specific original URLs 

### DIFF
--- a/code/web/release_notes/26.06.00.MD
+++ b/code/web/release_notes/26.06.00.MD
@@ -140,6 +140,9 @@
 
 </div>
 
+### Other Updates
+- Store original cover URLs by size and allow cover URLs to regenerate on reload. ([DIS-2286](https://aspen-discovery.atlassian.net/browse/DIS-2286)) (*YL*)
+
 //imani
 
 //jonah

--- a/code/web/services/GroupedWork/AJAX.php
+++ b/code/web/services/GroupedWork/AJAX.php
@@ -2861,7 +2861,7 @@ class GroupedWork_AJAX extends JSON_Action {
 			$bookcoverInfo->setImageSource('');
 			require_once ROOT_DIR . '/sys/SystemVariables.php';
 			if (SystemVariables::getSystemVariables()->useOriginalCoverUrls) {
-				$bookcoverInfo->setOriginalUrl(null);
+				$bookcoverInfo->clearOriginalUrls();
 				$bookcoverInfo->setLastUrlValidation(null);
 			}
 			$bookcoverInfo->update();

--- a/code/web/sys/Covers/BookCoverInfo.php
+++ b/code/web/sys/Covers/BookCoverInfo.php
@@ -18,6 +18,9 @@ class BookCoverInfo extends DataObject {
 	protected $uploadedImage;
 	protected $disallowThirdPartyCover;
 	protected $original_url;
+	protected $original_url_small;
+	protected $original_url_medium;
+	protected $original_url_large;
 	protected $last_url_validation;
 
 	public function getNumericColumnNames(): array {
@@ -92,8 +95,12 @@ class BookCoverInfo extends DataObject {
 	 * Get the original URL of the cover image
 	 * @return string|null
 	 */
-	public function getOriginalUrl(): ?string
+	public function getOriginalUrl(string $size): ?string
 	{
+		$sizeProperty = $this->getOriginalUrlPropertyForSize($size);
+		if ($sizeProperty !== null && !empty($this->$sizeProperty)) {
+			return $this->$sizeProperty;
+		}
 		return $this->original_url;
 	}
 
@@ -101,8 +108,20 @@ class BookCoverInfo extends DataObject {
 	 * Set the original URL of the cover image
 	 * @param ?string $url
 	 */
-	public function setOriginalUrl(?string $url): void {
+	public function setOriginalUrl(?string $url, string $size): void {
+		$sizeProperty = $this->getOriginalUrlPropertyForSize($size);
+		if ($sizeProperty !== null) {
+			$this->__set($sizeProperty, $url);
+			return;
+		}
 		$this->__set('original_url', $url);
+	}
+
+	public function clearOriginalUrls(): void {
+		$this->__set('original_url', null);
+		$this->__set('original_url_small', null);
+		$this->__set('original_url_medium', null);
+		$this->__set('original_url_large', null);
 	}
 
 	/**
@@ -181,5 +200,14 @@ class BookCoverInfo extends DataObject {
 
 	public function setFirstLoaded(int $firstLoaded): void {
 		$this->firstLoaded = $firstLoaded;
+	}
+
+	private function getOriginalUrlPropertyForSize(string $size): ?string {
+		return match ($size) {
+			'small' => 'original_url_small',
+			'medium' => 'original_url_medium',
+			'large' => 'original_url_large',
+			default => null,
+		};
 	}
 }

--- a/code/web/sys/Covers/BookCoverInfo.php
+++ b/code/web/sys/Covers/BookCoverInfo.php
@@ -95,6 +95,7 @@ class BookCoverInfo extends DataObject {
 	 * Get the original URL of the cover image
 	 * @return string|null
 	 */
+	//TODO: Keep original_url as a legacy fallback for one release, then remove the fallback and drop the column
 	public function getOriginalUrl(string $size): ?string
 	{
 		$sizeProperty = $this->getOriginalUrlPropertyForSize($size);

--- a/code/web/sys/Covers/BookCoverProcessor.php
+++ b/code/web/sys/Covers/BookCoverProcessor.php
@@ -46,10 +46,9 @@ class BookCoverProcessor {
 			if ($this->getCachedCover()) {
 				return true;
 			}
-		}
-
-		if ($this->checkForEarlyRedirect()) {
-			return true;
+			if ($this->checkForEarlyRedirect()) {
+				return true;
+			}
 		}
 
 		if($this->bookCoverInfo->getImageSource() == 'upload') {
@@ -2361,7 +2360,7 @@ class BookCoverProcessor {
 								return false;
 							}
 
-							$originalUrl = $referencedCoverInfo->getOriginalUrl();
+							$originalUrl = $referencedCoverInfo->getOriginalUrl($this->size);
 							if (!empty($originalUrl)) {
 								$url = $originalUrl;
 								$maybeHash = substr($originalUrl, 0, 32);
@@ -2649,7 +2648,7 @@ class BookCoverProcessor {
 				];
 				$validationHash = md5(implode('|', $validationFields));
 				$urlToStore = $validationHash . $url;
-				$this->bookCoverInfo->setOriginalUrl($urlToStore);
+				$this->bookCoverInfo->setOriginalUrl($urlToStore, $this->size);
 				$this->bookCoverInfo->update();
 
 				header("HTTP/1.1 301 Moved Permanently");
@@ -2672,7 +2671,7 @@ class BookCoverProcessor {
 	 */
 	private function checkForEarlyRedirect(): bool {
 		if ($this->bookCoverInfo &&
-			!empty($this->bookCoverInfo->getOriginalUrl()) &&
+			!empty($this->bookCoverInfo->getOriginalUrl($this->size)) &&
 			SystemVariables::getSystemVariables()->useOriginalCoverUrls &&
 			!str_starts_with($this->bookCoverInfo->getImageSource(), 'reference')
 		) {
@@ -2684,13 +2683,12 @@ class BookCoverProcessor {
 				$this->bookCoverInfo->getDisallowThirdPartyCover()
 			];
 			$currentHash = md5(implode('|', $validationFields));
-			$storedHash = substr($this->bookCoverInfo->getOriginalUrl(), 0, 32);
-			$url = substr($this->bookCoverInfo->getOriginalUrl(), 32);
+			$originalUrl = $this->bookCoverInfo->getOriginalUrl($this->size);
+			$storedHash = substr($originalUrl, 0, 32);
+			$url = substr($originalUrl, 32);
 
 			if ($currentHash === $storedHash && !empty($url)) {
-				// Check if URL needs to be validated based upon the expiration time; force validation if reload flag is set.
-				$forceValidation = $this->reload;
-				$validationResult = $this->validateCoverUrl($url, $this->bookCoverInfo->getImageSource(), $forceValidation);
+				$validationResult = $this->validateCoverUrl($url, $this->bookCoverInfo->getImageSource(), false);
 				if ($validationResult !== false) {
 					header("HTTP/1.1 301 Moved Permanently");
 					header("Location: $url");
@@ -2702,7 +2700,7 @@ class BookCoverProcessor {
 			}
 		} else {
 			$this->log("Debug - Early conditions failed: BookCoverInfo exists: " . ($this->bookCoverInfo ? "Yes" : "No") .
-				", Original URL exists: " . (!empty($this->bookCoverInfo) && !empty($this->bookCoverInfo->getOriginalUrl()) ? "Yes" : "No") .
+				", Original URL exists: " . (!empty($this->bookCoverInfo) && !empty($this->bookCoverInfo->getOriginalUrl($this->size)) ? "Yes" : "No") .
 				", useOriginalCoverUrls enabled: " . (SystemVariables::getSystemVariables()->useOriginalCoverUrls ? "Yes" : "No"));
 		}
 		return false;

--- a/code/web/sys/Covers/BookCoverProcessor.php
+++ b/code/web/sys/Covers/BookCoverProcessor.php
@@ -43,10 +43,7 @@ class BookCoverProcessor {
 
 		if (!$this->reload) {
 			$this->log("Looking for Cached cover", Logger::LOG_NOTICE);
-			if ($this->getCachedCover()) {
-				return true;
-			}
-			if ($this->checkForEarlyRedirect()) {
+			if ($this->getCachedCover() || $this->checkForEarlyRedirect()) {
 				return true;
 			}
 		}

--- a/code/web/sys/DBMaintenance/version_updates/26.06.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/26.06.00.php
@@ -112,8 +112,16 @@ function getUpdates26_06_00(): array {
 				'ALTER TABLE library ADD COLUMN allowToRenewILL TINYINT(1) DEFAULT 1'
 			]
 		], //allow_to_renew_ill_items
-
-
+		'store_original_cover_urls_by_size' => [
+			'title' => 'Store Original Cover URLs by Size',
+			'description' => 'Store original cover URLs separately for small, medium, and large cover requests.',
+			'continueOnError' => false,
+			'sql' => [
+				"ALTER TABLE bookcover_info ADD COLUMN IF NOT EXISTS original_url_small TEXT DEFAULT NULL",
+				"ALTER TABLE bookcover_info ADD COLUMN IF NOT EXISTS original_url_medium TEXT DEFAULT NULL",
+				"ALTER TABLE bookcover_info ADD COLUMN IF NOT EXISTS original_url_large TEXT DEFAULT NULL",
+			]
+		], //store_original_cover_urls_by_size
 
 		//imani
 


### PR DESCRIPTION
bookcover_info.original_url is currently a single value per grouped work. When System Variables > Use Original Cover URLs is enabled, early redirect returns only the original_url stored in DB regardless of requested size and reload=1. 

We should store original URLs by size (small, medium, large) instead of one shared URL and allow regenerating the URL on reload=1 

To test:
1. Enable System Variables > Use Original Cover URLs.
2. Configured Syndetics or another third-party cover.
3. Find a grouped work that uses a third-party cover and open a cover URL like: `https://AAA.aspendiscovery.org/bookcover.php?id={groupedWorkId}&size=medium&type=grouped_work&category=Books`
5. Confirm the request redirects to the vendor URL, for example: `https://syndetics.com/index.aspx?type=xw12&pagename=MC.GIF&client={client}&isbn={isbn}`
7. Change `size=medium` to `size=large` in the Aspen bookcover.php URL and reload.
8. Confirm it still redirects to the same medium Syndetics URL (MC.GIF) instead of a large one.
9. Add `&reload=1` to the Aspen bookcover.php URL and reload.
10. Before the fix, confirm it still redirects to the same medium Syndetics URL (MC.GIF).
11. Apply the PR.
12. Open the same bookcover.php URL with `size=large` and reload.
13. Confirm it now redirects to the large vendor URL with `LC.GIF`.
14. Add `&reload=1` to the same large Aspen URL and reload again.
15. Confirm it still redirects to the large vendor URL with `LC.GIF`.