### PR TITLE
DIS-2683: Display selected language for language change confirmation messages

### DIFF
--- a/code/web/release_notes/26.08.00.MD
+++ b/code/web/release_notes/26.08.00.MD
@@ -26,6 +26,10 @@
 // imani
 
 // yanjun
+### Language and Translation Updates
+- Language selection confirmation popups now display in the newly selected language instead of the previously active language. ([DIS-2683](https://aspen-discovery.atlassian.net/browse/DIS-2683)) (*YL*)
+- My Account language preference update messages now display in the user’s newly selected language. ([DIS-2683](https://aspen-discovery.atlassian.net/browse/DIS-2683)) (*YL*)
+
 
 // lucas
 

--- a/code/web/services/AJAX/JSON.php
+++ b/code/web/services/AJAX/JSON.php
@@ -643,6 +643,12 @@ class AJAX_JSON extends Action {
 				unset($_COOKIE['searchPreferenceLanguage']);
 			}
 		}
+		global $activeLanguage;
+		$selectedLanguage = new Language();
+		$selectedLanguage->code = $language;
+		if ($selectedLanguage->find(true)) {
+			$activeLanguage = $selectedLanguage;
+		}
 
 		$activeThemeId = $interface->getVariable('activeThemeId');
 		if (isset($_REQUEST['preferredTheme'])) {

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -1800,15 +1800,29 @@ class User extends DataObject {
 		$this->__set('allowAppRequestLogging', (isset($_POST['allowAppRequestLogging']) && $_POST['allowAppRequestLogging'] == 'on') ? 1 : 0);
 
 		$saveResult = $this->update();
+		if (isset($_REQUEST['profileLanguage'])) {
+			global $activeLanguage;
+			$selectedLanguage = new Language();
+			$selectedLanguage->code = $_REQUEST['profileLanguage'];
+			if ($selectedLanguage->find(true)) {
+				$activeLanguage = $selectedLanguage;
+			}
+		}
 		if ($saveResult === false) {
 			return [
 				'success' => false,
-				'message' => 'Could not save to the database.',
+				'message' => translate([
+					'text' => 'Could not save to the database.',
+					'isPublicFacing' => true,
+				]),
 			];
 		} else {
 			return [
 				'success' => true,
-				'message' => 'Your preferences were updated successfully.',
+				'message' => translate([
+					'text' => 'Your preferences were updated successfully.',
+					'isPublicFacing' => true,
+				]),
 			];
 		}
 	}


### PR DESCRIPTION
When a user changes Aspen’s language preference, the confirmation message is still displayed in the previously selected language instead of the newly selected language. 

This happens in two cases:
1. When a logged-out user selects Spanish, the confirmation pop-up says “Your settings have been updated” in English instead of Spanish. If the user selects back to English, the confirmation will display in Spanish instead of English. 
2. When a user changes language in the My Account, the message “Your preferences were updated successfully.” appears in English instead of the selected preferred language.

After the user selects a language, the confirmation message should display in that selected language.

To test:
1. Add English and Spanish in Admin > Languages.
2. Add Spanish translations for "Your settings have been updated." and "Your preferences were updated successfully."
3. While logged in, go to My Account > Your Preferences > Language, select Spanish, and save.
4. Confirm the success message displays in the previously active language instead of Spanish.
5. Change the language back to English and save.
6. Confirm the success message displays in the previously active language instead of English.
7. While logged out, change the interface language and repeat the same language-switching test.
8. Apply the PR.
9. Repeat the logged-in and logged-out language changes.
10. Confirm the success messages display in the newly selected language in both workflows.