### PR TITLE
DIS-2398: Allow Merging of Series

### DIFF
--- a/code/web/RecordDrivers/SeriesRecordDriver.php
+++ b/code/web/RecordDrivers/SeriesRecordDriver.php
@@ -94,11 +94,14 @@ class SeriesRecordDriver extends IndexRecordDriver {
 
 		$seriesObject = $this->getSeriesObject();
 		if ($seriesObject) {
+			$numTitles = $seriesObject->numScopedTitlesInSeries();
 			$interface->assign('summNumTitles', $seriesObject->numScopedTitlesInSeries());
 			$interface->assign('seriesObjectId', $seriesObject->id);
+			$interface->assign('seriesVersion', $seriesObject->version);
 		}else{
 			$interface->assign('summNumTitles', 0);
 			$interface->assign('seriesObjectId', -1);
+			$interface->assign('seriesVersion', -1);
 		}
 
 		if ($showListsAppearingOn) {

--- a/code/web/interface/themes/responsive/Series/result-tools.tpl
+++ b/code/web/interface/themes/responsive/Series/result-tools.tpl
@@ -10,9 +10,11 @@
 			<button onclick="return AspenDiscovery.Account.showSaveToListForm(this, 'Series', '{$summShortId|escape}');" class="btn btn-sm addToListBtn">{translate text="Add to List" isPublicFacing=true}</button>
 		</div>
 		{if !empty($loggedIn) && (in_array('Administer Series', $userPermissions))}
-			<div class="btn-group btn-group-sm">
-				<button onclick="return AspenDiscovery.Series.getGroupSeriesSearchForm(this, '{$summShortId|escape}', '{$searchId}', '{if empty($page)}1{else}{$page}{/if}');" class="btn btn-sm btn-tools">{translate text="Group With" isPublicFacing=true}</button>
-			</div>
+			{if $seriesVersion == 2}
+				<div class="btn-group btn-group-sm">
+					<button onclick="return AspenDiscovery.Series.getGroupSeriesSearchForm(this, '{$summShortId|escape}', '{$searchId}', '{if empty($page)}1{else}{$page}{/if}');" class="btn btn-sm btn-tools">{translate text="Group With" isPublicFacing=true}</button>
+				</div>
+			{/if}
 			{if $seriesObjectId != -1}
 				<div class="btn-group btn-group-sm">
 					<button value="editList" id="FavEdit" class="btn btn-sm btn-tools" onclick="return AspenDiscovery.Series.editAction({$seriesObjectId})">{translate text='Edit Series' isPublicFacing=true}</button>

--- a/code/web/services/Series/AJAX.php
+++ b/code/web/services/Series/AJAX.php
@@ -206,16 +206,24 @@ class Series_AJAX extends JSON_Action {
 			$seriesToGroupWith = new Series();
 			$seriesToGroupWith->seriesPermanentId = $seriesToGroupWithId;
 			if (!empty($seriesToGroupWithId) && $seriesToGroupWith->find(true)) {
-				$originalSeries->getSeriesMembers();
-				$originalSeries->seriesToGroupWithId = $seriesToGroupWithId;
-				$originalSeries->isIndexed = 0;
-				$originalSeries->update();
+				if (empty($seriesToGroupWith->seriesToGroupWithId)){
+					$originalSeries->getSeriesMembers();
+					$originalSeries->seriesToGroupWithId = $seriesToGroupWithId;
+					$originalSeries->isIndexed = 0;
+					$originalSeries->update();
 
-				$results['success'] = true;
-				$results['message'] = translate([
-					'text' => "Your series have been grouped successfully, the index will update shortly.",
-					'isAdminFacing' => true,
-				]);
+					$results['success'] = true;
+					$results['message'] = translate([
+						'text' => "Your series have been grouped successfully, the index will update shortly.",
+						'isAdminFacing' => true,
+					]);
+				} else {
+					$results['message'] = translate([
+						'text' => "The series you are trying to group to is already grouped to another series. Please wait for the index to update.",
+						'isAdminFacing' => true,
+					]);
+				}
+
 			} else {
 				$results['message'] = translate([
 					'text' => "Could not find series to group with.",

--- a/code/web/sys/Series/Series.php
+++ b/code/web/sys/Series/Series.php
@@ -181,10 +181,9 @@ class Series extends DataObject {
 
 
 	public function update(string $context = '') : int|bool {
-
+		$this->__set('dateUpdated', time());
 		if (!empty($this->_changedFields)) {
 			$this->reloadCover();
-			$this->__set('dateUpdated', time());
 		}
 		$ret = parent::update();
 		if ($ret !== FALSE) {


### PR DESCRIPTION
- Hide "Group With" button for version 1 series entries ("Could not find a series with that id." error)
- Don't allow grouping series onto other series if primary series has "seriesToGroupWithId" set (prevent isIndexed getting set to 0 for a primary series if user keeps merging series before indexer catches up)
- Set dateUpdated for series in update() function (fix issue with series indexer not updating series after series are merged)