### PR TITLE
DIS-2572: add configurable complexity score header for Cloudflare rate limiting

### DIFF
--- a/code/web/index.php
+++ b/code/web/index.php
@@ -1675,41 +1675,45 @@ function setCloudflareComplexityHeader(): void {
 	}
 
 	$headerName = $configArray['Security']['complexityHeaderName'] ?: 'x-complexity-score';
-	$uri = $_SERVER['REQUEST_URI'] ?? '/';
 
-	// Match the URI to a weight bucket. Add new cases here to extend.
-	$complexity = matchEndpointWeight($uri);
+	// Module and action are already parsed by loadModuleActionId()
+	$module = $_GET['module'] ?? '';
+	$action = $_GET['action'] ?? '';
+
+	$complexity = matchEndpointWeight($module, $action);
 
 	header("$headerName: $complexity");
 }
 
 /**
- * Map a request URI to a complexity weight score.
+ * Map module/action to a complexity weight score.
  *
  * Add new case blocks here to cover additional endpoints.
  *
- * @param string $uri The request URI (e.g. /Search/Results?page=2)
+ * @param string $module The request module (e.g. Search)
+ * @param string $action The request action (e.g. Results)
  * @return int The complexity weight (default 1)
  */
-function matchEndpointWeight(string $uri): int {
-	switch (true) {
+function matchEndpointWeight(string $module, string $action): int {
+	switch ($module . '/' . $action) {
 		// Score: 25 - Heavy search result pages
-		case preg_match('#^/Search/Results(?:\?|/|$)#', $uri):
-		case preg_match('#^/Union/Search(?:\?|/|$)#', $uri):
+		case 'Search/Results':
+		case 'Union/Search':
 			return 25;
 
 		// Score: 20 - AJAX/API search endpoints
-		case preg_match('#^/Search/AJAX(?:\?|/|$)#', $uri):
-		case preg_match('#^/API/SearchAPI(?:\?|/|$)#', $uri):
+		case 'Search/AJAX':
+		case 'API/SearchAPI':
 			return 20;
 
 		// Score: 15 - GroupedWork detail and AJAX endpoints
-		case preg_match('#^/GroupedWork(?:/|$)#', $uri):
+		case 'GroupedWork/Home':
+		case 'GroupedWork/AJAX':
 			return 15;
 
 		// Score: 10 - Record detail and Author home pages
-		case preg_match('#^/Record(?:/|$)#', $uri):
-		case preg_match('#^/Author/Home(?:\?|/|$)#', $uri):
+		case 'Record/Home':
+		case 'Author/Home':
 			return 10;
 	}
 

--- a/code/web/index.php
+++ b/code/web/index.php
@@ -1695,25 +1695,29 @@ function setCloudflareComplexityHeader(): void {
  * @return int The complexity weight (default 1)
  */
 function matchEndpointWeight(string $module, string $action): int {
-	switch ($module . '/' . $action) {
+	switch (true) {
 		// Score: 25 - Heavy search result pages
-		case 'Search/Results':
-		case 'Union/Search':
+		case $module === 'Search' && $action === 'Results':
+		case $module === 'Union' && $action === 'Search':
 			return 25;
 
 		// Score: 20 - AJAX/API search endpoints
-		case 'Search/AJAX':
-		case 'API/SearchAPI':
+		case $module === 'Search' && $action === 'AJAX':
+		case $module === 'API' && $action === 'SearchAPI':
 			return 20;
 
 		// Score: 15 - GroupedWork detail and AJAX endpoints
-		case 'GroupedWork/Home':
-		case 'GroupedWork/AJAX':
+		case $module === 'GroupedWork':
 			return 15;
 
-		// Score: 10 - Record detail and Author home pages
-		case 'Record/Home':
-		case 'Author/Home':
+		// Score: 10 - Record, Author, and eContent detail pages
+		case $module === 'Record':
+		case $module === 'Author' && $action === 'Home':
+		case $module === 'Hoopla':
+		case $module === 'OverDrive':
+		case $module === 'PalaceProject':
+		case $module === 'Axis360':
+		case $module === 'CloudLibrary':
 			return 10;
 	}
 

--- a/code/web/index.php
+++ b/code/web/index.php
@@ -1704,11 +1704,11 @@ function matchEndpointWeight(string $uri): int {
 			return 20;
 
 		// Score: 15 - GroupedWork detail and AJAX endpoints
-		case preg_match('#^/GroupedWork/[0-9]+/(?:Home|AJAX)(?:\?|/|$)#', $uri):
+		case preg_match('#^/GroupedWork(?:/|$)#', $uri):
 			return 15;
 
 		// Score: 10 - Record detail and Author home pages
-		case preg_match('#^/Record/[0-9]+(?:\?|/|$)#', $uri):
+		case preg_match('#^/Record(?:/|$)#', $uri):
 		case preg_match('#^/Author/Home(?:\?|/|$)#', $uri):
 			return 10;
 	}

--- a/code/web/index.php
+++ b/code/web/index.php
@@ -17,6 +17,9 @@ global $memoryWatcher;
 //Do additional tasks that are only needed when running the full website
 loadModuleActionId();
 $timer->logTime("Loaded Module and Action Id");
+
+// Set Cloudflare Rate Limit complexity header based on endpoint weight
+setCloudflareComplexityHeader();
 $memoryWatcher->logMemory("Loaded Module and Action Id");
 initializeSession();
 $timer->logTime("Initialized session");
@@ -1646,4 +1649,69 @@ function setRoute(string $module, string $action = 'Home', ?string $id = null): 
 
 function setEmptyRouteId(): void {
 	$_REQUEST['id'] = '';
+=======
+/**
+ * Set Cloudflare Rate Limit complexity header based on endpoint weight.
+ *
+ * This enables per-endpoint rate limiting in Cloudflare WAF Rate Limiting Rules.
+ * High-complexity endpoints (search, AJAX) get higher scores so they consume
+ * more of a client's rate limit budget.
+ *
+ * Configured via [Security] section in config.ini:
+ *   enableComplexityHeader  = true/false
+ *   complexityHeaderName    = x-complexity-score
+ *
+ * To add new endpoint weights, add a new case block below.
+ *
+ * @see https://developers.cloudflare.com/waf/rate-limiting-rules/
+ */
+function setCloudflareComplexityHeader(): void {
+	global $configArray;
+
+	// Bail early if feature is disabled
+	if (empty($configArray['Security']['enableComplexityHeader'])) {
+		return;
+	}
+
+	$headerName = $configArray['Security']['complexityHeaderName'] ?: 'x-complexity-score';
+	$uri = $_SERVER['REQUEST_URI'] ?? '/';
+
+	// Match the URI to a weight bucket. Add new cases here to extend.
+	$complexity = matchEndpointWeight($uri);
+
+	header("$headerName: $complexity");
+}
+
+/**
+ * Map a request URI to a complexity weight score.
+ *
+ * Add new case blocks here to cover additional endpoints.
+ *
+ * @param string $uri The request URI (e.g. /Search/Results?page=2)
+ * @return int The complexity weight (default 1)
+ */
+function matchEndpointWeight(string $uri): int {
+	switch (true) {
+		// Score: 25 - Heavy search result pages
+		case preg_match('#^/Search/Results(?:\?|/|$)#', $uri):
+		case preg_match('#^/Union/Search(?:\?|/|$)#', $uri):
+			return 25;
+
+		// Score: 20 - AJAX/API search endpoints
+		case preg_match('#^/Search/AJAX(?:\?|/|$)#', $uri):
+		case preg_match('#^/API/SearchAPI(?:\?|/|$)#', $uri):
+			return 20;
+
+		// Score: 15 - GroupedWork detail and AJAX endpoints
+		case preg_match('#^/GroupedWork/[0-9]+/(?:Home|AJAX)(?:\?|/|$)#', $uri):
+			return 15;
+
+		// Score: 10 - Record detail and Author home pages
+		case preg_match('#^/Record/[0-9]+(?:\?|/|$)#', $uri):
+		case preg_match('#^/Author/Home(?:\?|/|$)#', $uri):
+			return 10;
+	}
+
+	// Default: lightweight pages (static content, home page, etc.)
+	return 1;
 }

--- a/code/web/index.php
+++ b/code/web/index.php
@@ -1649,7 +1649,8 @@ function setRoute(string $module, string $action = 'Home', ?string $id = null): 
 
 function setEmptyRouteId(): void {
 	$_REQUEST['id'] = '';
-=======
+}
+
 /**
  * Set Cloudflare Rate Limit complexity header based on endpoint weight.
  *

--- a/code/web/release_notes/26.07.00.MD
+++ b/code/web/release_notes/26.07.00.MD
@@ -56,4 +56,5 @@
 ## This release includes sponsored developments from
 
 
-
+### Other Updates 
+- Add configurable complexity score header for Cloudflare rate limiting. ([DIS-2572](https://aspen-discovery.atlassian.net/browse/DIS-2572)) (*TS*)

--- a/sites/default/conf/config.ini
+++ b/sites/default/conf/config.ini
@@ -108,6 +108,14 @@ catalogUserAgent          = "Turning Leaf Technologies; Aspen Discovery"
 ;filters = "username:trim,password:trim"
 
 ; This section requires no changes for most installations
+[Security]
+; Enable the x-complexity-score response header for Cloudflare Rate Limiting
+; rules.  When enabled, Aspen sets the header on every request with a weight
+; value based on the endpoint (search results = 25, AJAX = 20, etc.).
+enableComplexityHeader        = false
+; Name of the response header sent to Cloudflare.
+complexityHeaderName          = x-complexity-score
+
 [Index]
 solrHost                      = localhost
 url                           = http://localhost:8080/solr


### PR DESCRIPTION
## Summary

Adds an opt-in `x-complexity-score` response header that enables per-endpoint rate limiting in Cloudflare WAF Rate Limiting Rules. Heavy endpoints (search results, AJAX) get higher scores so they consume more of a client's rate limit budget.

## What this does

- Adds `setCloudflareComplexityHeader()` called early in `index.php` request lifecycle
- New `matchEndpointWeight()` function using `switch(true)` for clean, extensible matching
- New `[Security]` config section in `config.ini` (disabled by default)

## Endpoint weights

| Score | Endpoints |
|---|---|
| **25** | `Search/Results`, `Union/Search` |
| **20** | `Search/AJAX`, `API/SearchAPI` |
| **15** | Any `GroupedWork` sub-path (e.g. `/GroupedWork/{id}/Home`) |
| **10** | Any `Record` sub-path, `Author/Home`, `Hoopla`, `OverDrive`, `PalaceProject`, `Axis360`, `CloudLibrary` |
| **1** | Everything else (default) |

## Configuration

Add to `config.ini`:

```ini
[Security]
enableComplexityHeader  = true
complexityHeaderName    = x-complexity-score
```

Both options are configurable per-site. The header name can be changed if your Cloudflare setup expects a different field name.

## How to use in Cloudflare

1. Go to **WAF → Rate Limiting Rules**
2. Create a rule that evaluates the `x-complexity-score` request header
3. Set thresholds based on your expected legitimate traffic

## Extending

To add new endpoint weights, add a `case` block in `matchEndpointWeight()`:

```php
case $module === 'YourModule' && $action === 'HeavyAction':
    return 30;
```

Match on `$module` alone for any sub-path, or add `&& $action === 'X'` to narrow it down.

## Files changed

- `code/web/index.php` — header logic (+24 lines net)
- `sites/default/conf/config.ini` — `[Security]` section (+8 lines)