### PR TITLE
DIS-2689: Preserve capitalization for grouped work series names

### DIFF
--- a/code/reindexer/src/org/aspen_discovery/reindexer/AbstractGroupedWorkSolr.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/AbstractGroupedWorkSolr.java
@@ -819,7 +819,7 @@ public abstract class AbstractGroupedWorkSolr implements DebugLogger {
 			// When this occurs, the more specific series (longer or with a volume) will be preserved.
 			// This logic only applies if the series module is NOT active.
 			// First Check the traced series
-			seriesInfo = getPreferredSeriesWithPartialMatching(seriesNameLower);
+			seriesInfo = getPreferredSeriesWithPartialMatching(normalizedSeriesName);
 		}else if (groupedWorkIndexer.getSeriesVersion() == 1) {
 			seriesInfo = new SeriesInfo(seriesName);
 		}else{ //version 2
@@ -836,9 +836,10 @@ public abstract class AbstractGroupedWorkSolr implements DebugLogger {
 		seriesInfo.addVolume(volume);
 	}
 
-	private SeriesInfo getPreferredSeriesWithPartialMatching(String seriesNameLower) {
+	private SeriesInfo getPreferredSeriesWithPartialMatching(String seriesName) {
+		String seriesNameLower = seriesName.toLowerCase();
 		if (series.isEmpty()) {
-			return new SeriesInfo(seriesNameLower);
+			return new SeriesInfo(seriesName);
 		}
 		Iterator<String> iterator = series.keySet().iterator();
 
@@ -851,7 +852,7 @@ public abstract class AbstractGroupedWorkSolr implements DebugLogger {
 				iterator.remove();
 			}
 		}
-		return new SeriesInfo(seriesNameLower);
+		return new SeriesInfo(seriesName);
 	}
 
 	private void addSeriesInfoToField(String seriesInfo, HashMap<String, String> seriesField) {

--- a/code/web/release_notes/26.08.00.MD
+++ b/code/web/release_notes/26.08.00.MD
@@ -30,6 +30,8 @@
 - Language selection confirmation popups now display in the newly selected language instead of the previously active language. ([DIS-2683](https://aspen-discovery.atlassian.net/browse/DIS-2683)) (*YL*)
 - My Account language preference update messages now display in the user’s newly selected language. ([DIS-2683](https://aspen-discovery.atlassian.net/browse/DIS-2683)) (*YL*)
 
+### Series Updates
+- Fix an issue where grouped work series names could display with lowercase when series data came from MARC records. ([DIS-2689](https://aspen-discovery.atlassian.net/browse/DIS-2689)) (*YL*)
 
 // lucas
 


### PR DESCRIPTION
Series from MARC records can display with lowercase in grouped work records even though the source records contain 490 0_ $a with the correct capitalization, and there is no NoveList/econtent source involved.

To Test:
1. Find a MARC record with Series names in all lowercase even 490_$a has correct capitalization
2. Apply the PR
3. Force reindex the record
4. Verify that the Series names are displayed with expected capitalization. 