### PR TITLE
DIS-2609: Event test require path fix

### DIFF
--- a/code/web/release_notes/26.07.00.MD
+++ b/code/web/release_notes/26.07.00.MD
@@ -50,6 +50,7 @@
 
 // jacob
 - Add a locale-aware date formatter to DateUtils. ([DIS-2605](https://aspen-discovery.atlassian.net/browse/DIS-2605)) (*JOM*)
+- Fix the EventRegistrationService require path in event tests. ([DIS-2609](https://aspen-discovery.atlassian.net/browse/DIS-2609)) (*JOM*)
 
 // pedro
 

--- a/tests/phpunit/tests/sys/Events/EventAttendeeCategoryTests.php
+++ b/tests/phpunit/tests/sys/Events/EventAttendeeCategoryTests.php
@@ -23,7 +23,7 @@ class EventAttendeeCategoryTests extends TestCase {
 		require_once ATTENDEE_PATH_TO_ROOT . 'code/web/sys/Events/EventTypeAttendeeCategory.php';
 		require_once ATTENDEE_PATH_TO_ROOT . 'code/web/sys/Events/UserAspenEventInstanceRegistration.php';
 		require_once ATTENDEE_PATH_TO_ROOT . 'code/web/sys/Events/UserAspenEventInstanceRegistrationAttendee.php';
-		require_once ATTENDEE_PATH_TO_ROOT . 'code/web/sys/Events/EventRegistrationService.php';
+		require_once ATTENDEE_PATH_TO_ROOT . 'code/web/services/EventRegistrationService.php';
 		require_once ATTENDEE_PATH_TO_ROOT . 'code/web/sys/Account/User.php';
 	}
 

--- a/tests/phpunit/tests/sys/Events/EventStaffRegistrationTests.php
+++ b/tests/phpunit/tests/sys/Events/EventStaffRegistrationTests.php
@@ -18,7 +18,7 @@ class EventStaffRegistrationTests extends TestCase {
 		require_once STAFF_REG_PATH_TO_ROOT . 'code/web/sys/Events/EventInstance.php';
 		require_once STAFF_REG_PATH_TO_ROOT . 'code/web/sys/Events/EventType.php';
 		require_once STAFF_REG_PATH_TO_ROOT . 'code/web/sys/Events/UserAspenEventInstanceRegistration.php';
-		require_once STAFF_REG_PATH_TO_ROOT . 'code/web/sys/Events/EventRegistrationService.php';
+		require_once STAFF_REG_PATH_TO_ROOT . 'code/web/services/EventRegistrationService.php';
 		require_once STAFF_REG_PATH_TO_ROOT . 'code/web/sys/Events/AspenEventSetting.php';
 		require_once STAFF_REG_PATH_TO_ROOT . 'code/web/sys/Events/UserEventsEntry.php';
 		require_once STAFF_REG_PATH_TO_ROOT . 'code/web/sys/Account/User.php';


### PR DESCRIPTION
Tests for events are pointing at the old location. This has since been migrated to a proper service and lives with the others. Tests need to be amended to match.
To test:
run tests and see they fail with invalid requires (imports)
Apply patch
Tests should resolve the requires correctly.