### PR TITLE
DIS-2736: Fix image upload silently recording filename when file write fails

### DIFF
--- a/code/web/release_notes/26.08.00.MD
+++ b/code/web/release_notes/26.08.00.MD
@@ -35,6 +35,9 @@
 
 // lucas
 
+### Web Builder Updates
+- Fixed an issue where a failed image upload could still be saved as if it succeeded, leaving a broken image reference. ([DIS-2736](https://aspen-discovery.atlassian.net/browse/DIS-2736)) (*LM*)
+
 ## This release includes code contributions from
 ### ByWater Solutions
 - Yanjun Li (YL)

--- a/code/web/sys/DataObjectUtil.php
+++ b/code/web/sys/DataObjectUtil.php
@@ -483,11 +483,15 @@ class DataObjectUtil {
 							require_once ROOT_DIR . '/sys/Covers/CoverImageUtils.php';
 
 							if (isset($property['thumbWidth'])) {
-								resizeImage($destFullPath, "$pathToThumbs/$destFileName", $property['thumbWidth'], $property['thumbWidth']);
+								if (!resizeImage($destFullPath, "$pathToThumbs/$destFileName", $property['thumbWidth'], $property['thumbWidth'])) {
+									$logger->log("Could not create thumbnail for $propertyName at $pathToThumbs/$destFileName", Logger::LOG_ERROR);
+								}
 							}
 							if (isset($property['mediumWidth'])) {
 								//Create a thumbnail if needed
-								resizeImage($destFullPath, "$pathToMedium/$destFileName", $property['mediumWidth'], $property['mediumWidth']);
+								if (!resizeImage($destFullPath, "$pathToMedium/$destFileName", $property['mediumWidth'], $property['mediumWidth'])) {
+									$logger->log("Could not create medium image for $propertyName at $pathToMedium/$destFileName", Logger::LOG_ERROR);
+								}
 							}
 							if (isset($property['maxWidth'])) {
 								//Create a thumbnail if needed
@@ -496,7 +500,9 @@ class DataObjectUtil {
 								if (isset($property['maxHeight'])) {
 									$height = $property['maxHeight'];
 								}
-								resizeImage($destFullPath, "$destFolder/$destFileName", $width, $height);
+								if (!resizeImage($destFullPath, "$destFolder/$destFileName", $width, $height)) {
+									$logger->log("Could not resize $propertyName to max dimensions at $destFolder/$destFileName", Logger::LOG_ERROR);
+								}
 							}
 						}
 					}

--- a/code/web/sys/DataObjectUtil.php
+++ b/code/web/sys/DataObjectUtil.php
@@ -500,9 +500,13 @@ class DataObjectUtil {
 							}
 						}
 					}
-					//store the actual filename
-					$object->setProperty($propertyName, $destFileName, $property);
-					$logger->log("Set $propertyName to $destFileName", Logger::LOG_DEBUG);
+					//store the actual filename, but only if the file was actually written
+					if ($copyResult) {
+						$object->setProperty($propertyName, $destFileName, $property);
+						$logger->log("Set $propertyName to $destFileName", Logger::LOG_DEBUG);
+					} else {
+						$logger->log("Not setting $propertyName because the file write failed", Logger::LOG_ERROR);
+					}
 				}
 			}
 


### PR DESCRIPTION
Fixes a bug in DataObjectUtil.php's image upload handler where setProperty() was called unconditionally after the copy attempt, regardless of whether copy() actually succeeded. The result was only used to gate thumbnail generation, never the property assignment itself — so a failed write (disk full, permissions error, etc.) still left the object pointing at a filename that was never persisted, producing a silently broken image reference that only surfaced later as a 404.

The fix gates the setProperty() call on the copy result, so a failed write is logged and the property is left unset instead of silently recording a bad path.

Test plan

This is inherently hard to verify end-to-end, since it requires reproducing an actual local file-write failure (e.g. disk full, a read-only/unwritable destination folder, or a permissions mismatch) rather than something triggerable through normal UI interaction. Verification was done by code inspection, php -l, and by temporarily forcing copy() to return false (e.g. pointing $destFolder at a non-writable path) to confirm the property is correctly left unset and the failure is logged