### PR TITLE
DIS-2695: Escape variationId in viewItem modal

### DIFF
--- a/code/web/interface/themes/responsive/Record/select-view-item-link-form.tpl
+++ b/code/web/interface/themes/responsive/Record/select-view-item-link-form.tpl
@@ -1,5 +1,5 @@
 {strip}
-	<form enctype="multipart/form-data" name="viewItem" id="viewItem" method="post" onsubmit="return AspenDiscovery.Record.viewItemLink({$variationId});">
+	<form enctype="multipart/form-data" name="viewItem" id="viewItem" method="post" onsubmit="return AspenDiscovery.Record.viewItemLink({json_encode($variationId)|escape:"html"});">
 		<input type="hidden" name="id" id="id" value="{$id}"/>
 		<div class="form-group">
 			<div class="form-group">

--- a/code/web/release_notes/26.07.00.MD
+++ b/code/web/release_notes/26.07.00.MD
@@ -168,6 +168,7 @@
 - Add additional cron jobs to the list of frequently run cron jobs to not log based on system variable settings. ([DIS-2687](https://aspen-discovery.atlassian.net/browse/DIS-2687)) (*MDN*)
 - Fix filtering by calculated integers (series and materials requests). ([DIS-2681](https://aspen-discovery.atlassian.net/browse/DIS-2681)) (*MDN*)
 - Do not display audiobook duration for non audiobooks. ([DIS-2694](https://aspen-discovery.atlassian.net/browse/DIS-2694)) (*MDN*)
+- Escape variation ID in viewItem modal ([DIS-2695](https://aspen-discovery.atlassian.net/browse/DIS-2695)) (*OR*)
 
 ## This release includes code contributions from
 ### ByWater Solutions


### PR DESCRIPTION
If this is a record page using getRecordActionsFromIndex, this value can be a string and should be escaped for JavaScript.