### PR TITLE
DIS-2386 Non fiction hold updates

### DIFF
--- a/code/web/RecordDrivers/GroupedWorkDriver.php
+++ b/code/web/RecordDrivers/GroupedWorkDriver.php
@@ -335,12 +335,12 @@ class GroupedWorkDriver extends IndexRecordDriver {
 				: 0,
 			fn() => GroupedWorkDriver::compareHoldability($a, $b),
 			fn() => GroupedWorkDriver::compareLanguagesForRecords($a, $b),
-			fn() => GroupedWorkDriver::compareEditionsForRecords($literaryForm, $a, $b),
 			fn() => GroupedWorkDriver::compareLocalAvailableItemsForRecords($a, $b),
 			fn() => GroupedWorkDriver::compareAvailabilityForRecords($a, $b),
 			fn() => GroupedWorkDriver::compareLocalItemsForRecords($a, $b),
 			//Status rankings should be between 4 (checked out and 1 currently available), we prefer the highest but could group some
-			fn() => $b->getStatusRanking() <=> $a->getStatusRanking(), 
+			fn() => $b->getStatusRanking() <=> $a->getStatusRanking(),
+			fn() => GroupedWorkDriver::compareEditionsForRecords($literaryForm, $a, $b),
 			fn() => $a->getHoldRatio() <=> $b->getHoldRatio(),
 			fn() => $b->getCopies() <=> $a->getCopies(),
 		];
@@ -355,7 +355,7 @@ class GroupedWorkDriver extends IndexRecordDriver {
 		return 0;
 	}
 
