### PR TITLE
DIS-2537 Add eCommerce Report editedStatus

### DIFF
--- a/code/web/release_notes/26.08.00.MD
+++ b/code/web/release_notes/26.08.00.MD
@@ -6,6 +6,8 @@
 // mark j
 
 // stephen
+### eCommerce Updates
+- Allow the statuses within an eCommerce Report to be edited ([DIS-2537](https://aspen-discovery.atlassian.net/browse/DIS-2537)) (*SW*)
 
 // bryan
 

--- a/code/web/sys/Account/UserPayment.php
+++ b/code/web/sys/Account/UserPayment.php
@@ -29,6 +29,7 @@ class UserPayment extends DataObject {
 	public $pay360Timestamp;
 	public $requestingUrl;
 	public $receiptUrl;
+	public $editedStatus;
 
 	static $_objectStructure = [];
 	static function getObjectStructure(string $context = ''): array {
@@ -140,6 +141,20 @@ class UserPayment extends DataObject {
 				'label' => 'Error?',
 				'description' => 'Whether or not an error occurred during processing of the payment',
 				'readOnly' => true,
+			],
+			'editedStatus' => [
+				'property' => 'editedStatus',
+				'type' => 'enum',
+				'label' => 'Edited Status',
+				'description' => 'Manually updated status for reconciliation purposes',
+				'values' => [
+					'' => '',
+					'completed' => 'Completed',
+					'cancelled' => 'Cancelled',
+					'declined' => 'Declined',
+					'error' => 'Error',
+				],
+				'readOnly' => !UserAccount::userHasPermission('Edit Payment Status'),
 			],
 			'message' => [
 				'property' => 'message',

--- a/code/web/sys/Administration/Role.php
+++ b/code/web/sys/Administration/Role.php
@@ -164,6 +164,7 @@ class Role extends DataObject {
 				'Block Patron Account Linking',
 				'Download MARC Records',
 				'Edit All Lists',
+				'Edit Payment Status',
 				'Force Reindexing of Records',
 				'Include Lists In Search Results',
 				'Import Materials Requests',

--- a/code/web/sys/DBMaintenance/version_updates/26.08.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/26.08.00.php
@@ -38,6 +38,23 @@ function getUpdates26_08_00(): array {
 		//tomas
 
 		// stephen
+		'permissions_edit_payment_status' => [
+			'title' => 'Create Edit Payment Status permission',
+			'description' => 'Adds a permission to edit statuses in eCommerce reports.',
+			'continueOnError' => false,
+			'sql' => [
+				"INSERT INTO permissions (sectionName, name, requiredModule, weight, description) VALUES ('eCommerce', 'Edit Payment Status', '', 10, 'Allows the user to manually update payment statuses')",
+				"INSERT INTO role_permissions(roleId, permissionId) VALUES ((SELECT roleId from roles where name='opacAdmin'), (SELECT id from permissions where name='Edit Payment Status'))",
+			]
+		], //permissions_edit_payment_status
+		'add_edited_status_to_user_payments' => [
+			'title' => 'Add editedStatus to user_payments table',
+			'description' => 'Adds a column to store a manually edited payment status.',
+			'continueOnError' => false,
+			'sql' => [
+				"ALTER TABLE user_payments ADD COLUMN editedStatus VARCHAR(20) NOT NULL DEFAULT ''",
+			]
+		], //add_edited_status_to_user_payments
 
 		//other
 


### PR DESCRIPTION
https://aspen-discovery.atlassian.net/browse/DIS-2537

Adds a field to user_payment and the eCommerce Report called Edited Status.

We want to maintain the original data so this does not allow the original Completed / Cancelled / Declined / Error flags to be edited.

Adds a new permission toggle for this feature which is by default turned on for opacAdmin.