### PR TITLE
DIS-2656: Duplicate Series can be created with v1 series implementation

### DIFF
--- a/code/java_shared_libraries/src/com/turning_leaf_technologies/strings/AspenStringUtils.java
+++ b/code/java_shared_libraries/src/com/turning_leaf_technologies/strings/AspenStringUtils.java
@@ -14,6 +14,7 @@ public class AspenStringUtils {
 	private static final Pattern cleaner2Pattern = Pattern.compile(".*\\p{L}\\p{L}\\.$");
 	private static final Pattern cleaner3Pattern = Pattern.compile(".*\\w\\p{InCombiningDiacriticalMarks}?\\w\\p{InCombiningDiacriticalMarks}?\\.$");
 	private static final Pattern cleaner4Pattern = Pattern.compile(".*\\p{Punct}\\.$");
+	private static final Pattern VOLUME_NUMBER_PATTERN = Pattern.compile("(\\d+(?:\\.\\d+)?)");
 
 	/**
 	 * Removes trailing characters (space, comma, slash, semicolon, colon),
@@ -99,6 +100,25 @@ public class AspenStringUtils {
 		} else {
 			return "";
 		}
+	}
+
+	/**
+	 * Reduce a volume string down to just its numeric value so that
+	 * "1", "bk. 1", "bk 01", and "vol. 1" all normalize to the same key.
+	 */
+	public static String normalizeVolume(String volume) {
+		if (volume == null || volume.isEmpty()) {
+			return "";
+		}
+		Matcher matcher = VOLUME_NUMBER_PATTERN.matcher(volume);
+		if (matcher.find()) {
+			String number = matcher.group(1);
+			// strip leading zeros ("01" -> "1") without breaking "0"
+			number = number.replaceFirst("^0+(?=\\d)", "");
+			return number;
+		}
+		// No digits at all (e.g. "special edition") — fall back to trimmed/lowercased text
+		return volume.trim().toLowerCase();
 	}
 
 	public static char convertStringToChar(String subfieldString) {

--- a/code/reindexer/src/org/aspen_discovery/reindexer/SeriesInfo.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/SeriesInfo.java
@@ -3,6 +3,7 @@ package org.aspen_discovery.reindexer;
 import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import com.turning_leaf_technologies.strings.AspenStringUtils;
 import java.text.Normalizer;
 import java.util.HashSet;
 
@@ -154,6 +155,8 @@ public class SeriesInfo {
 	 * If the volume is blank, it will be combined with a non-blank volume if one exists.
 	 * If the volume is not blank it will override the blank volume.
 	 * We can get multiple volumes for the same record within a series
+	 * Volumes are deduped by their numeric value, so "1", "bk. 1", and "vol. 1"
+	 * are all treated as the same volume even though the text differs.
 	 */
 	public void addVolume(String volume) {
 		if (volume.isEmpty()) {
@@ -162,7 +165,8 @@ public class SeriesInfo {
 				seriesVolumes.add(volume);
 			}
 		}else{
-			seriesVolumes.add(volume);
+			String normalizedVolume = AspenStringUtils.normalizeVolume(volume);
+			seriesVolumes.add(normalizedVolume);
 			//Remove the blank entry if we have one
 			seriesVolumes.remove("");
 		}

--- a/code/web/release_notes/26.08.00.MD
+++ b/code/web/release_notes/26.08.00.MD
@@ -3,6 +3,10 @@
 
 // kirstien
 
+// kodi
+### Series Updates
+- Update volumes for series to use normalized volume values for matching ([DIS-2656](https://aspen-discovery.atlassian.net/browse/DIS-2656)) (*KL*)
+
 // mark j
 
 // stephen


### PR DESCRIPTION
Update volumes for series info to use normalized volume values (prevents things like 1 and bk. 1 from both being added to a series though they are on the same record)

Update release notes