### PR TITLE
DIS-2461: Handle Hoopla Alternate Languages

### DIFF
--- a/code/reindexer/src/org/aspen_discovery/reindexer/HooplaProcessor2.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/HooplaProcessor2.java
@@ -369,6 +369,19 @@ class HooplaProcessor2 {
 				}else if (language.equalsIgnoreCase("Spanish")){
 					groupedWork.setLanguageBoostSpanish(10L);
 				}
+
+				// Add languages to translations
+				HashSet<String> translatedLanguages = new HashSet<>();
+				if (rawResponse.has("dubLanguage")) {
+					String translatedLanguage = StringUtils.capitalize(rawResponse.getString("dubLanguage").toLowerCase());
+					translatedLanguages.add(translatedLanguage);
+				}
+				if (rawResponse.has("SubTitleLanguage")) {
+					String translatedLanguage = StringUtils.capitalize(rawResponse.getString("SubTitleLanguage").toLowerCase());
+					translatedLanguages.add(translatedLanguage);
+				}
+				groupedWork.setTranslations(translatedLanguages);
+
 				long formatBoost = 1;
 				try {
 					formatBoost = Long.parseLong(indexer.translateSystemValue("format_boost_hoopla", primaryFormat, identifier));

--- a/code/web/release_notes/26.06.00.MD
+++ b/code/web/release_notes/26.06.00.MD
@@ -166,6 +166,7 @@
 - Prefer the 'artistFormal' field over the 'artist' field when grouping and indexing hoopla records. ([DIS-2385](https://aspen-discovery.atlassian.net/browse/DIS-2385)) (*MDN*)
 - Content Rating facets now include ratings from Hoopla titles. ([DIS-2478](https://aspen-discovery.atlassian.net/browse/DIS-2478)) (*YL*)
 - Display the number of Hoopla Flex titles for each library in Hoopla Settings for version 2. ([DIS-2479](https://aspen-discovery.atlassian.net/browse/DIS-2479)) (*YL*)
+- Add `SubTitleLanguage` and `DubLanguage` fields to the translations facet ([DIS-2461](https://aspen-discovery.atlassian.net/browse/DIS-2461)) (*KL*)
 
 <div markdown="1" class="settings">
 


### PR DESCRIPTION
Add logic to HooplaProcessor2.java to look for "dubLanguage" and "SubTitleLanguage" and add corresponding languages to the translations facet 
Update release notes

Tested on my local instance of Aspen