### PR TITLE
DIS-1737: Link author names to author search results 

### DIFF
--- a/code/web/interface/themes/responsive/Axis360/view-title-details.tpl
+++ b/code/web/interface/themes/responsive/Axis360/view-title-details.tpl
@@ -4,7 +4,7 @@
 		<div class="row">
 			<div class="result-label col-sm-4 col-xs-12">{translate text="Author" isPublicFacing=true}</div>
 			<div class="result-value col-sm-8 col-xs-12">
-				<a href='/Author/Home?author="{$recordDriver->getPrimaryAuthor()|escape:"url"}"'>{$recordDriver->getPrimaryAuthor()|highlight}</a>
+				<a href='/Search/Results?lookfor={$recordDriver->getPrimaryAuthor()|escape:"url"}&searchIndex=Author'>{$recordDriver->getPrimaryAuthor()|highlight}</a>
 			</div>
 		</div>
 	{/if}

--- a/code/web/interface/themes/responsive/CloudLibrary/view-title-details.tpl
+++ b/code/web/interface/themes/responsive/CloudLibrary/view-title-details.tpl
@@ -4,7 +4,7 @@
 		<div class="row">
 			<div class="result-label col-sm-4 col-xs-12">{translate text="Author" isPublicFacing=true} </div>
 			<div class="result-value col-sm-8 col-xs-12">
-				<a href='/Author/Home?author="{$recordDriver->getPrimaryAuthor()|escape:"url"}"'>{$recordDriver->getPrimaryAuthor()|highlight}</a>
+				<a href='/Search/Results?lookfor={$recordDriver->getPrimaryAuthor()|escape:"url"}&searchIndex=Author'>{$recordDriver->getPrimaryAuthor()|highlight}</a>
 			</div>
 		</div>
 	{/if}

--- a/code/web/interface/themes/responsive/ExternalEContent/view-title-details.tpl
+++ b/code/web/interface/themes/responsive/ExternalEContent/view-title-details.tpl
@@ -4,7 +4,7 @@
 		<div class="row">
 			<div class="result-label col-sm-4 col-xs-12">{translate text=Author isPublicFacing=true} </div>
 			<div class="result-value col-sm-8 col-xs-12">
-				<a href='/Author/Home?author="{$recordDriver->getAuthor()|escape:"url"}"'>{$recordDriver->getAuthor()|highlight}</a>
+				<a href='/Search/Results?lookfor={$recordDriver->getAuthor()|escape:"url"}&searchIndex=Author'>{$recordDriver->getAuthor()|highlight}</a>
 			</div>
 		</div>
 	{/if}

--- a/code/web/interface/themes/responsive/GroupedWork/full-record.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/full-record.tpl
@@ -43,7 +43,7 @@
 					<div class="row">
 						<div class="result-label col-sm-4 col-xs-12">{translate text=Author isPublicFacing=true} </div>
 						<div class="result-value col-sm-8 col-xs-12 notranslate">
-							<a href='/Author/Home?author="{$recordDriver->getPrimaryAuthor()|escape:"url"}"'>{$recordDriver->getPrimaryAuthor()|highlight}</a>
+							<a href='/Search/Results?lookfor={$recordDriver->getPrimaryAuthor()|escape:"url"}&searchIndex=Author'>{$recordDriver->getPrimaryAuthor()|highlight}</a>
 						</div>
 					</div>
 				{/if}

--- a/code/web/interface/themes/responsive/GroupedWork/metadataBlocks.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/metadataBlocks.tpl
@@ -3,10 +3,10 @@
 	<div class="result-value col-sm-8 col-xs-12 notranslate">
 		{if is_array($summAuthor)}
 			{foreach from=$summAuthor item=author}
-				<a href='/Author/Home?author="{$author|escape:"url"}"'>{$author|highlight}</a>
+				<a href='/Search/Results?lookfor={$author|escape:"url"}&searchIndex=Author'>{$author|highlight}</a>
 			{/foreach}
 		{else}
