### PR TITLE
DIS-2201: When loading EAN/UPC from 024 field do not check indicator

### DIFF
--- a/code/reindexer/src/org/aspen_discovery/reindexer/MarcRecordProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/MarcRecordProcessor.java
@@ -480,7 +480,7 @@ abstract class MarcRecordProcessor {
 		groupedWork.addIsbns(MarcUtil.getFieldList(record, "020a"), format);
 		List<DataField> upcFields = MarcUtil.getDataFields(record, 24);
 		for (DataField upcField : upcFields){
-			if (upcField.getIndicator1() == '1' && upcField.getSubfield('a') != null){
+			if (upcField.getSubfield('a') != null){
 				groupedWork.addUpc(upcField.getSubfield('a').getData());
 			}
 		}

--- a/code/web/release_notes/26.06.00.MD
+++ b/code/web/release_notes/26.06.00.MD
@@ -177,6 +177,7 @@
 ### Indexing Updates
 - Allow AR Facet data to be populated from MARC data. ([DIS-2392](https://aspen-discovery.atlassian.net/browse/DIS-2392)) (*MJ*)
 - Add feature to hide MARC fields which have a privacy indicator set (541, 542, 561, 583) ([DIS-1145](https://aspen-discovery.atlassian.net/browse/DIS-1145)) (*JW*)
+- When indexing EAN/UPC from 024 do not check indicator ([DIS-2201](https://aspen-discovery.atlassian.net/browse/DIS-2201)) (*KL*)
 
 ### Koha Updates
 - Add option to force new Aspen users to opt-in to Reading History regardless of Koha privacy settings ([DIS-1958](https://aspen-discovery.atlassian.net/browse/DIS-1958)) (*KK*)


### PR DESCRIPTION
Update MarcRecordProcessor.java to not check the indicator for the 024 field when getting EAN/UPC 
Update release notes

Tested on my local instance of Aspen