### PR TITLE
DIS-2099: Change arPoints from  int to decimal in db

### DIFF
--- a/code/web/release_notes/26.06.00.MD
+++ b/code/web/release_notes/26.06.00.MD
@@ -177,6 +177,7 @@
 ### Indexing Updates
 - Allow AR Facet data to be populated from MARC data. ([DIS-2392](https://aspen-discovery.atlassian.net/browse/DIS-2392)) (*MJ*)
 - Add feature to hide MARC fields which have a privacy indicator set (541, 542, 561, 583) ([DIS-1145](https://aspen-discovery.atlassian.net/browse/DIS-1145)) (*JW*)
+- Update arPoints in database to be stored as decimal values instead of integer values ([DIS-2099](https://aspen-discovery.atlassian.net/browse/DIS-2099)) (*KL*)
 
 ### Koha Updates
 - Add option to force new Aspen users to opt-in to Reading History regardless of Koha privacy settings ([DIS-1958](https://aspen-discovery.atlassian.net/browse/DIS-1958)) (*KK*)

--- a/code/web/sys/DBMaintenance/version_updates/26.06.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/26.06.00.php
@@ -283,6 +283,13 @@ function getUpdates26_06_00(): array {
 				'ALTER TABLE library ADD COLUMN moreLikeThisSettings tinyint(1) DEFAULT 1',
 			]
 		], //scoped_more_like_this
+		'accelerated_reading_points' => [
+			'title' => 'Accelerated Reading Points',
+			'description' => 'Update column for AR points to store decimal values.',
+			'sql' => [
+				'ALTER TABLE accelerated_reading_titles CHANGE COLUMN arPoints arPoints decimal(3,1) DEFAULT NULL',
+			]
+		], //accelerated_reading_points
 
 		//yanjun
 		'add_overdriveAdvantageId' => [


### PR DESCRIPTION
Update arPoints in accelerated_reading_titles to be type decimal instead of int 
Update release notes

Tested on my local instance of Aspen