-			<a href='/Author/Home?author="{$summAuthor|escape:"url"}"'>{$summAuthor|highlight}</a>
+			<a href='/Search/Results?lookfor={$summAuthor|escape:"url"}&searchIndex=Author'>{$summAuthor|highlight}</a>
 		{/if}
 	</div>
 {/if}

--- a/code/web/interface/themes/responsive/GroupedWork/view-title-details.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/view-title-details.tpl
@@ -11,7 +11,7 @@
 				{*create hidden div*}
 				<div id="additionalContributors" style="display:none">
 					{/if}
-					<a href='/Author/Home?author="{$contributor.name|trim|escape:"url"}"'>{$contributor.name|escape}</a>
+					<a href='/Search/Results?lookfor={$contributor.name|trim|escape:"url"}&searchIndex=Author'>{$contributor.name|escape}</a>
 					{if !empty($contributor.roles)}
 						&nbsp;{implode subject=$contributor.roles glue=", " translate=true isPublicFacing=true}
 					{/if}

--- a/code/web/interface/themes/responsive/GroupedWork/work-details.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/work-details.tpl
@@ -4,7 +4,7 @@
 			<div class="row">
 				<div class="result-label col-md-3">{translate text="Author" isPublicFacing=true} </div>
 				<div class="col-md-9 result-value notranslate">
-					<a href='/Author/Home?author="{$recordDriver->getPrimaryAuthor()|escape:"url"}"'>{$recordDriver->getPrimaryAuthor()|highlight}</a>
+					<a href='/Search/Results?lookfor={$recordDriver->getPrimaryAuthor()|escape:"url"}&searchIndex=Author'>{$recordDriver->getPrimaryAuthor()|highlight}</a>
 				</div>
 			</div>
 		{/if}

--- a/code/web/interface/themes/responsive/Hoopla/view-title-details.tpl
+++ b/code/web/interface/themes/responsive/Hoopla/view-title-details.tpl
@@ -5,7 +5,7 @@
 		<div class="row">
 			<div class="result-label col-sm-4 col-xs-12">{translate text="Author" isPublicFacing=true} </div>
 			<div class="result-value col-sm-8 col-xs-12">
-				<a href='/Author/Home?author={$recordDriver->getPrimaryAuthor()|escape:"url"}'>{$recordDriver->getPrimaryAuthor()|highlight}</a>
+				<a href='/Search/Results?lookfor={$recordDriver->getPrimaryAuthor()|escape:"url"}&searchIndex=Author'>{$recordDriver->getPrimaryAuthor()|highlight}</a>
 			</div>
 		</div>
 	{/if}

--- a/code/web/interface/themes/responsive/MyAccount/axis360Hold.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/axis360Hold.tpl
@@ -53,10 +53,10 @@
 							<div class="col-tn-8 result-value">
 								{if is_array($record->getAuthor())}
 									{foreach from=$record->getAuthor() item=author}
-										<a href='/Author/Home?author="{$author|escape:"url"}"'>{$author|highlight}</a>
+										<a href='/Search/Results?lookfor={$author|escape:"url"}&searchIndex=Author'>{$author|highlight}</a>
 									{/foreach}
 								{else}
-									<a href='/Author/Home?author="{$record->getAuthor()|escape:"url"}"'>{$record->getAuthor()|highlight}</a>
+									<a href='/Search/Results?lookfor={$record->getAuthor()|escape:"url"}&searchIndex=Author'>{$record->getAuthor()|highlight}</a>
 								{/if}
 							</div>
 						</div>

--- a/code/web/interface/themes/responsive/MyAccount/cloudLibraryHold.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/cloudLibraryHold.tpl
@@ -46,7 +46,7 @@
 						<div class="row">
 							<div class="result-label col-tn-4">{translate text='Author' isPublicFacing=true}</div>
 							<div class="col-tn-8 result-value">
