### PR TITLE
DIS-2620: fix: cron log for reading history notes

### DIFF
--- a/code/web/cron/loadInitialReadingHistory.php
+++ b/code/web/cron/loadInitialReadingHistory.php
@@ -116,6 +116,7 @@ foreach ($usersToProcess as $userId) {
 				}
 				if ($result['numTitles'] > 0) {
 					$cronLogEntry->notes .= "<br/>Found {$result['numTitles']} titles to load for $user->displayName ($user->id).";
+					$skippedDuplicates = 0;
 					foreach ($result['titles'] as $title) {
 						$userReadingHistoryEntry = new ReadingHistoryEntry();
 						$userReadingHistoryEntry->userId = $user->id;
@@ -147,6 +148,7 @@ foreach ($usersToProcess as $userId) {
 								$checkDuplicateEntry->whereAdd('barcode IS NULL OR barcode = ""');
 								$checkDuplicateEntry->whereAdd('checkInDate IS NOT NULL');
 								if ($checkDuplicateEntry->find(true)) {
+									$skippedDuplicates++;
 									continue;
 								}
 							}
@@ -160,12 +162,19 @@ foreach ($usersToProcess as $userId) {
 
 						$userReadingHistoryEntry->deleted = 0;
 						if (!$userReadingHistoryEntry->insert()) {
-							$cronLogEntry->numErrors++;
-							$cronLogEntry->notes .= "<br/>Error inserting reading history entry for user $user->id: " . $userReadingHistoryEntry->getLastError();
-							$errorCount++;
+							$lastError = $userReadingHistoryEntry->getLastError();
+							if (!empty($lastError)) {
+								$cronLogEntry->numErrors++;
+								$cronLogEntry->notes .= "<br/>Error inserting reading history entry for user $user->id: " . $lastError;
+								$errorCount++;
+							} else {
+								$skippedDuplicates++;
+							}
 						}
 					}
-
+					if ($skippedDuplicates > 0) {
+						$cronLogEntry->notes .= "<br/>Skipped $skippedDuplicates duplicate entries for $user->displayName ($user->id).";
+					}
 				}
 
 				// Mark that the initial reading history has been loaded and clear the timestamp.

--- a/code/web/release_notes/26.07.00.MD
+++ b/code/web/release_notes/26.07.00.MD
@@ -48,6 +48,10 @@
     - usage recorded before this change is attributed to day 0 of its month so that historical data remains viewable under the new periods.
 - Dates shown on the usage graphs and in their CSV downloads are formatted according to the configured locale. ([DIS-1689](https://aspen-discovery.atlassian.net/browse/DIS-1689)) (*CZ*)
 
+### Other Updates
+- Improve Reading History logging by reporting on skipped duplicates ([DIS-2620](https://aspen-discovery.atlassian.net/browse/DIS-2620)) (*CZ*)
+
+
 // jacob
 - Add a locale-aware date formatter to DateUtils. ([DIS-2605](https://aspen-discovery.atlassian.net/browse/DIS-2605)) (*JOM*)
 


### PR DESCRIPTION
Before this change, some skipped duplicates resulted in the same error message as for genuine DB insert failures being displayed in the cron logs - and without a clear message (as this would normally log the DB error, which in this case we do not have).

Instead, log skipped duplicates number per patron, so that administrators get a better understanding of whether imports truly failed (no history entry added where there should be one) or whether they were skipped by design.