### PR TITLE
DIS-2612: Use parsed URL paths for route matching

### DIFF
--- a/code/web/index.php
+++ b/code/web/index.php
@@ -1087,6 +1087,7 @@ function loadModuleActionId() {
 	if (str_starts_with($requestURI, '//')) {
 		$requestURI = substr($requestURI, 1);
 	}
+	$requestPath = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) ?: '/';
 	/** IndexingProfile[] $indexingProfiles */ global $indexingProfiles;
 	/** SideLoad[] $sideLoadSettings */ global $sideLoadSettings;
 	$allRecordModules = "OverDrive|GroupedWork|Record|ExternalEContent|Person|Library|Hoopla|CloudLibrary|Files|Axis360|WebBuilder|ProPay|CourseReserves|Springshare|LibraryMarket|Communico|PalaceProject|Assabet|AspenEvents|Series|LocalHop";
@@ -1097,22 +1098,22 @@ function loadModuleActionId() {
 		$allRecordModules .= '|' . $profile->recordUrlComponent;
 	}
 	$checkWebBuilderAliases = false;
-	if (preg_match("~^/(MyAccount)/([^/?]+)/([^/?]+)(\?.+)?~", $requestURI, $matches)) {
+	if (preg_match("~^/(MyAccount)/([^/]+)/([^/]+)/?$~", $requestPath, $matches)) {
 		setRoute($matches[1], $matches[2], $matches[3]);
-	} elseif (preg_match("~^/(MyAccount)/([^/?]+)(\?.+)?~", $requestURI, $matches)) {
+	} elseif (preg_match("~^/(MyAccount)/([^/]+)/?$~", $requestPath, $matches)) {
 		setRoute($matches[1], $matches[2]);
 		setEmptyRouteId();
-	} elseif (preg_match("~^/(MyAccount)/?~", $requestURI, $matches)) {
+	} elseif (preg_match("~^/(MyAccount)/?$~", $requestPath, $matches)) {
 		setRoute($matches[1]);
 		setEmptyRouteId();
-	} elseif (preg_match('~^/(Archive)/((?:[\\w\\d:]|%3A)+)/([^/?]+)~', $requestURI, $matches)) {
+	} elseif (preg_match('~^/(Archive)/((?:[\\w\\d:]|%3A)+)/([^/]+)/?$~', $requestPath, $matches)) {
 		setRoute($matches[1], $matches[3], urldecode($matches[2])); // Decodes colons % codes back into colons.
 		//Redirect things /GroupedWork/AJAX to the proper action
-	} elseif (preg_match("~^/($allRecordModules)/([a-zA-Z]+)(?:\?|/?$)~", $requestURI, $matches)) {
+	} elseif (preg_match("~^/($allRecordModules)/([a-zA-Z]+)/?$~", $requestPath, $matches)) {
 		setRoute($matches[1], $matches[2]);
 		//Redirect things /Record/.b3246786/Home to the proper action
 		//Also things like /OverDrive/84876507-043b-b3ce-2930-91af93d2a4f0/Home
-	} elseif (preg_match("~^/($allRecordModules)/([^/?]+?)/([^/?]+)~", $requestURI, $matches)) {
+	} elseif (preg_match("~^/($allRecordModules)/([^/]+)/([^/]+)/?$~", $requestPath, $matches)) {
 		//Getting some weird cases where the action is replaced with an email address for uintah.
 		//As a workaround, if the action looks like an email, change it to Home
 		if (preg_match('/[A-Z0-9][A-Z0-9._%+-]{0,63}@(?:[A-Z0-9-]{1,63}\.){1,8}[A-Z]{2,63}$/i', $matches[3])) {
@@ -1122,22 +1123,22 @@ function loadModuleActionId() {
 		}
 		setRoute($matches[1], $matches[3], $matches[2]);
 		//Redirect things /Record/.b3246786 to the proper action
-	} elseif (preg_match("~^/($allRecordModules)/([^/?]+?)(?:\?|/?$)~", $requestURI, $matches)) {
+	} elseif (preg_match("~^/($allRecordModules)/([^/]+)/?$~", $requestPath, $matches)) {
 		setRoute($matches[1], 'Home', $matches[2]);
-	} elseif (preg_match("~^/(Authentication)/(OAuth2)/([^/?]+)~", $requestURI, $matches)) {
+	} elseif (preg_match("~^/(Authentication)/(OAuth2)/([^/]+)/?$~", $requestPath, $matches)) {
 		setRoute($matches[1], 'OAuth2_' . $matches[3]); // OAuth2_Authorize or OAuth2_Token
-	} elseif (preg_match("~^/(\.well-known)/([^/?]+)~", $requestURI, $matches)) {
+	} elseif (preg_match("~^/(\.well-known)/([^/]+)/?$~", $requestPath, $matches)) {
 		// Map well-known requests to appropriate OAuth2/OIDC endpoints
 		$wellKnownType = $matches[2];
 		$action = $wellKnownType === 'jwks.json' ? 'OAuth2_JWKS' : 'OAuth2_Discovery';
 
 		setRoute('Authentication', $action);
-	} elseif (preg_match("~^/([^/?]+)/([^/?]+)~", $requestURI, $matches)) {
+	} elseif (preg_match("~^/([^/]+)/([^/]+)/?$~", $requestPath, $matches)) {
 		setRoute($matches[1], $matches[2]);
 		if (!file_exists(ROOT_DIR . '/services/' . $_REQUEST['module'] . '/' . $_REQUEST['action'] . '.php')) {
 			$checkWebBuilderAliases = true;
 		}
-	} elseif (preg_match("~^/([^/?]+)~", $requestURI, $matches)) {
+	} elseif (preg_match("~^/([^/]+)/?$~", $requestPath, $matches)) {
 		setRoute($matches[1]);
 		if (!file_exists(ROOT_DIR . '/services/' . $_REQUEST['module'] . '/' . $_REQUEST['action'] . '.php')) {
 			$checkWebBuilderAliases = true;

--- a/code/web/index.php
+++ b/code/web/index.php
@@ -678,9 +678,14 @@ if (UserAccount::isLoggedIn() && (!isset($_REQUEST['action']) || $_REQUEST['acti
 
 //Find a reasonable default location to go to
 if ($module == null && $action == null) {
-	//We have no information about where to go, go to the default location from config
-	$module = $configArray['Site']['defaultModule'];
-	$action = 'Home';
+	$requestPath = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) ?: '/';
+	if ($requestPath === '/') {
+		$module = $configArray['Site']['defaultModule'];
+		$action = 'Home';
+	} else {
+		$module = 'Error';
+		$action = 'Handle404';
+	}
 } elseif ($action == null) {
 	$action = 'Home';
 }

--- a/code/web/release_notes/26.07.00.MD
+++ b/code/web/release_notes/26.07.00.MD
@@ -20,6 +20,8 @@
 // olivia
 
 // lucas
+### Other Updates
+- Improve URL handling so invalid or malformed Aspen links now return the correct error page instead of loading unrelated content.([DIS-2612](https://aspen-discovery.atlassian.net/browse/DIS-2612)) (*YL*)
 
 ## This release includes code contributions from
 ### ByWater Solutions


### PR DESCRIPTION
Malformed URLs such as /Union/Search/Union/Search/Search/Results?lookfor=test could reach valid Aspen resources as long as the beginning of the URL matched a known route.

This change updates route matching to use the parsed URL path instead of raw REQUEST_URI, so routing is based only on the normalized path and not on extra malformed path segments or query.

This work also updates fallback behavior for invalid unmatched paths to return the 404 page instead of the home page. That can prevent bots from reaching valid Aspen resources through junk URLs while still giving real patrons a recovery path back into Aspen from the 404 page.

To Test
1. Confirm that both of these URLs work before applying the PR:
    * /Union/Search?lookfor=test
    * /Union/Search/Union/Search/Search/Results?lookfor=test
2. Apply the PR.
3. Confirm that the canonical URL still works:
    * /Union/Search?lookfor=test
4. Confirm that the malformed URL no longer works and returns the 404 page:
    * /Union/Search/Union/Search/Search/Results?lookfor=test