### PR TITLE
DIS-2402 - Properly Scope Work Info from Browse

### DIFF
--- a/code/web/release_notes/26.06.00.MD
+++ b/code/web/release_notes/26.06.00.MD
@@ -2,6 +2,7 @@
 //mark n
 ### Grouped Work Display
 - Add a new option to show the earliest publication date in search results and full record view. ([DIS-2452](https://aspen-discovery.atlassian.net/browse/DIS-2452)) (*MDN*)
+- When displaying Grouped Works from Browse Category, properly hide formats that should not show by default. ([DIS-2402](https://aspen-discovery.atlassian.net/browse/DIS-2402)) (*MDN*)
 
 <div markdown="1" class="settings">
 
@@ -15,7 +16,7 @@
 - Allow the Hold form to be bypassed when Prompt for Edition is enabled. ([DIS-2475](https://aspen-discovery.atlassian.net/browse/DIS-2475)) (*MDN*)
 
 ### Hoopla Updates
-- Prefer 'artistFormal' field over 'artist' field when grouping and indexing hoopla records. ([DIS-2385](https://aspen-discovery.atlassian.net/browse/DIS-2385)) (*MDN*)
+- Prefer the 'artistFormal' field over the 'artist' field when grouping and indexing hoopla records. ([DIS-2385](https://aspen-discovery.atlassian.net/browse/DIS-2385)) (*MDN*)
 
 ### Reading History Updates
 - When searching reading history, search using solr rather than the database for improved relevancy. ([DIS-2451](https://aspen-discovery.atlassian.net/browse/DIS-2451)) (*MDN*)

--- a/code/web/services/GroupedWork/AJAX.php
+++ b/code/web/services/GroupedWork/AJAX.php
@@ -642,10 +642,11 @@ class GroupedWork_AJAX extends JSON_Action {
 		}
 		$interface->assign('recordDriver', $recordDriver);
 
-		// if the grouped work consists of only 1 related item, return the record url, otherwise return the grouped-work url
+		//Load the Related Manifestations. This causes formats to be hidden appropriately
+		$recordDriver->getRelatedManifestations();
 		$relatedRecords = $recordDriver->getRelatedRecords();
 
-		// short version
+		// if the grouped work consists of only 1 related item, return the record url, otherwise return the grouped-work url
 		if (count($relatedRecords) == 1) {
 			$firstRecord = reset($relatedRecords);
 			$url = $firstRecord->getUrl();


### PR DESCRIPTION
- When displaying Grouped Works from Browse Category, properly hide formats that should not show by default.