### PR TITLE
DIS-1911: Improve text margins on generated event cover images

### DIFF
--- a/code/web/release_notes/26.08.00.MD
+++ b/code/web/release_notes/26.08.00.MD
@@ -17,6 +17,9 @@
 
 // olivia
 
+### Event Updates
+- Improve text margins on generated event cover images ([DIS-1911](https://aspen-discovery.atlassian.net/browse/DIS-1911)) (*OR*)
+
 // shipra
 
 // jonah

--- a/code/web/sys/Covers/EventCoverBuilder.php
+++ b/code/web/sys/Covers/EventCoverBuilder.php
@@ -76,7 +76,6 @@ class EventCoverBuilder extends AbstractCoverBuilder {
 		$y = addCenteredWrappedTextToImage($imageCanvas, $this->titleFont, $dayOfMonth, $title_font_size * 5, $title_font_size * .15 * 5, $x, $y, $this->imageWidth - 30, $textColor);
 
 		if (!empty($branch) && $displayBranchOnThumbnail) {
-			$y += 15;
 			$branch = StringUtils::trimStringToLengthAtWordBoundary($branch, 150, true);
 			$branch_font_size = $title_font_size * 1.0;
 
@@ -84,9 +83,9 @@ class EventCoverBuilder extends AbstractCoverBuilder {
 				$branchTotalHeight,
 				$branchLines,
 				$branch_font_size_final,
-			] = wrapTextForDisplay($this->titleFont, $branch, $branch_font_size, $branch_font_size * .15, $width, 100);
+			] = wrapTextForDisplay($this->titleFont, $branch, $branch_font_size, $branch_font_size * .15, $width, 30);
 			$y = addCenteredWrappedTextToImage($imageCanvas, $this->titleFont, $branchLines, $branch_font_size_final, $branch_font_size_final * .15, $x, $y, $this->imageWidth - 30, $textColor);
-			$y += 30; 
+			$y += 45;
 		}
 
 		$title = StringUtils::trimStringToLengthAtWordBoundary($title, 60, true);
@@ -95,8 +94,8 @@ class EventCoverBuilder extends AbstractCoverBuilder {
 			$totalHeight,
 			$lines,
 			$font_size,
-		] = wrapTextForDisplay($this->titleFont, $title, $title_font_size, $title_font_size * .15, $width, $this->imageHeight - $this->imageWidth - 20);
-		$y = $this->imageWidth + 5;
+		] = wrapTextForDisplay($this->titleFont, $title, $title_font_size, $title_font_size * .15, $width, $this->imageHeight - $this->imageWidth - 25);
+		$y = $this->imageWidth + 10;
 		addCenteredWrappedTextToImage($imageCanvas, $this->titleFont, $lines, $font_size, $font_size * .15, $x, $y, $this->imageWidth - 30, $textColor);
 	}
 }


### PR DESCRIPTION
This patch adjusts the branch location upwards slightly, and the event title downwards slightly. This gives both pieces a more comfortable margin.

Before and after comparison:

<img width="280" height="400" alt="image" src="https://github.com/user-attachments/assets/69498329-d85a-4b8c-b8d6-5724e99fa4cc" />

<img width="280" height="400" alt="image" src="https://github.com/user-attachments/assets/7efbb259-c5fb-4925-aeb0-0fab2e77f8cc" />
