### PR TITLE
Dis 2420: Sierra ILL Renewal

### DIFF
--- a/code/web/release_notes/26.06.00.MD
+++ b/code/web/release_notes/26.06.00.MD
@@ -132,6 +132,7 @@
 
 ### Sierra Updates
 - Add a library setting to control whether ILL items are renewable. ([DIS-2465](https://aspen-discovery.atlassian.net/browse/DIS-2465)) (*YL*)
+- Allow Sierra ILL checkouts to renew without recordId. ([DIS-2420](https://aspen-discovery.atlassian.net/browse/DIS-2420)) (*YL*)
 
 <div markdown="1" class="settings">
 
@@ -139,6 +140,7 @@
 - Library Systems > Interlibrary loans > Allow ILL Renewals
 
 </div>
+
 
 //imani
 

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -2304,10 +2304,10 @@ class MyAccount_AJAX extends JSON_Action {
 
 	function renewCheckout(): array {
 		$this->requireLoggedInUser();
-		$this->checkRequiredParameters(['patronId', 'recordId']);
+		$this->checkRequiredParameters(['patronId']);
 		$user = UserAccount::getLoggedInUser();
 		$patronId = $_REQUEST['patronId'];
-		$recordId = $_REQUEST['recordId'];
+		$recordId = $_REQUEST['recordId'] ?? '';
 		$renewIndicator = $_REQUEST['renewIndicator'] ?? '';
 		$patron = $user->getUserReferredTo($patronId);
 		$itemId = null;
@@ -2315,8 +2315,17 @@ class MyAccount_AJAX extends JSON_Action {
 
 		if ($patron) {
 			$accountProfile = $patron->getAccountProfile();
+			$driver = $accountProfile?->driver ?? '';
+
+			// Sierra ILL does not have recordId
+			$requiresRecordId = $driver !== 'Sierra';
+
 			// Evolve does not require a renew indicator
-			$requiresRenewIndicator = !($accountProfile && $accountProfile->driver === 'Evolve');
+			$requiresRenewIndicator = $driver !== 'Evolve';
+
+			if ($requiresRecordId) {
+				$this->checkRequiredParameters(['recordId']);
+			}
 			if ($requiresRenewIndicator) {
 				$this->checkRequiredParameters(['renewIndicator']);
 				if (strpos($renewIndicator, '|') > 0) {
@@ -2333,6 +2342,7 @@ class MyAccount_AJAX extends JSON_Action {
 		} else {
 			$renewResults = $this->failureResult(null, 'Sorry, it looks like you don\'t have access to that patron.');
 		}
+
 
 		global $interface;
 		$interface->assign('renewResults', $renewResults);


### PR DESCRIPTION
For Sierra libraries, ILL checkouts do not have a record ID, and Aspen sets checkout recordId to blank. However, /MyAccount/AJAX?method=renewCheckout requires recordId, which causes ILL renewal to fail.

We should allow renewals to proceed without recordId when the patron’s ILS driver is Sierra, while keeping the requirement for other drivers.

To Test:
1. Set up ILL for Sierra libraries 
2. Log in to an account with an ILL item checked out
3. Attempt to renew the ILL item from My Account.
4. The renewal fails
5. Apply the PR
6. Attempt to renew the ILL item again
7. The renewal succeeds