### PR TITLE
DIS-2506: Clear Stale Hoopla Account Summary

### DIFF
--- a/code/web/Drivers/HooplaDriver.php
+++ b/code/web/Drivers/HooplaDriver.php
@@ -216,6 +216,7 @@ class HooplaDriver extends AbstractEContentDriver {
 					$hooplaErrorMessage = empty($hooplaPatronStatusResponse['body']->message) ? '' : ' Hoopla Message :' . $hooplaPatronStatusResponse['body']->message;
 					$logger->log('Error retrieving patron status from Hoopla. User ID : ' . $user->id . $hooplaErrorMessage, Logger::LOG_NOTICE);
 					$this->hooplaPatronStatuses[$user->id] = false; // Don't do status call again for this user
+					$summary->resetCounters();
 				}
 				// Get Holds status for only the patrons can access to Hoopla Flex
 				if ($user->isValidForEContentSource('hoopla_flex')) {

--- a/code/web/release_notes/26.07.00.MD
+++ b/code/web/release_notes/26.07.00.MD
@@ -21,6 +21,10 @@
 
 // lucas
 
+// yanjun
+### Hoopla Updates
+- Fix an issue where Hoopla checkout counts were not updated if the Hoopla account summary refresh failed. ([DIS-2506](https://aspen-discovery.atlassian.net/browse/DIS-2506)) (*YL*)
+
 ## This release includes code contributions from
 ### ByWater Solutions
 - Yanjun Li (YL)


### PR DESCRIPTION
Hoopla Account Summary data can remain stale when the Hoopla status API call returns a non-200 response. Aspen might show no Hoopla titles in the checkout tab while still displaying an outdated Hoopla checkout count. We should reset the cached hoopla account summary counters for non-200 responses. 

To Test:
1. Log in as a patron with existing cached Hoopla checkout data 
2. Simulate a non-200 response from the Hoopla Status API 
3. Refresh the user account data in Aspen 
4. Confirm the cached Hoopla checkout data remaining
5. Apply the PR 
6. Repeat steps 2, 3, and confirm the cached Hoopla checkout is reset. 
7. Restore a normal successful Hoopla status response and confirm that valid Hoopla summary counts display again. 