### PR TITLE
DIS-2688: Fix library link  Add New error 

### DIFF
--- a/code/web/release_notes/26.08.00.MD
+++ b/code/web/release_notes/26.08.00.MD
@@ -26,6 +26,8 @@
 // imani
 
 // yanjun
++### Other Updates
++- Fix an issue where library links could fail to be added when creating a new record. ([DIS-2688](https://aspen-discovery.atlassian.net/browse/DIS-2688)) (*YL*)
 
 // lucas
 

--- a/code/web/sys/LibraryLocation/LibraryLink.php
+++ b/code/web/sys/LibraryLocation/LibraryLink.php
@@ -249,13 +249,15 @@ class LibraryLink extends DataObject {
 	}
 
 	public function getAccess() : array {
-		if (!isset($this->_allowAccess) && $this->id) {
+		if (!isset($this->_allowAccess)) {
 			$this->_allowAccess = [];
-			$patronTypeLink = new LibraryLinkAccess();
-			$patronTypeLink->libraryLinkId = $this->id;
-			$patronTypeLink->find();
-			while ($patronTypeLink->fetch()) {
-				$this->_allowAccess[$patronTypeLink->patronTypeId] = $patronTypeLink->patronTypeId;
+			if ($this->id) {
+				$patronTypeLink = new LibraryLinkAccess();
+				$patronTypeLink->libraryLinkId = $this->id;
+				$patronTypeLink->find();
+				while ($patronTypeLink->fetch()) {
+					$this->_allowAccess[$patronTypeLink->patronTypeId] = $patronTypeLink->patronTypeId;
+				}
 			}
 		}
 		return $this->_allowAccess;
@@ -284,20 +286,22 @@ class LibraryLink extends DataObject {
 	}
 
 	public function getLanguages() : array {
-		if (!isset($this->_languages) && $this->id) {
+		if (!isset($this->_languages)) {
 			$this->_languages = [];
-			try {
-				$language = new LibraryLinkLanguage();
-				$language->libraryLinkId = $this->id;
-				$language->find();
-				while ($language->fetch()) {
-					$this->_languages[$language->languageId] = $language->languageId;
-				}
-			} catch (Exception) {
-				//This happens when the table is not setup yet
-				$languageList = Language::getLanguageList();
-				foreach ($languageList as $languageId => $displayName) {
-					$this->_languages[$languageId] = $languageId;
+			if ($this->id) {
+				try {
+					$language = new LibraryLinkLanguage();
+					$language->libraryLinkId = $this->id;
+					$language->find();
+					while ($language->fetch()) {
+						$this->_languages[$language->languageId] = $language->languageId;
+					}
+				} catch (Exception) {
+					//This happens when the table is not setup yet
+					$languageList = Language::getLanguageList();
+					foreach ($languageList as $languageId => $displayName) {
+						$this->_languages[$languageId] = $languageId;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
When trying to Add New for Library Link /Admin/LibraryLinks?sort=category+asc&objectAction=addNew
get error messages: 
LibraryLink::getAccess(): Return value must be of type array, null returned
and 
LibraryLnk::getLanguages()Return value must be of type array, null returned

To test:
1. Open the link /Admin/LibraryLinks?sort=category+asc&objectAction=addNew
2. See error messages
3. Apply the PR
4. Refresh the page and verify there are no error messages. And a new library link can be added without issue. 