-								<a href='/Author/Home?author="{$record->getAuthor()|escape:"url"}"'>{$record->getAuthor()|highlight}</a>
+								<a href='/Search/Results?lookfor={$record->getAuthor()|escape:"url"}&searchIndex=Author'>{$record->getAuthor()|highlight}</a>
 							</div>
 						</div>
 					{/if}

--- a/code/web/interface/themes/responsive/MyAccount/curbsidePickupsHoldsReady.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/curbsidePickupsHoldsReady.tpl
@@ -63,10 +63,10 @@
 							<div class="col-tn-8 col-xs-8 result-value">
 								{if is_array($record->getAuthor())}
 									{foreach from=$record->getAuthor() item=author}
-										<a href='/Author/Home?"author={$author|escape:"url"}"'>{$author|highlight}</a>
+										<a href='/Search/Results?lookfor={$author|escape:"url"}&searchIndex=Author'>{$author|highlight}</a>
 									{/foreach}
 								{else}
-									<a href='/Author/Home?author="{$record->getAuthor()|escape:"url"}"'>{$record->getAuthor()|highlight}</a>
+									<a href='/Search/Results?lookfor={$record->getAuthor()|escape:"url"}&searchIndex=Author'>{$record->getAuthor()|highlight}</a>
 								{/if}
 							</div>
 						</div>

--- a/code/web/interface/themes/responsive/MyAccount/hooplaHold.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/hooplaHold.tpl
@@ -46,10 +46,10 @@
                             <div class="col-tn-8 result-value">
                                 {if is_array($record->getAuthor())}
                                     {foreach from=$record->getAuthor() item=author}
-                                        <a href='/Author/Home?author="{$author|escape:"url"}"'>{$author|highlight}</a>
+                                        <a href='/Search/Results?lookfor={$author|escape:"url"}&searchIndex=Author'>{$author|highlight}</a>
                                     {/foreach}
                                 {else}
-                                    <a href='/Author/Home?author="{$record->getAuthor()|escape:"url"}"'>{$record->getAuthor()|highlight}</a>
+                                    <a href='/Search/Results?lookfor={$record->getAuthor()|escape:"url"}&searchIndex=Author'>{$record->getAuthor()|highlight}</a>
                                 {/if}
                             </div>
                         </div>

--- a/code/web/interface/themes/responsive/MyAccount/ilsCheckedOutTitle.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/ilsCheckedOutTitle.tpl
@@ -72,10 +72,10 @@
 							<div class="col-sm-12 col-md-7 result-value">
 								{if is_array($record->getAuthor())}
 									{foreach from=$record->getAuthor() item=author}
-										<a href='/Author/Home?author="{$author|escape:"url"}"'>{$author|highlight}</a>
+										<a href='/Search/Results?lookfor={$author|escape:"url"}&searchIndex=Author'>{$author|highlight}</a>
 									{/foreach}
 								{else}
-									<a href='/Author/Home?author="{$record->getAuthor()|escape:"url"}"'>{$record->getAuthor()|highlight}</a>
+									<a href='/Search/Results?lookfor={$record->getAuthor()|escape:"url"}&searchIndex=Author'>{$record->getAuthor()|highlight}</a>
 								{/if}
 							</div>
 						</div>

--- a/code/web/interface/themes/responsive/MyAccount/ilsHold.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/ilsHold.tpl
@@ -75,10 +75,10 @@
 							<div class="col-tn-8 result-value">
 								{if is_array($record->getAuthor())}
 									{foreach from=$record->getAuthor() item=author}
-										<a href='/Author/Home?"author={$author|escape:"url"}"'>{$author|highlight}</a>
+										<a href='/Search/Results?lookfor={$author|escape:"url"}&searchIndex=Author'>{$author|highlight}</a>
 									{/foreach}
 								{else}
-									<a href='/Author/Home?author="{$record->getAuthor()|escape:"url"}"'>{$record->getAuthor()|highlight}</a>
+									<a href='/Search/Results?lookfor={$record->getAuthor()|escape:"url"}&searchIndex=Author'>{$record->getAuthor()|highlight}</a>
 								{/if}
 							</div>
 						</div>

