### PR TITLE
DIS-2366: Guard material requests pagination against division by zero

### DIFF
--- a/code/web/release_notes/26.06.00.MD
+++ b/code/web/release_notes/26.06.00.MD
@@ -140,6 +140,9 @@
 
 </div>
 
+### Material Requests Updates
+- Fix a division by zero error when viewing all filtered Material Requests with no matching results. ([DIS-2366](https://aspen-discovery.atlassian.net/browse/DIS-2366)) (*YL*)
+
 //imani
 
 //jonah

--- a/code/web/services/MaterialsRequest/ManageRequests.php
+++ b/code/web/services/MaterialsRequest/ManageRequests.php
@@ -390,7 +390,7 @@ class MaterialsRequest_ManageRequests extends Admin_Admin {
 				}
 			}
 			if($materialsRequestsPerPage == 'all') {
-				$materialsRequestsPerPage = $materialsRequests->count();
+				$materialsRequestsPerPage = max(1, $materialsRequests->count());
 				$interface->assign('showingAllRequests', true);
 			} else {
 				$interface->assign('showingAllRequests', false);


### PR DESCRIPTION
When viewing Material Requests, if staff selects “All” from the Entries Per Page dropdown and then modifies the filters, the page throws a Division by Zero error when the filtered result set is empty. Error as below:

Division by zero

Backtrace

[43] - /usr/local/aspen-discovery/code/web/sys/Pager.php
Pager->__construct [413] - /usr/local/aspen-discovery/code/web/services/MaterialsRequest/ManageRequests.php
MaterialsRequest_ManageRequests->launch [908] - /usr/local/aspen-discovery/code/web/index.php

To Test:
1. Go to Manage Materials Requests, set Entries Per Page to All 
2. Apply filters that return no results
3. See error
4. Apply the PR
5. Refresh the page with the same filters
6. See the page loads and shows an empty result. 