### PR TITLE
DIS-1404: fix typo in Icon.php causing 404 for pwa-icon.png

### DIFF
--- a/code/web/release_notes/26.07.00.MD
+++ b/code/web/release_notes/26.07.00.MD
@@ -21,6 +21,9 @@
 
 // lucas
 
+// imani
+- fixed typo causing Icon.php to consistently return 404 ([DIS-1404](https://aspen-discovery.atlassian.net/browse/DIS-1404)) (*IT*)
+
 ## This release includes code contributions from
 ### ByWater Solutions
 - Yanjun Li (YL)

--- a/code/web/services/AspenPWA/Icon.php
+++ b/code/web/services/AspenPWA/Icon.php
@@ -17,7 +17,7 @@ class AspenPWA_Icon extends Action {
 		$success = true;
 		//TODO we should return an error code instead of 200
 		// if we have no settings
-		if($setting)
+		if($settings)
 		{
 			$_REQUEST['themeId'] = $settings->themeId;
 		} else {


### PR DESCRIPTION
to test
visit /pwa-icon.png for a site with PWA enabled and an app logo in the theme
the url should resolve to the proper icon set in the current theme