### PR TITLE
DIS-2161: Ensure all available filters work for Events

### DIFF
--- a/code/web/interface/themes/responsive/DataObjectUtil/filterField.tpl
+++ b/code/web/interface/themes/responsive/DataObjectUtil/filterField.tpl
@@ -21,7 +21,7 @@
 		<div class="col-xs-5">
 			<input type="text" name="filterValue[{$filterField.property}]" class="form-control form-control-sm filterValue" aria-label="Filtering for {$filterField.label|escapeCSS}" {if !empty($appliedFilter)}value="{$appliedFilter.filterValue}"{/if}/>
 		</div>
-	{elseif $filterField.type == 'timestamp'}
+	{elseif $filterField.type == 'timestamp' || $filterField.type == 'date'}
 		<div class="col-xs-3">
 			{assign var=label value="Type of filtering for `$filterField.label`"}
 			<select name="filterType[{$filterField.property}]" id="filterType_{$filterField.property}" class="form-control form-control-sm filterType" aria-label="{translate text=$label inAttribute=true isAdminFacing=true}" onchange="AspenDiscovery.Admin.setDateFilterFieldVisibility('{$filterField.property}')">
@@ -32,12 +32,18 @@
 		</div>
 		<div class="col-xs-5">
 			{assign var=label value="Type of filtering for `$filterField.label`"}
-			<input type="text" name="filterValue[{$filterField.property}]" id="filterValue_{$filterField.property}" class="form-control form-control-sm filterValue" aria-label="" {if !empty($appliedFilter)}value="{$appliedFilter.filterValue|date_format:"%Y-%m-%d %H:%M"}"{/if}/>
-			<input type="text" name="filterValue2[{$filterField.property}]" id="filterValue2_{$filterField.property}" class="form-control form-control-sm filterValue" aria-label="" {if !empty($appliedFilter)}value="{$appliedFilter.filterValue2|date_format:"%Y-%m-%d %H:%M"}"{/if}/>
+			{assign var=dateFormat value=($filterField.type eq 'timestamp') ? '%Y-%m-%d %H:%M' : '%Y-%m-%d'}
+			<input type="text" name="filterValue[{$filterField.property}]" id="filterValue_{$filterField.property}" class="form-control form-control-sm filterValue" aria-label="" {if !empty($appliedFilter)}value="{$appliedFilter.filterValue|date_format:$dateFormat}"{/if}/>
+			<input type="text" name="filterValue2[{$filterField.property}]" id="filterValue2_{$filterField.property}" class="form-control form-control-sm filterValue" aria-label="" {if !empty($appliedFilter)}value="{$appliedFilter.filterValue2|date_format:$dateFormat}"{/if}/>
 			<script type="text/javascript">
 				$(document).ready(function(){ldelim}
+					{if $filterField.type == 'timestamp'}
 					rome(filterValue_{$filterField.property});
 					rome(filterValue2_{$filterField.property});
+					{else}
+					rome(filterValue_{$filterField.property}, {ldelim}date: true, time: false{rdelim});
+					rome(filterValue2_{$filterField.property}, {ldelim}date: true, time: false{rdelim});
+					{/if}
 					AspenDiscovery.Admin.setDateFilterFieldVisibility('{$filterField.property}');
 				{rdelim});
 			</script>

