### PR TITLE
DIS-2531: Load patron's preferred pickup location from Polaris

### DIFF
--- a/code/web/CatalogConnection.php
+++ b/code/web/CatalogConnection.php
@@ -2259,4 +2259,8 @@ class CatalogConnection {
 	public function getPatronHoldGroups($patronId): ?array {
 		return $this->driver->getPatronHoldGroups($patronId);
 	}
+
+	public function updatePreferredPickupLocation($user, $pickupLocation, $fromMasquerade): bool {
+		return $this->driver->updatePreferredPickupLocation($user, $pickupLocation, $fromMasquerade);
+	}
 }

--- a/code/web/Drivers/AbstractIlsDriver.php
+++ b/code/web/Drivers/AbstractIlsDriver.php
@@ -1065,6 +1065,10 @@ abstract class AbstractIlsDriver extends AbstractDriver {
 		return false;
 	}
 
+	public function updatePreferredPickupLocation($user, $pickupLocation, $fromMasquerade): bool {
+		return false;
+	}
+
 	public function isPatronAccountLocked(User $patron, $fine): bool {
 		return false;
 	}

--- a/code/web/Drivers/Polaris.php
+++ b/code/web/Drivers/Polaris.php
@@ -1867,7 +1867,7 @@ class Polaris extends AbstractIlsDriver {
 		// Update Preferred Pickup Location
 		if (!empty($pickupLocation)) {
 			$homeLibraryLocation = new Location();
-			if ($homeLibraryLocation->get('code', $pickupLocation)) {
+			if ($homeLibraryLocation->get('locationId', $pickupLocation)) {
 				$homeBranchCode = strtoupper($homeLibraryLocation->code);
 				$body->RequestPickupBranchID = $homeBranchCode;
 			}

--- a/code/web/Drivers/Polaris.php
+++ b/code/web/Drivers/Polaris.php
@@ -1263,7 +1263,12 @@ class Polaris extends AbstractIlsDriver {
 
 						if ($homeLocationChanged) {
 							//reset the patrons preferred pickup location to their new home library
-							$user->setPickupLocationId($user->homeLocationId);
+							//unless we get preferred pickup location from api response
+							if (isset($patronBasicData->RequestPickupBranchID)) {
+								$user->setPickupLocationId($patronBasicData->RequestPickupBranchID);
+							} else {
+								$user->setPickupLocationId($user->homeLocationId);
+							}
 							$user->setRememberHoldPickupLocation(0);
 						}
 					}
@@ -1845,6 +1850,35 @@ class Polaris extends AbstractIlsDriver {
 			$result['messages'][] = 'You do not have permission to update profile information.';
 		}
 		return $result;
+	}
+
+	function updatePreferredPickupLocation($patron, $pickupLocation, $fromMasquerade): bool {
+		$staffInfo = $this->getStaffUserInfo();
+		$polarisUrl = "/PAPIService/REST/public/v1/1033/100/1/patron/{$patron->getBarcode()}";
+		$body = new stdClass();
+		$body->LogonBranchID = $patron->getHomeLocationCode();
+		$body->LogonUserID = (string)$staffInfo['polarisId'];
+		$body->LogonWorkstationID = $this->getWorkstationID($patron);
+
+		//User the patron's home library rather than the active library just in case they are on the wrong interface
+		$library = $patron->getHomeLibrary();
+		$this->setupBodyForSelfRegAndPatronUpdateCall('patronUpdate', $body, $library);
+
+		// Update Preferred Pickup Location
+		if (!empty($pickupLocation)) {
+			$homeLibraryLocation = new Location();
+			if ($homeLibraryLocation->get('code', $pickupLocation)) {
+				$homeBranchCode = strtoupper($homeLibraryLocation->code);
+				$body->RequestPickupBranchID = $homeBranchCode;
+			}
+		}
+		$encodedBody = json_encode($body);
+		$response = $this->getWebServiceResponse($polarisUrl, 'PUT', $this->getAccessToken($patron->getBarcode(), $patron->getPasswordOrPin()), $encodedBody, $fromMasquerade || UserAccount::isUserMasquerading());
+		ExternalRequestLogEntry::logRequest('polaris.updatePatronInfo', 'PUT', $this->getWebServiceURL() . $polarisUrl, $this->apiCurlWrapper->getHeaders(), $encodedBody, $this->lastResponseCode, $response, []);
+		if ($response && $this->lastResponseCode == 200) {
+			return true;
+		}
+		return false;
 	}
 
 	function updatePin(User $patron, ?string $oldPin, string $newPin) {

--- a/code/web/release_notes/26.07.00.MD
+++ b/code/web/release_notes/26.07.00.MD
@@ -37,6 +37,9 @@
 
 </div>
 
+### Polaris Updates
+- When loading new patron info or updating preferred location for Polaris users, refer to/update RequestPickupBrancID via the Polaris API ([DIS-2531](https://aspen-discovery.atlassian.net/browse/DIS-2531)) (*KL*)
+
 ### Grouped Work Display Updates
 - Fix issue where grouped work descriptions were displaying on full record pages instead of the individual record's description ([DIS-2556](https://aspen-discovery.atlassian.net/browse/DIS-2556)) (*KL*)
 

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -1676,6 +1676,10 @@ class User extends DataObject {
 
 		//Make sure the selected location codes are in the database.
 		if (isset($_POST['pickupLocation'])) {
+			$catalogDriver = $this->getCatalogDriver();
+			if ($catalogDriver->driver instanceof Polaris) {
+				$catalogDriver->updatePreferredPickupLocation($this, $_POST['pickupLocation'], UserAccount::isUserMasquerading());
+			}
 			if ($_POST['pickupLocation'] == 0) {
 				$this->__set('pickupLocationId', $_POST['pickupLocation']);
 			} else {


### PR DESCRIPTION
- Update logic in Polaris driver to use RequestPickupBranchID for getting and setting preferred pickup location when the user logs in for the first time and when they update their preferences 
- Update release notes

Tested on my local instance of Aspen