### PR TITLE
DIS-2534: Fix Applied Filter labels for range filters

### DIFF
--- a/code/web/sys/SearchObject/AbstractGroupedWorkSearcher.php
+++ b/code/web/sys/SearchObject/AbstractGroupedWorkSearcher.php
@@ -1295,6 +1295,32 @@ abstract class SearchObject_AbstractGroupedWorkSearcher extends SearchObject_Sol
 		return $this->facetConfig;
 	}
 
+	/**
+	 * @return array
+	 */
+	public function getFullFacetConfig() : array {
+		if ($this->fullFacetConfig == null) {
+			$facetConfig = [];
+			$searchLibrary = Library::getActiveLibrary();
+			global $locationSingleton;
+			$searchLocation = $locationSingleton->getActiveLocation();
+			if ($searchLocation != null) {
+				$facets = $searchLocation->getGroupedWorkDisplaySettings()->getFacets();
+			} else {
+				$facets = $searchLibrary->getGroupedWorkDisplaySettings()->getFacets();
+			}
+			foreach ($facets as $facet) {
+				//Adjust facet name for local scoping
+				$facet->facetName = $this->getScopedFieldName($facet->getFacetName($this->searchVersion));
+				$facetConfig[$facet->facetName] = $facet;
+
+			}
+			$this->fullFacetConfig = $facetConfig;
+		}
+
+		return $this->fullFacetConfig;
+	}
+
 	function getMoreLikeThis($id, $selectedAvailabilityToggle = 'global', $availableOnly = false, $limitFormat = true, $limit = null, $format = null) {
 		if ($this->indexEngine instanceof GroupedWorksSolrConnector ||  $this->indexEngine instanceof GroupedWorksSolrConnector2) {
 			return $this->indexEngine->getMoreLikeThis($id, $selectedAvailabilityToggle, $availableOnly, $limitFormat, $limit, $format, $this->getFieldsToReturn());

--- a/code/web/sys/SearchObject/BaseSearcher.php
+++ b/code/web/sys/SearchObject/BaseSearcher.php
@@ -52,6 +52,7 @@ abstract class SearchObject_BaseSearcher {
 	protected $resultsAction = 'Results';
 	// Facets information
 	protected $facetConfig;    // Array of valid facet fields=>labels
+	protected $fullFacetConfig;
 	protected $facetOptions = [];
 	// Available sort options
 	protected $sortOptions = [];
@@ -277,6 +278,7 @@ abstract class SearchObject_BaseSearcher {
 		$shortField = $field;
 		$shortField = $this->getUnscopedFieldName($shortField);
 		$facetConfig = $this->getFacetConfig();
+		$fullFacetConfig = $this->getFullFacetConfig();
 		if (isset($facetConfig[$field])) {
 			$facetConfig = $facetConfig[$field];
 			if ($facetConfig instanceof FacetSetting) {
@@ -290,6 +292,13 @@ abstract class SearchObject_BaseSearcher {
 				return $facetConfig->displayName;
 			} else {
 				return $facetConfig;
+			}
+		} elseif (isset($fullFacetConfig[$field])) {
+			$fullFacetConfig = $fullFacetConfig[$field];
+			if ($fullFacetConfig instanceof FacetSetting) {
+				return $fullFacetConfig->displayName;
+			} else {
+				return $fullFacetConfig;
 			}
 		} else {
 			return ucwords(str_replace("_", " ", translate([
@@ -2790,6 +2799,10 @@ abstract class SearchObject_BaseSearcher {
 			$this->facetConfig = [];
 		}
 		return $this->facetConfig;
+	}
+
+	public function getFullFacetConfig() {
+		return $this->fullFacetConfig;
 	}
 
 	abstract function getSearchName();


### PR DESCRIPTION
Add function getFullFacetConfig() for cases where we need an applied facet label displayed in advanced search results but the facet is only enabled for advanced searches