### PR TITLE
DIS-2403: Scope More Like This

### DIFF
--- a/code/web/RecordDrivers/GroupedWorkDriver.php
+++ b/code/web/RecordDrivers/GroupedWorkDriver.php
@@ -1940,6 +1940,15 @@ class GroupedWorkDriver extends IndexRecordDriver {
 				$defaultAvailabilityToggle = $searchLibrary->getGroupedWorkDisplaySettings()->defaultAvailabilityToggle;
 			}
 
+			if ($_REQUEST['requestSource'] == 'getMoreLikeThis') {
+				if ($searchLibrary->moreLikeThisSettings == 2 || $searchLibrary->moreLikeThisSettings == 3) {
+					$defaultAvailabilityToggle = 'local';
+				}
+				if (($searchLibrary->moreLikeThisSettings == 3 || $searchLibrary->moreLikeThisSettings == 4) && !empty($_REQUEST['format'])) {
+					$selectedFormat[] = $_REQUEST['format'];
+				}
+			}
+
 			if (empty($selectedAvailability) && $defaultAvailabilityToggle != 'global') {
 				$selectedAvailability[] = $defaultAvailabilityToggle;
 			}
@@ -2036,13 +2045,14 @@ class GroupedWorkDriver extends IndexRecordDriver {
 		}
 	}
 
