### PR TITLE
DIS-2288: Better support for more currencies

### DIFF
--- a/code/web/interface/themes/responsive/DataObjectUtil/property.tpl
+++ b/code/web/interface/themes/responsive/DataObjectUtil/property.tpl
@@ -225,21 +225,9 @@
 					<a class="btn btn-default btn-sm" href="{$property.editLink|replace:'propertyValue':$propValue}">Edit {$property.label}</a>
 				</div>
 			</div>
-		{elseif $property.type == 'textFromNestedSection'}
-			<input type='text' name='{$propName}' id='{$propName}' value='{$propValue.$propName|escape}' {if !empty($property.accessibleLabel)}aria-label="{$property.accessibleLabel}"{/if} {if !empty($property.maxLength)}maxlength='{$property.maxLength}'{/if} {if !empty($property.size)}size='{$property.size}'{/if} class='form-control {if !empty($property.required)}required{/if}{if !empty($property.validationGroupName)} {$property.validationGroupName}-validation-group{/if}' {if !empty($property.autocomplete)}autocomplete="{$property.autocomplete}"{/if} {if !empty($property.readOnly)}readonly{/if}  {if !empty($property.forcesReindex)}aria-describedby="{$propName}HelpBlock"{/if} >
-			{if !empty($property.forcesReindex)}<span id="{$propName}HelpBlock" class="help-block" style="margin-top:0"><small class="text-warning"><i class="fas fa-exclamation-triangle"></i> {translate text="Updating this setting causes a nightly reindex" isAdminFacing=true}</small></span>{/if}
-			{if !empty($property.affectsLiDA)}<span id="{$propName}HelpBlock" class="help-block" style="margin-top:0"><small class="text-info"><i class="fas fa-info-circle"></i> {translate text="Aspen LiDA also uses this setting" isAdminFacing=true}</small></span>{/if}
-			{if !empty($property.warning)}<span id="{$propName}HelpBlock" class="help-block" style="margin-top:0"><small class="text-warning"><i class="fas fa-exclamation-triangle"></i> {$property.warning}</small></span>{/if}
-			{if !empty($property.note)}<span id="{$propName}HelpBlock" class="help-block" style="margin-top:0"><small><i class="fas fa-info-circle"></i> {$property.note}</small></span>{/if}
-			{if !empty($property.noteBullets)}
-				<ul class="help-block" style="margin-top: 0; margin-bottom: 10px;">
-					{foreach from=$property.noteBullets item=bullet}
-						<li><small>{$bullet}</small></li>
-					{/foreach}
-				</ul>
-			{/if}
-		{elseif $property.type == 'text' || $property.type == 'regularExpression' || $property.type == 'folder'}
-			<input type='text' name='{$propName}' id='{$propName}' value='{$propValue|escape}' {if !empty($property.accessibleLabel)}aria-label="{$property.accessibleLabel}"{/if} {if !empty($property.maxLength)}maxlength='{$property.maxLength}'{/if} {if !empty($property.size)}size='{$property.size}'{/if} class='form-control {if !empty($property.required)}required{/if}{if !empty($property.validationGroupName)} {$property.validationGroupName}-validation-group{/if}' {if !empty($property.autocomplete)}autocomplete="{$property.autocomplete}"{/if} {if !empty($property.readOnly)}readonly{/if}  {if !empty($property.forcesReindex)}aria-describedby="{$propName}HelpBlock"{/if} >
+		{elseif $property.type == 'text' || $property.type == 'textFromNestedSection' || $property.type == 'regularExpression' || $property.type == 'folder'}
+			{assign var=textValue value=($property.type == 'textFromNestedSection') ? $propValue.$propName : $propValue}
+			<input type='text' name='{$propName}' id='{$propName}' value='{$textValue|escape}' {if !empty($property.accessibleLabel)}aria-label="{$property.accessibleLabel}"{/if} {if !empty($property.maxLength)}maxlength='{$property.maxLength}'{/if} {if !empty($property.size)}size='{$property.size}'{/if} class='form-control {if !empty($property.required)}required{/if}{if !empty($property.validationGroupName)} {$property.validationGroupName}-validation-group{/if}' {if !empty($property.autocomplete)}autocomplete="{$property.autocomplete}"{/if} {if !empty($property.readOnly)}readonly{/if}  {if !empty($property.forcesReindex)}aria-describedby="{$propName}HelpBlock"{/if} >
 			{if !empty($property.forcesReindex)}<span id="{$propName}HelpBlock" class="help-block" style="margin-top:0"><small class="text-warning"><i class="fas fa-exclamation-triangle"></i> {translate text="Updating this setting causes a nightly reindex" isAdminFacing=true}</small></span>{/if}
 			{if !empty($property.affectsLiDA)}<span id="{$propName}HelpBlock" class="help-block" style="margin-top:0"><small class="text-info"><i class="fas fa-info-circle"></i> {translate text="Aspen LiDA also uses this setting" isAdminFacing=true}</small></span>{/if}
 			{if !empty($property.warning)}<span id="{$propName}HelpBlock" class="help-block" style="margin-top:0"><small class="text-warning"><i class="fas fa-exclamation-triangle"></i> {$property.warning}</small></span>{/if}

