### PR TITLE
DIS-1805: Display contributor 700$q in record details

### DIFF
--- a/code/web/RecordDrivers/MarcRecordDriver.php
+++ b/code/web/RecordDrivers/MarcRecordDriver.php
@@ -931,6 +931,7 @@ class MarcRecordDriver extends GroupedWorkSubDriver {
 			'b',
 			'c',
 			'd',
+			'q',
 		]);
 	}
 
@@ -950,6 +951,7 @@ class MarcRecordDriver extends GroupedWorkSubDriver {
 					'b',
 					'c',
 					'd',
+					'q',
 				], true);
 				$titleSubfieldArray = $this->getSubfieldArray($field, [
 					't',

--- a/code/web/release_notes/26.07.00.MD
+++ b/code/web/release_notes/26.07.00.MD
@@ -21,6 +21,9 @@
 
 // lucas
 
+### Other Updates
+- Add MARC 700 subfield q to contributor displays on record detail pages. ([DIS-1805](https://aspen-discovery.atlassian.net/browse/DIS-1805)) (*YL*)
+
 ## This release includes code contributions from
 ### ByWater Solutions
 - Yanjun Li (YL)


### PR DESCRIPTION
spen already displays the 1xx subfield q for the author section, so it would make sense for it to do the same for the contributor section. 

To Test:
1. Create a MARC record that includes contributor 700$q data
2. Confirm the contributor section on record detail page does not show the subfield q value
3. Apply the PR
4. Reindex the record
5. Refresh the record page and confirm the contributor section now includes the subfield q value 