### PR TITLE
DIS-2126: Slow query in DatabaseCleanup

### DIFF
--- a/code/cron/src/com/turning_leaf_technologies/cron/DatabaseCleanup.java
+++ b/code/cron/src/com/turning_leaf_technologies/cron/DatabaseCleanup.java
@@ -207,55 +207,55 @@ public class DatabaseCleanup implements IProcessHandler {
 				processLog.addNote("Deleted " + numUpdates + " user links where the linked account does not exist");
 			}
 
-			numUpdates = dbConn.prepareStatement("DELETE FROM user_link_blocks where primaryAccountId NOT IN (select id from user)").executeUpdate();
+			numUpdates = dbConn.prepareStatement("DELETE ulb FROM user_link_blocks ulb LEFT JOIN user u ON ulb.primaryAccountId = u.id WHERE u.id IS NULL").executeUpdate();
 			if (numUpdates > 0){
 				processLog.incUpdated();
 				processLog.addNote("Deleted " + numUpdates + " user link blocks where the primary account does not exist");
 			}
 
-			numUpdates = dbConn.prepareStatement("DELETE FROM user_link_blocks where blockedLinkAccountId NOT IN (select id from user)").executeUpdate();
+			numUpdates = dbConn.prepareStatement("DELETE ulb FROM user_link_blocks ulb LEFT JOIN user u ON ulb.blockedLinkAccountId = u.id WHERE u.id IS NULL").executeUpdate();
 			if (numUpdates > 0){
 				processLog.incUpdated();
 				processLog.addNote("Deleted " + numUpdates + " user link blocks where the blocked account does not exist");
 			}
 
-			numUpdates = dbConn.prepareStatement("DELETE FROM user_list where public = 0 and user_id NOT IN (select id from user)").executeUpdate();
+			numUpdates = dbConn.prepareStatement("DELETE ul FROM user_list ul LEFT JOIN user u ON ul.user_id = u.id WHERE ul.public = 0 AND u.id IS NULL").executeUpdate();
 			if (numUpdates > 0){
 				processLog.incUpdated();
 				processLog.addNote("Deleted " + numUpdates + " user_list where the user does not exist");
 			}
 
-			numUpdates = dbConn.prepareStatement("DELETE FROM user_not_interested where userId NOT IN (select id from user)").executeUpdate();
+			numUpdates = dbConn.prepareStatement("DELETE uni FROM user_not_interested uni LEFT JOIN user u ON uni.userId = u.id WHERE u.id IS NULL").executeUpdate();
 			if (numUpdates > 0){
 				processLog.incUpdated();
 				processLog.addNote("Deleted " + numUpdates + " user_not_interested where the user does not exist");
 			}
 
-			numUpdates = dbConn.prepareStatement("DELETE FROM user_reading_history_work where userId NOT IN (select id from user)").executeUpdate();
+			numUpdates = dbConn.prepareStatement("DELETE urh FROM user_reading_history_work urh LEFT JOIN user u ON urh.userId = u.id WHERE u.id IS NULL").executeUpdate();
 			if (numUpdates > 0){
 				processLog.incUpdated();
 				processLog.addNote("Deleted " + numUpdates + " user_reading_history_work where the user does not exist");
 			}
 
-			numUpdates = dbConn.prepareStatement("DELETE FROM user_roles where userId NOT IN (select id from user)").executeUpdate();
+			numUpdates = dbConn.prepareStatement("DELETE ur FROM user_roles ur LEFT JOIN user u ON ur.userId = u.id WHERE u.id IS NULL").executeUpdate();
 			if (numUpdates > 0){
 				processLog.incUpdated();
 				processLog.addNote("Deleted " + numUpdates + " user_roles where the user does not exist");
 			}
 
-			numUpdates = dbConn.prepareStatement("DELETE FROM search where user_id NOT IN (select id from user) and user_id != 0").executeUpdate();
+			numUpdates = dbConn.prepareStatement("DELETE s FROM search s LEFT JOIN user u ON s.user_id = u.id WHERE s.user_id != 0 AND u.id IS NULL").executeUpdate();
 			if (numUpdates > 0){
 				processLog.incUpdated();
 				processLog.addNote("Deleted " + numUpdates + " search where the user does not exist");
 			}
 
-			numUpdates = dbConn.prepareStatement("DELETE FROM user_work_review where userId NOT IN (select id from user)").executeUpdate();
+			numUpdates = dbConn.prepareStatement("DELETE uwr FROM user_work_review uwr LEFT JOIN user u ON uwr.userId = u.id WHERE u.id IS NULL").executeUpdate();
 			if (numUpdates > 0){
 				processLog.incUpdated();
 				processLog.addNote("Deleted " + numUpdates + " user_work_review where the user does not exist");
 			}
 
