### PR TITLE
DIS-2503: Show selected format volumes for placing holds 

### DIFF
--- a/code/web/release_notes/26.07.00.MD
+++ b/code/web/release_notes/26.07.00.MD
@@ -21,6 +21,9 @@
 
 // lucas
 
+### Holds Updates
+- Fix an issue where the place hold dialog could show volumes from the wrong format for records with multiple formats. ([DIS-2503](https://aspen-discovery.atlassian.net/browse/DIS-2503)) (*YL*)
+
 ## This release includes code contributions from
 ### ByWater Solutions
 - Yanjun Li (YL)

--- a/code/web/services/Record/AJAX.php
+++ b/code/web/services/Record/AJAX.php
@@ -792,7 +792,7 @@ class Record_AJAX extends JSON_Action {
 			foreach ($relatedRecord->recordVariations as $variation) {
 				foreach ($variation->getRecords() as $record) {
 					if ($record->id == $relatedRecord->id) {
-						$unsuppressedVolumeData = $relatedRecord->getUnsuppressedVolumeData(true);
+						$unsuppressedVolumeData = $record->getUnsuppressedVolumeData(true);
 						foreach ($unsuppressedVolumeData as $volumeInfo) {
 							if (!isset($volumeData[$volumeInfo->volumeId])) {
 								$volumeData[$volumeInfo->volumeId] = clone($volumeInfo);


### PR DESCRIPTION
When a record has multiple formats, the place hold modal for either format only shows one format's volumes instead of showing the selected format's volumes or all volumes for the record.


To test in Koha/KTD

1 - Find or create a record - add three items of Book type and three item groups - assign one item to each group

2 - Duplicate the record, add 245h ‘second edition’

3 - Again add 3 items of Book type, 3 groups, and assign one item to each group

4 - Search for the record in Aspen

5 - You should see the book types, expand to two editions, place hold on each, you see the expected volume

6 - Add a fourth item of ‘New book’ type - or anything else really - to the second record

7 - Search the record in Aspen

8 - Expand the book editions and try both place hold button - the first has the correct volumes, the second has none

