### PR TITLE
DIS-185: Fix 404 with working page for Grapes editors

### DIFF
--- a/code/web/release_notes/26.06.00.MD
+++ b/code/web/release_notes/26.06.00.MD
@@ -288,6 +288,7 @@
 - Bugfix for searching patrons on ils_username instead of displayName in Community Engagement's Admin View ([DIS-2406](https://aspen-discovery.atlassian.net/browse/DIS-2406)) (*PA*)
 - Let update script check if db is remote. ([DIS-2422](https://aspen-discovery.atlassian.net/browse/DIS-2422)) (*BNJ*)
 - Improve performance of DatabaseCleanup cron by rewriting NOT IN subqueries as LEFT JOIN anti-joins. ([DIS-2126](https://aspen-discovery.atlassian.net/browse/DIS-2126)) (*KMH*)
+- Fix 404 with working page for Grapes editors ([DIS-185](https://aspen-discovery.atlassian.net/browse/DIS-185)) (*OR*)
 
 ## This release includes code contributions from
 ### ByWater Solutions
@@ -310,6 +311,7 @@
 - Chloe Zermatten (CZ)
 - Jacob O'Mara (JOM)
 - Pedro Amorim (PA)
+- Olivia Reynolds (OR)
 
 ### Theke Solutions
 - Lucas Montoya (LM)

--- a/code/web/sys/WebBuilder/GrapesPage.php
+++ b/code/web/sys/WebBuilder/GrapesPage.php
@@ -285,13 +285,13 @@ class GrapesPage extends DB_LibraryLinkedObject {
 		if ($existingObject instanceof GrapesPage) {
 			$objectActions[] = [
 				'text' => 'Open in Editor',
-				'url' => '/services/WebBuilder/GrapesJSEditor?objectAction=edit&id=' . $existingObject->id . '&templateId=' . $existingObject->templatesSelect,
+				'url' => '/WebBuilder/GrapesJSEditor?objectAction=edit&id=' . $existingObject->id . '&templateId=' . $existingObject->templatesSelect,
 			];
 		}
 		if ($existingObject instanceof GrapesPage) {
 			$objectActions[] = [
 				'text' => 'View As Page',
-				// 'url' => '/services/WebBuilder/GrapesJSEditor?objectAction=edit&id=' . $this->id . '&templateId=' . $this->templatesSelect,
+				// 'url' => '/WebBuilder/GrapesJSEditor?objectAction=edit&id=' . $this->id . '&templateId=' . $this->templatesSelect,
 				'url' => $existingObject->urlAlias,
 			];
 		}
@@ -303,7 +303,7 @@ class GrapesPage extends DB_LibraryLinkedObject {
 		$objectActions = [];
 		$objectActions[] = [
 			'text' => 'Open in Editor',
-			'url' => '/services/WebBuilder/GrapesJSEditor?objectAction=edit&id=' . $this->id . '&templateId=' . $this->templatesSelect,
+			'url' => '/WebBuilder/GrapesJSEditor?objectAction=edit&id=' . $this->id . '&templateId=' . $this->templatesSelect,
 		];
 		$objectActions[] = [
 			'text' => 'View As Page',

--- a/code/web/sys/WebBuilder/GrapesTemplate.php
+++ b/code/web/sys/WebBuilder/GrapesTemplate.php
@@ -71,7 +71,7 @@ class GrapesTemplate extends DataObject {
 		if ($existingObject instanceof GrapesTemplate) {
 			$objectActions[] = [
 				'text' => 'Open in Editor',
-				'url' => '/services/WebBuilder/GrapesJSTemplates?objectAction=edit&id=' . $existingObject->id,
+				'url' => '/WebBuilder/GrapesJSTemplates?objectAction=edit&id=' . $existingObject->id,
 			];
 		}
 		return $objectActions;
@@ -82,7 +82,7 @@ class GrapesTemplate extends DataObject {
 		$objectActions = [];
 		$objectActions[] = [
 			'text' => 'Open in Editor',
-			'url' => '/services/WebBuilder/GrapesJSTemplates?objectAction=edit&id=' . $this->id,
+			'url' => '/WebBuilder/GrapesJSTemplates?objectAction=edit&id=' . $this->id,
 		];
 		return $objectActions;
 	}


### PR DESCRIPTION
Having `/services` at the beginning of the URL works fine within PHP, but Apache then rewrites the status code to a 404.