-			numUpdates = dbConn.prepareStatement("UPDATE browse_category SET userID = null where userId NOT IN (select id from user)").executeUpdate();
+			numUpdates = dbConn.prepareStatement("UPDATE browse_category bc LEFT JOIN user u ON bc.userId = u.id SET bc.userID = NULL WHERE u.id IS NULL").executeUpdate();
 			if (numUpdates > 0){
 				processLog.incUpdated();
 				processLog.addNote("Deleted " + numUpdates + " user_work_review where the user does not exist");

--- a/code/cron/src/com/turning_leaf_technologies/cron/DatabaseCleanup.java
+++ b/code/cron/src/com/turning_leaf_technologies/cron/DatabaseCleanup.java
@@ -195,13 +195,13 @@ public class DatabaseCleanup implements IProcessHandler {
 
 	private void removeUserDataForDeletedUsers(Connection dbConn, Logger logger, CronProcessLogEntry processLog) {
 		try {
-			int numUpdates = dbConn.prepareStatement("DELETE FROM user_link where primaryAccountId NOT IN (select id from user)").executeUpdate();
+			int numUpdates = dbConn.prepareStatement("DELETE ul FROM user_link ul LEFT JOIN user u ON ul.primaryAccountId = u.id WHERE u.id IS NULL").executeUpdate();
 			if (numUpdates > 0){
 				processLog.incUpdated();
 				processLog.addNote("Deleted " + numUpdates + " user links where the primary account does not exist");
 			}
 
-			numUpdates = dbConn.prepareStatement("DELETE FROM user_link where linkedAccountId NOT IN (select id from user)").executeUpdate();
+			numUpdates = dbConn.prepareStatement("DELETE ul FROM user_link ul LEFT JOIN user u ON ul.linkedAccountId = u.id WHERE u.id IS NULL").executeUpdate();
 			if (numUpdates > 0){
 				processLog.incUpdated();
 				processLog.addNote("Deleted " + numUpdates + " user links where the linked account does not exist");
@@ -213,7 +213,7 @@ public class DatabaseCleanup implements IProcessHandler {
 				processLog.addNote("Deleted " + numUpdates + " user link blocks where the primary account does not exist");
 			}
 
-			numUpdates = dbConn.prepareStatement("DELETE ulb FROM user_link_blocks ulb LEFT JOIN user u ON ulb.blockedLinkAccountId = u.id WHERE u.id IS NULL").executeUpdate();
+			numUpdates = dbConn.prepareStatement("DELETE ulb FROM user_link_blocks ulb LEFT JOIN user u ON ulb.blockedLinkAccountId = u.id WHERE ulb.blockedLinkAccountId IS NOT NULL AND u.id IS NULL").executeUpdate();
 			if (numUpdates > 0){
 				processLog.incUpdated();
 				processLog.addNote("Deleted " + numUpdates + " user link blocks where the blocked account does not exist");

--- a/code/web/release_notes/26.06.00.MD
+++ b/code/web/release_notes/26.06.00.MD
@@ -284,6 +284,10 @@
 
 //tomas
 
+//kyle
+### Cron Job Updates
+- Improve performance of DatabaseCleanup cron by rewriting NOT IN subqueries as LEFT JOIN anti-joins. ([DIS-2126](https://aspen-discovery.atlassian.net/browse/DIS-2126)) (*KMH*)
+
 ### Other Updates
 - Let update script check if db is remote. ([DIS-2422](https://aspen-discovery.atlassian.net/browse/DIS-2422)) (*BNJ*)
 
@@ -293,6 +297,7 @@
 - Imani Thomas (IT)
 - Jonah Wilson (JW)
 - Nick Clemens (NC)
+- Kyle Hall (KMH)
 
 ### Grove For Libraries
 - Mark Noble (MDN)


### PR DESCRIPTION
Test Plan:
* Delete a user who has rows in all affected tables, then run DatabaseCleanup.
* Confirm all related rows are cleaned up across every table in a single run.
* Confirm no rows that have a related user were deleted
* Confirm public lists for the deleted user were not deleted
* Confirm the search table did not have rows deleted where user id is 0
* For browse_category add rows referencing a deleted user. Confirm userID is set to NULL
* Run DatabaseCleanup again, confirm the second run reports 0 affected rows