### PR TITLE
DIS-2682: Applied facet display name mismatch for advanced-search-only facets

### DIFF
--- a/code/web/release_notes/26.08.00.MD
+++ b/code/web/release_notes/26.08.00.MD
@@ -122,6 +122,11 @@
 ### Web Builder Updates
 - Fixed an issue where a failed image upload could still be saved as if it succeeded, leaving a broken image reference. ([DIS-2736](https://aspen-discovery.atlassian.net/browse/DIS-2736)) (*LM*)
 - Fix Web Builder images being served with an incorrect content type, which could cause GIF and JPEG images to be mislabeled as PNG. ([DIS-2748](https://aspen-discovery.atlassian.net/browse/DIS-2748)) (*LM*)
+### Advanced Search Updates
+- Fix applied facet display names not matching the configured label for facets shown only in Advanced Search. ([DIS-2682](https://aspen-discovery.atlassian.net/browse/DIS-2682)) (*LM*)
+- Fix facets configured to show only in Advanced Search disappearing when "Show on Results Page" is unchecked. ([DIS-2682](https://aspen-discovery.atlassian.net/browse/DIS-2682)) (*LM*)
+- Fix facets not configured to show on the results page incorrectly appearing in the results sidebar after running an Advanced Search, unless the patron had actually filtered by that facet. ([DIS-2682](https://aspen-discovery.atlassian.net/browse/DIS-2682)) (*LM*)
+
 
 ## This release includes code contributions from
 ### ByWater Solutions

--- a/code/web/sys/SearchObject/AbstractGroupedWorkSearcher.php
+++ b/code/web/sys/SearchObject/AbstractGroupedWorkSearcher.php
@@ -11,6 +11,14 @@ abstract class SearchObject_AbstractGroupedWorkSearcher extends SearchObject_Sol
 	private bool $automaticFacetsApplied = false;
 
 	/**
+	 * True only while building the facet list for the advanced search form/popup
+	 * (initAdvancedFacets()). Distinct from isAdvanced(), which also stays true for
+	 * the results page after an advanced search is submitted -- that page's facet
+	 * sidebar must keep following showInResults, not showInAdvancedSearch.
+	 */
+	private bool $buildingAdvancedFacetList = false;
+
+	/**
 	 * This determines if Aspen applies the default availability toggle for the library
 	 * or location if no value is provided. It needs to be disabled to search across libraries
 	 * and locations.
@@ -297,6 +305,11 @@ abstract class SearchObject_AbstractGroupedWorkSearcher extends SearchObject_Sol
 		global $locationSingleton;
 		// Call the standard initialization routine in the parent:
 		parent::init();
+
+		// This is building the facet list for the advanced search screen, so treat it as an advanced search
+		// context even though no query has been submitted yet (isAdvanced would otherwise stay false).
+		$this->isAdvanced = true;
+		$this->buildingAdvancedFacetList = true;
 
 		$searchLibrary = Library::getActiveLibrary();
 
@@ -1466,13 +1479,16 @@ abstract class SearchObject_AbstractGroupedWorkSearcher extends SearchObject_Sol
 				//Adjust facet name for local scoping
 				$facet->facetName = $this->getScopedFieldName($facet->getFacetName($this->searchVersion));
 
-				global $action;
-				if ($action == 'Advanced') {
+				if ($this->buildingAdvancedFacetList) {
 					if ($facet->showInAdvancedSearch == 1) {
 						$facetConfig[$facet->facetName] = $facet;
 					}
 				} else {
-					if ($facet->showInResults == 1) {
+					// Also include facets that aren't normally shown in results but were
+					// actively filtered on (e.g. via the advanced search form) -- needed both
+					// to build the Solr filter query for that field and to surface it as a
+					// removable facet in the sidebar.
+					if ($facet->showInResults == 1 || isset($this->filterList[$facet->facetName])) {
 						$facetConfig[$facet->facetName] = $facet;
 					}
 				}


### PR DESCRIPTION
Facets configured to show only in Advanced Search (showInAdvancedSearch enabled, showInResults disabled) had three related problems:

1. They did not appear on the Advanced Search screen or in the AJAX facet-browse popup when "Show on Results Page" was disabled.
2. When applied, their filter chip and "More options" popup title showed the raw field name (via a ucwords() fallback) instead of the configured Display Name.
3. After running an Advanced Search, they incorrectly appeared as options in the results-page sidebar even when the patron never filtered by them — leaking the entire "Show on Advanced Search" facet set into results, not just the facets actually in use.

Root cause

getFacetConfig() originally determined the active facet set using the global $action == 'Advanced' check. Advanced search submissions actually execute under action=Results, not Advanced, so the check excluded advanced-search-only facets from the filtered config whenever a query had been submitted, causing getFacetLabel() to fall back to the raw field name (problem 2).

The check was replaced with $this->isAdvanced(), which detects advanced search context from request shape instead of the raw $action parameter. That alone didn't fix problem 1: initAdvancedFacets() — the method that builds the facet list for the blank Advanced Search page and the AJAX facet-browse popups — runs before any query is submitted, so isAdvanced() was never true there. It now explicitly sets isAdvanced = true in that method.

isAdvanced() stays true for the entire request once an Advanced Search is submitted, not just while building the Advanced Search form. Reusing it inside getFacetConfig() for the results page introduced problem 3: the results-page sidebar switched from the showInResults facet set to the full showInAdvancedSearch facet set for any search that came from the advanced form. The fix separates these two contexts:

- A dedicated buildingAdvancedFacetList flag, set only while initAdvancedFacets() builds the Advanced Search form/popup, selects the showInAdvancedSearch facet set independently of isAdvanced().
- Everywhere else (the results page, whether the search was basic or advanced), the facet set is the showInResults facets plus any facet the patron has actually applied a filter on — so a facet only enabled for Advanced Search shows up, correctly labeled, if and only if it's actively being used to filter the current search.

Test plan

Before:
1. Create a facet with "Show on Advanced Search" enabled and "Show on Results Page" disabled, with a custom Display Name.
2. Load the Advanced Search page: the facet does not appear in the filter list.
3. Enable "Show on Results Page" as well: the facet appears, but its applied filter chip and "More options" popup title show the raw field name instead of the configured Display Name.
4. Run an Advanced Search that filters on a different facet, one that also has "Show on Results Page" disabled: the unfiltered facet appears as an option in the results-page sidebar anyway.

After:
5. With "Show on Advanced Search" enabled and "Show on Results Page" disabled, the facet appears correctly on the Advanced Search page and in the AJAX facet-browse popup.
6. Applying the facet shows the configured Display Name on the filter chip and in the "More options" popup title, regardless of the "Show on Results Page" setting.
7. That applied facet also appears, correctly labeled, in the results-page sidebar as a removable filter, even though "Show on Results Page" is disabled.
8. Any other facet with "Show on Advanced Search" enabled and "Show on Results Page" disabled that was NOT filtered on does not appear in the results-page sidebar.
9. Facets configured to show only on the Results Page (not Advanced Search) continue to behave as before, with no regression on the standard search results filters.