### PR TITLE
DIS-2608: unit test site env

### DIFF
--- a/code/web/release_notes/26.07.00.MD
+++ b/code/web/release_notes/26.07.00.MD
@@ -14,6 +14,7 @@
 // chloe
 
 // jacob
+- Resolve the unit test site name from the SITE_NAME environment variable. ([DIS-2608](https://aspen-discovery.atlassian.net/browse/DIS-2608)) (*JOM*)
 
 // pedro
 

--- a/tests/phpunit/phpUnitBootstrap.php
+++ b/tests/phpunit/phpUnitBootstrap.php
@@ -1,5 +1,5 @@
 <?php
-$_SERVER['aspen_server'] = 'unit_tests.localhost';
+$_SERVER['aspen_server'] = getenv('SITE_NAME') ?: 'unit_tests.localhost';
 
 require_once '../../code/web/bootstrap.php';
 //Load a clean database at the start of unit testing?


### PR DESCRIPTION
This allows you to specify an env variable when running tests that will override the hardcoded test site and allow you to run tests on any site. Should not affect tests being run on the hardcoded test site. (unit_tests.localhost)

To test:
Run tests to ensure they run on the hardcoded site
Apply patch
Run tests normally and ensure they still run on the hardcoded site above
Assign the env var for SITE_NAME
See tests now run on that site instead