### PR TITLE
DIS-2479: Display the count of Flex titles

### DIFF
--- a/code/web/release_notes/26.06.00.MD
+++ b/code/web/release_notes/26.06.00.MD
@@ -140,6 +140,15 @@
 
 </div>
 
+### Hoopla Updates
+- Display the number of Hoopla Flex titles for each library in Hoopla Settings for version 2. ([DIS-2479](https://aspen-discovery.atlassian.net/browse/DIS-2479)) (*YL*)
+<div markdown="1" class="settings">
+
+#### New Settings
+- Hoopla Settings > Hoopla Library Information > Flex Title Count
+
+</div>
+
 //imani
 
 //jonah

--- a/code/web/sys/Hoopla/LibraryHooplaSetting.php
+++ b/code/web/sys/Hoopla/LibraryHooplaSetting.php
@@ -119,6 +119,14 @@ class LibraryHooplaSetting extends DataObject
 				'default' => false,
 				'forcesReindex' => false,
 			],
+			'numFlexTitles' => [
+				'property' => 'numFlexTitles',
+				'type' => 'integer',
+				'label' => 'Flex Title Count',
+				'description' => 'The number of active Hoopla Flex titles in the database for this library',
+				'hideInLists' => false,
+				'readOnly' => true,
+			],
 		];
 
 		self::$_objectStructure[$context] = $structure;
@@ -147,6 +155,26 @@ class LibraryHooplaSetting extends DataObject
 			}
 		}
 		return $this->_hooplaSettings;
+	}
+
+	public function __get($name)
+	{
+		if ($name == 'numFlexTitles') {
+			return $this->getNumFlexTitlesInDb();
+		}
+		return parent::__get($name);
+	}
+
+	public function getNumFlexTitlesInDb(): int
+	{
+		global $aspen_db;
+
+		$countStmt = $aspen_db->prepare('SELECT COUNT(DISTINCT hooplaId) as numFlexTitles FROM hoopla_flex_availability WHERE scopeLibraryId = ?');
+		$countStmt->bindValue(1, $this->libraryId, PDO::PARAM_INT);
+		$countStmt->execute();
+		$result = $countStmt->fetch(PDO::FETCH_ASSOC);
+
+		return (int)$result['numFlexTitles'];
 	}
 
 	public function update(string $context = ''): int|bool


### PR DESCRIPTION
Add a read-only value to Hoopla version 2 library settings that shows the number of Flex titles currently in the database for each library.

To Test:
1. Make sure Hoopla is using version 2.
2. Apply the PR.
3. Go to Hoopla Settings.
4. Confirm the Flex Title Count is shown for each library setting, libraries with Flex titles enabled show the expected count and libraries without Flex titles show 0.