### PR TITLE
DIS-2542: Fix check_tabs_vs_spaces failing on non-PR pushes

### DIFF
--- a/.github/workflows/pull_request_qa.yml
+++ b/.github/workflows/pull_request_qa.yml
@@ -2,7 +2,6 @@ name: Check Pull Request for QA Issues
 
 on:
   pull_request:
-  push:
 
 jobs:
   check_release_notes:
@@ -34,7 +33,7 @@ jobs:
       - name: Check for spaces instead of tabs
         run: |
           # Find files that are modified in the pull request
-          MODIFIED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} | grep -v 'code/aspen_app')
+          MODIFIED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }})
 
           # Loop through each file and check for spaces used instead of tabs
           EXIT_CODE=0


### PR DESCRIPTION
1. Only run these QA checks on PRs, as they all depend on the `github.event.pull_request.*` context variables.
2. Remove the call to grep that was directly causing the failure - LiDA is no longer in this repository so we don't need to filter it out.