### PR TITLE
DIS-774 Improved Cookie Handling

### DIFF
--- a/code/web/bootstrap.php
+++ b/code/web/bootstrap.php
@@ -340,7 +340,9 @@ function loadLibraryAndLocation() {
 	$branch = $locationSingleton->getBranchLocationCode();
 	if (!isset($_COOKIE['branch']) || $branch != $_COOKIE['branch']) {
 		if ($branch == '') {
-			setcookie('branch', $branch, time() - 1000, '/');
+			if (!empty($COOKIE['branch'])) {
+				setcookie('branch', $branch, time() - 1000, '/');
+			}
 		} else {
 			setcookie('branch', $branch, 0, '/');
 		}
@@ -350,7 +352,9 @@ function loadLibraryAndLocation() {
 	$subLocation = $locationSingleton->getSublocationCode();
 	if (!isset($_COOKIE['sublocation']) || $subLocation != $_COOKIE['sublocation']) {
 		if (empty($subLocation)) {
-			setcookie('sublocation', $subLocation, time() - 1000, '/');
+			if (!empty($COOKIE['sublocation'])) {
+				setcookie('sublocation', $subLocation, time() - 1000, '/');
+			}
 		} else {
 			setcookie('sublocation', $subLocation, 0, '/');
 		}

--- a/code/web/release_notes/26.07.00.MD
+++ b/code/web/release_notes/26.07.00.MD
@@ -150,6 +150,8 @@
 - Add MARC 700 subfield q to contributor displays on record detail pages. ([DIS-1805](https://aspen-discovery.atlassian.net/browse/DIS-1805)) (*YL*)
 - Improve URL handling so invalid or malformed Aspen links now return the correct error page instead of loading unrelated content.([DIS-2612](https://aspen-discovery.atlassian.net/browse/DIS-2612)) (*YL*)
 - Add configurable complexity score header for Cloudflare rate limiting. ([DIS-2572](https://aspen-discovery.atlassian.net/browse/DIS-2572)) (*TS*)
+- Do not send cookies for parameters that are remembered in cookies after they are cleared. ([DIS-774](https://aspen-discovery.atlassian.net/browse/DIS-774)) (*MDN*)
+- Do not send cookies for book covers. ([DIS-774](https://aspen-discovery.atlassian.net/browse/DIS-774)) (*MDN*)
 
 ## This release includes code contributions from
 ### ByWater Solutions

--- a/code/web/sys/Covers/BookCoverProcessor.php
+++ b/code/web/sys/Covers/BookCoverProcessor.php
@@ -602,6 +602,8 @@ class BookCoverProcessor {
 		} else {
 			$this->logTime("Added modification headers");
 		}
+		//Remove all cookies
+		header_remove("Set-Cookie");
 	}
 
 	private function getCoverFromProvider() : bool {

--- a/code/web/sys/IP/IPAddress.php
+++ b/code/web/sys/IP/IPAddress.php
@@ -520,8 +520,10 @@ class IPAddress extends DataObject {
 			$ip = $_COOKIE['test_ip'];
 		} else {
 			$ip = IPAddress::getClientIP();
-			setcookie('test_ip', null, time() - 3600, '/');
-			unset($_COOKIE['test_ip']);
+			if (!empty($_COOKIE['test_ip'])) {
+				setcookie('test_ip', null, time() - 3600, '/');
+				unset($_COOKIE['test_ip']);
+			}
 		}
 		IPAddress::$activeIp = $ip;
 		$timer->logTime("getActiveIp");


### PR DESCRIPTION
This was a 2 part fix requiring different testing.

 bookcover.php is now setup to never return cookies.

Parameters that set a cookie (branch, sublocation, test_ip) will now not return cookies if they are already cleared.

Test 1 by navigating to book covers and ensuring you don’t see a Set-Cookie header in the response.

Test 2 by setting a parameter, ensure it’s in the cookies, then clear it, ensure you get a Set-Cookie showing the cookie is deleted, refresh the page and ensure there is no Set-Cookie.