### PR TITLE
DIS 2607: Limit event dates  to 5 with show more

### DIFF
--- a/code/web/interface/themes/responsive/AspenEvents/event.tpl
+++ b/code/web/interface/themes/responsive/AspenEvents/event.tpl
@@ -51,11 +51,23 @@
 					{translate text="Other Dates in this Series" isPublicFacing=true}
 				</div>
 				<div class="panel-body">
-					{foreach from=$recordDriver->getOtherEventsInSeries() item=event key=key}
+					{foreach from=$recordDriver->getOtherEventsInSeries() item=event key=key name="eventDateLoop"}
+						{if $smarty.foreach.eventDateLoop.iteration == 6}
+							<div class="col-xs-12">
+								<a href="#" id="moreEventDates" onclick="AspenDiscovery.Events.moreEventDates(); return false;">{translate text='more' isPublicFacing=true} ...</a>
+							</div>
+							<div class="narrowGroupHidden" id="narrowGroupHidden_eventDates" style="display:none">
+						{/if}
 						<div class="col-xs-12">
-							<a href='/AspenEvents/{$key|escape:'url'}/Event'>{$event|date_format:"%x"}</a>
+							<a href='/AspenEvents/{$key|escape:'url'}/Event'>{$event|format_date_locale:'medium'}</a>
 						</div>
 					{/foreach}
+					{if $smarty.foreach.eventDateLoop.total > 5}
+						<div class="col-xs-12">
+							<a href="#" onclick="AspenDiscovery.Events.lessEventDates(); return false;">{translate text='less' isPublicFacing=true} ...</a>
+						</div>
+						</div>{* closes narrowGroupHidden div *}
+					{/if}
 				</div>
 			</div>
 		{/if}

--- a/code/web/interface/themes/responsive/AspenEvents/event.tpl
+++ b/code/web/interface/themes/responsive/AspenEvents/event.tpl
@@ -71,8 +71,8 @@
 						<li>{translate text="Date: " isPublicFacing=true}{$recordDriver->getStartDate()|format_date_locale:'full'}</li>
 						<li>{translate text="Time: All Day Event" isPublicFacing=true}</li>
 					{elseif $recordDriver->isMultiDayEvent()}
-						<li>{translate text="Start Date: " isPublicFacing=true}{$recordDriver->getStartDate()|format_date_locale:'long':'short'}</li>
-						<li>{translate text="End Date: " isPublicFacing=true}{$recordDriver->getEndDate()|format_date_locale:'long':'short'}</li>
+						<li>{translate text="Start Date: " isPublicFacing=true}{$recordDriver->getStartDate()|format_datetime_locale:'long'}</li>
+						<li>{translate text="End Date: " isPublicFacing=true}{$recordDriver->getEndDate()|format_datetime_locale:'long'}</li>
 					{else}
 						<li>{translate text="Date: " isPublicFacing=true}{$recordDriver->getStartDate()|format_date_locale:'full'}</li>
 						{if !$recordDriver->hiddenTimestamps()}

--- a/code/web/interface/themes/responsive/AspenEvents/event.tpl
+++ b/code/web/interface/themes/responsive/AspenEvents/event.tpl
@@ -68,15 +68,15 @@
 			<div class="col-xs-8">
 				<ul>
 					{if $recordDriver->isAllDayEvent()}
-						<li>{translate text="Date: " isPublicFacing=true}{$recordDriver->getStartDate()|date_format:"%A %B %e, %Y"}</li>
+						<li>{translate text="Date: " isPublicFacing=true}{$recordDriver->getStartDate()|format_date_locale:'full'}</li>
 						<li>{translate text="Time: All Day Event" isPublicFacing=true}</li>
 					{elseif $recordDriver->isMultiDayEvent()}
-						<li>{translate text="Start Date: " isPublicFacing=true}{$recordDriver->getStartDate()|date_format:"%a %b %e, %Y %l:%M%p"}</li>
-						<li>{translate text="End Date: " isPublicFacing=true}{$recordDriver->getEndDate()|date_format:"%a %b %e, %Y %l:%M%p"}</li>
+						<li>{translate text="Start Date: " isPublicFacing=true}{$recordDriver->getStartDate()|format_date_locale:'long':'short'}</li>
+						<li>{translate text="End Date: " isPublicFacing=true}{$recordDriver->getEndDate()|format_date_locale:'long':'short'}</li>
 					{else}
-						<li>{translate text="Date: " isPublicFacing=true}{$recordDriver->getStartDate()|date_format:"%A %B %e, %Y"}</li>
+						<li>{translate text="Date: " isPublicFacing=true}{$recordDriver->getStartDate()|format_date_locale:'full'}</li>
 						{if !$recordDriver->hiddenTimestamps()}