--- a/code/web/interface/themes/responsive/MyAccount/overdriveHold.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/overdriveHold.tpl
@@ -53,10 +53,10 @@
 							<div class="col-tn-8 result-value">
 								{if is_array($record->getAuthor())}
 									{foreach from=$record->getAuthor() item=author}
-										<a href='/Author/Home?author="{$author|escape:"url"}"'>{$author|highlight}</a>
+										<a href='/Search/Results?lookfor={$author|escape:"url"}&searchIndex=Author'>{$author|highlight}</a>
 									{/foreach}
 								{else}
-									<a href='/Author/Home?author="{$record->getAuthor()|escape:"url"}"'>{$record->getAuthor()|highlight}</a>
+									<a href='/Search/Results?lookfor={$record->getAuthor()|escape:"url"}&searchIndex=Author'>{$record->getAuthor()|highlight}</a>
 								{/if}
 							</div>
 						</div>

--- a/code/web/interface/themes/responsive/MyAccount/palaceProjectHold.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/palaceProjectHold.tpl
@@ -51,10 +51,10 @@
 							<div class="col-tn-8 result-value">
 								{if is_array($record->getAuthor())}
 									{foreach from=$record->getAuthor() item=author}
-										<a href='/Author/Home?author="{$author|escape:"url"}"'>{$author|highlight}</a>
+										<a href='/Search/Results?lookfor={$author|escape:"url"}&searchIndex=Author'>{$author|highlight}</a>
 									{/foreach}
 								{else}
-									<a href='/Author/Home?author="{$record->getAuthor()|escape:"url"}"'>{$record->getAuthor()|highlight}</a>
+									<a href='/Search/Results?lookfor={$record->getAuthor()|escape:"url"}&searchIndex=Author'>{$record->getAuthor()|highlight}</a>
 								{/if}
 							</div>
 						</div>

--- a/code/web/interface/themes/responsive/MyAccount/readingHistoryEntry.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/readingHistoryEntry.tpl
@@ -46,10 +46,10 @@
 						<div class="result-value col-tn-9">
 							{if is_array($record.author)}
 								{foreach from=$summAuthor item=author}
-									<a href='/Author/Home?author="{$author|escape:"url"}"'>{$author|highlight}</a>
+									<a href='/Search/Results?lookfor={$author|escape:"url"}&searchIndex=Author'>{$author|highlight}</a>
 								{/foreach}
 							{else}
-								<a href='/Author/Home?author="{$record.author|escape:"url"}"'>{$record.author|highlight}</a>
+								<a href='/Search/Results?lookfor={$record.author|escape:"url"}&searchIndex=Author'>{$record.author|highlight}</a>
 							{/if}
 						</div>
 					</div>

--- a/code/web/interface/themes/responsive/MyAccount/vdxRequest.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/vdxRequest.tpl
@@ -50,10 +50,10 @@
 						<div class="col-tn-8 result-value">
 							{if is_array($record->getAuthor())}
 								{foreach from=$record->getAuthor() item=author}
-									<a href='/Author/Home?"author={$author|escape:"url"}"'>{$author|highlight}</a>
+									<a href='/Search/Results?lookfor={$author|escape:"url"}&searchIndex=Author'>{$author|highlight}</a>
 								{/foreach}
 							{else}
-								<a href='/Author/Home?author="{$record->getAuthor()|escape:"url"}"'>{$record->getAuthor()|highlight}</a>
+								<a href='/Search/Results?lookfor={$record->getAuthor()|escape:"url"}&searchIndex=Author'>{$record->getAuthor()|highlight}</a>
 							{/if}
 						</div>
 					</div>

--- a/code/web/interface/themes/responsive/OverDrive/view-title-details.tpl
+++ b/code/web/interface/themes/responsive/OverDrive/view-title-details.tpl
@@ -4,7 +4,7 @@
 		<div class="row">
 			<div class="result-label col-sm-4 col-xs-12">{translate text="Author" isPublicFacing=true} </div>
 			<div class="result-value col-sm-8 col-xs-12">
