### PR TITLE
DIS-2601: Evolve driver update

### DIFF
--- a/code/web/Drivers/Evolve.php
+++ b/code/web/Drivers/Evolve.php
@@ -712,6 +712,7 @@ class Evolve extends AbstractIlsDriver {
 			}
 			$user->phone = $accountDetails->Phone;
 			$user->email = $accountDetails->Email;
+			$user->patronType = $accountDetails->Type;
 
 			//Load home location for the user
 			global $library;

--- a/code/web/release_notes/26.07.00.MD
+++ b/code/web/release_notes/26.07.00.MD
@@ -21,6 +21,9 @@
 
 // lucas
 
+// jonah
+- Update Evolve Driver to pass patronType value to database ([DIS-2601](https://aspen-discovery.atlassian.net/browse/DIS-2601)) (*JW*)
+
 ## This release includes code contributions from
 ### ByWater Solutions
 - Yanjun Li (YL)


### PR DESCRIPTION
Update patronType value for user from Evolve driver.


Testing Instructions:
Background: Bug relating to linking patrons when PatronType value is null in database.

Requires:
1. Evolve ILS instance
2. Patron in DB with no patronType;

Testing Instructions
Pre-Patch:

    Login or Masquerade as user without patronType

    Attempt to link account to another use with patronType

    Expected result: Failure

Post-Patch:

    Login as a user without patronType

        This should call the API and set the value in the database for the current user

    Attempt to link account to another user with patronType

    Expected result: Success (IF patron types are able to be linked)