--- a/code/web/interface/themes/responsive/DataObjectUtil/property.tpl
+++ b/code/web/interface/themes/responsive/DataObjectUtil/property.tpl
@@ -227,7 +227,7 @@
 			</div>
 		{elseif $property.type == 'text' || $property.type == 'textFromNestedSection' || $property.type == 'regularExpression' || $property.type == 'folder'}
 			{assign var=textValue value=($property.type == 'textFromNestedSection') ? $propValue.$propName : $propValue}
-			<input type='text' name='{$propName}' id='{$propName}' value='{$textValue|escape}' {if !empty($property.accessibleLabel)}aria-label="{$property.accessibleLabel}"{/if} {if !empty($property.maxLength)}maxlength='{$property.maxLength}'{/if} {if !empty($property.size)}size='{$property.size}'{/if} class='form-control {if !empty($property.required)}required{/if}{if !empty($property.validationGroupName)} {$property.validationGroupName}-validation-group{/if}' {if !empty($property.autocomplete)}autocomplete="{$property.autocomplete}"{/if} {if !empty($property.readOnly)}readonly{/if}  {if !empty($property.forcesReindex)}aria-describedby="{$propName}HelpBlock"{/if} >
+			<input type='text' name='{$propName}' id='{$propName}' value='{$textValue|escape}' {if !empty($property.accessibleLabel)}aria-label="{$property.accessibleLabel}"{/if} {if !empty($property.maxLength)}maxlength='{$property.maxLength}'{/if} {if !empty($property.size)}size='{$property.size}'{/if} class='form-control {if !empty($property.required)}required{/if}{if !empty($property.validationGroupName)} {$property.validationGroupName}-validation-group{/if}' {if !empty($property.autocomplete)}autocomplete="{$property.autocomplete}"{/if} {if !empty($property.readOnly)}readonly{/if}  {if !empty($property.forcesReindex)}aria-describedby="{$propName}HelpBlock"{/if} {if !empty($property.suggestions)}list="{$propName}DataList"{/if} >
 			{if !empty($property.forcesReindex)}<span id="{$propName}HelpBlock" class="help-block" style="margin-top:0"><small class="text-warning"><i class="fas fa-exclamation-triangle"></i> {translate text="Updating this setting causes a nightly reindex" isAdminFacing=true}</small></span>{/if}
 			{if !empty($property.affectsLiDA)}<span id="{$propName}HelpBlock" class="help-block" style="margin-top:0"><small class="text-info"><i class="fas fa-info-circle"></i> {translate text="Aspen LiDA also uses this setting" isAdminFacing=true}</small></span>{/if}
 			{if !empty($property.warning)}<span id="{$propName}HelpBlock" class="help-block" style="margin-top:0"><small class="text-warning"><i class="fas fa-exclamation-triangle"></i> {$property.warning}</small></span>{/if}
@@ -238,6 +238,13 @@
 						<li><small>{$bullet}</small></li>
 					{/foreach}
 				</ul>
