### PR TITLE
DIS-2645: Available hold block override for scan and go

### DIFF
--- a/code/web/Drivers/SirsiDynixROA.php
+++ b/code/web/Drivers/SirsiDynixROA.php
@@ -4049,6 +4049,19 @@ class SirsiDynixROA extends AbstractIlsDriver {
 							'isPublicFacing' => true,
 						]);
 					}
+				//unblock user from checking out when they have another hold ready for pickup
+				if ($currentItemLocation != 'HOLDS' && !empty($patronHoldsAndCheckouts->fields->holdRecordList)) {
+					//Get holds for the patron
+					if ($patronHoldsAndCheckouts && isset($patronHoldsAndCheckouts->fields)) {
+						foreach ($patronHoldsAndCheckouts->fields->holdRecordList as $hold) {
+							if (isset($hold->fields->status)) {
+								$holdStatus = strtolower($hold->fields->status);
+								if ($holdStatus == "being_held") {
+									$addOverrideCode = true;
+								}
+							}
+						}
+					}
 				}
 			}
 		}

--- a/code/web/release_notes/26.08.00.MD
+++ b/code/web/release_notes/26.08.00.MD
@@ -3,6 +3,10 @@
 
 // kirstien
 
+// kodi
+### Self Check Updates
+- For Symphony, add an override if the user is blocked from checking out an item because they have another hold ready ([DIS-2645](https://aspen-discovery.atlassian.net/browse/DIS-2645)) (*KL*)
+
 // mark j
 
 // stephen


### PR DESCRIPTION
Add override for patrons who are blocked because they have another item on hold

Update release notes