### PR TITLE
DIS-2504: Scheduled user agent cleanup

### DIFF
--- a/code/cron/src/com/turning_leaf_technologies/cron/DatabaseCleanup.java
+++ b/code/cron/src/com/turning_leaf_technologies/cron/DatabaseCleanup.java
@@ -4,6 +4,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.time.LocalDate;
 import java.util.Date;
 
 import org.apache.logging.log4j.Logger;
@@ -32,6 +33,7 @@ public class DatabaseCleanup implements IProcessHandler {
 
 		cleanupReadingHistory(dbConn, logger, processLog);
 		removeOldIndexingDiagnostics(dbConn, logger, processLog);
+		cleanupUserAgent(dbConn, logger, processLog);
 
 		removeOldObjectHistory(dbConn, logger, processLog);
 		removeLocalAnalyticsTracking(dbConn, logger, processLog);
@@ -123,6 +125,61 @@ public class DatabaseCleanup implements IProcessHandler {
 			processLog.saveResults();
 		} catch (SQLException e) {
 			processLog.incErrors("Unable to cleanup reading history. ", e);
+		}
+	}
+
+	private void cleanupUserAgent(Connection dbConn, Logger logger, CronProcessLogEntry processLog) {
+		LocalDate today = LocalDate.now();
+
+		// Only run this cleanup on the first day of the month.
+		if (today.getDayOfMonth() != 1) {
+			return;
+		}
+		int retentionMonths = 0;
+		boolean isDisabled = false;
+		try (PreparedStatement getRetentionStmt = dbConn.prepareStatement("SELECT userAgentRetentionMonths, disable_user_agent_logging FROM system_variables LIMIT 1")) {
+			ResultSet retentionRS = getRetentionStmt.executeQuery();
+			if (retentionRS.next()) {
+				retentionMonths = retentionRS.getInt("userAgentRetentionMonths");
+				isDisabled = retentionRS.getBoolean("disable_user_agent_logging");
+			}
+		} catch (SQLException e) {
+			processLog.incErrors("Unable to load user agent retention setting. ", e);
+			return;
+		}
+
+		if (isDisabled) {
+			processLog.addNote("User agent retention cleanup skipped because User agent tracking is disabled.");
+			processLog.saveResults();
+			return;
+		}
+
+		if (retentionMonths == 0) {
+			processLog.addNote("User agent retention cleanup is set to Do not clean up.");
+			processLog.saveResults();
+			return;
+		}
+
+		LocalDate cutoff = today.withDayOfMonth(1).minusMonths(retentionMonths);
+		int cutoffYear = cutoff.getYear();
+		int cutoffMonth = cutoff.getMonthValue();
+
+		try {
+			PreparedStatement deleteOldUsageStmt = dbConn.prepareStatement("DELETE FROM usage_by_user_agent WHERE year < ? OR (year = ? AND month < ?)");
+			deleteOldUsageStmt.setInt(1, cutoffYear);
+			deleteOldUsageStmt.setInt(2, cutoffYear);
+			deleteOldUsageStmt.setInt(3, cutoffMonth);
+			int usageRowsRemoved = deleteOldUsageStmt.executeUpdate();
+
+			PreparedStatement deleteUnusedUserAgentsStmt = dbConn.prepareStatement("DELETE user_agent FROM user_agent LEFT JOIN usage_by_user_agent ON usage_by_user_agent.userAgentId = user_agent.id WHERE usage_by_user_agent.id IS NULL AND user_agent.blockAccess = 0 AND user_agent.isBot = 0");
+			int userAgentRowsRemoved = deleteUnusedUserAgentsStmt.executeUpdate();
+
+			processLog.addNote("Removed " + usageRowsRemoved + " old user agent usage rows.");
+			processLog.addNote("Removed " + userAgentRowsRemoved + " unused user agent rows.");
+			processLog.incUpdated();
+			processLog.saveResults();
+		} catch (SQLException e) {
+			processLog.incErrors("Unable to cleanup user agent. ", e);
 		}
 	}
 

--- a/code/web/release_notes/26.07.00.MD
+++ b/code/web/release_notes/26.07.00.MD
@@ -21,6 +21,16 @@
 
 // lucas
 
