### PR TITLE
DIS-2531: Load patron's preferred pickup location from Polaris

### DIFF
--- a/code/web/Drivers/Polaris.php
+++ b/code/web/Drivers/Polaris.php
@@ -1261,7 +1261,7 @@ class Polaris extends AbstractIlsDriver {
 							}
 						}
 
-						if ($homeLocationChanged) {
+						if ($homeLocationChanged || $user->pickupLocationId != $patronBasicData->RequestPickupBranchID) {
 							//reset the patrons preferred pickup location to their new home library
 							//unless we get preferred pickup location from api response
 							if (isset($patronBasicData->RequestPickupBranchID)) {


### PR DESCRIPTION
Add check for user->pickupLocationId != $patronBasicData->RequestPickupBranchID to update the pickup location with the ils value if it is different in the ils vs aspen