-							<li>{translate text="Time: " isPublicFacing=true}{$recordDriver->getStartDate()|date_format:"%l:%M %p"} to {$recordDriver->getEndDate()|date_format:"%l:%M %p"}</li>
+							<li>{translate text="Time: " isPublicFacing=true}{$recordDriver->getStartDate()|format_time_range_locale:$recordDriver->getEndDate()}</li>
 						{/if}
 					{/if}
 					<li>{translate text="Branch: " isPublicFacing=true}{$recordDriver->getBranch()}</li>

--- a/code/web/interface/themes/responsive/css/calendar.less
+++ b/code/web/interface/themes/responsive/css/calendar.less
@@ -352,6 +352,14 @@
 							display: none;
 						}
 
+						.start-meridiem {
+							display: none;
+						}
+
+						.can-hide-end-time .start-meridiem {
+							display: inline;
+						}
+
 						.show-end-time {
 							white-space: nowrap;
 						}
@@ -359,6 +367,10 @@
 						@media (min-width: @screen-lg-min) { // Larger than landscape letter paper
 							.can-hide-end-time .end-time {
 								display: inline;
+							}
+
+							.can-hide-end-time .start-meridiem {
+								display: none;
 							}
 						}
 

--- a/code/web/interface/themes/responsive/css/main.css
+++ b/code/web/interface/themes/responsive/css/main.css
@@ -11749,6 +11749,12 @@ td[data-entry-id]:has(.date-edit:focus)::after {
   .calendar-row .calendar-day-cell .calendar-events .calendar-event .can-hide-end-time .end-time {
     display: none;
   }
+  .calendar-row .calendar-day-cell .calendar-events .calendar-event .start-meridiem {
+    display: none;
+  }
+  .calendar-row .calendar-day-cell .calendar-events .calendar-event .can-hide-end-time .start-meridiem {
+    display: inline;
+  }
   .calendar-row .calendar-day-cell .calendar-events .calendar-event .show-end-time {
     white-space: nowrap;
   }
@@ -11798,6 +11804,9 @@ td[data-entry-id]:has(.date-edit:focus)::after {
 @media print and (min-width: 768px) and (min-width: 1200px) {
   .calendar-row .calendar-day-cell .calendar-events .calendar-event .can-hide-end-time .end-time {
     display: inline;
+  }
+  .calendar-row .calendar-day-cell .calendar-events .calendar-event .can-hide-end-time .start-meridiem {
+    display: none;
   }
 }
 @media print and (min-width: 768px) and (min-width: 1700px) {
@@ -11954,6 +11963,12 @@ td[data-entry-id]:has(.date-edit:focus)::after {
   [data-context="print-layout"] .calendar-row .calendar-day-cell .calendar-events .calendar-event .can-hide-end-time .end-time {
     display: none;
   }
+  [data-context="print-layout"] .calendar-row .calendar-day-cell .calendar-events .calendar-event .start-meridiem {
+    display: none;
+  }
+  [data-context="print-layout"] .calendar-row .calendar-day-cell .calendar-events .calendar-event .can-hide-end-time .start-meridiem {
+    display: inline;
+  }
   [data-context="print-layout"] .calendar-row .calendar-day-cell .calendar-events .calendar-event .show-end-time {
     white-space: nowrap;
   }
@@ -12003,6 +12018,9 @@ td[data-entry-id]:has(.date-edit:focus)::after {
 @media (min-width: 768px) and (min-width: 1200px) {
   [data-context="print-layout"] .calendar-row .calendar-day-cell .calendar-events .calendar-event .can-hide-end-time .end-time {
     display: inline;
+  }
+  [data-context="print-layout"] .calendar-row .calendar-day-cell .calendar-events .calendar-event .can-hide-end-time .start-meridiem {
+    display: none;
   }
 }
 @media (min-width: 768px) and (min-width: 1700px) {
@@ -12783,4 +12801,3 @@ html.hero-slider-signage {
     overflow: visible !important;
   }
 }
-/*# sourceMappingURL=main.css.map */

--- a/code/web/interface/themes/responsive/js/aspen/events.js
+++ b/code/web/interface/themes/responsive/js/aspen/events.js
@@ -1053,6 +1053,16 @@ AspenDiscovery.Events = (function(){
 				setTimeout(function() { cell.css('background-color', ''); }, 1200);
 				checkbox.prop('checked', !attended);
 			});
+		},
+
+		lessEventDates: function() {
+			document.getElementById("moreEventDates").style.display = "block";
+			document.getElementById("narrowGroupHidden_eventDates").style.display = "none";
+		},
+
+		moreEventDates: function() {
+			document.getElementById("moreEventDates").style.display = "none";
+			document.getElementById("narrowGroupHidden_eventDates").style.display = "block";
 		}
 	};
 }(AspenDiscovery.Events || {}));

--- a/code/web/release_notes/26.07.00.MD
+++ b/code/web/release_notes/26.07.00.MD
@@ -14,6 +14,7 @@
 // chloe
 
 // jacob
+- Add a locale-aware date formatter to DateUtils. ([DIS-2605](https://aspen-discovery.atlassian.net/browse/DIS-2605)) (*JOM*)
 
 // pedro
 

--- a/code/web/release_notes/26.07.00.MD
+++ b/code/web/release_notes/26.07.00.MD
@@ -15,6 +15,7 @@
 
 // jacob
 - Add a locale-aware date formatter to DateUtils. ([DIS-2605](https://aspen-discovery.atlassian.net/browse/DIS-2605)) (*JOM*)
+- Add locale-aware time and date/time formatters to DateUtils. ([DIS-2606](https://aspen-discovery.atlassian.net/browse/DIS-2606)) (*JOM*)
 
 // pedro
 

--- a/code/web/release_notes/26.07.00.MD
+++ b/code/web/release_notes/26.07.00.MD
@@ -16,6 +16,7 @@
 // jacob
 - Add a locale-aware date formatter to DateUtils. ([DIS-2605](https://aspen-discovery.atlassian.net/browse/DIS-2605)) (*JOM*)
 - Add locale-aware time and date/time formatters to DateUtils. ([DIS-2606](https://aspen-discovery.atlassian.net/browse/DIS-2606)) (*JOM*)
+- Display event dates and times using locale-aware formatting, including 12-hour times on the calendar and multi-day views. ([DIS-1585](https://aspen-discovery.atlassian.net/browse/DIS-1585)) (*JOM*)
 
 // pedro
 

--- a/code/web/release_notes/26.07.00.MD
+++ b/code/web/release_notes/26.07.00.MD
@@ -17,6 +17,7 @@
 - Add a locale-aware date formatter to DateUtils. ([DIS-2605](https://aspen-discovery.atlassian.net/browse/DIS-2605)) (*JOM*)
 - Add locale-aware time and date/time formatters to DateUtils. ([DIS-2606](https://aspen-discovery.atlassian.net/browse/DIS-2606)) (*JOM*)
 - Display event dates and times using locale-aware formatting, including 12-hour times on the calendar and multi-day views. ([DIS-1585](https://aspen-discovery.atlassian.net/browse/DIS-1585)) (*JOM*)
+- Limit the list of series event dates to 5 with a show-more toggle. ([DIS-2607](https://aspen-discovery.atlassian.net/browse/DIS-2607)) (*JOM*)
 
 // pedro
 

--- a/code/web/services/Events/Calendar.php
+++ b/code/web/services/Events/Calendar.php
@@ -13,6 +13,7 @@ class Events_Calendar extends Action {
 		}
 		// Include Search Engine Class
 		require_once ROOT_DIR . '/sys/SolrConnector/Solr.php';
+		require_once ROOT_DIR . '/sys/Utils/DateUtils.php';
 
 		$today = new DateTime();
 		$useWeek = 0;
@@ -51,7 +52,8 @@ class Events_Calendar extends Action {
 			$weekFilter = $year . '-' . $paddedWeek;
 			$calendarStart = "{$year}W$paddedWeek";
 			$calendarStartDay = strtotime($calendarStart . " - 1 days"); // So that the week starts on Sunday
-			$formattedWeekYear = date("M j, Y", $calendarStartDay) . " - " . date("M j, Y", strtotime($calendarStart . "+ 5 days"));
+			$calendarEndDay = strtotime($calendarStart . "+ 5 days");
+			$formattedWeekYear = DateUtils::formatDateLocale($calendarStartDay, 'medium') . " - " . DateUtils::formatDateLocale($calendarEndDay, 'medium');
 			$month = date("n", strtotime($calendarStart));
 			$interface->assign('calendarMonth', $formattedWeekYear);
 			$monthLink = "/Events/Calendar?month=$month&year=$year";
@@ -80,8 +82,9 @@ class Events_Calendar extends Action {
 			$monthFilter = $year . '-' . $paddedMonth;
 			$calendarStart = "$paddedMonth/1/$year";
 			$calendarStartDay = new DateTime($calendarStart);
+
 			$monthDisplay = $this->getMonthDisplaySetting($calendarDisplaySettingId);
-			$formattedMonthYear = $monthDisplay ? $calendarStartDay->format("F Y") : $calendarStartDay->format("M Y");
+			$formattedMonthYear = DateUtils::formatDateLocale($calendarStartDay, 'medium', 'none', $monthDisplay ? 'MMMM yyyy' : 'MMM yyyy');
 			$week = (int)$calendarStartDay->format("W") + 1;
 			$interface->assign('calendarMonth', $formattedMonthYear);
 			$weekLink = "/Events/Calendar?week=$week&year=$year";
@@ -355,17 +358,15 @@ class Events_Calendar extends Action {
 					if (in_array($eventDay, $result['event_day'])) {
 						$startDate = new DateTime($result['start_date']);
 						$startDate->setTimezone($defaultTimezone);
-						if ($printEndTime) {
-							// Save space by leaving off AM/PM from start time
-							$formattedTime = date_format($startDate, "h:i");
-						} else {
-							$formattedTime = date_format($startDate, "h:iA");
-						}
 						$endDate = new DateTime($result['end_date']);
 						$endDate->setTimezone($defaultTimezone);
-						$formattedTime .= '<span class="end-time"> - ' . date_format($endDate, "h:iA") . "</span>";
+
 						if (($endDate->getTimestamp() - $startDate->getTimestamp()) > 24 * 60 * 60) {
 							$formattedTime = 'All day';
+						} else {
+							// Wrap the end time in a span so the calendar can hide it responsively.
+							$timeParts = DateUtils::formatTimeRangeParts($startDate, $endDate);
+							$formattedTime = $timeParts['start'] . '<span class="end-time"> - ' . $timeParts['end'] . '</span>';
 						}
 						$isCancelled = false;
 						if (array_key_exists('reservation_state', $result) && in_array('Cancelled', $result['reservation_state'])) {

--- a/code/web/services/Events/Calendar.php
+++ b/code/web/services/Events/Calendar.php
@@ -364,9 +364,11 @@ class Events_Calendar extends Action {
 						if (($endDate->getTimestamp() - $startDate->getTimestamp()) > 24 * 60 * 60) {
 							$formattedTime = 'All day';
 						} else {
-							// Wrap the end time in a span so the calendar can hide it responsively.
 							$timeParts = DateUtils::formatTimeRangeParts($startDate, $endDate);
-							$formattedTime = $timeParts['start'] . '<span class="end-time"> - ' . $timeParts['end'] . '</span>';
+							$startMeridiem = $timeParts['startMeridiem'] !== ''
+								? '<span class="start-meridiem"> ' . $timeParts['startMeridiem'] . '</span>'
+								: '';
+							$formattedTime = $timeParts['start'] . $startMeridiem . '<span class="end-time"> - ' . $timeParts['end'] . '</span>';
 						}
 						$isCancelled = false;
 						if (array_key_exists('reservation_state', $result) && in_array('Cancelled', $result['reservation_state'])) {

--- a/code/web/sys/Smarty/plugins/modifier.format_date_locale.php
+++ b/code/web/sys/Smarty/plugins/modifier.format_date_locale.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Smarty plugin
+ *
+ * @package    Smarty
+ * @subpackage PluginsModifier
+ */
+/**
+ * Smarty format_date_locale modifier plugin
+ * Type:     modifier
+ * Name:     format_date_locale
+ * Purpose:  format dates using locale-aware formatting via IntlDateFormatter
+ * Input:
+ *          - string: input date string or timestamp
+ *          - style: date style (short, medium, long, full)
+ *          - time_style: time style (none, short, medium, long, full)
+ *          - pattern: optional custom ICU date pattern (e.g., 'MMMM yyyy' for "March 2026")
+ *
+ * @param mixed  $string     input date string or timestamp
+ * @param string $style      date style (short, medium, long, full)
+ * @param string $time_style time style (none, short, medium, long, full)
+ * @param string $pattern    optional custom ICU date pattern
+ *
+ * @return string formatted date
+ */
+function smarty_modifier_format_date_locale($string, $style = 'medium', $time_style = 'none', $pattern = null)
+{
+	require_once ROOT_DIR . '/sys/Utils/DateUtils.php';
+	return DateUtils::formatDateLocale($string, $style, $time_style, $pattern);
+}

--- a/code/web/sys/Smarty/plugins/modifier.format_datetime_locale.php
+++ b/code/web/sys/Smarty/plugins/modifier.format_datetime_locale.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Smarty plugin
+ *
+ * @package    Smarty
+ * @subpackage PluginsModifier
+ */
+/**
+ * Smarty format_datetime_locale modifier plugin
+ * Type:     modifier
+ * Name:     format_datetime_locale
+ * Purpose:  format a datetime as a locale-aware date plus a forced 12-hour time
+ * Input:
+ *          - value: input datetime (DateTime object, string, or timestamp)
+ *          - date_style: date style (short, medium, long, full)
+ *
+ * @param mixed  $value      input datetime (DateTime object, string, or timestamp)
+ * @param string $date_style date style (short, medium, long, full)
+ *
+ * @return string formatted date and 12-hour time
+ */
+function smarty_modifier_format_datetime_locale($value, $date_style = 'long')
+{
+	require_once ROOT_DIR . '/sys/Utils/DateUtils.php';
+	return DateUtils::formatDateTimeLocale($value, $date_style);
+}

--- a/code/web/sys/Smarty/plugins/modifier.format_time_range_locale.php
+++ b/code/web/sys/Smarty/plugins/modifier.format_time_range_locale.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Smarty plugin
+ *
+ * @package    Smarty
+ * @subpackage PluginsModifier
+ */
+/**
+ * Smarty format_time_range_locale modifier plugin
+ * Type:     modifier
+ * Name:     format_time_range_locale
+ * Purpose:  format time ranges using locale-aware formatting, avoiding redundant AM/PM
+ * Input:
+ *          - start_time: start time (DateTime object, string, or timestamp)
+ *          - end_time: end time (DateTime object, string, or timestamp)
+ *          - format: null (default) = 12-hour with collapse; '24' forces 24-hour
+ *
+ * @param mixed  $start_time start time (DateTime object, string, or timestamp)
+ * @param mixed  $end_time   end time (DateTime object, string, or timestamp)
+ * @param string $format     null (default) for 12-hour with collapse, or '24'
+ *
+ * @return string formatted time range
+ */
+function smarty_modifier_format_time_range_locale($start_time, $end_time, $format = null)
+{
+	require_once ROOT_DIR . '/sys/Utils/DateUtils.php';
+	return DateUtils::formatTimeRange($start_time, $end_time, $format);
+}

--- a/code/web/sys/Utils/DateUtils.php
+++ b/code/web/sys/Utils/DateUtils.php
@@ -48,4 +48,59 @@ class DateUtils {
 		}
 		return str_replace('-', '_', $locale);
 	}
+
+	static function formatDateLocale($string, $dateStyle = 'medium', $timeStyle = 'none', $pattern = null): string|false {
+		global $activeLanguage;
+
+		if (empty($string) || $string === '0000-00-00' || $string === '0000-00-00 00:00:00') {
+			return '';
+		}
+
+		if ($string instanceof DateTime) {
+			$timestamp = $string->getTimestamp();
+		} elseif (is_numeric($string)) {
+			$timestamp = (int)$string;
+		} else {
+			$timestamp = strtotime($string);
+		}
+
+		if ($timestamp === false || $timestamp === -1) {
+			return '';
+		}
+
+		$dateStyleMap = [
+			'none'   => IntlDateFormatter::NONE,
+			'short'  => IntlDateFormatter::SHORT,
+			'medium' => IntlDateFormatter::MEDIUM,
+			'long'   => IntlDateFormatter::LONG,
+			'full'   => IntlDateFormatter::FULL,
+		];
+
+		$timeStyleMap = [
+			'none'   => IntlDateFormatter::NONE,
+			'short'  => IntlDateFormatter::SHORT,
+			'medium' => IntlDateFormatter::MEDIUM,
+			'long'   => IntlDateFormatter::LONG,
+			'full'   => IntlDateFormatter::FULL,
+		];
+
+		$dateStyleConstant = $dateStyleMap[strtolower($dateStyle)] ?? IntlDateFormatter::MEDIUM;
+		$timeStyleConstant = $timeStyleMap[strtolower($timeStyle)] ?? IntlDateFormatter::NONE;
+
+		$locale = $activeLanguage->locale ?? 'en_US';
+		$timezone = date_default_timezone_get();
+
+		$formatter = new IntlDateFormatter(
+			$locale,
+			$dateStyleConstant,
+			$timeStyleConstant,
+			$timezone
+		);
+
+		if ($pattern !== null) {
+			$formatter->setPattern($pattern);
+		}
+
+		return $formatter->format($timestamp);
+	}
 }

--- a/code/web/sys/Utils/DateUtils.php
+++ b/code/web/sys/Utils/DateUtils.php
@@ -103,4 +103,68 @@ class DateUtils {
 
 		return $formatter->format($timestamp);
 	}
+
+	static function formatTimeRange($startTime, $endTime, $format = null): string {
+		$parts = self::formatTimeRangeParts($startTime, $endTime, $format);
+		if ($parts['start'] === '' && $parts['end'] === '') {
+			return '';
+		}
+		return $parts['start'] . ' - ' . $parts['end'];
+	}
+
+	static function formatTimeRangeParts($startTime, $endTime, $format = null): array {
+		global $activeLanguage;
+		$empty = ['start' => '', 'end' => ''];
+
+		if (empty($startTime) || empty($endTime)) {
+			return $empty;
+		}
+
+		if ($startTime instanceof DateTime) {
+			$startTimestamp = $startTime->getTimestamp();
+		} elseif (is_numeric($startTime)) {
+			$startTimestamp = (int)$startTime;
+		} else {
+			$startTimestamp = strtotime($startTime);
+		}
+
+		if ($endTime instanceof DateTime) {
+			$endTimestamp = $endTime->getTimestamp();
+		} elseif (is_numeric($endTime)) {
+			$endTimestamp = (int)$endTime;
+		} else {
+			$endTimestamp = strtotime($endTime);
+		}
+
+		if ($startTimestamp === false || $startTimestamp === -1 ||
+			$endTimestamp === false || $endTimestamp === -1) {
+			return $empty;
+		}
+
+		$locale = $activeLanguage->locale ?? 'en_US';
+		$timezone = date_default_timezone_get();
+
+		$use12Hour = $format !== '24';
+
+		if (!$use12Hour) {
+			$formatter = new IntlDateFormatter($locale, IntlDateFormatter::NONE, IntlDateFormatter::NONE, $timezone);
+			$formatter->setPattern('HH:mm');
+			return [
+				'start' => $formatter->format($startTimestamp),
+				'end'   => $formatter->format($endTimestamp),
+			];
+		}
+
+		$withMeridiem = new IntlDateFormatter($locale, IntlDateFormatter::NONE, IntlDateFormatter::NONE, $timezone);
+		$withMeridiem->setPattern('h:mm a');
+		$noMeridiem = new IntlDateFormatter($locale, IntlDateFormatter::NONE, IntlDateFormatter::NONE, $timezone);
+		$noMeridiem->setPattern('h:mm');
+
+		$sameHalf = ((int)date('G', $startTimestamp) < 12) === ((int)date('G', $endTimestamp) < 12);
+
+		return [
+			'start' => ($sameHalf ? $noMeridiem : $withMeridiem)->format($startTimestamp),
+			'end'   => $withMeridiem->format($endTimestamp),
+		];
+	}
 }

--- a/code/web/sys/Utils/DateUtils.php
+++ b/code/web/sys/Utils/DateUtils.php
@@ -114,7 +114,7 @@ class DateUtils {
 
 	static function formatTimeRangeParts($startTime, $endTime, $format = null): array {
 		global $activeLanguage;
-		$empty = ['start' => '', 'end' => ''];
+		$empty = ['start' => '', 'startMeridiem' => '', 'end' => ''];
 
 		if (empty($startTime) || empty($endTime)) {
 			return $empty;
@@ -150,8 +150,9 @@ class DateUtils {
 			$formatter = new IntlDateFormatter($locale, IntlDateFormatter::NONE, IntlDateFormatter::NONE, $timezone);
 			$formatter->setPattern('HH:mm');
 			return [
-				'start' => $formatter->format($startTimestamp),
-				'end'   => $formatter->format($endTimestamp),
+				'start'         => $formatter->format($startTimestamp),
+				'startMeridiem' => '',
+				'end'           => $formatter->format($endTimestamp),
 			];
 		}
 
@@ -162,9 +163,29 @@ class DateUtils {
 
 		$sameHalf = ((int)date('G', $startTimestamp) < 12) === ((int)date('G', $endTimestamp) < 12);
 
+		if ($sameHalf) {
+			$meridiemOnly = new IntlDateFormatter($locale, IntlDateFormatter::NONE, IntlDateFormatter::NONE, $timezone);
+			$meridiemOnly->setPattern('a');
+			return [
+				'start'         => $noMeridiem->format($startTimestamp),
+				'startMeridiem' => $meridiemOnly->format($startTimestamp),
+				'end'           => $withMeridiem->format($endTimestamp),
+			];
+		}
+
 		return [
-			'start' => ($sameHalf ? $noMeridiem : $withMeridiem)->format($startTimestamp),
-			'end'   => $withMeridiem->format($endTimestamp),
+			'start'         => $withMeridiem->format($startTimestamp),
+			'startMeridiem' => '',
+			'end'           => $withMeridiem->format($endTimestamp),
 		];
+	}
+
+	static function formatDateTimeLocale($value, $dateStyle = 'long'): string {
+		$date = self::formatDateLocale($value, $dateStyle);
+		if ($date === '') {
+			return '';
+		}
+		$time = self::formatDateLocale($value, 'medium', 'none', 'h:mm a');
+		return $date . ' ' . $time;
 	}
 }

--- a/tests/phpunit/tests/sys/Util/DateUtilsTests.php
+++ b/tests/phpunit/tests/sys/Util/DateUtilsTests.php
@@ -1,0 +1,70 @@
+<?php
+namespace sys\Util;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class DateUtilsTests extends TestCase {
+	private ?string $originalTimezone = null;
+	private $originalActiveLanguage = null;
+
+	public function __construct(string $name) {
+		parent::__construct($name);
+		require_once __DIR__ . '/../../../../../code/web/sys/Utils/DateUtils.php';
+	}
+
+	protected function setUp(): void {
+		$this->originalTimezone = date_default_timezone_get();
+		date_default_timezone_set('UTC');
+
+		global $activeLanguage;
+		$this->originalActiveLanguage = $activeLanguage;
+		$activeLanguage = (object)['locale' => 'en_US'];
+	}
+
+	protected function tearDown(): void {
+		if ($this->originalTimezone !== null) {
+			date_default_timezone_set($this->originalTimezone);
+		}
+		global $activeLanguage;
+		$activeLanguage = $this->originalActiveLanguage;
+	}
+
+	public static function emptyDateProvider(): array {
+		return [
+			'empty string'        => [''],
+			'null'                => [null],
+			'zero date'           => ['0000-00-00'],
+			'zero datetime'       => ['0000-00-00 00:00:00'],
+			'unparseable string'  => ['not a date'],
+		];
+	}
+
+	#[DataProvider('emptyDateProvider')]
+	public function testFormatDateLocaleReturnsEmptyForInvalidInput($input): void {
+		$this->assertSame('', \DateUtils::formatDateLocale($input));
+	}
+
+	public static function patternProvider(): array {
+		return [
+			'iso date'        => ['2025-03-15', 'medium', 'none', 'yyyy-MM-dd', '2025-03-15'],
+			'iso datetime'    => ['2025-03-15 14:30:00', 'medium', 'short', 'yyyy-MM-dd HH:mm', '2025-03-15 14:30'],
+			'month and year'  => ['2025-03-15', 'medium', 'none', 'MMMM yyyy', 'March 2025'],
+		];
+	}
+
+	#[DataProvider('patternProvider')]
+	public function testFormatDateLocaleHonoursPattern($input, $dateStyle, $timeStyle, $pattern, $expected): void {
+		$this->assertSame($expected, \DateUtils::formatDateLocale($input, $dateStyle, $timeStyle, $pattern));
+	}
+
+	public function testFormatDateLocaleAcceptsDateTimeObject(): void {
+		$date = new \DateTime('2025-03-15 00:00:00', new \DateTimeZone('UTC'));
+		$this->assertSame('2025-03-15', \DateUtils::formatDateLocale($date, 'medium', 'none', 'yyyy-MM-dd'));
+	}
+
+	public function testFormatDateLocaleAcceptsNumericTimestamp(): void {
+		$timestamp = strtotime('2025-03-15 00:00:00');
+		$this->assertSame('2025-03-15', \DateUtils::formatDateLocale($timestamp, 'medium', 'none', 'yyyy-MM-dd'));
+	}
+}

--- a/tests/phpunit/tests/sys/Util/DateUtilsTests.php
+++ b/tests/phpunit/tests/sys/Util/DateUtilsTests.php
@@ -105,14 +105,22 @@ class DateUtilsTests extends TestCase {
 		$this->assertSame('9:00 - 10:30 AM', \DateUtils::formatTimeRange($start, $end, '12'));
 	}
 
-	public function testFormatTimeRangePartsReturnsSeparateStartAndEnd(): void {
+	public function testFormatTimeRangePartsCollapseExposesStartMeridiem(): void {
 		$parts = \DateUtils::formatTimeRangeParts('2025-01-01 09:00:00', '2025-01-01 10:30:00', '12');
 		$this->assertSame('9:00', $parts['start']);
+		$this->assertSame('AM', $parts['startMeridiem']);
 		$this->assertSame('10:30 AM', $parts['end']);
 	}
 
+	public function testFormatTimeRangePartsAcrossNoonKeepStartMeridiemInline(): void {
+		$parts = \DateUtils::formatTimeRangeParts('2025-01-01 09:00:00', '2025-01-01 13:00:00', '12');
+		$this->assertSame('9:00 AM', $parts['start']);
+		$this->assertSame('', $parts['startMeridiem']);
+		$this->assertSame('1:00 PM', $parts['end']);
+	}
+
 	public function testFormatTimeRangePartsAreEmptyForInvalidInput(): void {
-		$this->assertSame(['start' => '', 'end' => ''], \DateUtils::formatTimeRangeParts('', ''));
+		$this->assertSame(['start' => '', 'startMeridiem' => '', 'end' => ''], \DateUtils::formatTimeRangeParts('', ''));
 	}
 
 	public function testFormatTimeRangeDefaultsTo12Hour(): void {
@@ -132,5 +140,24 @@ class DateUtilsTests extends TestCase {
 		global $activeLanguage;
 		$activeLanguage = (object)['locale' => 'en_US'];
 		$this->assertSame('09:00 - 16:00', \DateUtils::formatTimeRange('2025-01-01 09:00:00', '2025-01-01 16:00:00', '24'));
+	}
+
+	public function testFormatDateTimeLocaleCombinesLocaleDateAnd12HourTime(): void {
+		$result = \DateUtils::formatDateTimeLocale('2025-07-07 09:00:00', 'long');
+		$this->assertStringContainsString('July 7, 2025', $result);
+		$this->assertStringContainsString('9:00 AM', $result);
+	}
+
+	public function testFormatDateTimeLocaleForces12HourInA24HourLocale(): void {
+		global $activeLanguage;
+		$activeLanguage = (object)['locale' => 'en_GB'];
+		$result = \DateUtils::formatDateTimeLocale('2025-07-07 16:00:00', 'long');
+		$this->assertStringContainsString('7 July 2025', $result);
+		$this->assertMatchesRegularExpression('/4:00\s*pm/i', $result);
+		$this->assertStringNotContainsString('16:00', $result);
+	}
+
+	public function testFormatDateTimeLocaleEmptyForInvalidInput(): void {
+		$this->assertSame('', \DateUtils::formatDateTimeLocale(''));
 	}
 }

--- a/tests/phpunit/tests/sys/Util/DateUtilsTests.php
+++ b/tests/phpunit/tests/sys/Util/DateUtilsTests.php
@@ -67,4 +67,70 @@ class DateUtilsTests extends TestCase {
 		$timestamp = strtotime('2025-03-15 00:00:00');
 		$this->assertSame('2025-03-15', \DateUtils::formatDateLocale($timestamp, 'medium', 'none', 'yyyy-MM-dd'));
 	}
+
+	public static function emptyTimeRangeProvider(): array {
+		return [
+			'both empty'        => ['', ''],
+			'empty start'       => ['', '2025-01-01 10:00:00'],
+			'empty end'         => ['2025-01-01 09:00:00', ''],
+			'unparseable start' => ['not a time', '2025-01-01 10:00:00'],
+			'unparseable end'   => ['2025-01-01 09:00:00', 'not a time'],
+		];
+	}
+
+	#[DataProvider('emptyTimeRangeProvider')]
+	public function testFormatTimeRangeReturnsEmptyForInvalidInput($start, $end): void {
+		$this->assertSame('', \DateUtils::formatTimeRange($start, $end));
+	}
+
+	public static function timeRangeProvider(): array {
+		return [
+			'both am, 12h'             => ['2025-01-01 09:00:00', '2025-01-01 10:30:00', '12', '9:00 - 10:30 AM'],
+			'both pm, 12h'             => ['2025-01-01 13:00:00', '2025-01-01 14:30:00', '12', '1:00 - 2:30 PM'],
+			'across noon, 12h'         => ['2025-01-01 09:00:00', '2025-01-01 13:00:00', '12', '9:00 AM - 1:00 PM'],
+			'noon boundary differs'    => ['2025-01-01 11:00:00', '2025-01-01 12:00:00', '12', '11:00 AM - 12:00 PM'],
+			'noon and after same half' => ['2025-01-01 12:00:00', '2025-01-01 13:00:00', '12', '12:00 - 1:00 PM'],
+			'24 hour format'           => ['2025-01-01 09:00:00', '2025-01-01 10:30:00', '24', '09:00 - 10:30'],
+		];
+	}
+
+	#[DataProvider('timeRangeProvider')]
+	public function testFormatTimeRange($start, $end, $format, $expected): void {
+		$this->assertSame($expected, \DateUtils::formatTimeRange($start, $end, $format));
+	}
+
+	public function testFormatTimeRangeAcceptsDateTimeObjects(): void {
+		$start = new \DateTime('2025-01-01 09:00:00', new \DateTimeZone('UTC'));
+		$end = new \DateTime('2025-01-01 10:30:00', new \DateTimeZone('UTC'));
+		$this->assertSame('9:00 - 10:30 AM', \DateUtils::formatTimeRange($start, $end, '12'));
+	}
+
+	public function testFormatTimeRangePartsReturnsSeparateStartAndEnd(): void {
+		$parts = \DateUtils::formatTimeRangeParts('2025-01-01 09:00:00', '2025-01-01 10:30:00', '12');
+		$this->assertSame('9:00', $parts['start']);
+		$this->assertSame('10:30 AM', $parts['end']);
+	}
+
+	public function testFormatTimeRangePartsAreEmptyForInvalidInput(): void {
+		$this->assertSame(['start' => '', 'end' => ''], \DateUtils::formatTimeRangeParts('', ''));
+	}
+
+	public function testFormatTimeRangeDefaultsTo12Hour(): void {
+		$this->assertSame('9:00 - 10:30 AM', \DateUtils::formatTimeRange('2025-01-01 09:00:00', '2025-01-01 10:30:00'));
+	}
+
+	public function testFormatTimeRangeForces12HourEvenInA24HourLocale(): void {
+		global $activeLanguage;
+		$activeLanguage = (object)['locale' => 'en_GB'];
+		$default = \DateUtils::formatTimeRange('2025-01-01 11:00:00', '2025-01-01 16:00:00');
+		$this->assertMatchesRegularExpression('/\d{1,2}:\d{2}\s*[ap]m/i', $default);
+		$this->assertStringNotContainsString('16:00', $default);
+		$this->assertSame(\DateUtils::formatTimeRange('2025-01-01 11:00:00', '2025-01-01 16:00:00', '12'), $default);
+	}
+
+	public function testFormatTimeRangeForces24HourOnRequest(): void {
+		global $activeLanguage;
+		$activeLanguage = (object)['locale' => 'en_US'];
+		$this->assertSame('09:00 - 16:00', \DateUtils::formatTimeRange('2025-01-01 09:00:00', '2025-01-01 16:00:00', '24'));
+	}
 }


### PR DESCRIPTION
For events with lots of instances the left menu can be extremely large. we should cap at 5 and have a show more to show the whole set

To test:
Create events with more than 5 instances and index
On an event instance's page the 'other events in this series' section on the left will show all the events
Apply patch
It will now show 5 and a show more button that will allow you to see the rest 