### PR TITLE
DIS-2478: Add Hoopla Content Ratings

### DIFF
--- a/code/reindexer/src/org/aspen_discovery/reindexer/HooplaProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/HooplaProcessor.java
@@ -19,6 +19,7 @@ import java.sql.SQLException;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Locale;
 
 class HooplaProcessor {
 	private final GroupedWorkIndexer indexer;
@@ -444,6 +445,10 @@ class HooplaProcessor {
 				boolean pa = productRS.getBoolean("pa");
 				boolean profanity = productRS.getBoolean("profanity");
 				String rating = productRS.getString("rating");
+				String normalizedRating = normalizeHooplaContentRating(rating);
+				if (normalizedRating != null) {
+					groupedWork.addContentRating(normalizedRating);
+				}
 
 				for (Scope scope : indexer.getScopes()) {
 					boolean okToAdd;
@@ -489,6 +494,38 @@ class HooplaProcessor {
 		doubleDecodeRawResponseRS.close();
 
 		return null;
+	}
+
+	private String normalizeHooplaContentRating(String rating) {
+		if (rating == null) {
+			return null;
+		}
+
+		String normalizedRating = rating.toUpperCase(Locale.ROOT).replaceAll("[-\\s]", "");
+		if (normalizedRating.isEmpty()) {
+			return null;
+		}
+
+		switch (normalizedRating) {
+			case "PG13":
+				return "PG-13 Rated";
+			case "NC17":
+				return "NC-17 Rated";
+			case "TVY7":
+				return "TV-Y7 Rated";
+			case "TVY":
+				return "TV-Y Rated";
+			case "TVG":
+				return "TV-G Rated";
+			case "TVPG":
+				return "TV-PG Rated";
+			case "TV14":
+				return "TV-14 Rated";
+			case "TVMA":
+				return "TV-MA Rated";
+			default:
+				return normalizedRating + " Rated";
+		}
 	}
 
 }

--- a/code/reindexer/src/org/aspen_discovery/reindexer/HooplaProcessor2.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/HooplaProcessor2.java
@@ -19,6 +19,7 @@ import java.sql.SQLException;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 
 class HooplaProcessor2 {
@@ -459,6 +460,11 @@ class HooplaProcessor2 {
 				boolean profanity = productRS.getBoolean("profanity");
 				String rating = productRS.getString("rating");
 
+				String normalizedRating = normalizeHooplaContentRating(rating);
+				if (normalizedRating != null) {
+					groupedWork.addContentRating(normalizedRating);
+				}
+
 				ItemInfo baseItemInfo = new ItemInfo();
 				baseItemInfo.setIsEContent(true);
 				baseItemInfo.seteContentUrl(rawResponse.getString("url"));
@@ -605,6 +611,38 @@ class HooplaProcessor2 {
 			}
 		}
 		return entitlementsByScope;
+	}
+
+	private String normalizeHooplaContentRating(String rating) {
+		if (rating == null) {
+			return null;
+		}
+
+		String normalizedRating = rating.toUpperCase(Locale.ROOT).replaceAll("[-\\s]", "");
+		if (normalizedRating.isEmpty()) {
+			return null;
+		}
+
+		switch (normalizedRating) {
+			case "PG13":
+				return "PG-13 Rated";
+			case "NC17":
+				return "NC-17 Rated";
+			case "TVY7":
+				return "TV-Y7 Rated";
+			case "TVY":
+				return "TV-Y Rated";
+			case "TVG":
+				return "TV-G Rated";
+			case "TVPG":
+				return "TV-PG Rated";
+			case "TV14":
+				return "TV-14 Rated";
+			case "TVMA":
+				return "TV-MA Rated";
+			default:
+				return normalizedRating + " Rated";
+		}
 	}
 
 }

--- a/code/web/release_notes/26.06.00.MD
+++ b/code/web/release_notes/26.06.00.MD
@@ -140,6 +140,9 @@
 
 </div>
 
+### Hoopla Updates
+- Content Rating facets now include ratings from Hoopla titles. ([DIS-2478](https://aspen-discovery.atlassian.net/browse/DIS-2478)) (*YL*)
+
 //imani
 
 //jonah


### PR DESCRIPTION
Hoopla provides movie and TV ratings in the metadata. We should index Hoopla rating values so they appear in the Content Rating facet 

To test:
1. Apply the PR.
2. Reindex Hoopla records.
3. Confirm Hoopla ratings now appear in the Content Rating facet.