### PR TITLE
DIS-2644: Item in transit cannot check out in scan and go

### DIFF
--- a/code/web/Drivers/SirsiDynixROA.php
+++ b/code/web/Drivers/SirsiDynixROA.php
@@ -4049,6 +4049,16 @@ class SirsiDynixROA extends AbstractIlsDriver {
 							'isPublicFacing' => true,
 						]);
 					}
+				} elseif ($currentItemLocation == "INTRANSIT") {
+					$params = [
+						'itemBarcode' => $barcode
+					];
+					$additionalHeaders = [
+						'SD-Preferred-Role: STAFF',
+						'SD-Prompt-Return: CIRC_TRANSIT_OVRCD/Y;CKOBLOCKS/' . $this->accountProfile->overrideCode
+					];
+
+					$this->getWebServiceResponse('unTransit', $webServiceURL . '/circulation/transit/untransit', $params, $sessionToken, 'POST', $additionalHeaders);
 				}
 			}
 		}

--- a/code/web/release_notes/26.08.00.MD
+++ b/code/web/release_notes/26.08.00.MD
@@ -3,6 +3,10 @@
 
 // kirstien
 
+//kodi
+### Self Check Updates
+- For Symphony, fix issue where items marked as in transit could not be checked out ([DIS-2644](https://aspen-discovery.atlassian.net/browse/DIS-2644)) (*KL*)
+
 // mark j
 
 // stephen


### PR DESCRIPTION
Use /circulation/transit/untransit endpoint for symphony to allow users to self check items marked as in transit

Update release notes