### PR TITLE
DIS-2633 use userId sent up to renewItem to determine user for renew…

### DIFF
--- a/code/web/release_notes/26.08.00.MD
+++ b/code/web/release_notes/26.08.00.MD
@@ -1,0 +1,1 @@
+- use userId sent up to renewItem to determine user for renewCheckout instead of loggedIn user to allow linkedAccount renewals from LiDA ([DIS-2633](https://aspen-discovery.atlassian.net/browse/DIS-2633)) (*IT*)

--- a/code/web/services/API/UserAPI.php
+++ b/code/web/services/API/UserAPI.php
@@ -1726,7 +1726,15 @@ class UserAPI extends AbstractAPI {
 		$user = $this->getUserForApiCall();
 		if ($user && !($user instanceof AspenError)) {
 			if ($source == 'ils' || $source == null || $source == $library->interLibraryLoanName) {
-				$result = $user->renewCheckout($recordId, $itemBarcode);
+				$patron = $user->getUserReferredTo($_REQUEST['userId'] ?? $user->id);
+				$result = null;
+				if($patron)
+				{
+					$result = $patron->renewCheckout($recordId, $itemBarcode);
+				}
+				else {
+					$result = $user->renewCheckout($recordId, $itemBarcode);
+				}
 
 				if(isset($result['confirmRenewalFee']) && $result['confirmRenewalFee']) {
 					$action = $result['api']['action'] ?? null;


### PR DESCRIPTION
to test:
* log into LiDA with an account with a linked account with checkouts
* try to renew the checkouts for linked items
* successfully renew the linked items.