### PR TITLE
DIS-1689: fixes

### DIFF
--- a/code/web/interface/themes/responsive/Admin/usage-graph-data-filters.tpl
+++ b/code/web/interface/themes/responsive/Admin/usage-graph-data-filters.tpl
@@ -10,7 +10,9 @@
 			</select>
 			<div id='custom-usage-period-wrapper' {if $timeframe != 'custom'}hidden{/if}>
 				<div class="{if !empty($customPeriodStartWarning)}has-error{/if}">
-					<label for='customUsagePeriodStart' class="control-label">{translate text='Custom period start (date)' isAdminFacing=true}</label>
+					<label for='customUsagePeriodStart' class="control-label">
+						{translate text="Custom period start (date) - available from %1%" 1={$earliestUsageDate|format_date_locale:'short'} isAdminFacing=true}
+					</label>
 					<input type='date' name='customUsagePeriodStart' id='customUsagePeriodStart' min='{$earliestUsageDate|default:"2019-01-01"}' value='{$customUsagePeriodStart|default:''}' class='form-control' {if $timeframe == 'custom'}required{/if}>
 				</div>
 				<label for='customUsagePeriodDuration'>{translate text='Custom period duration (days)' isAdminFacing=true}</label>

--- a/code/web/services/Admin/AbstractUsageGraphs.php
+++ b/code/web/services/Admin/AbstractUsageGraphs.php
@@ -52,10 +52,12 @@ abstract class Admin_AbstractUsageGraphs extends Admin_Admin {
 		$interface->assign('instance', $instanceName);
 		$interface->assign('timeframe', $timeframe);
 
+		$usage = new AspenUsage();
+		// Only used by custom, but assign it always so it's in the DOM when custom fields render dynamically before reload.
+		$earliestUsageDate = $usage->getEarliestUsageDate();
+		$interface->assign('earliestUsageDate', $earliestUsageDate);
+
 		if ($timeframe === 'custom') {
-			$usage = new AspenUsage();
-			$earliestUsageDate = $usage->getEarliestUsageDate();
-			$interface->assign('earliestUsageDate', $earliestUsageDate);
 			$interface->assign('customUsagePeriodStart', $customUsagePeriodStart);
 			$interface->assign('customUsagePeriodDuration', $customUsagePeriodDuration);
 			$interface->assign('customPeriodStartWarning', $this->getCustomPeriodStartWarning($customUsagePeriodStart, $earliestUsageDate));


### PR DESCRIPTION
- display earliest available date for 'custom period' to explain date-range behaviour
- surface earliestUsageDate to the DOM unconditionally so the JS date-range check and "available from" label work while custom fields render dynamically, before the server round-trip