+### Cron Updates
+- Add scheduled monthly cleanup for user agent usage statistics based on the configured User Agent Cleanup Retention setting. User agents marked as bots or blocked are preserved. ([DIS-2504](https://aspen-discovery.atlassian.net/browse/DIS-2504)) (*YL*)
+
+<div markdown="1" class="settings">
+
+#### New Settings
+- System Variables > User Agent Cleanup Retention
+
+</div>
+
 ## This release includes code contributions from
 ### ByWater Solutions
 - Yanjun Li (YL)

--- a/code/web/sys/DBMaintenance/version_updates/26.07.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/26.07.00.php
@@ -31,6 +31,14 @@ function getUpdates26_07_00(): array {
 				'ALTER TABLE system_variables ADD COLUMN userAgentRetentionMonths INT NOT NULL DEFAULT 3'
 			]
 		], //add_user_agent_retention_months
+		'add_user_agent_usage_year_month_index' => [
+			'title' => 'Add User Agent Usage Year Month Index',
+			'description' => 'Add an index on year and month to usage_by_user_agent for retention cleanup',
+			'continueOnError' => false,
+			'sql' => [
+				'ALTER TABLE usage_by_user_agent ADD INDEX idx_year_month (year, month)'
+			]
+		], //add_user_agent_usage_year_month_index
 
 		//imani
 

--- a/code/web/sys/DBMaintenance/version_updates/26.07.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/26.07.00.php
@@ -23,6 +23,14 @@ function getUpdates26_07_00(): array {
 		//kodi
 
 		//yanjun
+		'add_user_agent_retention_months' => [
+			'title' => 'Add User Agent Retention Months',
+			'description' => 'Add userAgentRetentionMonths column to system_variables',
+			'continueOnError' => false,
+			'sql' => [
+				'ALTER TABLE system_variables ADD COLUMN userAgentRetentionMonths INT NOT NULL DEFAULT 3'
+			]
+		], //add_user_agent_retention_months
 
 		//imani
 

--- a/code/web/sys/SystemVariables.php
+++ b/code/web/sys/SystemVariables.php
@@ -64,6 +64,7 @@ class SystemVariables extends DataObject {
 	/** @noinspection PhpUnused */
 	public $removeTheWordSeriesFromEndOfSeries;
 	public $disable_user_agent_logging;
+	public $userAgentRetentionMonths;
 	public $logFrequentCrons;
 	public $hooplaVersion;
 
@@ -511,6 +512,21 @@ class SystemVariables extends DataObject {
 				'label' => 'Disable User Agent Tracking',
 				'description' => 'When enabled, disables all user agent tracking including logging, spam detection, and blocking.',
 				'default' => false,
+			],
+			'userAgentRetentionMonths' => [
+				'property' => 'userAgentRetentionMonths',
+				'type' => 'enum',
+				'values' => [
+					0 => 'Do not clean up',
+					1 => '1 month',
+					3 => '3 months',
+					6 => '6 months',
+					12 => '12 months',
+				],
+				'label' => 'User Agent Cleanup Retention',
+				'description' => 'Controls how many months of user agent usage statistics are retained. User agents marked as bots or blocked are preserved.',
+				'note' => 'Changes to this setting take effect on the first day of the next month.',
+				'default' => 3,
 			],
 			'logFrequentCrons' => [
 				'property' => 'logFrequentCrons',


### PR DESCRIPTION
Aspen currently logs user agent activity into user_agent and usage_by_user_agent without a regular cleanup. On large sites, both tables can grow into millions of rows. We should add a scheduled cleanup process to remove old usage_by_user_agent rows and delete unreferenced user_agent rows. Adding a setting to control how many months of usage data to keep. 

To Test:
1. Apply the PR 
2. Go to System Variables, change User Agent Cleanup Retention dropdown and save
3.  Before running cron, check DB for expected cleanup counts:   SELECT COUNT(*)  FROM usage_by_user_agent WHERE year < <cutoffYear> OR (year = <cutoffYear> AND month < <cutoffMonth>);
4. Run cron.jar 
5. Review Cron Logs > Primary Cron > Database Cleanup notes, confirm the notes show the expected number of removed usage rows and unused user agent rows
6. Repeat step 3 to confirm old usage_by_user_agent rows were deleted
7. Set User Agent Cleanup Retention to Do not clean up, run cron again and confirm the log says renting cleanup is set to Do not clean up 
8. Enabled Disable User Agent Tracking, run cron again and confirm the cleanup skip because user agent tracking is disabled. 