### PR TITLE
DIS-2296: Fix Docker setup issues: script reliability, file operations, and timezone configuration

### DIFF
--- a/code/web/release_notes/26.08.00.MD
+++ b/code/web/release_notes/26.08.00.MD
@@ -28,6 +28,9 @@
 // yanjun
 
 // lucas
+### Docker Updates
+- Replace `TIMEZONE` env var with `TZ` and set timezone via PHP-FPM pool config instead of `timedatectl`, which requires systemd and fails silently in containers. ([DIS-2296](https://aspen-discovery.atlassian.net/browse/DIS-2296)) (*LM*)
+- Replace `exec()` shell calls in container scripts with PHP native functions and fix retry logic, hardcoded constants, and a dead signal trap in Apache startup. ([DIS-2296](https://aspen-discovery.atlassian.net/browse/DIS-2296)) (*LM*)
 
 ## This release includes code contributions from
 ### ByWater Solutions

--- a/docker/README.md
+++ b/docker/README.md
@@ -3,8 +3,8 @@
 ## Quick Start
 
 ```bash
-curl -O https://raw.githubusercontent.com/Aspen-Discovery/aspen-discovery/26.05.00/docker/docker-compose.yml
-curl -O https://raw.githubusercontent.com/Aspen-Discovery/aspen-discovery/26.05.00/docker/files/env/default.env
+curl -O https://raw.githubusercontent.com/Aspen-Discovery/aspen-discovery/26.07.00/docker/docker-compose.yml
+curl -O https://raw.githubusercontent.com/Aspen-Discovery/aspen-discovery/26.07.00/docker/files/env/default.env
 cp default.env .env
 ```
 
@@ -32,9 +32,10 @@ Access Aspen at http://localhost:85 (default credentials: `aspen_admin` / `secre
 | `URL` | `http://localhost:85` | Public URL |
 | `TITLE` | `Aspen Discovery` | Library title |
 | `LIBRARY` | `Test Library` | Library name |
-| `TIMEZONE` | `America/Argentina/Cordoba` | PHP timezone |
+| `TZ` | `America/Argentina/Cordoba` | Container and PHP timezone |
 | `ASPEN_ADMIN_PASSWORD` | `secretPass123` | Admin password — **change before going live** |
 | `ASPEN_HOME` | `./aspen` | Directory where instance files are stored (conf, data, logs) |
+| `ASPEN_ADMIN_PASSWORD` | `secretPass123` | Admin password |
 | `SUPPORTING_COMPANY` | `ByWater Solutions` | Support company name |
 
 ### Database
@@ -77,7 +78,7 @@ Environment variables are synced to configuration files on every container start
 
 **Supported variables for runtime updates:**
 - `DATABASE_HOST`, `DATABASE_PORT`, `DATABASE_NAME`, `DATABASE_USER`, `DATABASE_PASSWORD`
-- `TIMEZONE`, `URL`, `TITLE`, `LIBRARY`
+- `TZ`, `URL`, `TITLE`, `LIBRARY`
 - `SOLR_HOST`, `SOLR_PORT`
 
 **Note:** Changing database credentials requires the MariaDB user to already exist. MariaDB only creates users on first initialization.

--- a/docker/files/env/default.env
+++ b/docker/files/env/default.env
@@ -27,7 +27,7 @@ DATABASE_USER=aspenusr
 DATABASE_PASSWORD=aspenpasswd
 DATABASE_ROOT_USER=root
 DATABASE_ROOT_PASSWORD=password
-TIMEZONE=America/Argentina/Cordoba
+TZ=America/Argentina/Cordoba
 
 # =============================================================================
 # DOCKER IMAGES

--- a/docker/files/php_fpm/php-fpm.conf
+++ b/docker/files/php_fpm/php-fpm.conf
@@ -59,6 +59,10 @@ php_admin_value[session.gc_maxlifetime] = 6000
 ; php_admin_value[error_reporting] = 2047
 
 
+; Timezone
+php_admin_value[date.timezone] = {timezone}
+
+
 ; Memory and Execution Settings
 php_admin_value[memory_limit] = 512M
 php_admin_value[max_execution_time] = 300

--- a/docker/files/scripts/apache.sh
+++ b/docker/files/scripts/apache.sh
@@ -26,20 +26,6 @@ log_info "Starting Apache initialization"
 
 export CONFIG_DIRECTORY="/usr/local/aspen-discovery/sites/${SITE_NAME}"
 
-# Function to handle shutdown signals
-shutdown_handler() {
-    log_info "Received shutdown signal, stopping Apache gracefully..."
-    if [ -n "$APACHE_PID" ]; then
-        kill -TERM "$APACHE_PID" 2>/dev/null || true
-        wait "$APACHE_PID" 2>/dev/null || true
-    fi
-    log_info "Apache stopped"
-    exit 0
-}
-
-# Set up signal handlers for graceful shutdown
-trap shutdown_handler SIGTERM SIGINT SIGQUIT
-
 # Check if site configuration exists
 apacheConfFile="$CONFIG_DIRECTORY/httpd-${SITE_NAME}.conf"
 log_info "Waiting for site configuration: $apacheConfFile"
@@ -98,7 +84,7 @@ fi
 log_info "Apache configuration is valid"
 
 
-# Start Apache and capture its PID
+# Apache runs as PID 1 via exec — Docker signals it directly for graceful shutdown
 log_info "Starting Apache in foreground mode..."
 exec apache2 -D FOREGROUND
 

--- a/docker/files/scripts/createConfig.php
+++ b/docker/files/scripts/createConfig.php
@@ -42,7 +42,7 @@ $variables = [
 	'solrPort' => getenv('SOLR_PORT') ?? 8983,
 	'phpFpmHost' => getenv('PHP_FPM_HOST') ?? 'localhost',
 	'phpFpmPort' => getenv('PHP_FPM_PORT') ?? '9000',
-	'timezone' => getenv('TIMEZONE') ?? 'US/Central',
+	'timezone' => getenv('TZ') ?? 'US/Central',
 	'aspenAdminPassword' => getenv('ASPEN_ADMIN_PASSWORD'),
 	'databaseHost' => getenv('DATABASE_HOST') ?? 'localhost',
 	'databasePort' => getenv('DATABASE_PORT') ?? 3306,
@@ -139,11 +139,6 @@ try {
 	replaceVariables($siteDir . "/conf/php-fpm.conf", $variables);
 	replaceVariables($siteDir . "/conf/crontab", $variables);
 
-	DockerLogger::info("Setting system timezone: {$variables['timezone']}");
-	
-	// Set timezone
-	exec('sudo timedatectl set-timezone "' . $variables['timezone'] . '"');
-	
 	// Create temp directory
 	if (!file_exists('/tmp')) {
 		mkdir('/tmp');

--- a/docker/files/scripts/createDirs.php
+++ b/docker/files/scripts/createDirs.php
@@ -28,7 +28,7 @@ try {
 	//Create temp smarty directory
 	$tmpDir = "$aspenDir/tmp/smarty/compile";
 	if (!file_exists($tmpDir)) {
-		exec("mkdir -p $tmpDir");
+		mkdir($tmpDir, 0755, true);
 		DockerLogger::setPermissions($tmpDir, $newOwner, '755');
 		DockerLogger::info("Created temp smarty directory: {$tmpDir}");
 	}
@@ -36,7 +36,7 @@ try {
 	//Create data directory and sub-directories
 	$dataDir = "/data/aspen-discovery/$siteName";
 	if (!file_exists($dataDir)) {
-		exec("mkdir -p $dataDir");
+		mkdir($dataDir, 0755, true);
 		DockerLogger::setPermissions($dataDir, $newOwner, '755');
 		DockerLogger::info("Created data directory: {$dataDir}");
 	}
@@ -44,12 +44,12 @@ try {
 	$subdirectories = ['images', 'files', 'fonts'];
 	foreach ($subdirectories as $subdirectory) {
 		if (!file_exists("$dataDir/$subdirectory")) {
-			exec("mkdir -p $dataDir/$subdirectory");
+			mkdir("$dataDir/$subdirectory", 0755, true);
 		}
 	}
 
 	if (!file_exists("/data/aspen-discovery/accelerated_reader")) {
-		exec("mkdir -p /data/aspen-discovery/accelerated_reader");
+		mkdir('/data/aspen-discovery/accelerated_reader', 0755, true);
 	}
 	DockerLogger::setPermissions("/data/aspen-discovery/accelerated_reader", $newOwner, '755');
 
@@ -65,9 +65,9 @@ try {
 
 	foreach ($toDelete as $file) {
 		if (is_dir("$dataDir/$file")) {
-			exec("rm -Rf $dataDir/$file");
+			recursive_delete("$dataDir/$file");
 		} else {
-			exec("rm $dataDir/$file");
+			@unlink("$dataDir/$file");
 		}
 	}
 	
@@ -105,13 +105,13 @@ try {
 	//Logs directory
 	$logDir = "/var/log/aspen-discovery/$siteName";
 	if (!file_exists($logDir)) {
-		exec("mkdir -p $logDir");
+		mkdir($logDir, 0755, true);
 		DockerLogger::setPermissions($logDir, $newOwner, '755');
 	}
 
 	$logDir2 = "/var/log/aspen-discovery/$siteName/logs";
 	if (!file_exists($logDir2)) {
-		exec("mkdir -p $logDir2");
+		mkdir($logDir2, 0755, true);
 		DockerLogger::setPermissions($logDir2, $newOwner, '755');
 	}
 
@@ -145,6 +145,21 @@ try {
 
 } catch (Exception $e) {
 	DockerLogger::error("Error assigning permissions and ownership: " . $e->getMessage());
+}
+
+function recursive_delete(string $path): void {
+	if (is_dir($path)) {
+		$entries = scandir($path);
+		foreach ($entries as $entry) {
+			if ($entry === '.' || $entry === '..') {
+				continue;
+			}
+			recursive_delete($path . '/' . $entry);
+		}
+		rmdir($path);
+	} else {
+		unlink($path);
+	}
 }
 
 function recursive_copy($src, $dst): void {

--- a/docker/files/scripts/cron.sh
+++ b/docker/files/scripts/cron.sh
@@ -38,7 +38,7 @@ while [ ! -f "$confSiteFile" ]; do
 	sleep 5
 	((tries++))
 
-	if [ $tries -eq 10 ] ; then
+	if [ $tries -eq $MAX_TRIES ] ; then
 		log_error "Site configuration not initialized. Skipping cron startup and waiting..."
 		exit 1
 	fi

--- a/docker/files/scripts/initDatabase.php
+++ b/docker/files/scripts/initDatabase.php
@@ -26,6 +26,7 @@ if ($databasePort != "3306") {
 DockerLogger::info("Checking database connection to: {$databaseHost}:{$databasePort}");
 
 //Check if aspen database has already been initialized
+$maxTries = 5;
 $tries = 0;
 $databaseIsDown = true;
 
@@ -36,12 +37,12 @@ while ($databaseIsDown) {
 		$updateUserStmt = $aspenDatabase->prepare($statement);
 		$databaseIsDown = false;
 	} catch (PDOException $e) {
-		if ($tries == 5){
-			DockerLogger::error("Database connection failed: " . $e->getMessage());
-		}
-		DockerLogger::warn("Database not ready, retrying... (attempt " . ($tries + 1) . "/5)");
-		sleep(5);
 		$tries++;
+		if ($tries >= $maxTries) {
+			DockerLogger::error("Database connection failed after {$maxTries} attempts: " . $e->getMessage());
+		}
+		DockerLogger::warn("Database not ready, retrying... (attempt {$tries}/{$maxTries})");
+		sleep(5);
 	}
 }
 

--- a/docker/files/scripts/syncEnvToConfig.php
+++ b/docker/files/scripts/syncEnvToConfig.php
@@ -33,7 +33,7 @@ $envMapping = [
 	'DATABASE_PASSWORD' => ['config.pwd.ini', 'Database', 'database_password'],
 
 	// Site (config.ini)
-	'TIMEZONE'          => ['config.ini', 'Site', 'timezone'],
+	'TZ'                => ['config.ini', 'Site', 'timezone'],
 	'URL'               => ['config.ini', 'Site', 'url'],
 	'TITLE'             => ['config.ini', 'Site', 'title'],
 	'LIBRARY'           => ['config.ini', 'Site', 'libraryName'],


### PR DESCRIPTION
A set of improvements were made to the Docker container scripts and configuration: 
- The TIMEZONE env var was renamed to TZ (the standard Linux/PHP name) and the timezone is now set via the PHP-FPM pool config instead of timedatectl calls that require systemd and don't work in containers.
- File operations in createDirs.php were replaced with PHP native functions instead of exec() shell calls. 
- Retry logic in initDatabase.php was corrected to use $maxTries instead of a hardcoded value, with an accurate attempt counter.
- cron.sh was updated to reference $MAX_TRIES consistently. 
- apache.sh had a dead signal trap removed since Apache runs as PID 1 via exec and Docker signals it directly.