### PR TITLE
DIS-1909: events waiting list - email fixes

### DIFF
--- a/code/web/services/EventRegistrationService.php
+++ b/code/web/services/EventRegistrationService.php
@@ -1,5 +1,6 @@
 <?php
 
+require_once ROOT_DIR . '/sys/Utils/DateUtils.php';
 require_once ROOT_DIR . '/sys/Events/EventInstance.php';
 require_once ROOT_DIR . '/sys/Events/UserAspenEventInstanceRegistration.php';
 

--- a/code/web/sys/Email/EmailTemplate.php
+++ b/code/web/sys/Email/EmailTemplate.php
@@ -40,6 +40,10 @@ class EmailTemplate extends DataObject {
 				'campaignComplete' => 'Campaign Complete',
 				'milestoneComplete' => 'Milestone Complete',
 				'staffCampaignComplete' => 'Campaign Complete Staff Alert',
+			];
+		}
+		if (in_array('Events', $enabledModules)) {
+			$availableTemplates += [
 				'registerForEventFromWaitingList' => 'Register for Event From Waiting List',
 				'eventWaitingListInviteExpired' => 'Waiting List Invitation Expired',
 				'eventCancellationRegistered' => 'Cancellation of an Event (Registered Patron)',


### PR DESCRIPTION
Two fixes related to the event registration (DIS-1597) development, more specifically to email notification (DIS-1909) for patrons being promoted from the waiting list. These address bugs found while testing 26.06.00.

More specifically:

- email templates relevant to events should display depending on event module activation status, not campaign module
-  DateUtils need to be explicitly imported so they may be used when sending event related emails