+			{/if}
+			{if !empty($property.suggestions)}
+				<datalist id="{$propName}DataList">
+					{foreach from=$property.suggestions item=suggestion}
+						<option value={$suggestion|escape}></option>
+					{/foreach}
+				</datalist>
 			{/if}
 		{elseif $property.type == 'integer'}
 			<input type='number' name='{$propName}' id='{$propName}' value='{$propValue|escape}' {if !empty($property.accessibleLabel)}aria-label="{$property.accessibleLabel}"{/if} {if isset($property.max)}max="{$property.max}"{/if} {if isset($property.min)}min="{$property.min}"{/if} {if !empty($property.maxLength)}maxlength='{$property.maxLength}'{/if} {if !empty($property.size)}size='{$property.size}'{/if} class='form-control {if !empty($property.required)}required{/if}' {if !empty($property.readOnly)}readonly{/if}{if !empty($property.onchange)} onchange="{$property.onchange}"{/if}>

--- a/code/web/release_notes/26.07.00.MD
+++ b/code/web/release_notes/26.07.00.MD
@@ -54,8 +54,12 @@
 // pedro
 
 // olivia
+### Administration Updates
+- Remove restrictions on currency code system variable ([DIS-2288](https://aspen-discovery.atlassian.net/browse/DIS-2288) (*OR*)
+
 ### Other Updates
 - Use Koha's "BorrowersTitles" system preference for the self-registration form ([DIS-1554](https://aspen-discovery.atlassian.net/browse/DIS-1554)) (*OR*)
+- Consolidate and improve support for currency symbols ([DIS-2288](https://aspen-discovery.atlassian.net/browse/DIS-2288) (*OR*)
 
 //shipra
 ### Other Updates

--- a/code/web/services/Donations/NewDonation.php
+++ b/code/web/services/Donations/NewDonation.php
@@ -144,8 +144,9 @@ class Donations_NewDonation extends Action {
 			$interface->assign('donationFormFields', $donationFormFields);
 
 			// Get the value options to display for the form
+			require_once ROOT_DIR . '/sys/Utils/StringUtils.php';
 			$values = Donation::getDonationValues($donationSettings->id);
-			$symbol = $donation->getCurrencySymbol();
+			$symbol = StringUtils::getCurrencySymbol();
 			$interface->assign('donationValues', $values);
 			$interface->assign('currencySymbol', $symbol);
 

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -3,6 +3,7 @@
 use JetBrains\PhpStorm\NoReturn;
 
 require_once ROOT_DIR . '/JSON_Action.php';
+require_once ROOT_DIR . '/sys/Utils/StringUtils.php';
 
 class MyAccount_AJAX extends JSON_Action {
 	/** @noinspection PhpMissingClassConstantTypeInspection */
@@ -5537,7 +5538,6 @@ class MyAccount_AJAX extends JSON_Action {
 		$finesPaid = '';
 		$purchaseUnits = [];
 		$purchaseUnits['items'] = [];
-		require_once ROOT_DIR . '/sys/Utils/StringUtils.php';
 		$totalFines = 0;
 
 		$currencyCode = 'USD';
@@ -7888,7 +7888,7 @@ class MyAccount_AJAX extends JSON_Action {
 					$snakeCaseFieldName = str_replace(" ", "_", strtolower($urlParameterSettings['am_kohaAdditionalField']));
 					$paymentRequestUrl .= urlencode(isset($fineDetails[$snakeCaseFieldName]) && $fineDetails[$snakeCaseFieldName] ? $fineDetails[$snakeCaseFieldName] : "none specified");
 				} else {
-					$paymentRequestUrl .= !empty($urlParameterSettings['am_value']) ? $urlParameterSettings['am_value'] : str_replace(SystemVariables::getSystemVariables()->getCurrencySymbol(), '', $fineDetails['amount']);
+					$paymentRequestUrl .= !empty($urlParameterSettings['am_value']) ? $urlParameterSettings['am_value'] : str_replace(StringUtils::getCurrencySymbol(), '', $fineDetails['amount']);
 				}
 			}
 			if ($urlParameterSettings["cmt_includeInUrl"]) {
@@ -7962,7 +7962,7 @@ class MyAccount_AJAX extends JSON_Action {
 					$snakeCaseFieldName = str_replace(" ", "_", strtolower($urlParameterSettings['am_kohaAdditionalField']));
 					$hashParams .= urlencode(isset($fineDetails[$snakeCaseFieldName]) && $fineDetails[$snakeCaseFieldName] ? $fineDetails[$snakeCaseFieldName] : "none specified");
 				} else {
-					$hashParams .= isset($urlParameterSettings['am_value']) && $urlParameterSettings['am_value'] ? $urlParameterSettings['am_value'] : str_replace(SystemVariables::getSystemVariables()->getCurrencySymbol(), '', $fineDetails['amount']);
+					$hashParams .= isset($urlParameterSettings['am_value']) && $urlParameterSettings['am_value'] ? $urlParameterSettings['am_value'] : str_replace(StringUtils::getCurrencySymbol(), '', $fineDetails['amount']);
 				}
 			}
 			if ($urlParameterSettings["cmt_includeInHash"]) {

--- a/code/web/sys/Donations/Donation.php
+++ b/code/web/sys/Donations/Donation.php
@@ -291,24 +291,6 @@ class Donation extends DataObject {
 		}
 	}
 
-	function getCurrencySymbol() {
-		$currencyCode = 'USD';
-		$systemVariables = SystemVariables::getSystemVariables();
-		if (!empty($systemVariables->currencyCode)) {
-			$currencyCode = $systemVariables->currencyCode;
-		}
-		if ($currencyCode == 'USD') {
-			$currencySymbol = '$';
-		} elseif ($currencyCode == 'EUR') {
-			$currencySymbol = '€';
-		} elseif ($currencyCode == 'CAD') {
-			$currencySymbol = '$';
-		} elseif ($currencyCode == 'GBP') {
-			$currencySymbol = '£';
-		}
-		return $currencySymbol;
-	}
-
 	function getDonationFormFields(DonationsSetting $donationSettings) {
 		require_once ROOT_DIR . '/sys/Donations/DonationFormFields.php';
 		$fieldsToSortByCategory = $donationSettings->getDefaultFormFields();

--- a/code/web/sys/ECommerce/StripeSetting.php
+++ b/code/web/sys/ECommerce/StripeSetting.php
@@ -160,12 +160,13 @@ class StripeSetting extends DataObject {
 
 		require_once ROOT_DIR . '/sys/Account/User.php';
 		require_once ROOT_DIR . '/sys/SystemVariables.php';
+		require_once ROOT_DIR . '/sys/Utils/StringUtils.php';
 		$systemVariables = SystemVariables::getSystemVariables();
 		$currencyCode = 'USD';
 		$currencySymbol = '$';
 		if (!empty($systemVariables) && !empty($systemVariables->currencyCode)) {
 			$currencyCode = $systemVariables->currencyCode;
-			$currencySymbol = $systemVariables->getCurrencySymbol();
+			$currencySymbol = StringUtils::getCurrencySymbol();
 		}
 		$stripeCurrency = strtolower($currencyCode);
 
@@ -198,7 +199,7 @@ class StripeSetting extends DataObject {
 		if (!empty($user->ils_barcode)) {
 			$metadata['Patron Barcode'] = $user->ils_barcode;
 		}
-		require_once ROOT_DIR . '/sys/Utils/StringUtils.php';
+
 		foreach ($paymentLines as $i => $paymentLine) {
 			$metadata['Line ' . ($i + 1)] = $paymentLine->description . " - " . StringUtils::formatCurrency($paymentLine->amountPaid);
 		}

--- a/code/web/sys/SystemVariables.php
+++ b/code/web/sys/SystemVariables.php
@@ -580,26 +580,6 @@ class SystemVariables extends DataObject {
 		return SystemVariables::$_systemVariables;
 	}
 
-	public function getCurrencySymbol() : string {
-		$currencyCode = 'USD';
-		$systemVariables = SystemVariables::getSystemVariables();
-		if (!empty($systemVariables->currencyCode)) {
-			$currencyCode = $systemVariables->currencyCode;
-		}
-		if ($currencyCode == 'USD') {
-			$currencySymbol = '$';
-		} elseif ($currencyCode == 'EUR') {
-			$currencySymbol = '€';
-		} elseif ($currencyCode == 'CAD') {
-			$currencySymbol = '$';
-		} elseif ($currencyCode == 'GBP') {
-			$currencySymbol = '£';
-		} else {
-			$currencySymbol = '';
-		}
-		return $currencySymbol;
-	}
-
 	public function update(string $context = '') : int|bool {
 		if ($this->trackIpAddresses == 0) {
 			//Delete all previously stored usage stats.

--- a/code/web/sys/SystemVariables.php
+++ b/code/web/sys/SystemVariables.php
@@ -127,16 +127,17 @@ class SystemVariables extends DataObject {
 			],
 			'currencyCode' => [
 				'property' => 'currencyCode',
-				'type' => 'enum',
-				'values' => [
-					'USD' => 'USD',
-					'CAD' => 'CAD',
-					'EUR' => 'EUR',
-					'GBP' => 'GBP',
+				'type' => 'text',
+				'suggestions' => [
+					'USD',
+					'CAD',
+					'EUR',
+					'GBP',
 				],
 				'label' => 'Currency Code',
 				'description' => 'Currency code to use when formatting money',
 				'required' => true,
+				'maxLength' => 3,
 				'default' => 'USD',
 			],
 			'indexingSection' => [

--- a/code/web/sys/Utils/StringUtils.php
+++ b/code/web/sys/Utils/StringUtils.php
@@ -15,7 +15,7 @@ class StringUtils {
 		return $string;
 	}
 
-	static function formatCurrency($number) : string {
+	static function getCurrencyFormatter() : NumberFormatter {
 		global $activeLanguage;
 
 		$currencyCode = 'USD';
@@ -24,23 +24,21 @@ class StringUtils {
 			$currencyCode = $variables->currencyCode;
 		}
 
-		$currencyFormatter = new NumberFormatter($activeLanguage->locale . '@currency=' . $currencyCode, NumberFormatter::CURRENCY);
+		return new NumberFormatter($activeLanguage->locale . '@currency=' . $currencyCode, NumberFormatter::CURRENCY);
+	}
 
-		return $currencyFormatter->formatCurrency($number, $currencyCode);
+	static function formatCurrency(float $number) : string {
+		$currencyCode = 'USD';
+		$variables = new SystemVariables();
+		if ($variables->find(true)) {
+			$currencyCode = $variables->currencyCode;
+		}
+
+		return static::getCurrencyFormatter()->formatCurrency($number, $currencyCode);
 	}
 
 	static function getCurrencySymbol() : string {
-		global $activeLanguage;
-
-		$currencyCode = 'USD';
-		$variables = new SystemVariables();
-		if ($variables->find(true)) {
-			$currencyCode = $variables->currencyCode;
-		}
-
-		$currencyFormatter = new NumberFormatter($activeLanguage->locale . '@currency=' . $currencyCode, NumberFormatter::CURRENCY);
-
-		return $currencyFormatter->getSymbol(NumberFormatter::CURRENCY_SYMBOL);
+		return static::getCurrencyFormatter()->getSymbol(NumberFormatter::CURRENCY_SYMBOL);
 	}
 
 	static function truncate($string, $length = 80, $etc = '...', $break_words = false, $middle = false) : string {


### PR DESCRIPTION
This PR does a bunch of preliminary work, but the primary user-visible change is in allowing any currency code to be specified in a system variable (with suggestions for the existing options). To support this wider range, this PR also switches to using PHP's `NumberFormatter` everywhere a currency symbol is needed.

*Note*: Under some circumstances, this may be an visible change. For example, using the currency code `CAD` when the user's locale is `en-US` will result in the currency symbol "CA$". However, if the locale is set to `en-CA` as appropriate, the currency symbol will be "$" as before.