### PR TITLE
DIS-2658: Eliminate humor as fiction/nonfiction determination of literary form

### DIFF
--- a/code/reindexer/src/org/aspen_discovery/reindexer/MarcRecordProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/MarcRecordProcessor.java
@@ -900,6 +900,7 @@ abstract class MarcRecordProcessor {
 			}else if (subjectForm.equalsIgnoreCase("Poetry")
 					|| subjectForm.equalsIgnoreCase("Juvenile Poetry")
 					){
+				addToMapWithCount(literaryFormsWithCount, "Fiction");
 				addToMapWithCount(literaryFormsWithCount, "Non Fiction");
 				addToMapWithCount(literaryFormsFull, "Poetry");
 				if (groupedWork != null && groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Literary Form is non fiction/poetry based on 'poetry' in 650v, 651v", 2);}
@@ -981,6 +982,7 @@ abstract class MarcRecordProcessor {
 			subjectForm = AspenStringUtils.trimTrailingPunctuation(subjectForm).toLowerCase();
 			if (subjectForm.startsWith("instructional film")
 					|| subjectForm.startsWith("educational film")
+					|| subjectForm.startsWith("nonfiction film")
 					) {
 				addToMapWithCount(literaryFormsWithCount, "Non Fiction");
 				addToMapWithCount(literaryFormsFull, "Non Fiction");

--- a/code/reindexer/src/org/aspen_discovery/reindexer/MarcRecordProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/MarcRecordProcessor.java
@@ -911,10 +911,8 @@ abstract class MarcRecordProcessor {
 					|| subjectForm.equalsIgnoreCase("Humor, Juvenile")
 					|| subjectForm.equalsIgnoreCase("Humour")
 					){
-				addToMapWithCount(literaryFormsWithCount, "Fiction");
-				addToMapWithCount(literaryFormsFull, "Fiction");
 				addToMapWithCount(literaryFormsFull, "Humor, Satires, etc.");
-				if (groupedWork != null && groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Literary Form is fiction/humor based on 650v, 651v", 2);}
+				if (groupedWork != null && groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Literary Form is humor based on 650v, 651v", 2);}
 			}else if (subjectForm.equalsIgnoreCase("Correspondence")
 					){
 				addToMapWithCount(literaryFormsWithCount, "Non Fiction");

--- a/code/web/release_notes/26.08.00.MD
+++ b/code/web/release_notes/26.08.00.MD
@@ -3,6 +3,10 @@
 
 // kirstien
 
+// kodi
+### Indexing Updates
+- When determining literary form based on 650v and 651v, do not classify humor as fiction ([DIS-2658](https://aspen-discovery.atlassian.net/browse/DIS-2658)) (*KL*)
+
 // mark j
 
 // stephen


### PR DESCRIPTION
Remove literary form assignment of "Fiction" when determining literary form based on 650v and 651v

Update release notes