### PR TITLE
DIS-2670: Consolidate database update script

### DIFF
--- a/code/web/release_notes/26.08.00.MD
+++ b/code/web/release_notes/26.08.00.MD
@@ -40,6 +40,7 @@
 ### Docker Updates
 - Replace `TIMEZONE` env var with `TZ` and set timezone via PHP-FPM pool config instead of `timedatectl`, which requires systemd and fails silently in containers. ([DIS-2296](https://aspen-discovery.atlassian.net/browse/DIS-2296)) (*LM*)
 - Replace `exec()` shell calls in container scripts with PHP native functions and fix retry logic, hardcoded constants, and a dead signal trap in Apache startup. ([DIS-2296](https://aspen-discovery.atlassian.net/browse/DIS-2296)) (*LM*)
+- Consolidate Docker database update script to delegate to SystemAPI, eliminating a duplicate implementation that had diverged from the authoritative version used by the web admin UI and nightly cron job ([DIS-2670](https://aspen-discovery.atlassian.net/browse/DIS-2670)) (*LM*)
 
 ## This release includes code contributions from
 ### ByWater Solutions

--- a/code/web/services/API/SystemAPI.php
+++ b/code/web/services/API/SystemAPI.php
@@ -1360,9 +1360,9 @@ class SystemAPI extends AbstractAPI {
 										$searchEntry->propertyName = $existingProperty;
 										$searchEntry->delete(true);
 									}
-								}catch (Exception $e) {
+								}catch (Throwable $e) {
 									global $logger;
-									$logger->log("Error processing $serviceClassName\n", $e);
+									$logger->log("Error processing $serviceClassName: " . $e->getMessage(), Logger::LOG_WARNING);
 								}
 							}else{
 								//echo("Skipping $serviceDirectory/$serviceFile\n");

--- a/docker/files/scripts/updateDatabase.php
+++ b/docker/files/scripts/updateDatabase.php
@@ -15,269 +15,35 @@ if (file_exists(ROOT_DIR . '/sys/Greenhouse/CompanionSystem.php')) {
 	require_once ROOT_DIR . '/sys/Greenhouse/CompanionSystem.php';
 }
 
+require_once ROOT_DIR . '/services/API/SystemAPI.php';
+
 global $configArray;
 global $serverName;
+global $aspen_db;
+
+if (!checkDatabaseConnection($aspen_db) || !isDatabaseInitialized($aspen_db)) {
+	DockerLogger::error("Cannot connect to the database to run updates");
+	exit(1);
+}
 
 DockerLogger::info("Running pending database updates");
 
-# Run Updates
-$completedUpdates = runPendingDatabaseUpdates();
-DockerLogger::info("Database updates completed - Success: " . $completedUpdates['success']);
-DockerLogger::info("Update message: " . $completedUpdates['message']);
+$systemAPI = new SystemAPI();
+$completedUpdates = $systemAPI->runPendingDatabaseUpdates();
 
-if (isset($completedUpdates['errors']) && $completedUpdates['errors']){
-	DockerLogger::warn("Database update errors found:");
-	foreach ($completedUpdates['errors'] as $errorArray) {
-		foreach($errorArray as $updateName => $error){
-			if(empty($error)){
-				continue;
-			} else{
-				DockerLogger::warn("Update '{$updateName}': {$error}");
-			}
-		}
-	}
+DockerLogger::info("Database updates completed - Success: " . ($completedUpdates['success'] ? 'true' : 'false'));
+DockerLogger::info("Update message: " . strip_tags($completedUpdates['message']));
+
+if (!$completedUpdates['success']) {
+	DockerLogger::warn("Some database updates failed. See message above for details.");
 }
 
-# Update CSS
 DockerLogger::info("Updating CSS for all themes");
-$result = updateCssForAllThemes();
+global $interface;
+$interface = new UInterface();
+$result = $systemAPI->updateCssForAllThemes();
 if ($result['success'] != true) {
 	DockerLogger::warn("Error updating CSS: " . $result['message']);
 } else {
 	DockerLogger::info($result['message']);
 }
-
-
-function updateCssForAllThemes() : array {
-
-	global $interface;
-	$interface = new UInterface();
-
-	Theme::updateCssForAllThemes();
-	return [
-		'success' => true,
-		'message' => "Updated CSS for All Themes",
-	];
-}
-
-
-function getDatabaseUpdates(): array {
-	require_once ROOT_DIR . '/sys/DBMaintenance/library_location_updates.php';
-	$library_location_updates = getLibraryLocationUpdates();
-	require_once ROOT_DIR . '/sys/DBMaintenance/summon_updates.php';
-	$summonUpdates = getSummonUpdates();
-	require_once ROOT_DIR . '/sys/DBMaintenance/cloud_library_updates.php';
-	$cloudLibraryUpdates = getCloudLibraryUpdates();
-	require_once ROOT_DIR . '/sys/DBMaintenance/grapes_web_builder_updates.php';
-	$grapesWebBuilderUpdates = getGrapesWebBuilderUpdates();
-	require_once ROOT_DIR . '/sys/DBMaintenance/heycentric_updates.php';
-	$heycentricUpdates = getHeyCentricUpdates();
-	require_once ROOT_DIR . '/sys/DBMaintenance/community_engagement_updates.php';
-	$communityEngagementUpdates = getCommunityEngagementUpdates();
-	require_once ROOT_DIR . '/sys/DBMaintenance/talpa_updates.php';
-	$talpaUpdates = getTalpaUpdates();
-	require_once ROOT_DIR . '/sys/DBMaintenance/gale_updates.php';
-	$galeUpdates = getGaleUpdates();
-	
-	$baseUpdates = array_merge($library_location_updates, $summonUpdates, $cloudLibraryUpdates, $grapesWebBuilderUpdates, $communityEngagementUpdates, $talpaUpdates, $heycentricUpdates, $galeUpdates);
-	//Get version updates
-	require_once ROOT_DIR . '/sys/Utils/StringUtils.php';
-	$versionUpdates = scandir(ROOT_DIR . '/sys/DBMaintenance/version_updates', SCANDIR_SORT_ASCENDING);
-	foreach ($versionUpdates as $updateFile) {
-		if (is_file(ROOT_DIR . '/sys/DBMaintenance/version_updates/' . $updateFile)) {
-			if (StringUtils::endsWith($updateFile, '.php')) {
-				include_once ROOT_DIR . "/sys/DBMaintenance/version_updates/$updateFile";
-				$version = substr($updateFile, 0, strrpos($updateFile, '.'));
-				$updateFunction = 'getUpdates' . str_replace('.', '_', $version);
-				$updates = $updateFunction();
-				$baseUpdates = array_merge($baseUpdates, $updates);
-			}
-		}
-	}
-	return $baseUpdates;
-}
-
-function getPendingDatabaseUpdates() : array {
-	$availableUpdates = getDatabaseUpdates();
-	$availableUpdates = pruneCompletedUpdates($availableUpdates);
-	$pendingUpdates = [];
-	foreach ($availableUpdates as $key => $update) {
-		if (!$update['alreadyRun']) {
-			$pendingUpdates[$key] = $update;
-		}
-	}
-	return $pendingUpdates;
-}
-
-function pruneCompletedUpdates($availableUpdates) {
-
-	global $aspen_db;
-	foreach ($availableUpdates as $key => $update) {    
-		$update['alreadyRun'] = false;
-		$result = $aspen_db->query("SELECT * from db_update where update_key = " . $aspen_db->quote($key));
-		if ($result != false && $result->rowCount() > 0) {
-			$update['alreadyRun'] = true;
-		}
-		$availableUpdates[$key] = $update;
-	}
-	return $availableUpdates;
-}
-
-function runPendingDatabaseUpdates() {
-
-	# Check database connection
-	global $aspen_db;
-	if (!checkDatabaseConnection($aspen_db) || !isDatabaseInitialized($aspen_db)) {
-		DockerLogger::error("Cannot connect to the database to run updates)");
-		exit(1);
-	}
-	
-	$pendingUpdates = getPendingDatabaseUpdates();
-	$updates = 0;
-	$failedUpdates = 0;
-	$errors = [];
-	foreach ($pendingUpdates as $updateName => $updateProperties) {
-		$updates++;
-		$response = runDatabaseUpdate($pendingUpdates,$updateName);
-		if ($response['success'] != "true") {
-			$failedUpdates++;
-			$errors[] = $response['errors'];
-		}
-	}
-
-	// Make sure full nightly index is set to run after completing DB updates
-	prepareNightlyFullIndexing();
-
-	if ($failedUpdates == 0) {
-		return [
-			'success' => "true",
-			'message' => $updates . " updates ran successfully",
-			'errors' => false
-		];
-	} else {
-		return [
-			'success' => "false",
-			'message' => $updates - $failedUpdates . " of " . $updates . " updates ran successfully",
-			'errors' => $errors
-		];
-	}
-}
-
-# ================================================================================
-
-function prepareNightlyFullIndexing(): void {
-	require_once ROOT_DIR . '/sys/SystemVariables.php';
-	SystemVariables::forceNightlyIndex('Docker DB Update');
-}
-
-function runDatabaseUpdate(&$availableUpdates, $updateName): array {
-	if ($availableUpdates == null) {
-		$availableUpdates = getDatabaseUpdates();
-	}
-
-	if (!isset($availableUpdates[$updateName])) {
-		return [
-			'success' => false,
-			'message' => 'Could not find update to run',
-			'errors'  => []
-		];
-	}
-
-	$updateToRun = $availableUpdates[$updateName];
-	$sqlErrors   = [];
-	$updateOk    = true;
-
-	if (!isset($updateToRun['sql'])) {
-		print($updateName . " doesn't have SQL statements to execute\n");
-		return [
-			'success' => false,
-			'message' => 'No SQL statements',
-			'errors'  => []
-		];
-	}
-
-	foreach ($updateToRun['sql'] as $sql) {
-		if (function_exists($sql)) {
-			$sql($updateToRun);
-		} else {
-			$queryResult = runSQLStatement($updateToRun, $sql);
-			$updateOk = $updateOk && $queryResult['success'];
-			if (!$queryResult['success']) {
-				$sqlErrors[$updateName] = $queryResult['status'] ?? 'Unknown error';
-			}
-		}
-	}
-
-
-	markUpdateAsRun($updateName);
-
-
-	$availableUpdates[$updateName] = $updateToRun;
-
-	return [
-		'success' => $updateOk,
-		'message' => empty($updateToRun['status']) ? 'Status not returned' : $updateToRun['status'],
-		'errors'  => $sqlErrors
-	];
-}
-
-function runSQLStatement(&$update, $sql): array {
-	global $aspen_db;
-	set_time_limit(500);
-
-	$red    = "\033[31m";
-	$yellow = "\033[33m";
-	$reset  = "\033[0m";
-	$bold   = "\033[1m";
-
-	$result = [
-		'success' => false,
-		'status'  => '',
-	];
-
-	try {
-		$aspen_db->query($sql);
-
-		if (!isset($update['status'])) {
-			$update['success'] = true;
-			$update['status']  = translate([
-				'text'          => 'Update succeeded',
-				'isAdminFacing' => true,
-			]);
-		}
-
-		$result['success'] = $update['success'];
-		$result['status']  = $update['status'];
-
-	} catch (PDOException $e) {
-		$update['success'] = false;
-
-		if (isset($update['continueOnError']) && $update['continueOnError']) {
-			if (!isset($update['status'])) {
-				$update['status'] = '';
-			}
-			$update['status'] .= '<br/><strong>' . $sql . '</strong><br/>Warning: ' . $e;
-			$result['status'] = "[{$yellow}WARNING{$reset}] {$bold}$sql{$reset} : " . $e->getMessage() . PHP_EOL;
-		} else {
-			$update['status'] = '<br/><strong>' . $sql . '</strong><br/>Update failed: ' . $e;
-			$result['status'] = "[{$red}ERROR{$reset}] {$bold}$sql{$reset} : " . $e->getMessage() . PHP_EOL;
-		}
-
-		$result['success'] = $update['success'];
-	}
-
-	return $result;
-}
-
-
-function markUpdateAsRun($update_key) {
-	global $aspen_db;
-	$result = $aspen_db->query("SELECT * from db_update where update_key = " . $aspen_db->quote($update_key));
-	if ($result->rowCount() != false) {
-		//Update the existing value
-		$aspen_db->query("UPDATE db_update SET date_run = CURRENT_TIMESTAMP WHERE update_key = " . $aspen_db->quote($update_key));
-	} else {
-		$aspen_db->query("INSERT INTO db_update (update_key) VALUES (" . $aspen_db->quote($update_key) . ")");
-	}
-}
-?>


### PR DESCRIPTION
The Docker container startup script updateDatabase.php maintained its own copy of the entire database update logic, duplicated from SystemAPI. Over time the two diverged, the Docker copy was missing update sources added to SystemAPI and had a bug where failed updates were still marked as run.

Test plan

  Before patching

  1. Start the Docker container and watch the startup logs
  2. Verify updateDatabase.php runs its own local runPendingDatabaseUpdates() function (visible in the script itself)
  3. Introduce a DB update that fails . Confirm markUpdateAsRun is still called, marking a failed update as completed
  4. Configure an environment with no ILS/catalog account profile
  5. Observe the container crash with an uncaught TypeError during updateAdminPropertiesSearchIndex()
  6. Observe a secondary crash in Logger.php from the invalid log level argument in the catch block

  After patching

  1. Start the Docker container and watch the startup logs
  2. Confirm the log shows:
  [BACKEND] [INFO] Running pending database updates
  [BACKEND] [INFO] Database updates completed - Success: true
  [BACKEND] [INFO] Update message: N updates ran successfully
  [BACKEND] [INFO] Updating CSS for all themes
  [BACKEND] [INFO] Updated CSS for All Themes
  3. Confirm no local update functions exist in updateDatabase.php. All logic goes through SystemAPI.
  4. Introduce a DB update that fails. Confirm it is NOT marked as run in the db_update table.
  5. Configure an environment with no ILS/catalog account profile.
  6. Confirm the container starts successfully, with any catalog-related errors logged as warnings instead of
  crashing the process.
  7. Confirm the web admin UI "Run Database Updates" and the nightly cron job produce identical results to the
  Docker startup run.