### PR TITLE
DIS-2495: Set Koha renewIndicator before non-nightly checks 

### DIFF
--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -576,14 +576,13 @@ class Koha extends AbstractIlsDriver {
 			}
 			$curCheckout->dueDate = $dueTime;
 			$curCheckout->itemId = $itemNumber;
+			$curCheckout->renewIndicator = $curRow['itemnumber'];
 
 			if( !$options['isNightlyUpdate'] ) {
 				$checkouts[$curCheckout->source . $curCheckout->sourceId . $curCheckout->userId] = $curCheckout;
 				continue;
 			}
 
-
-			$curCheckout->renewIndicator = $curRow['itemnumber'];
 			if ($kohaVersion >= 22.11) {
 				$curCheckout->renewCount = $curRow['renewals_count'];
 			} else {

--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -576,13 +576,14 @@ class Koha extends AbstractIlsDriver {
 			}
 			$curCheckout->dueDate = $dueTime;
 			$curCheckout->itemId = $itemNumber;
-			$curCheckout->renewIndicator = $curRow['itemnumber'];
 
-			if( !$options['isNightlyUpdate'] ) {
+			if($options['isNightlyUpdate'] ) {
 				$checkouts[$curCheckout->source . $curCheckout->sourceId . $curCheckout->userId] = $curCheckout;
 				continue;
 			}
 
+
+			$curCheckout->renewIndicator = $curRow['itemnumber'];
 			if ($kohaVersion >= 22.11) {
 				$curCheckout->renewCount = $curRow['renewals_count'];
 			} else {

--- a/code/web/release_notes/26.05.02.MD
+++ b/code/web/release_notes/26.05.02.MD
@@ -3,6 +3,9 @@
 ### Other Updates
 - Fix bug where Aspen could not properly authenticate with Koha when updating messaging settings ([DIS-2489](https://aspen-discovery.atlassian.net/browse/DIS-2489)) (*JW*)
 
+### Koha Updates
+- Fix a Koha renewal issue by correcting the isNightlyUpdate condition used during checkout loading. ([DIS-2495](https://aspen-discovery.atlassian.net/browse/DIS-2495)) (*YL*)
+
 ## This release includes code contributions from
 ### Grove
 - Mark Noble (MDN)


### PR DESCRIPTION
To Test:
1. log in as a patron with renewable items
2. Attempt to renew the item
3. See modal loading and renew fail
4. Apply PR
5. Renew the item again
6. Renew succeeds 