### PR TITLE
DIS-2677 update grantTokenAccess and setLibraryCache to parse the result wrapper

### DIFF
--- a/code/web/Action.php
+++ b/code/web/Action.php
@@ -192,7 +192,7 @@ abstract class Action
 			$result = $curlWrapper->curlPostPage($systemVariables->greenhouseUrl . '/API/GreenhouseAPI?method=authenticateTokens', $postData);
 			if (!empty($result)) {
 				$data = json_decode($result, true);
-				$isValid = $data['success'];
+				$isValid = $data['result']['success'];
 
 				if($isValid) {
 					return true;

--- a/code/web/Action.php
+++ b/code/web/Action.php
@@ -192,7 +192,11 @@ abstract class Action
 			$result = $curlWrapper->curlPostPage($systemVariables->greenhouseUrl . '/API/GreenhouseAPI?method=authenticateTokens', $postData);
 			if (!empty($result)) {
 				$data = json_decode($result, true);
-				$isValid = $data['result']['success'];
+				if(array_key_exists("result", $data))
+				{
+					$data = $data['result'];
+				}
+				$isValid = $data['success'];
 
 				if($isValid) {
 					return true;
@@ -204,6 +208,10 @@ abstract class Action
 			$result = $curlWrapper->curlPostPage($configArray['Site']['url'] . '/API/GreenhouseAPI?method=authenticateTokens', $postData);
 			if (!empty($result)) {
 				$data = json_decode($result, true);
+				if(array_key_exists("result", $data))
+				{
+					$data = $data['result'];
+				}
 				$isValid = $data['success'];
 
 				if($isValid) {

--- a/code/web/release_notes/26.08.00.MD
+++ b/code/web/release_notes/26.08.00.MD
@@ -24,6 +24,7 @@
 // kyle
 
 // imani
+- Parse result wrapper for api responses in grantTokenAccess and setLibraryCache ([DIS-2677](https://aspen-discovery.atlassian.net/browse/DIS-2677)) (*IT*)
 
 // yanjun
 

--- a/code/web/services/API/GreenhouseAPI.php
+++ b/code/web/services/API/GreenhouseAPI.php
@@ -572,7 +572,11 @@ class GreenhouseAPI extends AbstractAPI {
 	public function setLibraryCache($aspenSite): void {
 		$fetchLibraryUrl = $aspenSite->baseUrl . '/API/GreenhouseAPI?method=getLibrary';
 		if ($data = @file_get_contents($fetchLibraryUrl)) {
-			$searchData = json_decode($data)->result;
+			$searchData = json_decode($data);
+			if(property_exists($searchData, "result"))
+			{
+				$searchData = $searchData->result;
+			}
 			$libraryLocation = new AspenSiteCache();
 			$libraryLocation->siteId = $aspenSite->id;
 			$libraryLocation->delete(true);

--- a/code/web/services/API/GreenhouseAPI.php
+++ b/code/web/services/API/GreenhouseAPI.php
@@ -572,7 +572,7 @@ class GreenhouseAPI extends AbstractAPI {
 	public function setLibraryCache($aspenSite): void {
 		$fetchLibraryUrl = $aspenSite->baseUrl . '/API/GreenhouseAPI?method=getLibrary';
 		if ($data = @file_get_contents($fetchLibraryUrl)) {
-			$searchData = json_decode($data);
+			$searchData = json_decode($data)->result;
 			$libraryLocation = new AspenSiteCache();
 			$libraryLocation->siteId = $aspenSite->id;
 			$libraryLocation->delete(true);


### PR DESCRIPTION
* enable api requests for your ip
* ensure you have site listings set up as community in the Greenhouse Site Listings page
* navigate to /API/GreenhouseAPI?method=getLibraries&reload=true 
* you should get a full lists of community sites in your listings
* without this fix you should see errors in your log about $searchData not having success

