### PR TITLE
DIS-2497: Use item_type_id for koha 25.11+ hold placement

### DIFF
--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -1939,7 +1939,7 @@ class Koha extends AbstractIlsDriver {
 				//If there is more than one item type for the variation, we don't know what to place a hold on so just do bib level.
 				//If there is just one, we can do an item type hold
 				if (count($allItemTypes) == 1) {
-					$holdParams['item_type'] = reset($allItemTypes);
+					$holdParams[$this->getKohaVersion() >= 25.11 ? 'item_type_id' : 'item_type'] = reset($allItemTypes);
 				}
 			}
 		}

--- a/code/web/release_notes/26.05.02.MD
+++ b/code/web/release_notes/26.05.02.MD
@@ -3,9 +3,13 @@
 ### Other Updates
 - Fix bug where Aspen could not properly authenticate with Koha when updating messaging settings ([DIS-2489](https://aspen-discovery.atlassian.net/browse/DIS-2489)) (*JW*)
 
+### Koha Updates
+- Fix a hold placement issue in Koha 25.11 caused by the item type parameter name changing from item_type to item_type_id.([DIS-2497](https://aspen-discovery.atlassian.net/browse/DIS-2497)) (*YL*)
+
 ## This release includes code contributions from
 ### Grove
 - Mark Noble (MDN)
 
 ### ByWater Solutions
 - Jonah Wilson (JW)
+- Yanjun Li (YL)


### PR DESCRIPTION
Koha 25.11 changed the place hold parameter from  item_type to item_type_id .

To test:
1. Attempt to place an item-type hold with koha 25.11+
2. See a 400 error 
3. Apply the PR
4. Place the hold successfully