### PR TITLE
DIS-2690: Clear Stale Hoopla account summary for holds

### DIFF
--- a/code/web/Drivers/HooplaDriver.php
+++ b/code/web/Drivers/HooplaDriver.php
@@ -240,6 +240,7 @@ class HooplaDriver extends AbstractEContentDriver {
 						global $logger;
 						$errorMessage = empty($holdsResponse['body']->message) ? '' : ' Hoopla Message: ' . $holdsResponse['body']->message;
 						$logger->log('Error retrieving holds from Hoopla. User ID: ' . $user->id . $errorMessage, Logger::LOG_NOTICE);
+						$summary->resetCounters();
 					}
 				} else {
 					$summary->numAvailableHolds = 0;

--- a/code/web/release_notes/26.07.00.MD
+++ b/code/web/release_notes/26.07.00.MD
@@ -49,7 +49,7 @@
 - Fix an issue where grouped work descriptions were displaying on full record pages instead of the individual record's description ([DIS-2556](https://aspen-discovery.atlassian.net/browse/DIS-2556)) (*KL*)
 
 ### Hoopla Updates
-- Fix an issue where Hoopla checkout counts were not updated if the Hoopla account summary refresh failed. ([DIS-2506](https://aspen-discovery.atlassian.net/browse/DIS-2506)) (*YL*)
+- Fix an issue where Hoopla checkout counts were not updated if the Hoopla account summary refresh failed. ([DIS-2506](https://aspen-discovery.atlassian.net/browse/DIS-2506))([DIS-2690](https://aspen-discovery.atlassian.net/browse/DIS-2690)) (*YL*)
 
 ### Holds Updates
 - Fix an issue where the place hold dialog could show volumes from the wrong format for records with multiple formats. ([DIS-2503](https://aspen-discovery.atlassian.net/browse/DIS-2503)) (*YL*)


### PR DESCRIPTION

[DIS-2506](https://aspen-discovery.atlassian.net/browse/DIS-2506) fixed the issue for checkouts, but didn’t add the reset counter to holds. 

Holds should have a reset counter if the API request doesn’t return 200 OK

To Test:
1. Log in as a patron with existing cached Hoopla holds data
2. Simulate a non-200 response from the Hoopla holds API
3. Refresh the user account data in Aspen
4. Confirm the cached Hoopla holds data remaining
5. Apply the PR
6. Repeat steps 2, 3, and confirm the cached Hoopla holds is reset.
7. Restore a normal successful Hoopla holds response and confirm that valid Hoopla summary counts display again.

[DIS-2506]: https://aspen-discovery.atlassian.net/browse/DIS-2506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