### PR TITLE
DIS-2605: International date formatter

### DIFF
--- a/code/web/release_notes/26.07.00.MD
+++ b/code/web/release_notes/26.07.00.MD
@@ -14,6 +14,7 @@
 // chloe
 
 // jacob
+- Add a locale-aware date formatter to DateUtils. ([DIS-2605](https://aspen-discovery.atlassian.net/browse/DIS-2605)) (*JOM*)
 
 // pedro
 

--- a/code/web/sys/Smarty/plugins/modifier.format_date_locale.php
+++ b/code/web/sys/Smarty/plugins/modifier.format_date_locale.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Smarty plugin
+ *
+ * @package    Smarty
+ * @subpackage PluginsModifier
+ */
+/**
+ * Smarty format_date_locale modifier plugin
+ * Type:     modifier
+ * Name:     format_date_locale
+ * Purpose:  format dates using locale-aware formatting via IntlDateFormatter
+ * Input:
+ *          - string: input date string or timestamp
+ *          - style: date style (short, medium, long, full)
+ *          - time_style: time style (none, short, medium, long, full)
+ *          - pattern: optional custom ICU date pattern (e.g., 'MMMM yyyy' for "March 2026")
+ *
+ * @param mixed  $string     input date string or timestamp
+ * @param string $style      date style (short, medium, long, full)
+ * @param string $time_style time style (none, short, medium, long, full)
+ * @param string $pattern    optional custom ICU date pattern
+ *
+ * @return string formatted date
+ */
+function smarty_modifier_format_date_locale($string, $style = 'medium', $time_style = 'none', $pattern = null)
+{
+	require_once ROOT_DIR . '/sys/Utils/DateUtils.php';
+	return DateUtils::formatDateLocale($string, $style, $time_style, $pattern);
+}

--- a/code/web/sys/Utils/DateUtils.php
+++ b/code/web/sys/Utils/DateUtils.php
@@ -48,4 +48,59 @@ class DateUtils {
 		}
 		return str_replace('-', '_', $locale);
 	}
+
+	static function formatDateLocale($string, $dateStyle = 'medium', $timeStyle = 'none', $pattern = null): string|false {
+		global $activeLanguage;
+
+		if (empty($string) || $string === '0000-00-00' || $string === '0000-00-00 00:00:00') {
+			return '';
+		}
+
+		if ($string instanceof DateTime) {
+			$timestamp = $string->getTimestamp();
+		} elseif (is_numeric($string)) {
+			$timestamp = (int)$string;
+		} else {
+			$timestamp = strtotime($string);
+		}
+
+		if ($timestamp === false || $timestamp === -1) {
+			return '';
+		}
+
+		$dateStyleMap = [
+			'none'   => IntlDateFormatter::NONE,
+			'short'  => IntlDateFormatter::SHORT,
+			'medium' => IntlDateFormatter::MEDIUM,
+			'long'   => IntlDateFormatter::LONG,
+			'full'   => IntlDateFormatter::FULL,
+		];
+
+		$timeStyleMap = [
+			'none'   => IntlDateFormatter::NONE,
+			'short'  => IntlDateFormatter::SHORT,
+			'medium' => IntlDateFormatter::MEDIUM,
+			'long'   => IntlDateFormatter::LONG,
+			'full'   => IntlDateFormatter::FULL,
+		];
+
+		$dateStyleConstant = $dateStyleMap[strtolower($dateStyle)] ?? IntlDateFormatter::MEDIUM;
+		$timeStyleConstant = $timeStyleMap[strtolower($timeStyle)] ?? IntlDateFormatter::NONE;
+
+		$locale = $activeLanguage->locale ?? 'en_US';
+		$timezone = date_default_timezone_get();
+
+		$formatter = new IntlDateFormatter(
+			$locale,
+			$dateStyleConstant,
+			$timeStyleConstant,
+			$timezone
+		);
+
+		if ($pattern !== null) {
+			$formatter->setPattern($pattern);
+		}
+
+		return $formatter->format($timestamp);
+	}
 }

--- a/tests/phpunit/tests/sys/Util/DateUtilsTests.php
+++ b/tests/phpunit/tests/sys/Util/DateUtilsTests.php
@@ -1,0 +1,70 @@
+<?php
+namespace sys\Util;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class DateUtilsTests extends TestCase {
+	private ?string $originalTimezone = null;
+	private $originalActiveLanguage = null;
+
+	public function __construct(string $name) {
+		parent::__construct($name);
+		require_once __DIR__ . '/../../../../../code/web/sys/Utils/DateUtils.php';
+	}
+
+	protected function setUp(): void {
+		$this->originalTimezone = date_default_timezone_get();
+		date_default_timezone_set('UTC');
+
+		global $activeLanguage;
+		$this->originalActiveLanguage = $activeLanguage;
+		$activeLanguage = (object)['locale' => 'en_US'];
+	}
+
+	protected function tearDown(): void {
+		if ($this->originalTimezone !== null) {
+			date_default_timezone_set($this->originalTimezone);
+		}
+		global $activeLanguage;
+		$activeLanguage = $this->originalActiveLanguage;
+	}
+
+	public static function emptyDateProvider(): array {
+		return [
+			'empty string'        => [''],
+			'null'                => [null],
+			'zero date'           => ['0000-00-00'],
+			'zero datetime'       => ['0000-00-00 00:00:00'],
+			'unparseable string'  => ['not a date'],
+		];
+	}
+
+	#[DataProvider('emptyDateProvider')]
+	public function testFormatDateLocaleReturnsEmptyForInvalidInput($input): void {
+		$this->assertSame('', \DateUtils::formatDateLocale($input));
+	}
+
+	public static function patternProvider(): array {
+		return [
+			'iso date'        => ['2025-03-15', 'medium', 'none', 'yyyy-MM-dd', '2025-03-15'],
+			'iso datetime'    => ['2025-03-15 14:30:00', 'medium', 'short', 'yyyy-MM-dd HH:mm', '2025-03-15 14:30'],
+			'month and year'  => ['2025-03-15', 'medium', 'none', 'MMMM yyyy', 'March 2025'],
+		];
+	}
+
+	#[DataProvider('patternProvider')]
+	public function testFormatDateLocaleHonoursPattern($input, $dateStyle, $timeStyle, $pattern, $expected): void {
+		$this->assertSame($expected, \DateUtils::formatDateLocale($input, $dateStyle, $timeStyle, $pattern));
+	}
+
+	public function testFormatDateLocaleAcceptsDateTimeObject(): void {
+		$date = new \DateTime('2025-03-15 00:00:00', new \DateTimeZone('UTC'));
+		$this->assertSame('2025-03-15', \DateUtils::formatDateLocale($date, 'medium', 'none', 'yyyy-MM-dd'));
+	}
+
+	public function testFormatDateLocaleAcceptsNumericTimestamp(): void {
+		$timestamp = strtotime('2025-03-15 00:00:00');
+		$this->assertSame('2025-03-15', \DateUtils::formatDateLocale($timestamp, 'medium', 'none', 'yyyy-MM-dd'));
+	}
+}


### PR DESCRIPTION
This gives the option for date formatting in both php and smarty files to be internationally formatted based on currently active language.
To test: 
run `php phpunit.phar --no-configuration tests/sys/Util/DateUtilsTests.php`