-				<a href='/Author/Home?author="{$recordDriver->getAuthor()|escape:"url"}"'>{$recordDriver->getAuthor()|highlight}</a>
+				<a href='/Search/Results?lookfor={$recordDriver->getAuthor()|escape:"url"}&searchIndex=Author'>{$recordDriver->getAuthor()|highlight}</a>
 			</div>
 		</div>
 	{/if}
@@ -21,7 +21,7 @@
 						{*create hidden div*}
 						<div id="additionalContributors" style="display:none">
 					{/if}
-					<a href='/Author/Home?author="{$contributor.name|trim|escape:"url"}"'>{$contributor.name|escape}</a>
+					<a href='/Search/Results?lookfor={$contributor.name|trim|escape:"url"}&searchIndex=Author'>{$contributor.name|escape}</a>
 					{if !empty($contributor.roles)}
 						&nbsp;{implode subject=$contributor.roles glue=", " translate=true isPublicFacing=true}
 					{/if}

--- a/code/web/interface/themes/responsive/PalaceProject/view-title-details.tpl
+++ b/code/web/interface/themes/responsive/PalaceProject/view-title-details.tpl
@@ -4,7 +4,7 @@
 		<div class="row">
 			<div class="result-label col-sm-4 col-xs-12">{translate text="Author" isPublicFacing=true}</div>
 			<div class="result-value col-sm-8 col-xs-12">
-				<a href='/Author/Home?author="{$recordDriver->getPrimaryAuthor()|escape:"url"}"'>{$recordDriver->getPrimaryAuthor()|highlight}</a>
+				<a href='/Search/Results?lookfor={$recordDriver->getPrimaryAuthor()|escape:"url"}&searchIndex=Author'>{$recordDriver->getPrimaryAuthor()|highlight}</a>
 			</div>
 		</div>
 	{/if}

--- a/code/web/interface/themes/responsive/Record/view-title-details-horiz.tpl
+++ b/code/web/interface/themes/responsive/Record/view-title-details-horiz.tpl
@@ -19,7 +19,7 @@
             {if empty($recordDriver->getAuthor()) && !empty($recordDriver->get880Authors())}
 				<span class="agrAuthor">{implode subject=$recordDriver->get880Authors() glue=',' removeTrailingPunctuationFromTerms=true}</span>
             {else}
-				<a href='/Author/Home?author="{$recordDriver->getAuthor()|escape:"url"}"'>{$recordDriver->getAuthor()|highlight}</a>{if !empty($recordDriver->get880Authors())} <span class="agrAuthor">({implode subject=$recordDriver->get880Authors() glue=',' removeTrailingPunctuationFromTerms=true})</span>{/if}<br/>
+				<a href='/Search/Results?lookfor={$recordDriver->getAuthor()|escape:"url"}&searchIndex=Author'>{$recordDriver->getAuthor()|highlight}</a>{if !empty($recordDriver->get880Authors())} <span class="agrAuthor">({implode subject=$recordDriver->get880Authors() glue=',' removeTrailingPunctuationFromTerms=true})</span>{/if}<br/>
             {/if}
 		</div>
 	</div>
@@ -42,7 +42,7 @@
                 {else}
 				<div class="contributor">
                     {/if}
-					<a href='/Author/Home?author="{$contributor.name|trim|escape:"url"}"'>{$contributor.name|escape}</a>
+					<a href='/Search/Results?lookfor={$contributor.name|trim|escape:"url"}&searchIndex=Author'>{$contributor.name|escape}</a>
                     {if !empty($contributor.roles)}
 						&nbsp;{implode subject=$contributor.roles glue=", " translate=true isPublicFacing=true removeTrailingPunctuationFromTerms=true}
                     {/if}

