### PR TITLE
DIS-2412: Use grouped work display info for series in search results

### DIFF
--- a/code/web/RecordDrivers/GroupedWorkDriver.php
+++ b/code/web/RecordDrivers/GroupedWorkDriver.php
@@ -3059,6 +3059,10 @@ class GroupedWorkDriver extends IndexRecordDriver {
 				return true;
 			}
 		}
+		$displayInfo = $this->getDisplayInfo();
+		if ($displayInfo != null && !empty($displayInfo->seriesName)) {
+			return true;
+		}
 		//Get a list of isbns from the record
 		$novelist = NovelistFactory::getNovelist();
 		return $novelist->doesGroupedWorkHaveCachedSeries($this->getPermanentId());

--- a/code/web/release_notes/26.06.00.MD
+++ b/code/web/release_notes/26.06.00.MD
@@ -140,6 +140,9 @@
 
 </div>
 
+### Series Updates
+- Search results now display series information from Grouped Work Display Info when indexed series and NoveList series are not available.([DIS-2412](https://aspen-discovery.atlassian.net/browse/DIS-2412)) (*YL*)
+
 //imani
 
 //jonah


### PR DESCRIPTION
Grouped works/records detail pages will display Series information if Aspen can get Series data from 1) Indexed Series, 2) NoveList, or 3) Grouped Work Display Info. 
Search results currently display Series data from 1) Indexed Series, 2) NoveList, but do not use 3) Grouped Work Display Info. We should update search results  for consistency with grouped work detail pages.

To test:
1. Make sure the Series Module is disabled and NoveList is not configured.
2. Find a grouped work that does not show any series information in search results.
3. Add series information in Grouped Work Display Info and reindex that grouped work.
4. Search for that grouped work.
5. Confirm that the series information only appears on the grouped work detail page but not in search results.
6. Apply the PR.
7. Search for the same grouped work again.
8. Confirm the series information now appears in the search results as well.