### PR TITLE
DIS-2610:Fix donation email displaying raw HTML tags

### DIFF
--- a/code/web/release_notes/26.07.00.MD
+++ b/code/web/release_notes/26.07.00.MD
@@ -21,12 +21,16 @@
 
 // lucas
 
+//shipra
+- Fix the issue where Donation emails displayed raw HTML tags. ([DIS-2610] (https://aspen-discovery.atlassian.net/browse/DIS-2610)) (*SSP*)
+
 ## This release includes code contributions from
 ### ByWater Solutions
 - Yanjun Li (YL)
 - Imani Thomas (IT)
 - Jonah Wilson (JW)
 - Kyle Hall (KMH)
+- Shipra Satish Poojary (SSP)
 
 ### Grove For Libraries
 - Mark Noble (MDN)

--- a/code/web/sys/Donations/Donation.php
+++ b/code/web/sys/Donations/Donation.php
@@ -447,7 +447,7 @@ class Donation extends DataObject {
 			$error = $mail->send($this->email, translate([
 				'text' => 'Your Donation Receipt',
 				'isPublicFacing' => true,
-			]), $body, $replyToAddress);
+			]), null, $replyToAddress, $body);
 			if (($error instanceof AspenError)) {
 				global $interface;
 				$interface->assign('error', $error->getMessage());


### PR DESCRIPTION
In Donation Settings → Email Template 
If a Library has configured Email template to be sent after making a donation. The email they receive shows raw HTML code (like <p> and <br>)