### PR TITLE
DIS-2549: Skip indexing MARC 856 4 0 image links

### DIFF
--- a/code/reindexer/src/org/aspen_discovery/reindexer/SideLoadedEContentProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/SideLoadedEContentProcessor.java
@@ -131,6 +131,10 @@ class SideLoadedEContentProcessor extends MarcRecordProcessor{
 					//Try to determine if this is a resource or not.
 					if (urlField.getIndicator1() == '4' || urlField.getIndicator1() == ' ' || urlField.getIndicator1() == '0') {
 						if (urlField.getIndicator2() == ' ' || urlField.getIndicator2() == '0' || urlField.getIndicator2() == '1' || urlField.getIndicator2() == '4') {
+							Subfield subfield3 = urlField.getSubfield('3');
+							if (subfield3 != null && subfield3.getData().trim().equalsIgnoreCase("Image")) {
+								continue;
+							}
 							urlIndex++;
 
 							hasValidUrl = true;

--- a/code/web/release_notes/26.07.00.MD
+++ b/code/web/release_notes/26.07.00.MD
@@ -21,6 +21,9 @@
 
 // lucas
 
+### Sideloads Updates
+- Fix an issue where sideloaded eContent records could show image-only 856 links as extra "Access Online" links. ([DIS-2549](https://aspen-discovery.atlassian.net/browse/DIS-2549)) (*YL*)
+
 ## This release includes code contributions from
 ### ByWater Solutions
 - Yanjun Li (YL)


### PR DESCRIPTION
Some sideloaded records, such as from Comics Plus, may include multiple 856 links to online content. 

For Comics Plus, for example, the records often include two 856 links: One for access to the material, and one for a cover image. Both generally have an 856 with first indicator 4, second indicator 0 (856 4 0).

In this case, Aspen is indexing both links and showing two different “Access Online” buttons. One goes to the resource, the other only goes to a page showing the cover image. 

Aspen should only index the valid resource link. 

To Test:
1. Index a sideload record whose MARC contains two valid 856 4 0 links: one resource link and one image link with subfield 3 set to Image.
2. Open the record detail page and verify it shows an extra Access Online link for the image URL.
3. Apply the PR.
4. Reindex the record.
5. Refresh the record detail page and verify it shows only one Access Online link, pointing to the actual resource URL.
