### PR TITLE
DIS-2575: Initialize Koha messaging Days In Advance

### DIFF
--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -6593,6 +6593,7 @@ class Koha extends AbstractIlsDriver {
 					'allowableTransports' => [],
 					'wantsDigest' => 0,
 					'selectedTransports' => [],
+					'daysInAdvance' => 0,
 				];
 			}
 			$messagingSettings[$transportId]['allowableTransports'][$transportSetting['message_transport_type']] = $transportSetting['message_transport_type'];

--- a/code/web/release_notes/26.07.00.MD
+++ b/code/web/release_notes/26.07.00.MD
@@ -21,6 +21,9 @@
 
 // lucas
 
+### Koha Updates
+- Fix a warning in Koha Messaging Settings that could occur when advance notice days were set to 0. ([DIS-2575](https://aspen-discovery.atlassian.net/browse/DIS-2575)) (*YL*)
+
 ## This release includes code contributions from
 ### ByWater Solutions
 - Yanjun Li (YL)


### PR DESCRIPTION
In Koha’s native OPAC, if there is no value set for “Days in advance” for the Advance Notice, Koha displays a dropdown with warning: 
“Warning: Undefined array key “daysinAdvance” in /usr/local/aspen-discovery/tmp/smarty/compile/.../kohaMessagingSettings.tpl”

To Test:
1. Log in to Aspen as a patron whose “Days in advance” for Advance Notice is set to 0.
2. Go to My Account > Message Settings.
3. Confirm that the warning message appears in the “Days in Advance” dropdown.
4. Change “Days in advance” to 1.
5. Reload the page and confirm that the warning message disappears.
6. Apply the PR.
7. Reload the page and confirm that no warning message appears when “Days in advance” is set to either 1 or 0.