### PR TITLE
DIS-2480: Fix Material Request Usage Dashboard graphs page

### DIFF
--- a/code/web/release_notes/26.07.00.MD
+++ b/code/web/release_notes/26.07.00.MD
@@ -19,7 +19,10 @@
 
 // olivia
 
-// lucas
+// luca
+
+//shipra
+- Fix Material Request Usage Dashboard graph page returning a 500 error when viewing usage statistics. ([DIS-2480] (https://aspen-discovery.atlassian.net/browse/DIS-2480)) (*SSP*)
 
 ## This release includes code contributions from
 ### ByWater Solutions
@@ -27,6 +30,7 @@
 - Imani Thomas (IT)
 - Jonah Wilson (JW)
 - Kyle Hall (KMH)
+- Shipra Satish Poojary (SSP)
 
 ### Grove For Libraries
 - Mark Noble (MDN)

--- a/code/web/services/MaterialsRequest/UsageGraphs.php
+++ b/code/web/services/MaterialsRequest/UsageGraphs.php
@@ -2,7 +2,8 @@
 
 require_once ROOT_DIR . '/services/Admin/AbstractUsageGraphs.php';
 require_once ROOT_DIR . '/sys/SystemLogging/AspenUsage.php';
-require_once ROOT_DIR . '/sys/MaterialsRequestUsage.php';
+require_once ROOT_DIR . '/sys/MaterialsRequests/MaterialsRequestUsage.php';
+require_once ROOT_DIR . '/sys/MaterialsRequests/MaterialsRequestStatus.php';
 require_once ROOT_DIR . '/sys/Utils/GraphingUtils.php';
 
 class MaterialsRequest_UsageGraphs extends Admin_AbstractUsageGraphs {


### PR DESCRIPTION
Material Request Usage Dashboard: When clicking on graph icon gives 500 error

To reproduce:
1. Go to Administration → Materials Requests → Usage Dashboard
2. Click the blue/arrow icon next to any statistics (like Request Pending)
3. The page fails to load with HTTP 500 error