### PR TITLE
DIS-2463: Fix 'More Options' error when selecting advanced search facet

### DIFF
--- a/code/web/release_notes/26.07.00.MD
+++ b/code/web/release_notes/26.07.00.MD
@@ -132,25 +132,14 @@
 - Fix Material Request Usage Dashboard graph page returning a 500 error when viewing usage statistics. ([DIS-2480] (https://aspen-discovery.atlassian.net/browse/DIS-2480)) (*SSP*)
 - Fix the issue where Donation emails displayed raw HTML tags. ([DIS-2610] (https://aspen-discovery.atlassian.net/browse/DIS-2610)) (*SSP*)
 
-// lucas
-### Other Updates
-- Improve URL handling so invalid or malformed Aspen links now return the correct error page instead of loading unrelated content.([DIS-2612](https://aspen-discovery.atlassian.net/browse/DIS-2612)) (*YL*)
-
 // jonah
 
 - Fix bug associated with placing holds on formats which contain an apostrophe. ([DIS-2548](https://aspen-discovery.atlassian.net/browse/DIS-2548)) (*JW*)
-
-// jonah
 - Update Evolve Driver to pass patronType value to database ([DIS-2601](https://aspen-discovery.atlassian.net/browse/DIS-2601)) (*JW*)
 
-### Sideloads Updates
-- Fix an issue where sideloaded eContent records could show image-only 856 links as extra "Access Online" links. ([DIS-2549](https://aspen-discovery.atlassian.net/browse/DIS-2549)) (*YL*)
-
+// kyle
 ### Reading History Updates
 - Update reading history cron job to make API requests via localhost instead of the public URL, preventing requests from leaving the server and being subject to WAF rules. ([DIS-1960](https://aspen-discovery.atlassian.net/browse/DIS-1960)) (*KMH*)
-
-### Koha Updates
-- Fix a warning in Koha Messaging Settings that could occur when advance notice days were set to 0. ([DIS-2575](https://aspen-discovery.atlassian.net/browse/DIS-2575)) (*YL*)
 
 // imani
 - fixed typo causing Icon.php to consistently return 404 ([DIS-1404](https://aspen-discovery.atlassian.net/browse/DIS-1404)) (*IT*)
@@ -159,12 +148,17 @@
 ### eCommerce Updates
 - Fix an issue where certain payment workflows could create duplicate donation reports for a single donation. ([DIS-2546](https://aspen-discovery.atlassian.net/browse/DIS-2546)) (*YL*)
 
-// yanjun
 ### Hoopla Updates
 - Fix an issue where Hoopla checkout counts were not updated if the Hoopla account summary refresh failed. ([DIS-2506](https://aspen-discovery.atlassian.net/browse/DIS-2506)) (*YL*)
 
 ### Holds Updates
 - Fix an issue where the place hold dialog could show volumes from the wrong format for records with multiple formats. ([DIS-2503](https://aspen-discovery.atlassian.net/browse/DIS-2503)) (*YL*)
+
+### Koha Updates
+- Fix a warning in Koha Messaging Settings that could occur when advance notice days were set to 0. ([DIS-2575](https://aspen-discovery.atlassian.net/browse/DIS-2575)) (*YL*)
+
+### Sideloads Updates
+- Fix an issue where sideloaded eContent records could show image-only 856 links as extra "Access Online" links. ([DIS-2549](https://aspen-discovery.atlassian.net/browse/DIS-2549)) (*YL*)
 
 ### Cron Updates
 - Add scheduled monthly cleanup for user agent usage statistics based on the configured User Agent Cleanup Retention setting. User agents marked as bots or blocked are preserved. ([DIS-2504](https://aspen-discovery.atlassian.net/browse/DIS-2504)) (*YL*)
@@ -178,6 +172,11 @@
 
 ### Other Updates
 - Add MARC 700 subfield q to contributor displays on record detail pages. ([DIS-1805](https://aspen-discovery.atlassian.net/browse/DIS-1805)) (*YL*)
+- Improve URL handling so invalid or malformed Aspen links now return the correct error page instead of loading unrelated content.([DIS-2612](https://aspen-discovery.atlassian.net/browse/DIS-2612)) (*YL*)
+
+// lucas
+### Advanced Search
+- Fix "More options..." popup failing for facets that are configured to appear only in the Advanced Search. ([DIS-2463](https://aspen-discovery.atlassian.net/browse/DIS-2463)) (*LM*)
 
 ## This release includes code contributions from
 ### ByWater Solutions

--- a/code/web/services/Search/AJAX.php
+++ b/code/web/services/Search/AJAX.php
@@ -799,6 +799,9 @@ class AJAX extends JSON_Action {
 		$facetName = $_REQUEST['facetName'];
 		$interface->assign('facetName', $facetName);
 
+		global $action;
+		$action = 'Advanced';
+
 		$searchObject = SearchObjectFactory::initSearchObject();
 		$searchObject->initAdvancedFacets();
 		$searchObject->disableLogging();
@@ -862,6 +865,9 @@ class AJAX extends JSON_Action {
 		$facetName  = $_REQUEST['facetName'];
 		$searchTerm = $_REQUEST['searchTerm'];
 		$interface->assign('facetName', $facetName);
+
+		global $action;
+		$action = 'Advanced';
 
 		$searchObject = SearchObjectFactory::initSearchObject();
 		$searchObject->initAdvancedFacets();


### PR DESCRIPTION
When a facet is configured to appear only in the Advanced Search (showInAdvancedSearch = 1, showInResults = 0), clicking "More options..." in the dropdown fails with "That facet could not be found."

The root cause is that getFacetConfig() uses the global $action variable to decide which facets to return. During AJAX calls $action is 'AJAX', so advanced-search-only facets are excluded from both the Solr query and the config lookup.

The fix sets $action = 'Advanced' before the search object is initialized in both getAdvancedSearchFacetPopup() and searchAdvancedFacetTerms() in Search/AJAX.php, ensuring the correct facet set is used throughout.

Before patching:
1 - Run UPDATE grouped_work_facet SET showInResults = 0 WHERE facetName = 'language';
2 - Open Advanced Search
3 - Open the Language dropdown and select "More options..."
4 - See an error modal: "That facet could not be found"

After patching:
5 - Repeat steps 3 - 4
6 - The popup opens with the full list of language values
7 - Type a keyword (e.g. "spa") in the search field -- filtered results appear
8 - Select a value -- the Language dropdown reflects it
9 - Run UPDATE grouped_work_facet SET showInResults = 1 WHERE facetName = 'language';