-	private function getPrimaryLiteraryForm(): string {
+	public function getPrimaryLiteraryForm(): string {
 		if (!isset($this->fields['literary_form'])) {
 			return '';
 		}

--- a/code/web/interface/themes/responsive/Record/hold-popup.tpl
+++ b/code/web/interface/themes/responsive/Record/hold-popup.tpl
@@ -22,7 +22,7 @@
 						<p class="alert alert-info">
 							{translate text="Select which editions of this format you want to place holds on. By default, all editions are selected." isPublicFacing=true}
 						</p>
-						
+
 						<div class="editions-list">
 							<ul class="list-unstyled">
 								<li>
@@ -31,9 +31,9 @@
 									{foreach from=$editions item=edition}
 										<li class="edition-item mb-2" style="display: none;">
 											<label>
-												<input type="checkbox" 
-													name="hyperholdRecord[]" 
-													value="{$edition.id}" 
+												<input type="checkbox"
+													name="hyperholdRecord[]"
+													value="{$edition.id}"
 													checked="checked"
 													class="edition-checkbox">
 												<strong>{$edition.title|escape}</strong>
@@ -44,9 +44,9 @@
 									{/foreach}
 							</ul>
 						</div>
-						
+
 						<hr>
-					</div>	
+					</div>
 				{/if}
 
 				<div class="holdsSummary">
@@ -266,6 +266,9 @@
 					{/if}
 					<input type="hidden" name="holdPromptForEditions" id="holdPromptForEditions" value="{$holdPromptForEditions}">
 					{if $holdPromptForEditions > 0 && count($editionOptions) > 0 && $promptForEdition}
+						{if !empty($holdEditionPromptMessage)}
+							<div class="alert alert-info">{translate text=$holdEditionPromptMessage isPublicFacing=true}</div>
+						{/if}
 						<div id="editionSelectionOptions" class="form-group">
 							<label class="control-label" for="selectedEditionOption">{translate text="Do you want to place a hold on the suggested edition or a specific edition?" isPublicFacing=true}</label>
 							<select name="selectedEditionOption" id="selectedEditionOption" class="form-control"  onchange="AspenDiscovery.GroupedWork.showEditionSwiper()">
@@ -295,7 +298,7 @@
 														</div>
 														<div class="edition-data">
 															{$edition->publicationDate}. {$edition->publisher}. {$edition->physical}.<br/>
-															{include file='GroupedWork/statusIndicator.tpl' statusInformation=$relatedRecord->getStatusInformation() viewingIndividualRecord=1}
+															{include file='GroupedWork/statusIndicator.tpl' statusInformation=$edition->getStatusInformation() viewingIndividualRecord=1}
 															<span>{$current} of {count($editionOptions)}</span>
 														</div>
 													</label>
@@ -355,7 +358,7 @@
 <script>
 	$('#toggleEditions').on('click', function(e){
 		e.preventDefault();
-		$('.edition-item').toggle(); 
+		$('.edition-item').toggle();
 		if ($('.edition-item:visible').length) {
 			$(this).text('Hide Editions');
 		} else {

--- a/code/web/release_notes/26.06.00.MD
+++ b/code/web/release_notes/26.06.00.MD
@@ -14,6 +14,9 @@
 
 ### Hold Updates
 - Allow the Hold form to be bypassed when Prompt for Edition is enabled. ([DIS-2475](https://aspen-discovery.atlassian.net/browse/DIS-2475)) (*MDN*)
+- Updates for holds on Non-Fiction materials with multiple available editions. ([DIS-2386](https://aspen-discovery.atlassian.net/browse/DIS-2386)) (*MDN*)
+  - Sort editions by availability before sorting by publication date, so available editions are shown first. 
+  - When placing a if the selected edition is not the newest edition, force the user to confirm they want a hold on the older edition.
 
 ### Hoopla Updates
 - Prefer the 'artistFormal' field over the 'artist' field when grouping and indexing hoopla records. ([DIS-2385](https://aspen-discovery.atlassian.net/browse/DIS-2385)) (*MDN*)

--- a/code/web/services/Record/AJAX.php
+++ b/code/web/services/Record/AJAX.php
@@ -352,6 +352,7 @@ class Record_AJAX extends JSON_Action {
 			}
 
 			$marcRecord = new MarcRecordDriver($id);
+			$groupedWorkDriver = $marcRecord->getGroupedWorkDriver();
 
 			$allowEditionSelection = (isset($_REQUEST['allowEditionSelection']) && $_REQUEST['allowEditionSelection'] == '1');
 			$interface->assign('allowEditionSelection', $allowEditionSelection);
@@ -365,7 +366,6 @@ class Record_AJAX extends JSON_Action {
 			if (isset($_REQUEST['format']) && !empty($_REQUEST['format'])) {
 				$currentFormat = $_REQUEST['format'];
 			} elseif ($selectedVariationId !== -1) {
-				$groupedWorkDriver = $marcRecord->getGroupedWorkDriver();
 				if ($groupedWorkDriver) {
 					$relatedRecord = $groupedWorkDriver->getRelatedRecord($marcRecord->getIdWithSource());
 					if ($relatedRecord && !empty($relatedRecord->recordVariations)) {
@@ -2106,6 +2106,42 @@ class Record_AJAX extends JSON_Action {
 
 		global $library;
 
+		//Check to see if this is a non-fiction work
+		$isNonFiction = false;
+		$groupedWorkDriver = $marcRecord->getGroupedWorkDriver();
+		if ($groupedWorkDriver->getPrimaryLiteraryForm()) {
+			$literaryForm = $groupedWorkDriver->getPrimaryLiteraryForm();
+			$isNonFiction = $literaryForm == 'Non Fiction';
+		}
+
+		//If it is a non-fiction work, we will prompt the user for the edition if they aren't placing a hold on the latest
+		if ($isNonFiction) {
+			$selectedRecordLatestPubDate = 0;
+			foreach ($marcRecord->getPublicationDates() as $selectedRecordPubDate) {
+				if (preg_match('/(\d{4})/', $selectedRecordPubDate, $matches)) {
+					$selectedRecordLatestPubDate = max($selectedRecordLatestPubDate, $matches[1]);
+				}
+			}
+			$marcRecordFormat = $marcRecord->getPrimaryFormat();
+			foreach ($groupedWorkDriver->getRelatedRecords() as $relatedRecord) {
+				if ($relatedRecord->getFormat() == $marcRecordFormat) {
+					foreach ($relatedRecord->getDriver()->getPublicationDates() as $relatedRecordPubDate) {
+						if (preg_match('/(\d{4})/', $relatedRecordPubDate, $matches)) {
+							if ($matches[1] > $selectedRecordLatestPubDate) {
+								$holdPromptForEditions = 2;
+								$promptForEdition = true;
+								$interface->assign('holdEditionPromptMessage', 'You are placing a hold on an earlier version of this title. If you need the latest information, you can request the newer edition instead, though wait times may be longer.');
+								break;
+							}
+						}
+					}
+				}
+				if ($promptForEdition && $holdPromptForEditions == 2) {
+					break;
+				}
+			}
+		}
+
 		//This needs to come before determining if the hold prompt can be bypassed
 		$editionOptions = [];
 		if ($holdPromptForEditions > 0 && $promptForEdition) {
@@ -2162,8 +2198,10 @@ class Record_AJAX extends JSON_Action {
 		}else{
 			//We are not prompting for a specific edition, make sure the hold prompt can still be bypassed.
 			$holdPromptForEditions = 0;
-			$interface->assign('holdPromptForEditions', $holdPromptForEditions);
 		}
+
+		$interface->assign('holdPromptForEditions', $holdPromptForEditions);
+
 		$interface->assign('editionOptions', $editionOptions);
 
 		//Check to see if we can bypass the holds popup and just place the hold


### PR DESCRIPTION
  - Sort editions by availability before sorting by publication date, so available editions are shown first.
  - When placing a if the selected edition is not the newest edition, force the user to confirm they want a hold on the older edition.