### PR TITLE
DIS-2466 Issues with saved search email templates

### DIFF
--- a/code/web/cron/updateSavedSearches.php
+++ b/code/web/cron/updateSavedSearches.php
@@ -190,30 +190,49 @@ foreach ($usersWithUpdatesToEmail as $data) {
 		$activeLanguage = $validLanguages['en'];
 	}
 	$emailTemplate = EmailTemplate::getActiveTemplate('savedSearchAlert', $activeUser);
-	$emailTemplate->plainTextBody .= "\r\n%searchHistory.url%";
-	$emailTemplate->plainTextBody .= "\r\n%searchHistory.updatedSearchesWithSampleTitles%";
 
 	$emailAddress = $data['user']->email;
 
 	$updatedSearches = "";
-	$updatedSearchesHtml = '<li>';
+	$updatedSearchesHtml = "<ul>";
+
 	$updatedSearchesWithSampleTitles = "";
-	$updatedSearchesWithSampleTitlesHtml = "";
+	$updatedSearchesWithSampleTitlesHtml = "<ul>";
+
+	$nl = PHP_EOL;
+
 	foreach ($data['updatedSearches'] as $updatedSearch) {
-		$updatedSearches .= "{$updatedSearch['title']} ({$updatedSearch['url']})\r\n";
-		$updatedSearchesHtml .= "<ul><strong style='font-size: 125%;'><a href='{$updatedSearch['url']}'>{$updatedSearch['title']}</a></strong></ul>";
-		$updatedSearchesWithSampleTitles .= "{$updatedSearch['title']} ({$updatedSearch['url']})\r\n";
-		$updatedSearchesWithSampleTitlesHtml = "<strong style='font-size: 125%;'><a href='{$updatedSearch['url']}'>{$updatedSearch['title']}</a></strong>";
-		$updatedSearchesWithSampleTitlesHtml .= "<ul>";
-		foreach ($updatedSearch['newTitles'] as $newTitle) {
-			$titleUrl = $data['baseUrl'] . "/GroupedWork/" . $newTitle['id'];
-			$updatedSearchesWithSampleTitles .= "{$newTitle['title_display']} - {$newTitle['author_display']} ($titleUrl)\r\n";
-			$updatedSearchesWithSampleTitlesHtml .= "<li><a href='$titleUrl'>{$newTitle['title_display']}</a> {$newTitle['author_display']}</li>";
+		$title = $updatedSearch['title'];
+		$url = $updatedSearch['url'];
+		if (empty($title) || empty($url)) {
+			continue;
 		}
-		$updatedSearchesWithSampleTitles .= "\r\n";
-		$updatedSearchesWithSampleTitlesHtml .= "</ul><br/>";
-;	}
-	$updatedSearchesHtml .= '</li>';
+
+		$updatedSearches .= "{$title} ({$url}){$nl}";
+		$updatedSearchesWithSampleTitles .= "{$title} ({$url}){$nl}";
+		$updatedSearchesHtml .= "<li><strong style='font-size:125%;'><a href='{$url}'>{$title}</a></strong></li>";
+		$updatedSearchesWithSampleTitlesHtml .= "<li><strong style='font-size:125%;'><a href='{$url}'>{$title}</a></strong>";
+
+		if (!empty($updatedSearch['newTitles']) && is_array($updatedSearch['newTitles'])) {
+			$updatedSearchesWithSampleTitlesHtml .= "<ul>";
+			foreach ($updatedSearch['newTitles'] as $newTitle) {
+				$titleId = $newTitle['id'] ?? null;
+				if (!$titleId) {
+					continue;
+				}
+				$titleUrl = rtrim($data['baseUrl'] ?? '', '/') . "/GroupedWork/" . $titleId;
+				$displayTitle = $newTitle['title_display'] ?? '';
+				$displayAuthor = $newTitle['author_display'] ?? '';
+				$updatedSearchesWithSampleTitles .= $displayTitle . " - " . $displayAuthor . " (" . $titleUrl . ")" . $nl;
+				$updatedSearchesWithSampleTitlesHtml .= "<li><a href='{$titleUrl}'>{$displayTitle}</a> {$displayAuthor}</li>";
+			}
+			$updatedSearchesWithSampleTitlesHtml .= "</ul>";
+		}
+		$updatedSearchesWithSampleTitlesHtml .= "</li>";
+		$updatedSearchesWithSampleTitles .= $nl;
+	}
+	$updatedSearchesHtml .= "</ul>";
+	$updatedSearchesWithSampleTitlesHtml .= "</ul>";
 
 	$parameters = [
 		'user' => $activeUser,

--- a/code/web/release_notes/26.06.00.MD
+++ b/code/web/release_notes/26.06.00.MD
@@ -115,6 +115,7 @@
 
 ### Saved Search Updates
 - Allow users to choose which saved searches to send notifications for. ([DIS-2469](https://aspen-discovery.atlassian.net/browse/DIS-2469)) (*SW*)
+- Fix issues with saved search email templates. ([DIS-2466](https://aspen-discovery.atlassian.net/browse/DIS-2466)) (*SW*)
 
 //yanjun
 ### OverDrive Updates

--- a/code/web/sys/Email/EmailTemplate.php
+++ b/code/web/sys/Email/EmailTemplate.php
@@ -310,6 +310,7 @@ class EmailTemplate extends DataObject {
 			return false;
 		}
 		$updatedPlainTextBody = $this->applyParameters($this->plainTextBody, $parameters);
+		$updatedHtmlBody = null;
 		if (!empty($this->htmlBody)){
 			$updatedHtmlBody = $this->applyParameters($this->htmlBody, $parameters);
 		}

--- a/code/web/sys/Email/EmailTemplate.php
+++ b/code/web/sys/Email/EmailTemplate.php
@@ -310,10 +310,7 @@ class EmailTemplate extends DataObject {
 			return false;
 		}
 		$updatedPlainTextBody = $this->applyParameters($this->plainTextBody, $parameters);
-		if (empty($this->htmlBody)) {
-			$updatedHtmlBody = $updatedPlainTextBody;
-			$updatedHtmlBody = str_replace("\r\n", "<br/>", $updatedHtmlBody);
-		}else{
+		if (!empty($this->htmlBody)){
 			$updatedHtmlBody = $this->applyParameters($this->htmlBody, $parameters);
 		}
 		$updatedSubject = $this->applyParameters($this->subject, $parameters);


### PR DESCRIPTION
https://aspen-discovery.atlassian.net/browse/DIS-2466

Addresses bugs in the email templates.

HTML versions of the templates were never set as empty because of EmailTemplate.php around line 314. So even if you wanted to use the plaintext version, you would get an HTML rendered version. That explains the customer's points #3 and #5 in the ticket. Using the plaintext versions of the variables didn't work right since they would render as html.

#4 appears the be syntax in this specific template which is fixed here

#2 is library.contactEmail which is set in Admin > Primary Config > Library Systems > General Email Address (LiDA only)

#1 I just can't reproduce:

<img width="335" height="760" alt="image" src="https://github.com/user-attachments/assets/464e03b5-c6f5-4126-ac92-de73c978e58c" />


Also note line 206 in the existing template code reassigns $updatedSearchesWithSampleTitlesHtml instead of concatenating, which was probably an issue.