--- a/code/web/interface/themes/responsive/Record/view-title-details.tpl
+++ b/code/web/interface/themes/responsive/Record/view-title-details.tpl
@@ -19,7 +19,7 @@
 				{if empty($recordDriver->getAuthor()) && !empty($recordDriver->get880Authors())}
 					<span class="agrAuthor">{implode subject=$recordDriver->get880Authors() glue=',' removeTrailingPunctuationFromTerms=true}</span>
 				{else}
-					<a href='/Author/Home?author="{$recordDriver->getAuthor()|escape:"url"}"'>{$recordDriver->getAuthor()|highlight}</a>{if !empty($recordDriver->get880Authors())} <span class="agrAuthor">({implode subject=$recordDriver->get880Authors() glue=',' removeTrailingPunctuationFromTerms=true})</span>{/if}<br/>
+					<a href='/Search/Results?lookfor={$recordDriver->getAuthor()|escape:"url"}&searchIndex=Author'>{$recordDriver->getAuthor()|highlight}</a>{if !empty($recordDriver->get880Authors())} <span class="agrAuthor">({implode subject=$recordDriver->get880Authors() glue=',' removeTrailingPunctuationFromTerms=true})</span>{/if}<br/>
 				{/if}
 			</div>
 		</div>
@@ -42,7 +42,7 @@
 					{else}
 						<div class="contributor">
 					{/if}
-					<a href='/Author/Home?author="{$contributor.name|trim|escape:"url"}"'>{$contributor.name|escape}</a>
+					<a href='/Search/Results?lookfor={$contributor.name|trim|escape:"url"}&searchIndex=Author'>{$contributor.name|escape}</a>
 					{if !empty($contributor.roles)}
 						&nbsp;{implode subject=$contributor.roles glue=", " translate=true isPublicFacing=true removeTrailingPunctuationFromTerms=true}
 					{/if}

--- a/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/combinedResult.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/combinedResult.tpl
@@ -36,10 +36,10 @@
 						<div class="result-value col-tn-8 notranslate">
 							{if is_array($summAuthor)}
 								{foreach from=$summAuthor item=author}
-									<a href='/Author/Home?author="{$author|escape:"url"}"'>{$author|highlight}</a>
+									<a href='/Search/Results?lookfor={$author|escape:"url"}&searchIndex=Author'>{$author|highlight}</a>
 								{/foreach}
 							{else}
-								<a href='/Author/Home?author="{$summAuthor|escape:"url"}"'>{$summAuthor|highlight}</a>
+								<a href='/Search/Results?lookfor={$summAuthor|escape:"url"}&searchIndex=Author'>{$summAuthor|highlight}</a>
 							{/if}
 						</div>
 					</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/courseReserveEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/courseReserveEntry.tpl
@@ -28,10 +28,10 @@
 					<div class="result-value col-tn-9 col-xs-9 notranslate">
 						{if is_array($summAuthor)}
 							{foreach from=$summAuthor item=author}
-								<a href='/Author/Home?author="{$author|escape:"url"}"'>{$author|highlight}</a>
+								<a href='/Search/Results?lookfor={$author|escape:"url"}&searchIndex=Author'>{$author|highlight}</a>
 							{/foreach}
 						{else}
-							<a href='/Author/Home?author="{$summAuthor|escape:"url"}"'>{$summAuthor|highlight}</a>
+							<a href='/Search/Results?lookfor={$summAuthor|escape:"url"}&searchIndex=Author'>{$summAuthor|highlight}</a>
 						{/if}
 					</div>
 				</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/listEntry.tpl
@@ -37,10 +37,10 @@
 					<div class="result-value col-tn-9 col-xs-9 notranslate">
 						{if is_array($summAuthor)}
 							{foreach from=$summAuthor item=author}
-								<a href='/Author/Home?author="{$author|escape:"url"}"'>{$author|highlight}</a>
+								<a href='/Search/Results?lookfor={$author|escape:"url"}&searchIndex=Author'>{$author|highlight}</a>
 							{/foreach}
 						{else}
