### PR TITLE
DIS-2654 Allow non-searchable lists to be viewed from a list

### DIFF
--- a/code/web/release_notes/26.08.00.MD
+++ b/code/web/release_notes/26.08.00.MD
@@ -6,6 +6,8 @@
 // mark j
 
 // stephen
+### Other Updates
+- Allow non-searchable lists to be viewed from a list ([DIS-2654](https://aspen-discovery.atlassian.net/browse/DIS-2654)) (*SW*)
 
 // bryan
 

--- a/code/web/sys/UserLists/UserList.php
+++ b/code/web/sys/UserLists/UserList.php
@@ -768,29 +768,56 @@ class UserList extends DataObject {
 			$filteredIdsBySource[$listItemEntry['source']][] = $listItemEntry['sourceId'];
 		}
 
-		//Load the actual items from each source
-		$listResults = [];
-		foreach ($filteredIdsBySource as $sourceType => $sourceIds) {
-			if (!$forLiDA || ($forLiDA && in_array($sourceType, AbstractAPI::getValidSourcesForLiDA()))) {
+	// Load the actual items from each source
+	$listResults = [];
+	foreach ($filteredIdsBySource as $sourceType => $sourceIds) {
+		if (!$forLiDA || ($forLiDA && in_array($sourceType, AbstractAPI::getValidSourcesForLiDA()))) {
+			// Nested lists
+			if ($sourceType === 'Lists') {
+				require_once ROOT_DIR . '/RecordDrivers/ListsRecordDriver.php';
+				$records = [];
+				foreach ($sourceIds as $id) {
+					$userList = new UserList();
+					$userList->id = $id;
+					
+					if ($userList->find(true)) {
+						if ($userList->public) {
+							$records[] = new ListsRecordDriver([
+								'id' => $userList->id,
+								'title_display' => $userList->title,
+							]);
+						} else {
+							// Don't display private nested lists
+							foreach ($filteredListEntries as $key => $entry) {
+								if ($entry['sourceId'] === $id) {
+									unset($filteredListEntries[$key]);
+									break;
+								}
+							}
+						}
+					}
+				} 
+			} else {
 				$searchObject = SearchObjectFactory::initSearchObject($sourceType);
 				if ($searchObject === false) {
 					AspenError::raiseError("Unknown List Entry Source $sourceType");
 				} else {
 					$records = $searchObject->getRecords($sourceIds);
-					if ($format == 'html') {
-						$listResults = $listResults + $this->getResultListHTML($records, $filteredListEntries, $allowEdit, $start);
-					} elseif ($format == 'summary') {
-						$listResults = $listResults + $this->getResultListSummary($records, $filteredListEntries);
-					} elseif ($format == 'recordDrivers') {
-						$listResults = $listResults + $this->getResultListRecordDrivers($records, $filteredListEntries);
-					} elseif ($format == 'citations') {
-						$listResults = $listResults + $this->getResultListCitations($records, $filteredListEntries, $citationFormat);
-					} else {
-						AspenError::raiseError("Unknown display format $format in getListRecords");
-					}
 				}
 			}
+			if ($format == 'html') {
+				$listResults = $listResults + $this->getResultListHTML($records, $filteredListEntries, $allowEdit, $start);
+			} elseif ($format == 'summary') {
+				$listResults = $listResults + $this->getResultListSummary($records, $filteredListEntries);
+			} elseif ($format == 'recordDrivers') {
+				$listResults = $listResults + $this->getResultListRecordDrivers($records, $filteredListEntries);
+			} elseif ($format == 'citations') {
+				$listResults = $listResults + $this->getResultListCitations($records, $filteredListEntries, $citationFormat);
+			} else {
+				AspenError::raiseError("Unknown display format $format in getListRecords");
+			}
 		}
+	}
 
 		if ($format == 'html') {
 			//Add in non-owned results for anything that is left


### PR DESCRIPTION
https://aspen-discovery.atlassian.net/browse/DIS-2654

Fixes an issue where nested lists appear as "not in the catalog" inside the parent list when made non-searchable.

This was caused by UserList.php around line ~777, we were using the search functionality to get the records.

Private sublists will not appear in parent lists.