### PR TITLE
DIS-2159: Allow sorting events by Start Date

### DIFF
--- a/code/web/services/Admin/ObjectEditor.php
+++ b/code/web/services/Admin/ObjectEditor.php
@@ -1256,7 +1256,7 @@ abstract class ObjectEditor extends Admin_Admin {
 	private function addFieldToSortableFieldsArray(&$sortableFields, $field) : void {
 		if ($field['type'] == 'section') {
 			foreach ($field['properties'] as $subField) {
-				$this->addFieldToSortableFieldsArray($batchFormatFields, $subField);
+				$this->addFieldToSortableFieldsArray($sortableFields, $subField);
 			}
 		} else {
 			$canSort = !isset($field['canSort']) || ($field['canSort'] == true);

--- a/code/web/sys/Events/Event.php
+++ b/code/web/sys/Events/Event.php
@@ -18,7 +18,11 @@ class Event extends DataObject {
 	public $displayEventBranchOnThumbnail;
 	public $_typeFields = [];
 	public $startDate;
+
+	// Used as an alias for startDate at the root of the model structure
+	// so that it can be displayed in lists
 	public $_startDateForList;
+
 	public $hideTimestamps;
 	public $startTime;
 	public $eventLength;

--- a/code/web/sys/Events/Event.php
+++ b/code/web/sys/Events/Event.php
@@ -274,7 +274,7 @@ class Event extends DataObject {
 			'startDate' => [
 				'property' => 'startDate',
 				'type' => 'date',
-				'label' => 'Event Date',
+				'label' => 'Start Date',
 				'description' => 'The date this event starts',
 				'onchange' => "return AspenDiscovery.Events.updateRecurrenceOptions(this.value);",
 			],


### PR DESCRIPTION
This PR fixes a typo in gathering sortable fields from sections. This allows enumerating and then sorting by the non-aliased `startDate` field.