-							<a href='/Author/Home?author="{$summAuthor|escape:"url"}"'>{$summAuthor|highlight}</a>
+							<a href='/Search/Results?lookfor={$summAuthor|escape:"url"}&searchIndex=Author'>{$summAuthor|highlight}</a>
 						{/if}
 					</div>
 				</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/seriesEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/seriesEntry.tpl
@@ -25,10 +25,10 @@
 						<div class="result-value col-tn-9 col-xs-9 notranslate">
 							{if is_array($summAuthor)}
 								{foreach from=$summAuthor item=author}
-									<a href='/Author/Home?author="{$author|escape:"url"}"'>{$author|highlight}</a>
+									<a href='/Search/Results?lookfor={$author|escape:"url"}&searchIndex=Author'>{$author|highlight}</a>
 								{/foreach}
 							{else}
-								<a href='/Author/Home?author="{$summAuthor|escape:"url"}"'>{$summAuthor|highlight}</a>
+								<a href='/Search/Results?lookfor={$summAuthor|escape:"url"}&searchIndex=Author'>{$summAuthor|highlight}</a>
 							{/if}
 						</div>
 					</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/Index/combinedResult.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Index/combinedResult.tpl
@@ -36,10 +36,10 @@
 						<div class="result-value col-tn-8 notranslate">
 							{if is_array($summAuthor)}
 								{foreach from=$summAuthor item=author}
-									<a href='/Author/Home?author="{$author|escape:"url"}"'>{$author|highlight}</a>
+									<a href='/Search/Results?lookfor={$author|escape:"url"}&searchIndex=Author'>{$author|highlight}</a>
 								{/foreach}
 							{else}
-								<a href='/Author/Home?author="{$summAuthor|escape:"url"}"'>{$summAuthor|highlight}</a>
+								<a href='/Search/Results?lookfor={$summAuthor|escape:"url"}&searchIndex=Author'>{$summAuthor|highlight}</a>
 							{/if}
 						</div>
 					</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/Index/nonowned_result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Index/nonowned_result.tpl
@@ -25,10 +25,10 @@
 					<div class="col-md-9 result-value  notranslate">
 						{if is_array($record.author)}
 							{foreach from=$summAuthor item=author}
-								<a href='/Author/Home?author="{$author|escape:"url"}"'>{$author|highlight}</a>
+								<a href='/Search/Results?lookfor={$author|escape:"url"}&searchIndex=Author'>{$author|highlight}</a>
 							{/foreach}
 						{else}
-							<a href='/Author/Home?author="{$record.author|escape:"url"}"'>{$record.author|highlight}</a>
+							<a href='/Search/Results?lookfor={$record.author|escape:"url"}&searchIndex=Author'>{$record.author|highlight}</a>
 						{/if}
 					</div>
 				</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/Series/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Series/listEntry.tpl
@@ -41,14 +41,14 @@
 								{if $author == "Various"}
 									{translate text="Various" isPublicFacing=true}
 								{else}
-									<a href='/Author/Home?author="{$author|escape:"url"}"'>{$author|highlight}</a> <br/>
+									<a href='/Search/Results?lookfor={$author|escape:"url"}&searchIndex=Author'>{$author|highlight}</a> <br/>
 								{/if}
 							{/foreach}
 						{else}
 							{if $author == "Various"}
 								{translate text="Various" isPublicFacing=true}
 							{else}
-								<a href='/Author/Home?author="{$summAuthor|escape:"url"}"'>{$summAuthor|highlight}</a>
+								<a href='/Search/Results?lookfor={$summAuthor|escape:"url"}&searchIndex=Author'>{$summAuthor|highlight}</a>
 							{/if}
 						{/if}
 					</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/Series/result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Series/result.tpl
@@ -37,14 +37,14 @@
 							{if $author == "Various"}
 								{translate text="Various" isPublicFacing=true}
 							{else}
