### PR TITLE
DIS-2158: Allow sorting and filtering events by instanceCount

### DIFF
--- a/code/web/release_notes/26.08.00.MD
+++ b/code/web/release_notes/26.08.00.MD
@@ -92,6 +92,11 @@
 // pedro
 
 // olivia
+### Aspen Events Updates
+- Allow sorting events by their upcoming count ([DIS-2158](https://aspen-discovery.atlassian.net/browse/DIS-2158)) (*OR*)
+
+### Other Updates
+- Allow DataObjects to specify calculated columns ([DIS-2158](https://aspen-discovery.atlassian.net/browse/DIS-2158)) (*OR*)
 
 ### Event Updates
 - Improve text margins on generated event cover images ([DIS-1911](https://aspen-discovery.atlassian.net/browse/DIS-1911)) (*OR*)

--- a/code/web/sys/DB/DataObject.php
+++ b/code/web/sys/DB/DataObject.php
@@ -92,6 +92,14 @@ abstract class DataObject implements JsonSerializable {
 
 	}
 
+	// Including SQL expressions to calculate columns here allows them to be
+	// used for sorts and filters, as they're included in every generated
+	// SELECT from the object.
+	// Example: return ['_name_length' => 'LENGTH(name)']
+	public static function getCalculatedColumns() : array {
+		return [];
+	}
+
 	function __toString() {
 		$stringProperty = $this->__primaryKey;
 		if ($this->__displayNameColumn != null) {
@@ -875,6 +883,10 @@ abstract class DataObject implements JsonSerializable {
 			if ($this->__selectAllColumns) {
 				$selectClause = '*, ' . $selectClause;
 			}
+		}
+
+		foreach($this->getCalculatedColumns() as $name => $expression) {
+			$selectClause .= ", ($expression) AS $name";
 		}
 
 		$query = 'SELECT ' . $selectClause . ' from ' . $this->__table;

--- a/code/web/sys/Events/Event.php
+++ b/code/web/sys/Events/Event.php
@@ -193,12 +193,11 @@ class Event extends DataObject {
 				'hideInLists' => true,
 			],
 			'instanceCount' => [
-				'property' => 'instanceCount',
-				'type' => 'integer',
+				'property' => '_instanceCount',
+				'type' => 'calculatedInteger',
 				'label' => 'Total Upcoming Events',
 				'hiddenByDefault' => true,
 				'readOnly' => true,
-				'canSort' => false
 			],
 			'dateUpdated' => [
 				'property' => 'dateUpdated',
@@ -707,6 +706,14 @@ class Event extends DataObject {
 		];
 	}
 
+	public static function getCalculatedColumns() : array {
+		$todayDate = date('Y-m-d');
+		$todayTime = date('H:i:s');
+		return [
+			'_instanceCount' => "SELECT COUNT(1) FROM event_instance WHERE eventId=event.id AND deleted = 0 AND date > '$todayDate' OR (date = '$todayDate' AND time > '$todayTime')"
+		];
+	}
+
 	public function getAdditionalListActions(): array {
 		$objectActions[] = [
 			'text' => 'Edit Specific Dates',
@@ -939,16 +946,15 @@ class Event extends DataObject {
 	}
 
 	public function getInstanceCount() {
-		if (!isset($this->_instanceCount) && $this->id) {
-			$this->_instanceCount = '';
-			$instance = new EventInstance();
-			$instance->eventId = $this->id;
-			$todayDate = date('Y-m-d');
-			$todayTime = date('H:i:s');
-			$instance->whereAdd("deleted = 0 AND date > '$todayDate' OR (date = '$todayDate' and time > '$todayTime')");
-			$this->_instanceCount = $instance->count();
+		if(empty($this->id)) {
+			return $this->_instanceCount;
 		}
-		return $this->_instanceCount;
+
+		// Fetch this same event from the database, to ensure the count is fresh
+		$event = new Event();
+		$event->id = $this->id;
+		$event->find(true);
+		return $event->_instanceCount;
 	}
 
 	public function saveFields() : void {


### PR DESCRIPTION
This PR adds infrastructure to DataObjects to allow them to specify SQL expressions for calculated columns. As these expressions are then used consistently for `SELECT` statements, they can also be used in sorts and filters. This new functionality is then used to support sorting and filtering events by their upcoming instance count.