--- a/code/web/release_notes/26.06.00.MD
+++ b/code/web/release_notes/26.06.00.MD
@@ -294,6 +294,8 @@
 - Fix 404 with working page for Grapes editors ([DIS-185](https://aspen-discovery.atlassian.net/browse/DIS-185)) (*OR*)
 - Allow SMTP Relays that do not require authentication to be used. ([DIS-2492](https://aspen-discovery.atlassian.net/browse/DIS-2492)) (*MDN*)
 - Fix error loading available database updates when plugins are disabled. ([DIS-2493](https://aspen-discovery.atlassian.net/browse/DIS-2493)) (*MDN*)
+- Support filtering on 'date' fields ([DIS-2161](https://aspen-discovery.atlassian.net/browse/DIS-2161)) (*OR*)
+- Disable unsupported sorts/filters for Events ([DIS-2161](https://aspen-discovery.atlassian.net/browse/DIS-2161)) (*OR*, *CZ*)
 
 ## This release includes code contributions from
 ### ByWater Solutions

--- a/code/web/services/Admin/ObjectEditor.php
+++ b/code/web/services/Admin/ObjectEditor.php
@@ -1362,7 +1362,8 @@ abstract class ObjectEditor extends Admin_Admin {
 		$table = empty($filter['field']['filterOmitTablename']) ? "$object->__table." : '';
 		$addAsHaving = in_array($filter['field']['type'], ['calculatedInteger', 'calculatedBoolean']);
 		$fullFieldName = "$table$fieldName";
-		switch ($filter['filterType']) {
+		$filterType = $filter['filterType'];
+		switch ($filterType) {
 			case 'matches':
 				if ($filter['field']['type'] == 'enum' && $filter['filterValue'] == 'all_values') {
 					//Skip this value
@@ -1385,25 +1386,23 @@ abstract class ObjectEditor extends Admin_Admin {
 				$object->whereAdd("$fullFieldName like " . $object->escape($filter['filterValue'] . '%'));
 				break;
 			case 'beforeTime':
-				$fieldValue = strtotime($filter['filterValue2']);
-				if ($fieldValue !== false) {
-					$object->whereAdd("$fullFieldName" . ' < ' . $fieldValue);
-				}
-				break;
 			case 'afterTime':
-				$fieldValue = strtotime($filter['filterValue']);
-				if ($fieldValue !== false) {
-					$object->whereAdd("$fullFieldName" . ' > ' . $fieldValue);
-				}
-				break;
 			case 'betweenTimes':
-				$fieldValue = strtotime($filter['filterValue']);
-				if ($fieldValue !== false) {
-					$object->whereAdd("$fullFieldName" . ' > ' . $fieldValue);
+				$fieldValueLower = null;
+				$fieldValueUpper = null;
+				if($filter['field']['type'] == 'timestamp') {
+					$fieldValueLower = strtotime($filter['filterValue']);
+					$fieldValueUpper = strtotime($filter['filterValue2']);
+				} elseif ($filter['field']['type'] == 'date') {
+					$fieldValueLower = 'DATE(' . $object->escape($filter['filterValue']) . ')';
+					$fieldValueUpper = 'DATE(' . $object->escape($filter['filterValue2']) . ')';
 				}
-				$fieldValue2 = strtotime($filter['filterValue2']);
-				if ($fieldValue2 !== false) {
-					$object->whereAdd("$fullFieldName" . ' < ' . $fieldValue2);
+
+				if ($fieldValueLower && ($filterType == 'afterTime' || $filterType == 'betweenTimes')) {
+					$object->whereAdd("$fullFieldName" . ' > ' . $fieldValueLower);
+				}
+				if ($fieldValueUpper && ($filterType == 'beforeTime' || $filterType == 'betweenTimes')) {
+					$object->whereAdd("$fullFieldName" . ' < ' . $fieldValueUpper);
 				}
 				break;
 			case 'lessThan':

--- a/code/web/sys/Events/Event.php
+++ b/code/web/sys/Events/Event.php
@@ -194,6 +194,7 @@ class Event extends DataObject {
 				'label' => 'Total Upcoming Events',
 				'hiddenByDefault' => true,
 				'readOnly' => true,
+				'canSort' => false
 			],
 			'dateUpdated' => [
 				'property' => 'dateUpdated',
@@ -272,6 +273,7 @@ class Event extends DataObject {
 				'label' => 'Event Date',
 				'description' => 'The date this event starts',
 				'onchange' => "return AspenDiscovery.Events.updateRecurrenceOptions(this.value);",
+				'canSort' => false
 			],
 			'hideTimestamps' => [
 				'property' => 'hideTimestamps',
@@ -301,6 +303,7 @@ class Event extends DataObject {
 				'label' => 'End Date',
 				'description' => 'The date this event ends',
 				'note' => 'Automatically calculated based on Event Date, Start Time, and Event Length',
+				'canSort' => false
 			],
 			'endTime' => [
 				'property' => 'endTime',
@@ -482,6 +485,7 @@ class Event extends DataObject {
 				'note' => 'To update, change the scheduling options above',
 				'readOnly' => true,
 				'hiddenByDefault' => true,
+				'canSort' => false
 			],
 		];
 		if ($context == 'addNew') {

--- a/code/web/sys/Events/Event.php
+++ b/code/web/sys/Events/Event.php
@@ -273,7 +273,6 @@ class Event extends DataObject {
 				'label' => 'Event Date',
 				'description' => 'The date this event starts',
 				'onchange' => "return AspenDiscovery.Events.updateRecurrenceOptions(this.value);",
-				'canSort' => false
 			],
 			'hideTimestamps' => [
 				'property' => 'hideTimestamps',


### PR DESCRIPTION
This PR makes sure that every listed filter for managing events is usable. It adds support for filtering on `date` fields by adapting the similar support for `timestamp` fields. The remaining unsupported fields for filtering are computed in PHP, so they have been disabled.