-								<a href='/Author/Home?author="{$author|escape:"url"}"'>{$author|highlight}</a> <br/>
+								<a href='/Search/Results?lookfor={$author|escape:"url"}&searchIndex=Author'>{$author|highlight}</a> <br/>
 							{/if}
 						{/foreach}
 					{else}
 						{if $author == "Various"}
 							{translate text="Various" isPublicFacing=true}
 						{else}
-							<a href='/Author/Home?author="{$summAuthor|escape:"url"}"'>{$summAuthor|highlight}</a>
+							<a href='/Search/Results?lookfor={$summAuthor|escape:"url"}&searchIndex=Author'>{$summAuthor|highlight}</a>
 						{/if}
 					{/if}
 				</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/Talpa/result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Talpa/result.tpl
@@ -61,14 +61,14 @@
 								{if is_array($summAuthor)}
 									{foreach from=$summAuthor item=author}
 										{if !$talpaResult}
-											<a href='/Author/Home?author="{$author|escape:"url"}"'>{$author|highlight}</a>
+											<a href='/Search/Results?lookfor={$author|escape:"url"}&searchIndex=Author'>{$author|highlight}</a>
 										{else}
 											{$author|highlight}
 										{/if}
 									{/foreach}
 								{else}
 									{if !$talpaResult}
-										<a href='/Author/Home?author="{$summAuthor|escape:"url"}"'>{$summAuthor|highlight}</a>
+										<a href='/Search/Results?lookfor={$summAuthor|escape:"url"}&searchIndex=Author'>{$summAuthor|highlight}</a>
 									{else}
 										{$summAuthor|highlight}
 									{/if}

--- a/code/web/interface/themes/responsive/Series/placeholderListEntry.tpl
+++ b/code/web/interface/themes/responsive/Series/placeholderListEntry.tpl
@@ -29,10 +29,10 @@
 						<div class="result-value col-tn-9 col-xs-9 notranslate">
 							{if is_array($placeholder['author'])}
 								{foreach from=$placeholder['author'] item=author}
-									<a href='/Author/Home?author="{$author|escape:"url"}"'>{$author|highlight}</a> <br/>
+									<a href='/Search/Results?lookfor={$author|escape:"url"}&searchIndex=Author'>{$author|highlight}</a> <br/>
 								{/foreach}
 							{else}
-								<a href='/Author/Home?author="{$placeholder['author']|escape:"url"}"'>{$placeholder['author']|highlight}</a>
+								<a href='/Search/Results?lookfor={$placeholder['author']|escape:"url"}&searchIndex=Author'>{$placeholder['author']|highlight}</a>
 							{/if}
 						</div>
 					</div>

--- a/code/web/interface/themes/responsive/Series/seriesMembers.tpl
+++ b/code/web/interface/themes/responsive/Series/seriesMembers.tpl
@@ -20,7 +20,7 @@
 												{if $author == "Various"}
 													{translate text="Various" isPublicFacing=true}
 												{else}
-													<a href='/Author/Home?author="{$author|escape:"url"}"'>{$author|highlight}</a> <br/>
+													<a href='/Search/Results?lookfor={$author|escape:"url"}&searchIndex=Author'>{$author|highlight}</a> <br/>
 												{/if}
 											{/foreach}
 										{else}

--- a/code/web/release_notes/26.07.00.MD
+++ b/code/web/release_notes/26.07.00.MD
@@ -20,6 +20,8 @@
 // olivia
 
 // lucas
+### Other Updates
+- Update author links across Aspen to open author search results instead of the Author Home page. ([DIS-1737](https://aspen-discovery.atlassian.net/browse/DIS-1737)) (*YL*)
 
 ## This release includes code contributions from
 ### ByWater Solutions


### PR DESCRIPTION
Link author names to author search results instead of Author Home page. 

To Test:
1. Open search results page, a record, grouped work, or My Account checkouts holds titles etc that display an author link
2. Click the author name and confirm it opens the author home page 
3. Apply the PR
4. Refresh the same page and click the author name again
5. Confirm it now opens search results for that author 