### PR TITLE
DIS-2611: Introduce StorageDriver abstraction for user-uploaded file paths

### DIFF
--- a/code/web/bootstrap.php
+++ b/code/web/bootstrap.php
@@ -308,6 +308,7 @@ function requireSystemLibraries() {
 	require_once ROOT_DIR . '/sys/Translation/Translator.php';
 	require_once ROOT_DIR . '/Drivers/AbstractIlsDriver.php';
 	require_once ROOT_DIR . '/sys/IP/IPAddress.php';
+	require_once ROOT_DIR . '/sys/Storage/StorageDriverFactory.php';
 }
 
 function initLocale() {

--- a/code/web/release_notes/26.08.00.MD
+++ b/code/web/release_notes/26.08.00.MD
@@ -152,6 +152,10 @@
 - Replace `TIMEZONE` env var with `TZ` and set timezone via PHP-FPM pool config instead of `timedatectl`, which requires systemd and fails silently in containers. ([DIS-2296](https://aspen-discovery.atlassian.net/browse/DIS-2296)) (*LM*)
 - Replace `exec()` shell calls in container scripts with PHP native functions and fix retry logic, hardcoded constants, and a dead signal trap in Apache startup. ([DIS-2296](https://aspen-discovery.atlassian.net/browse/DIS-2296)) (*LM*)
 - Consolidate Docker database update script to delegate to SystemAPI, eliminating a duplicate implementation that had diverged from the authoritative version used by the web admin UI and nightly cron job ([DIS-2670](https://aspen-discovery.atlassian.net/browse/DIS-2670)) (*LM*)
+### Storage Updates
+- Introduce a configurable storage abstraction layer for uploaded files ([DIS-2611](https://aspen-discovery.atlassian.net/browse/DIS-2611)) (*LM*)
+  - The local filesystem backend is active by default; no configuration change is required for existing installations.
+  - Administrators can manage storage backends under Admin > System Administration > Storage Settings.
 
 ### Web Builder Updates
 - Fixed an issue where a failed image upload could still be saved as if it succeeded, leaving a broken image reference. ([DIS-2736](https://aspen-discovery.atlassian.net/browse/DIS-2736)) (*LM*)

--- a/code/web/services/Admin/StorageSettings.php
+++ b/code/web/services/Admin/StorageSettings.php
@@ -1,0 +1,81 @@
+<?php
+
+require_once ROOT_DIR . '/Action.php';
+require_once ROOT_DIR . '/services/Admin/ObjectEditor.php';
+require_once ROOT_DIR . '/sys/Storage/StorageSetting.php';
+
+class Admin_StorageSettings extends ObjectEditor {
+	function getObjectType(): string {
+		return 'StorageSetting';
+	}
+
+	function getToolName(): string {
+		return 'StorageSettings';
+	}
+
+	function getPageTitle(): string {
+		return 'Storage Settings';
+	}
+
+	function getAllObjects(int $page, int $recordsPerPage): array {
+		$object = new StorageSetting();
+		$object->find();
+		$objectList = [];
+		while ($object->fetch()) {
+			$objectList[$object->id] = clone $object;
+		}
+		return $objectList;
+	}
+
+	function getDefaultSort(): string {
+		return 'id asc';
+	}
+
+	function canSort(): bool {
+		return false;
+	}
+
+	function canAddNew(): bool {
+		return true;
+	}
+
+	function canDelete(): bool {
+		return true;
+	}
+
+	function getObjectStructure($context = ''): array {
+		return StorageSetting::getObjectStructure($context);
+	}
+
+	function getPrimaryKeyColumn(): string {
+		return 'id';
+	}
+
+	function getIdKeyColumn(): string {
+		return 'id';
+	}
+
+	function getAdditionalObjectActions(?DataObject $existingObject): array {
+		return [];
+	}
+
+	function getInstructions(): string {
+		return '';
+	}
+
+	function getBreadcrumbs(): array {
+		$breadcrumbs = [];
+		$breadcrumbs[] = new Breadcrumb('/Admin/Home', 'Administration Home');
+		$breadcrumbs[] = new Breadcrumb('/Admin/Home#system_admin', 'System Administration');
+		$breadcrumbs[] = new Breadcrumb('/Admin/StorageSettings', 'Storage Settings');
+		return $breadcrumbs;
+	}
+
+	function getActiveAdminSection(): string {
+		return 'system_admin';
+	}
+
+	public function getViewPermissions(): array {
+		return ['Administer Storage Settings'];
+	}
+}

--- a/code/web/services/WebBuilder/ViewImage.php
+++ b/code/web/services/WebBuilder/ViewImage.php
@@ -33,7 +33,7 @@ class WebBuilder_ViewImage extends Action {
 		$storageKey = 'uploads/web_builder_image/' . $size . '/' . $this->uploadedImage->fullSizePath;
 
 		require_once ROOT_DIR . '/sys/Storage/StorageDriverFactory.php';
-		$storage = StorageDriverFactory::get();
+		$storage = StorageDriverFactory::getById($this->uploadedImage->storageSettingId);
 
 		$directUrl = $storage->url($storageKey);
 		if ($directUrl !== '') {

--- a/code/web/services/WebBuilder/ViewImage.php
+++ b/code/web/services/WebBuilder/ViewImage.php
@@ -6,12 +6,11 @@ class WebBuilder_ViewImage extends Action {
 	private $uploadedImage;
 
 	function launch() {
-		global $interface;
+		global $interface, $logger;
 
 		$id = strip_tags($_REQUEST['id']);
 		$interface->assign('id', $id);
 
-		require_once ROOT_DIR . '/sys/File/ImageUpload.php';
 		$this->uploadedImage = new ImageUpload();
 		$this->uploadedImage->id = $id;
 		if (!$this->uploadedImage->find(true)) {
@@ -25,7 +24,16 @@ class WebBuilder_ViewImage extends Action {
 		}
 
 		$extension = pathinfo($this->uploadedImage->fullSizePath, PATHINFO_EXTENSION);
-		if ((isset($_REQUEST['size'])) && $extension != 'svg') {
+		$mimeTypesByExtension = [
+			'svg' => 'image/svg+xml',
+			'gif' => 'image/gif',
+			'jpg' => 'image/jpeg',
+			'jpeg' => 'image/jpeg',
+			'png' => 'image/png',
+		];
+		$contentType = $mimeTypesByExtension[strtolower($extension)] ?? 'application/octet-stream';
+
+		if ((isset($_REQUEST['size'])) && $contentType != 'image/svg+xml') {
 			$size = $_REQUEST['size'];
 		} else {
 			$size = 'full';
@@ -34,45 +42,37 @@ class WebBuilder_ViewImage extends Action {
 
 		require_once ROOT_DIR . '/sys/Storage/StorageDriverFactory.php';
 		$storage = StorageDriverFactory::getById($this->uploadedImage->storageSettingId);
+		$logger->log("ViewImage: serving image id=$id size=$size key=$storageKey storageSettingId=" . var_export($this->uploadedImage->storageSettingId, true), Logger::LOG_DEBUG);
 
 		$directUrl = $storage->url($storageKey);
 		if ($directUrl !== '') {
+			$logger->log("ViewImage: redirecting image id=$id to $directUrl", Logger::LOG_DEBUG);
 			header('Location: ' . $directUrl, true, 302);
 			die();
 		}
 
-			$mimeTypesByExtension = [
-				'svg' => 'image/svg+xml',
-				'gif' => 'image/gif',
-				'jpg' => 'image/jpeg',
-				'jpeg' => 'image/jpeg',
-				'png' => 'image/png',
-			];
-			header('Content-Type: ' . ($mimeTypesByExtension[strtolower($extension)] ?? 'application/octet-stream'));
+		$stream = $storage->readStream($storageKey);
+
+		if ($stream !== false) {
+			$logger->log("ViewImage: proxied image id=$id key=$storageKey", Logger::LOG_DEBUG);
+
+			header('Content-Type: ' . $contentType);
 			header('Content-Transfer-Encoding: binary');
-			header('Content-Length: ' . $size);
 
-			if ($size > $chunkSize) {
-				$handle = fopen($fullPath, 'rb');
-
-				while (!feof($handle)) {
-					set_time_limit(300);
-					print(@fread($handle, $chunkSize));
-
-					ob_flush();
-					flush();
-				}
-
-				fclose($handle);
-			} else {
-				$readResult = readfile($fullPath);
+			set_time_limit(300);
+			$chunkSize = 2 * (1024 * 1024);
+			while (!feof($stream)) {
+				set_time_limit(300);
+				echo fread($stream, $chunkSize);
+				ob_flush();
+				flush();
 			}
-
+			fclose($stream);
 			die();
 		} else {
+			$logger->log("ViewImage: failed to read image id=$id key=$storageKey from storageSettingId=" . var_export($this->uploadedImage->storageSettingId, true), Logger::LOG_ERROR);
 			AspenError::raiseError(new AspenError("Image $id does not exist"));
 		}
-
 	}
 
 	function getBreadcrumbs(): array {

--- a/code/web/services/WebBuilder/ViewImage.php
+++ b/code/web/services/WebBuilder/ViewImage.php
@@ -24,23 +24,22 @@ class WebBuilder_ViewImage extends Action {
 			die();
 		}
 
-		global $serverName;
-		$dataPath = '/data/aspen-discovery/' . $serverName . '/uploads/web_builder_image/';
 		$extension = pathinfo($this->uploadedImage->fullSizePath, PATHINFO_EXTENSION);
 		if ((isset($_REQUEST['size'])) && $extension != 'svg') {
 			$size = $_REQUEST['size'];
 		} else {
 			$size = 'full';
 		}
-		$dataPath .= $size . '/';
-		$fullPath = $dataPath . $this->uploadedImage->fullSizePath;
+		$storageKey = 'uploads/web_builder_image/' . $size . '/' . $this->uploadedImage->fullSizePath;
 
-		if ($file = @fopen($fullPath, 'r')) {
-			fclose($file);
-			set_time_limit(300);
-			$chunkSize = 2 * (1024 * 1024);
+		require_once ROOT_DIR . '/sys/Storage/StorageDriverFactory.php';
+		$storage = StorageDriverFactory::get();
 
-			$size = intval(sprintf("%u", filesize($fullPath)));
+		$directUrl = $storage->url($storageKey);
+		if ($directUrl !== '') {
+			header('Location: ' . $directUrl, true, 302);
+			die();
+		}
 
 			$mimeTypesByExtension = [
 				'svg' => 'image/svg+xml',

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -4348,6 +4348,7 @@ class User extends DataObject {
 		$sections['system_admin']->addAction(new AdminAction('USPS Settings', 'Settings to allow Aspen Discovery to validate addresses via USPS API.', '/Admin/USPS'), 'Administer System Variables');
 		$sections['system_admin']->addAction(new AdminAction('Variables', 'Variables set by the Aspen Discovery itself as part of background processes.', '/Admin/Variables'), 'Administer System Variables');
 		$sections['system_admin']->addAction(new AdminAction('System Variables', 'Settings for Aspen Discovery that apply to all libraries on this installation.', '/Admin/SystemVariables'), 'Administer System Variables');
+		$sections['system_admin']->addAction(new AdminAction('Storage Settings', 'Configure the storage backend for uploaded files (local or S3-compatible).', '/Admin/StorageSettings'), 'Administer Storage Settings');
 		$sections['system_admin']->addAction(new AdminAction('Object Restorations', 'Restore soft-deleted objects from the recycle bin.', '/Admin/ObjectRestorations'), 'Administer Object Restoration');
 		$sections['system_admin']->addAction(new AdminAction('Manually Run Cron', 'Manually Start Cron Processes.', '/Admin/CronRunner'), 'Manually Run Cron Processes');
 		$sections['system_admin']->addAction(new AdminAction('Consolidate Reading History', 'Consolidate Reading History Entries to minimize database size.', '/Admin/ConsolidateReadingHistory'), 'Perform System Maintenance');

--- a/code/web/sys/DBMaintenance/version_updates/26.08.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/26.08.00.php
@@ -110,6 +110,22 @@ function getUpdates26_08_00(): array {
 		//mark j
 
 		//lucas
+		'storage_settings' => [
+			'title' => 'Add storage settings table',
+			'description' => 'Add table to configure the storage backend for uploaded files.',
+			'continueOnError' => false,
+			'sql' => [
+				"CREATE TABLE IF NOT EXISTS storage_settings (
+					id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+					name VARCHAR(255) NOT NULL DEFAULT '',
+					driver ENUM('local') NOT NULL DEFAULT 'local',
+					isActive TINYINT(1) NOT NULL DEFAULT 0
+				) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
+				"INSERT INTO storage_settings (name, driver, isActive) VALUES ('Local Storage', 'local', 1)",
+				"INSERT INTO permissions (sectionName, name, requiredModule, weight, description) VALUES ('System Administration', 'Administer Storage Settings', '', 0, 'Allows the user to configure the storage backend for uploaded files.')",
+				"INSERT INTO role_permissions(roleId, permissionId) VALUES ((SELECT roleId FROM roles WHERE name='opacAdmin'), (SELECT id FROM permissions WHERE name='Administer Storage Settings'))",
+			],
+		], //storage_settings
 
 		//tomas
 

--- a/code/web/sys/DBMaintenance/version_updates/26.08.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/26.08.00.php
@@ -127,6 +127,16 @@ function getUpdates26_08_00(): array {
 			],
 		], //storage_settings
 
+		//lucas
+		'image_uploads_storage_setting_id' => [
+			'title' => 'Track storage backend per image upload',
+			'description' => 'Add storageSettingId to image_uploads so each file remembers which storage backend it was actually written to. NULL means Local Storage, since that was the only backend before this feature existed.',
+			'continueOnError' => false,
+			'sql' => [
+				"ALTER TABLE image_uploads ADD COLUMN storageSettingId INT NULL DEFAULT NULL",
+			],
+		], //image_uploads_storage_setting_id
+
 		//tomas
 
 		// stephen

--- a/code/web/sys/DataObjectUtil.php
+++ b/code/web/sys/DataObjectUtil.php
@@ -447,41 +447,74 @@ class DataObjectUtil {
 						}
 					}
 					global $serverName;
-					if (isset($property['storagePath'])) {
+					if (isset($property['storagePath']) || isset($property['path'])) {
 						$destFileName = ($object->getPrimaryKeyValue() != null) ? $objectType."_".$serverName."_".$object->getPrimaryKeyValue().$fileType : "Temp_".$_FILES[$propertyName]["name"];
-						$destFolder = $property['storagePath'];
+						$destFolder = $property['storagePath'] ?? $property['path'];
 						$destFullPath = $destFolder . '/' . $destFileName;
 						$copyResult = copy($_FILES[$propertyName]["tmp_name"], $destFullPath);
 						$logger->log("Copied file to $destFullPath result: $copyResult", Logger::LOG_DEBUG);
-					} else {
+					} elseif (isset($property['storageKey'])) {
 						$logger->log("Creating thumbnails for $propertyName", Logger::LOG_DEBUG);
-						global $serverName;
-						if (isset($property['path'])) {
-							$destFolder = $property['path'];
-							$destFileName = ($object->getPrimaryKeyValue() != null) ? $objectType."_".$serverName."_".$object->getPrimaryKeyValue().$fileType : "Temp_".$_FILES[$propertyName]["name"];
-							if (!file_exists($destFolder)) {
-								mkdir($destFolder, 0755, true);
-							}
-							$pathToThumbs = $destFolder . '/thumbnail';
-							$pathToMedium = $destFolder . '/medium';
-						} else {
-							$destFileName = ($object->getPrimaryKeyValue() != null) ? $serverName."_".$objectType."_".$object->getPrimaryKeyValue().$fileType : "Temp_".$_FILES[$propertyName]["name"];
-							$destFolder = $configArray['Site']['local'] . '/files/original';
-							$pathToThumbs = $configArray['Site']['local'] . '/files/thumbnail';
-							$pathToMedium = $configArray['Site']['local'] . '/files/medium';
+						$storageKey = $property['storageKey'];
+						$destFileName = ($object->getPrimaryKeyValue() != null) ? $objectType."_".$serverName."_".$object->getPrimaryKeyValue().$fileType : "Temp_".$_FILES[$propertyName]["name"];
+						$storage = StorageDriverFactory::get();
+
+						$uploadTmp = $_FILES[$propertyName]["tmp_name"];
+
+						//check for previous upload that needs to be overwritten to new naming convention
+						$prevKey = $storageKey . '/Temp_' . $_FILES[$propertyName]["name"];
+						if ($storage->exists($prevKey)) {
+							$storage->delete($prevKey);
 						}
 
+						require_once ROOT_DIR . '/sys/Covers/CoverImageUtils.php';
+
+						if (isset($property['maxWidth'])) {
+							$width = $property['maxWidth'];
+							$height = isset($property['maxHeight']) ? $property['maxHeight'] : $property['maxWidth'];
+							$resizedTmp = tempnam(sys_get_temp_dir(), 'aspen_img_');
+							resizeImage($uploadTmp, $resizedTmp, $width, $height);
+							$storeSource = $resizedTmp;
+						} else {
+							$storeSource = $uploadTmp;
+						}
+
+						$copyResult = $storage->write($storageKey . '/' . $destFileName, $storeSource);
+
+						if (isset($resizedTmp)) {
+							unlink($resizedTmp);
+							unset($resizedTmp);
+						}
+
+						if ($copyResult) {
+							$derivativeBase = dirname($storageKey);
+							if (isset($property['thumbWidth'])) {
+								$thumbTmp = tempnam(sys_get_temp_dir(), 'aspen_img_');
+								resizeImage($uploadTmp, $thumbTmp, $property['thumbWidth'], $property['thumbWidth']);
+								$storage->write($derivativeBase . '/thumbnail/' . $destFileName, $thumbTmp);
+								unlink($thumbTmp);
+							}
+							if (isset($property['mediumWidth'])) {
+								$medTmp = tempnam(sys_get_temp_dir(), 'aspen_img_');
+								resizeImage($uploadTmp, $medTmp, $property['mediumWidth'], $property['mediumWidth']);
+								$storage->write($derivativeBase . '/medium/' . $destFileName, $medTmp);
+								unlink($medTmp);
+							}
+						}
+					} else {
+						global $configArray;
+						$destFileName = ($object->getPrimaryKeyValue() != null) ? $serverName."_".$objectType."_".$object->getPrimaryKeyValue().$fileType : "Temp_".$_FILES[$propertyName]["name"];
+						$destFolder = $configArray['Site']['local'] . '/files/original';
+						$pathToThumbs = $configArray['Site']['local'] . '/files/thumbnail';
+						$pathToMedium = $configArray['Site']['local'] . '/files/medium';
 						$destFullPath = $destFolder . '/' . $destFileName;
-						//check for previous upload that needs to be overwritten to new naming convention
-						$prevUpload = $destFolder . '/' . "Temp_" . $_FILES[$propertyName]["name"];
+						$prevUpload = $destFolder . '/' . 'Temp_' . $_FILES[$propertyName]['name'];
 						if (file_exists($prevUpload)) {
 							rename($prevUpload, $destFullPath);
 						}
 						$copyResult = copy($_FILES[$propertyName]["tmp_name"], $destFullPath);
-
 						if ($copyResult) {
 							require_once ROOT_DIR . '/sys/Covers/CoverImageUtils.php';
-
 							if (isset($property['thumbWidth'])) {
 								if (!resizeImage($destFullPath, "$pathToThumbs/$destFileName", $property['thumbWidth'], $property['thumbWidth'])) {
 									$logger->log("Could not create thumbnail for $propertyName at $pathToThumbs/$destFileName", Logger::LOG_ERROR);
@@ -494,7 +527,6 @@ class DataObjectUtil {
 								}
 							}
 							if (isset($property['maxWidth'])) {
-								//Create a thumbnail if needed
 								$width = $property['maxWidth'];
 								$height = $property['maxWidth'];
 								if (isset($property['maxHeight'])) {
@@ -591,23 +623,12 @@ class DataObjectUtil {
 					//return an error to the browser
 					$logger->log("Error uploading file " . $_FILES[$propertyName]["error"], Logger::LOG_ERROR);
 				} elseif (true) { //TODO: validate the file type
-					//Copy the full image to the correct location
-					//Filename is the name of the object + the original filename
-					global $configArray;
 					$destFileName = $_FILES[$propertyName]["name"];
-					$destFolder = $configArray['Site']['local'] . '/fonts';
-					$destFullPath = $destFolder . '/' . $destFileName;
-					$copyResult = copy($_FILES[$propertyName]["tmp_name"], $destFullPath);
+					$copyResult = StorageDriverFactory::get()->write('fonts/' . $destFileName, $_FILES[$propertyName]["tmp_name"]);
 					if ($copyResult) {
-						$logger->log("Copied file from {$_FILES[$propertyName]["tmp_name"]} to $destFullPath", Logger::LOG_NOTICE);
+						$logger->log("Stored font file: fonts/{$destFileName}", Logger::LOG_NOTICE);
 					} else {
-						$logger->log("Could not copy file from {$_FILES[$propertyName]["tmp_name"]} to $destFullPath", Logger::LOG_ERROR);
-						if (!file_exists($_FILES[$propertyName]["tmp_name"])) {
-							$logger->log("  Uploaded file did not exist", Logger::LOG_ERROR);
-						}
-						if (!is_writable($destFullPath)) {
-							$logger->log("  Destination is not writable", Logger::LOG_ERROR);
-						}
+						$logger->log("Could not store font file: fonts/{$destFileName}", Logger::LOG_ERROR);
 					}
 					//store the actual filename
 					$object->setProperty($propertyName, $destFileName, $property);

--- a/code/web/sys/File/ImageUpload.php
+++ b/code/web/sys/File/ImageUpload.php
@@ -319,7 +319,7 @@ class ImageUpload extends DataObject {
 
 	private function calculateAspectRatio() : void {
 		if ($this->type === 'hero_slider' && !empty($this->fullSizePath)) {
-			$contents = StorageDriverFactory::get()->read('uploads/web_builder_image/full/' . $this->fullSizePath);
+			$contents = StorageDriverFactory::getById($this->storageSettingId)->read('uploads/web_builder_image/full/' . $this->fullSizePath);
 			if ($contents !== false) {
 				$imageInfo = getimagesizefromstring($contents);
 				if ($imageInfo !== false) {
@@ -360,7 +360,7 @@ class ImageUpload extends DataObject {
 		global $logger;
 		if (!empty($this->fullSizePath) && !empty($this->id)) {
 			require_once ROOT_DIR . '/sys/Covers/CoverImageUtils.php';
-			$storage = StorageDriverFactory::get();
+			$storage = StorageDriverFactory::getById($this->storageSettingId);
 
 			$sourceContents = $storage->read('uploads/web_builder_image/full/' . $this->fullSizePath);
 			if ($sourceContents === false) {
@@ -455,7 +455,7 @@ class ImageUpload extends DataObject {
 
 	public function delete(bool $useWhere = false, bool $hardDelete = false) : bool|int {
 		if ($hardDelete) {
-			$storage = StorageDriverFactory::get();
+			$storage = StorageDriverFactory::getById($this->storageSettingId);
 			foreach ([
 				'full'    => $this->fullSizePath,
 				'x-large' => $this->xLargeSizePath,
@@ -482,7 +482,6 @@ class ImageUpload extends DataObject {
 	 * @return int
 	 */
 	public static function purgeExpired(int $olderThanSecs = 2592000): int {
-		$storage = StorageDriverFactory::get();
 		$cutOff = time() - $olderThanSecs;
 		$expiredIds = [];
 		$fetchObj = new static();
@@ -491,6 +490,7 @@ class ImageUpload extends DataObject {
 		$fetchObj->whereAdd("dateDeleted > 0 AND dateDeleted < $cutOff");
 		$fetchObj->find();
 		while ($fetchObj->fetch()) {
+			$storage = StorageDriverFactory::getById($fetchObj->storageSettingId);
 			foreach ([
 				'full'    => $fetchObj->fullSizePath,
 				'x-large' => $fetchObj->xLargeSizePath,

--- a/code/web/sys/File/ImageUpload.php
+++ b/code/web/sys/File/ImageUpload.php
@@ -31,6 +31,10 @@ class ImageUpload extends DataObject {
 	public $pageLink;
 	public $startDate;
 	public $endDate;
+	// Which storage_settings row this upload's files actually live on.
+	// NULL means Local Storage; not part of the admin edit form, set only
+	// by the storage write path.
+	public $storageSettingId;
 
 	static $xLargeSize = 1100;
 	static $largeSize = 600;
@@ -47,6 +51,7 @@ class ImageUpload extends DataObject {
 			'aspectRatioHeight',
 			'startDate',
 			'endDate',
+			'storageSettingId',
 		];
 	}
 

--- a/code/web/sys/File/ImageUpload.php
+++ b/code/web/sys/File/ImageUpload.php
@@ -361,9 +361,11 @@ class ImageUpload extends DataObject {
 		if (!empty($this->fullSizePath) && !empty($this->id)) {
 			require_once ROOT_DIR . '/sys/Covers/CoverImageUtils.php';
 			$storage = StorageDriverFactory::getById($this->storageSettingId);
+			$logger->log("generateDerivatives: image id=$this->id storageSettingId=" . var_export($this->storageSettingId, true), Logger::LOG_DEBUG);
 
 			$sourceContents = $storage->read('uploads/web_builder_image/full/' . $this->fullSizePath);
 			if ($sourceContents === false) {
+				$logger->log("generateDerivatives: could not read source for image id=$this->id fullSizePath=$this->fullSizePath", Logger::LOG_ERROR);
 				return;
 			}
 			$srcTmp = tempnam(sys_get_temp_dir(), 'aspen_src_');
@@ -388,6 +390,7 @@ class ImageUpload extends DataObject {
 				if (resizeImage($srcTmp, $destTmp, $cfg['size'], $cfg['size'])) {
 					if ($storage->write('uploads/web_builder_image/' . $variant . '/' . $this->fullSizePath, $destTmp)) {
 						$this->{$cfg['prop']} = $this->fullSizePath;
+						$logger->log("generateDerivatives: wrote $variant derivative for image id=$this->id", Logger::LOG_DEBUG);
 					} else {
 						$logger->log('Failed to write ' . $variant . ' derivative image to storage for fullSizePath ' . $this->fullSizePath, Logger::LOG_ERROR);
 					}
@@ -455,7 +458,9 @@ class ImageUpload extends DataObject {
 
 	public function delete(bool $useWhere = false, bool $hardDelete = false) : bool|int {
 		if ($hardDelete) {
+			global $logger;
 			$storage = StorageDriverFactory::getById($this->storageSettingId);
+			$logger->log("ImageUpload::delete: hard deleting image id=$this->id storageSettingId=" . var_export($this->storageSettingId, true), Logger::LOG_DEBUG);
 			foreach ([
 				'full'    => $this->fullSizePath,
 				'x-large' => $this->xLargeSizePath,
@@ -482,6 +487,7 @@ class ImageUpload extends DataObject {
 	 * @return int
 	 */
 	public static function purgeExpired(int $olderThanSecs = 2592000): int {
+		global $logger;
 		$cutOff = time() - $olderThanSecs;
 		$expiredIds = [];
 		$fetchObj = new static();
@@ -491,6 +497,7 @@ class ImageUpload extends DataObject {
 		$fetchObj->find();
 		while ($fetchObj->fetch()) {
 			$storage = StorageDriverFactory::getById($fetchObj->storageSettingId);
+			$logger->log("ImageUpload::purgeExpired: purging image id=$fetchObj->id storageSettingId=" . var_export($fetchObj->storageSettingId, true), Logger::LOG_DEBUG);
 			foreach ([
 				'full'    => $fetchObj->fullSizePath,
 				'x-large' => $fetchObj->xLargeSizePath,

--- a/code/web/sys/File/ImageUpload.php
+++ b/code/web/sys/File/ImageUpload.php
@@ -55,7 +55,6 @@ class ImageUpload extends DataObject {
 		if (isset(self::$_objectStructure[$context]) && self::$_objectStructure[$context] !== null) {
 			return self::$_objectStructure[$context];
 		}
-		global $serverName;
 		$allSharingOptions = [
 			0 => 'Not Shared',
 			1 => 'Selected Library',
@@ -140,7 +139,7 @@ class ImageUpload extends DataObject {
 				'description' => 'The full size image (max width 1068px for web builder images, 3840px for hero sliders).',
 				'maxWidth' => 3840,  // 4K width - suitable for digital signage
 				'maxHeight' => 2160, // 4K height
-				'path' => '/data/aspen-discovery/' . $serverName . '/uploads/web_builder_image/full',
+				'storageKey' => 'uploads/web_builder_image/full',
 				'displayUrl' => '/WebBuilder/ViewImage?size=full&id=',
 				'hideInLists' => true,
 				'required' => true,
@@ -161,7 +160,7 @@ class ImageUpload extends DataObject {
 				'description' => 'The x-large size image (max width 1100 px).',
 				'maxWidth' => ImageUpload::$xLargeSize,
 				'maxHeight' => ImageUpload::$xLargeSize,
-				'path' => '/data/aspen-discovery/' . $serverName . '/uploads/web_builder_image/x-large',
+				'storageKey' => 'uploads/web_builder_image/x-large',
 				'displayUrl' => '/WebBuilder/ViewImage?size=x-large&id=',
 				'hideInLists' => true,
 				'note' => translate(['text' => 'Allowed formats: GIF, JPG, JPEG, PNG, SVG', 'isAdminFacing' => true]),
@@ -181,7 +180,7 @@ class ImageUpload extends DataObject {
 				'description' => 'The medium size image (max width 600px).',
 				'maxWidth' => ImageUpload::$largeSize,
 				'maxHeight' => ImageUpload::$largeSize,
-				'path' => '/data/aspen-discovery/' . $serverName . '/uploads/web_builder_image/large',
+				'storageKey' => 'uploads/web_builder_image/large',
 				'displayUrl' => '/WebBuilder/ViewImage?size=large&id=',
 				'hideInLists' => true,
 				'note' => translate(['text' => 'Allowed formats: GIF, JPG, JPEG, PNG, SVG', 'isAdminFacing' => true]),
@@ -201,7 +200,7 @@ class ImageUpload extends DataObject {
 				'description' => 'The medium size image (max width 400px).',
 				'maxWidth' => ImageUpload::$mediumSize,
 				'maxHeight' => ImageUpload::$mediumSize,
-				'path' => '/data/aspen-discovery/' . $serverName . '/uploads/web_builder_image/medium',
+				'storageKey' => 'uploads/web_builder_image/medium',
 				'displayUrl' => '/WebBuilder/ViewImage?size=medium&id=',
 				'hideInLists' => true,
 				'note' => translate(['text' => 'Allowed formats: GIF, JPG, JPEG, PNG, SVG', 'isAdminFacing' => true]),
@@ -221,7 +220,7 @@ class ImageUpload extends DataObject {
 				'description' => 'The small size image (max width 200px).',
 				'maxWidth' => ImageUpload::$smallSize,
 				'maxHeight' => ImageUpload::$smallSize,
-				'path' => '/data/aspen-discovery/' . $serverName . '/uploads/web_builder_image/small',
+				'storageKey' => 'uploads/web_builder_image/small',
 				'displayUrl' => '/WebBuilder/ViewImage?size=small&id=',
 				'note' => translate(['text' => 'Allowed formats: GIF, JPG, JPEG, PNG, SVG', 'isAdminFacing' => true]),
 				'validTypes' => ['image/gif', 'image/jpeg', 'image/png', 'image/svg+xml']
@@ -315,10 +314,9 @@ class ImageUpload extends DataObject {
 
 	private function calculateAspectRatio() : void {
 		if ($this->type === 'hero_slider' && !empty($this->fullSizePath)) {
-			global $serverName;
-			$imagePath = '/data/aspen-discovery/' . $serverName . '/uploads/web_builder_image/full/' . $this->fullSizePath;
-			if (file_exists($imagePath)) {
-				$imageInfo = getimagesize($imagePath);
+			$contents = StorageDriverFactory::get()->read('uploads/web_builder_image/full/' . $this->fullSizePath);
+			if ($contents !== false) {
+				$imageInfo = getimagesizefromstring($contents);
 				if ($imageInfo !== false) {
 					[$width, $height] = $imageInfo;
 					if ($width && $height) {
@@ -354,74 +352,44 @@ class ImageUpload extends DataObject {
 	}
 
 	private function generateDerivatives() : void {
+		global $logger;
 		if (!empty($this->fullSizePath) && !empty($this->id)) {
-			global $serverName;
 			require_once ROOT_DIR . '/sys/Covers/CoverImageUtils.php';
-			$fullSizeFile = '/data/aspen-discovery/' . $serverName . '/uploads/web_builder_image/full/' . $this->fullSizePath;
-			if ($this->generateXLargeSize) {
-				$xLargeFilePath = '/data/aspen-discovery/' . $serverName . '/uploads/web_builder_image/x-large/';
-				if (!file_exists($xLargeFilePath)) {
-					mkdir($xLargeFilePath, 0755, true);
+			$storage = StorageDriverFactory::get();
+
+			$sourceContents = $storage->read('uploads/web_builder_image/full/' . $this->fullSizePath);
+			if ($sourceContents === false) {
+				return;
+			}
+			$srcTmp = tempnam(sys_get_temp_dir(), 'aspen_src_');
+			file_put_contents($srcTmp, $sourceContents);
+
+			foreach ([
+				'x-large' => ['flag' => 'generateXLargeSize', 'prop' => 'xLargeSizePath', 'size' => ImageUpload::$xLargeSize],
+				'large'   => ['flag' => 'generateLargeSize',   'prop' => 'largeSizePath',   'size' => ImageUpload::$largeSize],
+				'medium'  => ['flag' => 'generateMediumSize',  'prop' => 'mediumSizePath',  'size' => ImageUpload::$mediumSize],
+				'small'   => ['flag' => 'generateSmallSize',   'prop' => 'smallSizePath',   'size' => ImageUpload::$smallSize],
+			] as $variant => $cfg) {
+				if (!$this->{$cfg['flag']}) {
+					continue;
 				}
-				$xLargeFile = $xLargeFilePath . $this->fullSizePath;
 				if (!empty($_FILES['fullSizePath']['full_path'])) {
-					$prevUpload = $xLargeFilePath . "Temp_" . $_FILES['fullSizePath']['full_path'];
-					if (file_exists($prevUpload)) {
-						unlink($prevUpload);
+					$tempKey = 'uploads/web_builder_image/' . $variant . '/Temp_' . $_FILES['fullSizePath']['full_path'];
+					if ($storage->exists($tempKey)) {
+						$storage->delete($tempKey);
 					}
 				}
-				if (resizeImage($fullSizeFile, $xLargeFile, ImageUpload::$xLargeSize, ImageUpload::$xLargeSize)) {
-					$this->xLargeSizePath = $this->fullSizePath;
-				}
-			}
-			if ($this->generateLargeSize) {
-				$largeFilePath = '/data/aspen-discovery/' . $serverName . '/uploads/web_builder_image/large/';
-				if (!file_exists($largeFilePath)) {
-					mkdir($largeFilePath, 0755, true);
-				}
-				$largeFile = $largeFilePath . $this->fullSizePath;
-				if (!empty($_FILES['fullSizePath']['full_path'])) {
-					$prevUpload = $largeFilePath . "Temp_" . $_FILES['fullSizePath']['full_path'];
-					if (file_exists($prevUpload)) {
-						unlink($prevUpload);
+				$destTmp = tempnam(sys_get_temp_dir(), 'aspen_dst_');
+				if (resizeImage($srcTmp, $destTmp, $cfg['size'], $cfg['size'])) {
+					if ($storage->write('uploads/web_builder_image/' . $variant . '/' . $this->fullSizePath, $destTmp)) {
+						$this->{$cfg['prop']} = $this->fullSizePath;
+					} else {
+						$logger->log('Failed to write ' . $variant . ' derivative image to storage for fullSizePath ' . $this->fullSizePath, Logger::LOG_ERROR);
 					}
 				}
-				if (resizeImage($fullSizeFile, $largeFile, ImageUpload::$largeSize, ImageUpload::$largeSize)) {
-					$this->largeSizePath = $this->fullSizePath;
-				}
+				unlink($destTmp);
 			}
-			if ($this->generateMediumSize) {
-				$mediumFilePath = '/data/aspen-discovery/' . $serverName . '/uploads/web_builder_image/medium/';
-				if (!file_exists($mediumFilePath)) {
-					mkdir($mediumFilePath, 0755, true);
-				}
-				$mediumFile = $mediumFilePath . $this->fullSizePath;
-				if (!empty($_FILES['fullSizePath']['full_path'])) {
-					$prevUpload = $mediumFilePath . "Temp_" . $_FILES['fullSizePath']['full_path'];
-					if (file_exists($prevUpload)) {
-						unlink($prevUpload);
-					}
-				}
-				if (resizeImage($fullSizeFile, $mediumFile, ImageUpload::$mediumSize, ImageUpload::$mediumSize)) {
-					$this->mediumSizePath = $this->fullSizePath;
-				}
-			}
-			if ($this->generateSmallSize) {
-				$smallFilePath = '/data/aspen-discovery/' . $serverName . '/uploads/web_builder_image/small/';
-				if (!file_exists($smallFilePath)) {
-					mkdir($smallFilePath, 0755, true);
-				}
-				$smallFile = $smallFilePath . $this->fullSizePath;
-				if (!empty($_FILES['fullSizePath']['full_path'])) {
-					$prevUpload = $smallFilePath . "Temp_" . $_FILES['fullSizePath']['full_path'];
-					if (file_exists($prevUpload)) {
-						unlink($prevUpload);
-					}
-				}
-				if (resizeImage($fullSizeFile, $smallFile, ImageUpload::$smallSize, ImageUpload::$smallSize)) {
-					$this->smallSizePath = $this->fullSizePath;
-				}
-			}
+			unlink($srcTmp);
 		}
 	}
 
@@ -481,22 +449,17 @@ class ImageUpload extends DataObject {
 	}
 
 	public function delete(bool $useWhere = false, bool $hardDelete = false) : bool|int {
-		global $serverName;
 		if ($hardDelete) {
-			$baseDir = '/data/aspen-discovery/' . $serverName . '/uploads/web_builder_image';
-			$variants = [
-				'full' => $this->fullSizePath,
+			$storage = StorageDriverFactory::get();
+			foreach ([
+				'full'    => $this->fullSizePath,
 				'x-large' => $this->xLargeSizePath,
-				'large' => $this->largeSizePath,
-				'medium' => $this->mediumSizePath,
-				'small' => $this->smallSizePath,
-			];
-			foreach ($variants as $size => $filename) {
+				'large'   => $this->largeSizePath,
+				'medium'  => $this->mediumSizePath,
+				'small'   => $this->smallSizePath,
+			] as $size => $filename) {
 				if (!empty($filename)) {
-					$path = $baseDir . '/' . $size . '/' . $filename;
-					if (file_exists($path)) {
-						@unlink($path);
-					}
+					$storage->delete('uploads/web_builder_image/' . $size . '/' . $filename);
 				}
 			}
 		}
@@ -514,8 +477,7 @@ class ImageUpload extends DataObject {
 	 * @return int
 	 */
 	public static function purgeExpired(int $olderThanSecs = 2592000): int {
-		global $serverName;
-		$baseDir = '/data/aspen-discovery/' . $serverName . '/uploads/web_builder_image';
+		$storage = StorageDriverFactory::get();
 		$cutOff = time() - $olderThanSecs;
 		$expiredIds = [];
 		$fetchObj = new static();
@@ -524,21 +486,15 @@ class ImageUpload extends DataObject {
 		$fetchObj->whereAdd("dateDeleted > 0 AND dateDeleted < $cutOff");
 		$fetchObj->find();
 		while ($fetchObj->fetch()) {
-			// Remove each size variant from disk.
-			$paths = [
-				'full' => $fetchObj->fullSizePath,
+			foreach ([
+				'full'    => $fetchObj->fullSizePath,
 				'x-large' => $fetchObj->xLargeSizePath,
-				'large' => $fetchObj->largeSizePath,
-				'medium' => $fetchObj->mediumSizePath,
-				'small' => $fetchObj->smallSizePath,
-			];
-
-			foreach ($paths as $size => $filename) {
+				'large'   => $fetchObj->largeSizePath,
+				'medium'  => $fetchObj->mediumSizePath,
+				'small'   => $fetchObj->smallSizePath,
+			] as $size => $filename) {
 				if (!empty($filename)) {
-					$fullPath = $baseDir . '/' . $size . '/' . $filename;
-					if (file_exists($fullPath)) {
-						@unlink($fullPath);
-					}
+					$storage->delete('uploads/web_builder_image/' . $size . '/' . $filename);
 				}
 			}
 			$expiredIds[] = $fetchObj->id;

--- a/code/web/sys/Storage/LocalStorageDriver.php
+++ b/code/web/sys/Storage/LocalStorageDriver.php
@@ -27,6 +27,14 @@ class LocalStorageDriver implements StorageDriver {
 		return file_get_contents($path);
 	}
 
+	public function readStream(string $key) {
+		$path = $this->fullPath($key);
+		if (!file_exists($path)) {
+			return false;
+		}
+		return fopen($path, 'rb');
+	}
+
 	public function write(string $key, string $tmpPath, string $mimeType = ''): bool {
 		$dest = $this->fullPath($key);
 		$dir = dirname($dest);

--- a/code/web/sys/Storage/LocalStorageDriver.php
+++ b/code/web/sys/Storage/LocalStorageDriver.php
@@ -1,0 +1,50 @@
+<?php
+
+require_once ROOT_DIR . '/sys/Storage/StorageDriver.php';
+
+class LocalStorageDriver implements StorageDriver {
+	private string $dataRoot;
+
+	public function __construct(string $dataRoot) {
+		$this->dataRoot = rtrim($dataRoot, '/');
+	}
+
+	private function fullPath(string $key): string {
+		return $this->dataRoot . '/' . ltrim($key, '/');
+	}
+
+	public function url(string $key, array $transforms = []): string {
+		// Files under dataRoot are not served directly by Apache; callers
+		// must proxy the bytes themselves via read().
+		return '';
+	}
+
+	public function read(string $key): string|false {
+		$path = $this->fullPath($key);
+		if (!file_exists($path)) {
+			return false;
+		}
+		return file_get_contents($path);
+	}
+
+	public function write(string $key, string $tmpPath, string $mimeType = ''): bool {
+		$dest = $this->fullPath($key);
+		$dir = dirname($dest);
+		if (!file_exists($dir)) {
+			mkdir($dir, 0755, true);
+		}
+		return copy($tmpPath, $dest);
+	}
+
+	public function delete(string $key): bool {
+		$path = $this->fullPath($key);
+		if (!file_exists($path)) {
+			return false;
+		}
+		return unlink($path);
+	}
+
+	public function exists(string $key): bool {
+		return file_exists($this->fullPath($key));
+	}
+}

--- a/code/web/sys/Storage/StorageDriver.php
+++ b/code/web/sys/Storage/StorageDriver.php
@@ -24,6 +24,14 @@ interface StorageDriver {
 	public function read(string $key): string|false;
 
 	/**
+	 * Returns a readable stream resource for the given key, or false if not
+	 * found. Callers serving the bytes directly to an HTTP response (e.g.
+	 * proxying an image) should use this instead of read() to avoid buffering
+	 * the entire file in memory.
+	 */
+	public function readStream(string $key);
+
+	/**
 	 * Stores the file at $tmpPath under $key.
 	 * $mimeType is required for remote backends (e.g. S3 Content-Type header).
 	 * Returns true on success.

--- a/code/web/sys/Storage/StorageDriver.php
+++ b/code/web/sys/Storage/StorageDriver.php
@@ -1,0 +1,44 @@
+<?php
+
+interface StorageDriver {
+	/**
+	 * Returns a public-facing URL the caller can redirect a browser to, or an
+	 * empty string if this driver cannot serve the key directly and the
+	 * caller must proxy the bytes itself via read() instead.
+	 * LocalStorageDriver always returns ''. Uploaded files live outside the
+	 * Apache docroot and there is no alias serving them directly.
+	 * Remote drivers return an absolute URL when configured with a public
+	 * base URL, enabling the browser to fetch bytes directly from the
+	 * backend instead of round-tripping through the app server.
+	 *
+	 * @param array $transforms  e.g. ['width' => 400, 'fit' => 'cover']
+	 *                           Applied as URL params by drivers that support it.
+	 */
+	public function url(string $key, array $transforms = []): string;
+
+	/**
+	 * Returns the file contents for the given key, or false if not found.
+	 * Callers that need a local path for processing (e.g. image resize) should
+	 * write the result to a temp file themselves.
+	 */
+	public function read(string $key): string|false;
+
+	/**
+	 * Stores the file at $tmpPath under $key.
+	 * $mimeType is required for remote backends (e.g. S3 Content-Type header).
+	 * Returns true on success.
+	 */
+	public function write(string $key, string $tmpPath, string $mimeType = ''): bool;
+
+	/**
+	 * Deletes the file identified by key.
+	 * Returns true if the file was deleted, false if it did not exist or
+	 * deletion failed.
+	 */
+	public function delete(string $key): bool;
+
+	/**
+	 * Returns true if a file exists for the given key.
+	 */
+	public function exists(string $key): bool;
+}

--- a/code/web/sys/Storage/StorageDriverFactory.php
+++ b/code/web/sys/Storage/StorageDriverFactory.php
@@ -21,14 +21,14 @@ class StorageDriverFactory {
 		self::$instance = null;
 	}
 
-	private static function create(): StorageDriver {
+	public static function resolveDataRoot(): string {
 		global $configArray, $serverName;
+		return $configArray['Site']['dataPath'] ?? '/data/aspen-discovery/' . $serverName;
+	}
 
-		$dataRoot = $configArray['Site']['dataPath']
-			?? '/data/aspen-discovery/' . $serverName;
-
+	private static function create(): StorageDriver {
 		// Phase 2 (cdn_storage_driver) extends this method to instantiate
 		// S3StorageDriver when the active StorageSetting has driver='s3'.
-		return new LocalStorageDriver($dataRoot);
+		return new LocalStorageDriver(self::resolveDataRoot());
 	}
 }

--- a/code/web/sys/Storage/StorageDriverFactory.php
+++ b/code/web/sys/Storage/StorageDriverFactory.php
@@ -8,9 +8,11 @@ class StorageDriverFactory {
 	private static array $instancesById = [];
 
 	public static function get(): StorageDriver {
+		global $logger;
 		if (self::$instance === null) {
 			self::$instance = self::create();
 		}
+		$logger->log('StorageDriverFactory::get() resolved active driver ' . get_class(self::$instance), Logger::LOG_DEBUG);
 		return self::$instance;
 	}
 
@@ -19,12 +21,15 @@ class StorageDriverFactory {
 	// storage_settings.id; null means Local Storage, since that was the only
 	// backend before per-file tracking existed.
 	public static function getById(?int $id): StorageDriver {
+		global $logger;
 		if ($id === null) {
+			$logger->log('StorageDriverFactory::getById(null) resolved LocalStorageDriver', Logger::LOG_DEBUG);
 			return self::getLocalDriver();
 		}
 		if (!isset(self::$instancesById[$id])) {
 			self::$instancesById[$id] = self::createFromId($id);
 		}
+		$logger->log("StorageDriverFactory::getById($id) resolved " . get_class(self::$instancesById[$id]), Logger::LOG_DEBUG);
 		return self::$instancesById[$id];
 	}
 

--- a/code/web/sys/Storage/StorageDriverFactory.php
+++ b/code/web/sys/Storage/StorageDriverFactory.php
@@ -4,12 +4,28 @@ require_once ROOT_DIR . '/sys/Storage/LocalStorageDriver.php';
 
 class StorageDriverFactory {
 	private static ?StorageDriver $instance = null;
+	private static ?StorageDriver $localInstance = null;
+	private static array $instancesById = [];
 
 	public static function get(): StorageDriver {
 		if (self::$instance === null) {
 			self::$instance = self::create();
 		}
 		return self::$instance;
+	}
+
+	// Resolves the driver a specific file was actually written to, which may
+	// differ from the currently active driver returned by get(). $id is a
+	// storage_settings.id; null means Local Storage, since that was the only
+	// backend before per-file tracking existed.
+	public static function getById(?int $id): StorageDriver {
+		if ($id === null) {
+			return self::getLocalDriver();
+		}
+		if (!isset(self::$instancesById[$id])) {
+			self::$instancesById[$id] = self::createFromId($id);
+		}
+		return self::$instancesById[$id];
 	}
 
 	// Allows tests to inject a driver without touching config.
@@ -19,6 +35,8 @@ class StorageDriverFactory {
 
 	public static function reset(): void {
 		self::$instance = null;
+		self::$localInstance = null;
+		self::$instancesById = [];
 	}
 
 	public static function resolveDataRoot(): string {
@@ -27,8 +45,17 @@ class StorageDriverFactory {
 	}
 
 	private static function create(): StorageDriver {
-		// Phase 2 (cdn_storage_driver) extends this method to instantiate
-		// S3StorageDriver when the active StorageSetting has driver='s3'.
-		return new LocalStorageDriver(self::resolveDataRoot());
+		return self::getLocalDriver();
+	}
+
+	private static function createFromId(int $id): StorageDriver {
+		return self::getLocalDriver();
+	}
+
+	private static function getLocalDriver(): StorageDriver {
+		if (self::$localInstance === null) {
+			self::$localInstance = new LocalStorageDriver(self::resolveDataRoot());
+		}
+		return self::$localInstance;
 	}
 }

--- a/code/web/sys/Storage/StorageDriverFactory.php
+++ b/code/web/sys/Storage/StorageDriverFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+require_once ROOT_DIR . '/sys/Storage/LocalStorageDriver.php';
+
+class StorageDriverFactory {
+	private static ?StorageDriver $instance = null;
+
+	public static function get(): StorageDriver {
+		if (self::$instance === null) {
+			self::$instance = self::create();
+		}
+		return self::$instance;
+	}
+
+	// Allows tests to inject a driver without touching config.
+	public static function set(StorageDriver $driver): void {
+		self::$instance = $driver;
+	}
+
+	public static function reset(): void {
+		self::$instance = null;
+	}
+
+	private static function create(): StorageDriver {
+		global $configArray, $serverName;
+
+		$dataRoot = $configArray['Site']['dataPath']
+			?? '/data/aspen-discovery/' . $serverName;
+
+		// Phase 2 (cdn_storage_driver) extends this method to instantiate
+		// S3StorageDriver when the active StorageSetting has driver='s3'.
+		return new LocalStorageDriver($dataRoot);
+	}
+}

--- a/code/web/sys/Storage/StorageSetting.php
+++ b/code/web/sys/Storage/StorageSetting.php
@@ -1,0 +1,93 @@
+<?php
+
+class StorageSetting extends DataObject {
+	public $__table = 'storage_settings';
+	public $id;
+	public $name;
+	public $driver;
+	public $isActive;
+
+	static $_objectStructure = [];
+	static function getObjectStructure(string $context = ''): array {
+		if (isset(self::$_objectStructure[$context]) && self::$_objectStructure[$context] !== null) {
+			return self::$_objectStructure[$context];
+		}
+
+		$structure = [
+			'id' => [
+				'property' => 'id',
+				'type' => 'label',
+				'label' => 'Id',
+				'description' => 'The unique id',
+			],
+			'name' => [
+				'property' => 'name',
+				'type' => 'text',
+				'label' => 'Name',
+				'description' => 'A label to identify this storage configuration.',
+				'maxLength' => 255,
+				'required' => true,
+			],
+			'driver' => [
+				'property' => 'driver',
+				'type' => 'enum',
+				'values' => [
+					'local' => 'Local Storage',
+				],
+				'label' => 'Storage Driver',
+				'description' => 'The storage backend to use for uploaded files.',
+				'default' => 'local',
+				'required' => true,
+			],
+			'isActive' => [
+				'property' => 'isActive',
+				'type' => 'checkbox',
+				'label' => 'Active',
+				'description' => 'Use this configuration as the active storage backend. Only one configuration can be active at a time.',
+				'default' => 0,
+			],
+			'effectiveDataRoot' => [
+				'property'    => 'effectiveDataRoot',
+				'type'        => 'label',
+				'label'       => 'Storage Directory',
+				'description' => 'The directory where uploaded files are stored on this server. To change this, update the data path in your server configuration.',
+				'hideInLists' => true,
+			],
+		];
+
+		self::$_objectStructure[$context] = $structure;
+		return self::$_objectStructure[$context];
+	}
+
+	public function update(string $context = ''): int|bool {
+		if ($this->isActive) {
+			global $aspen_db;
+			$aspen_db->query('UPDATE storage_settings SET isActive = 0 WHERE id != ' . (int)$this->id);
+		}
+		return parent::update($context);
+	}
+
+	public function insert(string $context = ''): int|bool {
+		// On insert, deactivate all others if this one is set as active.
+		if ($this->isActive) {
+			global $aspen_db;
+			$aspen_db->query('UPDATE storage_settings SET isActive = 0');
+		}
+		return parent::insert($context);
+	}
+
+	public function __get($name) {
+		if ($name === 'effectiveDataRoot') {
+			return StorageDriverFactory::resolveDataRoot();
+		}
+		return parent::__get($name);
+	}
+
+	function getActiveAdminSection(): string {
+		return 'system_admin';
+	}
+
+	function canActiveUserEdit(): bool {
+		return UserAccount::userHasPermission('Administer Storage Settings');
+	}
+}

--- a/code/web/sys/Storage/StorageSetting.php
+++ b/code/web/sys/Storage/StorageSetting.php
@@ -90,4 +90,16 @@ class StorageSetting extends DataObject {
 	function canActiveUserEdit(): bool {
 		return UserAccount::userHasPermission('Administer Storage Settings');
 	}
+
+	public function getLinkedObjectStructure(): array {
+		return [
+			[
+				'object' => 'ImageUpload',
+				'class' => ROOT_DIR . '/sys/File/ImageUpload.php',
+				'linkingProperty' => 'storageSettingId',
+				'objectName' => 'Image Upload',
+				'objectNamePlural' => 'Image Uploads',
+			],
+		];
+	}
 }


### PR DESCRIPTION
  This patch introduces a storage abstraction layer for Aspen's uploaded files. Previously, all file operations
  (upload, resize, delete) were hardcoded to the local filesystem using direct copy(), unlink(), and path-string
  calls scattered across DataObjectUtil and ImageUpload. This made it impossible to use any other storage
  backend without touching core code.

  The change wraps all file operations behind a StorageDriver interface, with LocalStorageDriver as the default
  implementation. A new storage_settings table allows administrators to manage storage configurations under
  System Administration.

  Existing installations are not affected. The database migration seeds a "Local Storage" record as the active
  backend, so the factory always falls back to the same local filesystem behavior as before. Files stay at the
  same paths, the database stores only filenames (not full paths), and the URLs served to the browser are
  identical. No data migration is required.

  Test Plan

  Before merging (local driver)

  Regression: objects not managed by the driver

  - Open a record with an existing uploaded image (e.g., a staff member photo) and confirm it still displays
  correctly after the migration runs.
  - Confirm the image URL matches the previous format (/files/original/).
  - Upload a new image to a record that supports thumbnail and medium sizes (e.g., a staff member photo).
  Confirm the original, thumbnail, and medium files are created under the correct directories (files/original/,
  files/thumbnail/, files/medium/).
  - Upload a second image to the same record. Confirm the previous image is replaced and the old file is
  removed.
  - Delete the image from a record. Confirm the file is removed from disk.

  Web Builder Images: StorageDriver path

  - Navigate to Admin > Web Builder > Images and upload a new image. Confirm the file is written through the
  driver to the correct storage path.
  - Open the image in the browser (via /WebBuilder/ViewImage). Confirm it is served correctly through
  StorageDriverFactory::get()->read().
  - Confirm thumbnail and full-size variants are both accessible.

  Admin UI

  - Navigate to Admin > System Administration > Storage Settings. Confirm the seeded "Local Storage" record is
  present and marked as active.
  - Open the record and confirm the "Storage Directory" field shows the correct resolved path for the server.
  - Confirm only one configuration can be active at a time: activating a second one deactivates the first.