### PR TITLE
DIS-2734: Hoopla Flex-enabled libraries show inaccurate remaining checkout count

### DIFF
--- a/code/web/Drivers/HooplaDriver.php
+++ b/code/web/Drivers/HooplaDriver.php
@@ -240,7 +240,8 @@ class HooplaDriver extends AbstractEContentDriver {
 						global $logger;
 						$errorMessage = empty($holdsResponse['body']->message) ? '' : ' Hoopla Message: ' . $holdsResponse['body']->message;
 						$logger->log('Error retrieving holds from Hoopla. User ID: ' . $user->id . $errorMessage, Logger::LOG_NOTICE);
-						$summary->resetCounters();
+						$summary->numAvailableHolds = 0;
+						$summary->numUnavailableHolds = 0;
 					}
 				} else {
 					$summary->numAvailableHolds = 0;

--- a/code/web/release_notes/26.07.01.MD
+++ b/code/web/release_notes/26.07.01.MD
@@ -1,0 +1,7 @@
+## Aspen Discovery Updates
+### Hoopla Updates
+- Fix an issue where Hoopla Flex-enabled libraries were showing inaccurate checkout counts ([DIS-2734](https://aspen-discovery.atlassian.net/browse/DIS-2734)) (*KL*)
+
+## This release includes code contributions from
+### Grove For Libraries
+- Kodi Lein (KL)


### PR DESCRIPTION
When getting hold response for hoopla flex users, do not reset all counters if we receive an empty response

Update release notes