-	public function getScrollerTitle($index, $scrollerName) {
+	public function getScrollerTitle($index, $scrollerName, $format = null) {
 		global $interface;
 		$interface->assign('index', $index);
 		$interface->assign('scrollerName', $scrollerName);
 		$interface->assign('id', $this->getPermanentId());
 		$interface->assign('title', $this->getTitle());
 		$interface->assign('linkUrl', $this->getLinkUrl());
+		$interface->assign('format', $format);
 		$interface->assign('bookCoverUrl', $this->getBookcoverUrl('small'));
 		$interface->assign('bookCoverUrlMedium', $this->getBookcoverUrl('medium'));
 
@@ -2053,6 +2063,7 @@ class GroupedWorkDriver extends IndexRecordDriver {
 			'image' => $this->getBookcoverUrl('medium'),
 			'title' => $this->getTitle(),
 			'author' => $this->getPrimaryAuthor(),
+			'format' => $format,
 			'formattedTitle' => $interface->fetch('RecordDrivers/GroupedWork/scroller-title.tpl'),
 		];
 	}

--- a/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/browse_result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/browse_result.tpl
@@ -7,7 +7,7 @@
 
 	{if $accessibleBrowseCategories == '1' && $action != 'Results' && !$isForSearchResults}
 	<div class="swiper-slide browse-thumbnail {$coverStyle}">
-		<a onclick="return AspenDiscovery.GroupedWork.showGroupedWorkInfo('{$summId}', {if !empty($browseCategoryId)}'{$browseCategoryId}'{/if});" href="{$summUrl}">
+		<a onclick="return AspenDiscovery.GroupedWork.showGroupedWorkInfo('{$summId}', {if !empty($browseCategoryId)}'{$browseCategoryId}'{/if},'','');" href="{$summUrl}">
 			<img src="{$bookCoverUrlMedium}" alt="{$summTitle|escape}{if !empty($summSubTitle)} {$summSubTitle|escape}{/if}" title="{$summTitle|escape}{if !empty($summSubTitle)} {$summSubTitle|escape}{/if}" class="{$coverStyle}{if $useOriginalCoverUrls} use-original-covers{/if}" loading="lazy">
 			<div class="swiper-lazy-preloader"></div>
 		</a>
@@ -15,7 +15,7 @@
 	{else}
 		{if $browseMode == '1'}
 			<div class="browse-list grid-item {$coverStyle} {if $browseStyle == 'grid'}browse-grid-style col-tn-6 col-xs-6 col-sm-6 col-md-4 col-lg-3{/if}">
-				<a onclick="return AspenDiscovery.GroupedWork.showGroupedWorkInfo('{$summId}', '{$browseCategoryId}');" href="{$summUrl}">
+				<a onclick="return AspenDiscovery.GroupedWork.showGroupedWorkInfo('{$summId}', '{$browseCategoryId}','','');" href="{$summUrl}">
 					<img class="img-responsive{if $useOriginalCoverUrls} use-original-covers{/if}" src="{$bookCoverUrl}" alt="{$summTitle|escape} {$summSubTitle|escape} {$vSummAuthor|escape}" title="{$summTitle|escape}{if !empty($summSubTitle)} {$summSubTitle|escape}{/if} {$vSummAuthor|escape}">
 					<div class="info">{if !empty($isNew)}<span class="new-result-badge">{translate text="New!" isPublicFacing=true}</span><br/>{/if}<strong>{$summFullTitle|truncate:40}</strong><span>{$vSummAuthor|truncate:40}</span></div>
 				</a>
@@ -24,7 +24,7 @@
 		{else}{*Default Browse Mode (covers) *}
 
 			<div class="browse-thumbnail grid-item {$coverStyle} {if $browseStyle == 'grid'}col-tn-6 col-xs-4 col-sm-4 col-md-3 col-lg-2{/if}">
-				<a onclick="return AspenDiscovery.GroupedWork.showGroupedWorkInfo('{$summId}', {if !empty($browseCategoryId)}'{$browseCategoryId}'{/if});" href="{$summUrl}">
+				<a onclick="return AspenDiscovery.GroupedWork.showGroupedWorkInfo('{$summId}', {if !empty($browseCategoryId)}'{$browseCategoryId}'{/if},'','');" href="{$summUrl}">
 					{if !empty($isNew)}<span class="browse-cover-badge">{translate text="New!" isPublicFacing=true}</span> {/if}
 					<div>
 						<img src="{$bookCoverUrlMedium}" alt="{$summTitle|escape}{if !empty($summSubTitle)} {$summSubTitle|escape}{/if} {$vSummAuthor|escape}" title="{$summTitle|escape}{if !empty($summSubTitle)} {$summSubTitle|escape}{/if} {$vSummAuthor|escape}" class="{$coverStyle} browse-{$browseStyle} {if $browseCategoryRatingsMode != 0}ratings-on{/if}{if $useOriginalCoverUrls} use-original-covers{/if}">

--- a/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/scroller-title.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/scroller-title.tpl
@@ -1,5 +1,5 @@
 {strip}
-	<div id="scrollerTitle{$scrollerName}{$index}" class="scrollerTitle" onclick="return AspenDiscovery.GroupedWork.showGroupedWorkInfo('{$id}');" onkeypress="return AspenDiscovery.GroupedWork.showGroupedWorkInfo('{$id}')" tabindex="0">
+	<div id="scrollerTitle{$scrollerName}{$index}" class="scrollerTitle" onclick="return AspenDiscovery.GroupedWork.showGroupedWorkInfo('{$id}','','{$format}', 'getMoreLikeThis');" onkeypress="return AspenDiscovery.GroupedWork.showGroupedWorkInfo('{$id}','','{$format}', 'getMoreLikeThis')" tabindex="0">
 		<img src="{$bookCoverUrlMedium}" class="scrollerTitleCover" alt="{$title} Cover"/>
 	</div>
 {/strip}

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -12444,7 +12444,8 @@ AspenDiscovery.GroupedWork = (function(){
 
 			var params = {
 				'method':'getMoreLikeThis',
-				'format':format
+				'format': format,
+				'requestUrl' : encodeURIComponent(window.location.href)
 			};
 
 			if (forceReload !== undefined) {
@@ -12620,10 +12621,16 @@ AspenDiscovery.GroupedWork = (function(){
 		},
 
 
-		showGroupedWorkInfo:function(id, browseCategoryId){
+		showGroupedWorkInfo:function(id, browseCategoryId, format, requestSource){
 			var url = Globals.path + "/GroupedWork/" + encodeURIComponent(id) + "/AJAX?method=getWorkInfo";
 			if (browseCategoryId !== undefined){
 				url += "&browseCategoryId=" + browseCategoryId;
+			}
+			if (format !== undefined){
+				url += "&format=" + format;
+			}
+			if (requestSource !== undefined){
+				url += "&requestSource=" + requestSource;
 			}
 			AspenDiscovery.loadingMessage();
 			$.getJSON(url, function(data){

--- a/code/web/interface/themes/responsive/js/aspen/grouped-work.js
+++ b/code/web/interface/themes/responsive/js/aspen/grouped-work.js
@@ -205,7 +205,8 @@ AspenDiscovery.GroupedWork = (function(){
 
 			var params = {
 				'method':'getMoreLikeThis',
-				'format':format
+				'format': format,
+				'requestUrl' : encodeURIComponent(window.location.href)
 			};
 
 			if (forceReload !== undefined) {
@@ -381,10 +382,16 @@ AspenDiscovery.GroupedWork = (function(){
 		},
 
 
-		showGroupedWorkInfo:function(id, browseCategoryId){
+		showGroupedWorkInfo:function(id, browseCategoryId, format, requestSource){
 			var url = Globals.path + "/GroupedWork/" + encodeURIComponent(id) + "/AJAX?method=getWorkInfo";
 			if (browseCategoryId !== undefined){
 				url += "&browseCategoryId=" + browseCategoryId;
+			}
+			if (format !== undefined){
+				url += "&format=" + format;
+			}
+			if (requestSource !== undefined){
+				url += "&requestSource=" + requestSource;
 			}
 			AspenDiscovery.loadingMessage();
 			$.getJSON(url, function(data){

--- a/code/web/services/GroupedWork/AJAX.php
+++ b/code/web/services/GroupedWork/AJAX.php
@@ -329,7 +329,8 @@ class GroupedWork_AJAX extends JSON_Action {
 				$selectedAvailabilityToggle = 'local';
 			}
 			UserAccount::getActiveUserObj();
-			if (($library->moreLikeThisSettings == 3 || $library->moreLikeThisSettings == 4) && !empty($_REQUEST['format'])) {
+			$format = null;
+			if (($library->moreLikeThisSettings == 3 || $library->moreLikeThisSettings == 4) && !empty($_REQUEST['format']) && !str_contains($_REQUEST['requestUrl'], 'GroupedWork')) {
 				$format = $_REQUEST['format'];
 				$similar = $db->getMoreLikeThis($id, $selectedAvailabilityToggle, false, true, null, $format);
 			} else{
@@ -342,7 +343,7 @@ class GroupedWork_AJAX extends JSON_Action {
 				$similarTitles = [];
 				foreach ($similar['response']['docs'] as $key => $similarTitle) {
 					$similarTitleDriver = new GroupedWorkDriver($similarTitle);
-					$similarTitles[] = $similarTitleDriver->getScrollerTitle($key, 'MoreLikeThis');
+					$similarTitles[] = $similarTitleDriver->getScrollerTitle($key, 'MoreLikeThis', $format);
 				}
 				$similarTitlesInfo = [
 					'titles' => $similarTitles,


### PR DESCRIPTION
Update logic for getMoreLikeThis() to only use format exclusion when the user is viewing individual records (not grouped works) 
Update logic for getWorkInfo() and getRelatedManifestations() to use appropriate settings for scoping more like this, using a new "requestSource" variable