### PR TITLE
DIS-2250 OAuth SSO fixes

### DIFF
--- a/code/web/release_notes/26.08.00.MD
+++ b/code/web/release_notes/26.08.00.MD
@@ -1,5 +1,11 @@
 ## Aspen Discovery Updates
 // mark n
+### SSO Updates
+- Update SSO Authentication using OAuth. ([DIS-2250](https://aspen-discovery.atlassian.net/browse/DIS-2250)) (*MDN*)
+  - Fix loading Access Token and Resource Owner information for OAuth.  
+  - Updates so account profiles for SSO no longer must be named admin_sso (to accommodate multiple SSO settings).
+  - Increase username column length to allow using email as SSO username. 
+  - Correct setting up administrators using SSO username to handle account profiles not named admin_sso.
 
 // kirstien
 

--- a/code/web/release_notes/26.08.00.MD
+++ b/code/web/release_notes/26.08.00.MD
@@ -6,6 +6,7 @@
   - Updates so account profiles for SSO no longer must be named admin_sso (to accommodate multiple SSO settings).
   - Increase username column length to allow using email as SSO username. 
   - Correct setting up administrators using SSO username to handle account profiles not named admin_sso.
+  - Properly set patron type when authenticating staff.
 
 // kirstien
 

--- a/code/web/services/Admin/Administrators.php
+++ b/code/web/services/Admin/Administrators.php
@@ -107,27 +107,32 @@ class Admin_Administrators extends ObjectEditor {
 					if($numResults == 0) {
 						$newAdmin = UserAccount::findNewUser('', $login);
 						if ($newAdmin === false) {
-							// Try searching by username field for admin_sso users.
-							$newAdmin = new User();
-							$newAdmin->username = $login;
-							$newAdmin->source = 'admin_sso';
-							$newAdmin->find();
-							$numResults = $newAdmin->getNumResults();
-							if($numResults == 0) {
-								$newAdmin = false;
-								$errors[$login] = translate([
-									'text' => 'Could not find a user with that barcode or username.',
-									'isAdminFacing' => true,
-								]);
-							} elseif ($numResults == 1) {
-								$newAdmin->fetch();
-							} elseif ($numResults > 1) {
-								$newAdmin = false;
-								$errors[$login] = translate([
-									'text' => 'Found multiple (%1%) users with that username. (The database needs to be cleaned up.)',
-									'1' => $numResults,
-									'isAdminFacing' => true,
-								]);
+							// Check to see if this is an SSO account. If so we will check all Account profiles that authenticate with SSO
+							$ssoAccountProfiles = new AccountProfile();
+							$ssoAccountProfiles->authenticationMethod = 'sso';
+							$ssoAccountProfiles->find();
+							while ($ssoAccountProfiles->fetch()) {
+								$newAdmin = new User();
+								$newAdmin->username = $login;
+								$newAdmin->source = $ssoAccountProfiles->name;
+								$newAdmin->find();
+								$numResults = $newAdmin->getNumResults();
+								if($numResults == 0) {
+									$newAdmin = false;
+									$errors[$login] = translate([
+										'text' => 'Could not find a user with that barcode or username.',
+										'isAdminFacing' => true,
+									]);
+								} elseif ($numResults == 1) {
+									$newAdmin->fetch();
+								} elseif ($numResults > 1) {
+									$newAdmin = false;
+									$errors[$login] = translate([
+										'text' => 'Found multiple (%1%) users with that username. (The database needs to be cleaned up.)',
+										'1' => $numResults,
+										'isAdminFacing' => true,
+									]);
+								}
 							}
 						}
 					} elseif ($numResults == 1) {

--- a/code/web/sys/Authentication/OAuthAuthentication.php
+++ b/code/web/sys/Authentication/OAuthAuthentication.php
@@ -18,6 +18,7 @@ class OAuthAuthentication extends Action {
 	protected $staffPType;
 	protected $staffPTypeAttr;
 	protected $staffPTypeAttrValue;
+	protected $accountProfileName = 'ils';
 	/** @var CurlWrapper */
 	private $curlWrapper;
 
@@ -54,8 +55,9 @@ class OAuthAuthentication extends Action {
 
 			require_once ROOT_DIR . '/sys/Account/AccountProfile.php';
 			$accountProfile = new AccountProfile();
-			$accountProfile->id = $library->accountProfileId;
+			$accountProfile->ssoSettingId = $ssoSettings->id;
 			if($accountProfile->find(true)) {
+				$this->accountProfileName = $accountProfile->name;
 				if($accountProfile->authenticationMethod === 'sso') {
 					$this->ssoAuthOnly = true;
 				} else {
@@ -146,18 +148,20 @@ class OAuthAuthentication extends Action {
 	}
 
 	public function getAccessToken($accessTokenUrl, array $options = [], $returnToken = false) {
-		$queryString = $this->buildQueryString($options);
-		$url = $this->appendQuery($accessTokenUrl, $queryString);
 		$this->initCurlWrapper();
-		$response = $this->curlWrapper->curlPostPage($url, '');
-		$options = json_decode($response, true);
-		if (!empty($options['access_token'])) {
-			$this->accessToken = $options['access_token'];
-			if (!empty($options['refresh_token'])) {
-				$this->refreshToken = $options['refresh_token'];
+		$headers = [
+			'Content-Type: application/x-www-form-urlencoded',
+		];
+		$this->curlWrapper->addCustomHeaders($headers, false);
+		$response = $this->curlWrapper->curlPostPage($accessTokenUrl, $options);
+		$decodedResponse = json_decode($response, true);
+		if (!empty($decodedResponse['access_token'])) {
+			$this->accessToken = $decodedResponse['access_token'];
+			if (!empty($decodedResponse['refresh_token'])) {
+				$this->refreshToken = $decodedResponse['refresh_token'];
 			}
 			if ($returnToken) {
-				return $options['access_token'];
+				return $decodedResponse['access_token'];
 			}
 			return true;
 		}
@@ -190,20 +194,35 @@ class OAuthAuthentication extends Action {
 	}
 
 	private function getResourceOwner($resourceOwnerDetailsUrl): bool {
-		$url = $resourceOwnerDetailsUrl . "?access_token=" . $this->accessToken;
+		global $logger;
 		$this->initCurlWrapper();
+		if ($this->gateway == 'google') {
+			$url = $resourceOwnerDetailsUrl . "?access_token=" . $this->accessToken;
+		}else{
+			$url = $resourceOwnerDetailsUrl;
+			$this->curlWrapper->addCustomHeaders([
+				"Authorization: Bearer " . $this->accessToken,
+			], true);
+		}
 		$response = $this->curlWrapper->curlGetPage($url);
 		$options = json_decode($response, true);
 		if (is_array($options)) {
+			if (IPAddress::showDebuggingInformation()){
+				$logger->log('Resource Owner Information', Logger::LOG_DEBUG);
+				$logger->log($options, Logger::LOG_DEBUG);
+			}
 			$this->resourceOwner = $options;
 			return true;
+		}else{
+			$logger->log('Error getting resource owner, options were not an array', Logger::LOG_ERROR);
 		}
 		return false;
 	}
 
 	private function validateAccount(): bool {
 		global $logger;
-		if($this->ssoAuthOnly === false) {
+		if ($this->ssoAuthOnly === false) {
+
 			$catalogConnection = CatalogFactory::getCatalogConnectionInstance();
 
 			if ($this->getUserId()) {
@@ -232,7 +251,6 @@ class OAuthAuthentication extends Action {
 					$logger->log('Error self registering user ' . print_r($this->getUserId(), true), Logger::LOG_ERROR);
 					return false;
 				}
-				$user = $catalogConnection->findNewUser($this->getUserId(), '');
 			} else {
 				$user->oAuthAccessToken = $this->accessToken;
 				$user->oAuthRefreshToken = $this->refreshToken;
@@ -240,24 +258,23 @@ class OAuthAuthentication extends Action {
 				if($this->updateAccount) {
 					$user->updatePatronInfo(true);
 				}
-				$user = $catalogConnection->findNewUser($this->getUserId(), '');
 			}
-			return $this->login($user);
+			$user = $catalogConnection->findNewUser($this->getUserId(), '');
 		} else {
 			// we only want to authenticate the user via SSO as determined by the account profile
-			$user = UserAccount::findNewAspenUser('user_id', $this->getUserId());
+			$user = UserAccount::findNewAspenUser('username', $this->getUserId(), $this->accountProfileName);
 			if (!$user instanceof User) {
 				$logger->log('No user found in Aspen, creating a new one...', Logger::LOG_ERROR);
 				$tmpUser = $this->createNewAspenUser();
 				if($tmpUser) {
-					$user = UserAccount::findNewAspenUser('user_id', $this->getUserId());
+					$user = UserAccount::findNewAspenUser('username', $this->getUserId(), $this->accountProfileName);
 				} else {
 					$logger->log('Error creating Aspen user ' . print_r($this->getUserId(), true), Logger::LOG_ERROR);
 					return false;
 				}
 			}
-			return $this->login($user);
 		}
+		return $this->login($user);
 	}
 
 	private function getUserId() {
@@ -266,7 +283,7 @@ class OAuthAuthentication extends Action {
 
 	public function searchArray($array, $needle) {
 		$result = false;
-		foreach ($array as $obj) {
+		foreach ($array as $key => $obj) {
 			if (is_array($obj)) {
 				foreach ($obj as $n) {
 					if (array_key_exists($needle, $n)) {
@@ -274,11 +291,9 @@ class OAuthAuthentication extends Action {
 						break;
 					}
 				}
-			} else {
-				if (array_key_exists($needle, $obj)) {
-					$result = $obj[$needle];
-					break;
-				}
+			} else if ($key == $needle) {
+				$result = $obj;
+				break;
 			}
 		}
 		return $result;
@@ -316,7 +331,7 @@ class OAuthAuthentication extends Action {
 		$tmpUser->firstname = $this->getFirstName();
 		$tmpUser->lastname = $this->getLastName() ?? '';
 		$tmpUser->username = $this->getUserId();
-		$tmpUser->unique_ils_id = $this->getUserId();
+		$tmpUser->unique_ils_id = "";
 		$tmpUser->phone = '';
 		$tmpUser->displayName = '';
 		$tmpUser->patronType = '';
@@ -333,6 +348,7 @@ class OAuthAuthentication extends Action {
 		$tmpUser->myLocation1Id = 0;
 		$tmpUser->myLocation2Id = 0;
 		$tmpUser->created = date('Y-m-d');
+		$tmpUser->source = $this->accountProfileName;
 		if($tmpUser->insert()) {
 			return true;
 		}

--- a/code/web/sys/Authentication/OAuthAuthentication.php
+++ b/code/web/sys/Authentication/OAuthAuthentication.php
@@ -15,6 +15,7 @@ class OAuthAuthentication extends Action {
 	protected $resourceOwner;
 	protected $redirectUri;
 	protected $matchpoints;
+	protected $staffOnly; //True if all users in the IdP are staff users
 	protected $staffPType;
 	protected $staffPTypeAttr;
 	protected $staffPTypeAttrValue;
@@ -39,9 +40,9 @@ class OAuthAuthentication extends Action {
 			$this->redirectUri = $ssoSettings->getRedirectUrl();
 			$this->matchpoints = $ssoSettings->getMatchpoints();
 			$this->grantType = $ssoSettings->getAuthenticationGrantType();
+			$this->staffOnly = $ssoSettings->staffOnly;
 			$this->staffPTypeAttr = $ssoSettings->oAuthStaffPTypeAttr ?? null;
 			$this->staffPTypeAttrValue = $ssoSettings->oAuthStaffPTypeAttrValue ?? null;
-			$this->updateAccount = $ssoSettings->updateAccount ?? false;
 
 			if($ssoSettings->staffOnly === 1 || $ssoSettings->staffOnly === '1') {
 				$this->staffPType = $ssoSettings->oAuthStaffPType;
@@ -242,7 +243,7 @@ class OAuthAuthentication extends Action {
 				$newUser['cat_username'] = $this->getUserId();
 				$newUser['ils_barcode'] = $this->getUserId();
 				$newUser['category_id'] = null;
-				if ($this->staffPType && $this->isStaffUser()) {
+				if (!empty($this->staffPType) && $this->isStaffUser()) {
 					$newUser['category_id'] = $this->staffPType;
 				}
 				$selfReg = $catalogConnection->selfRegister(true, $newUser);
@@ -316,6 +317,9 @@ class OAuthAuthentication extends Action {
 	}
 
 	private function isStaffUser(): bool {
+		if ($this->staffOnly) {
+			return true;
+		}
 		if($this->staffPTypeAttr && $this->staffPTypeAttrValue) {
 			if($this->getStaffAttribute() === $this->staffPTypeAttrValue) {
 				return true;
@@ -334,7 +338,11 @@ class OAuthAuthentication extends Action {
 		$tmpUser->unique_ils_id = "";
 		$tmpUser->phone = '';
 		$tmpUser->displayName = '';
-		$tmpUser->patronType = '';
+		if ($this->isStaffUser() && !empty($this->staffPType)) {
+			$tmpUser->patronType = $this->staffPType;
+		}else{
+			$this->staffPType = '';
+		}
 		$tmpUser->trackReadingHistory = false;
 
 		$location = new Location();

--- a/code/web/sys/DBMaintenance/version_updates/26.08.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/26.08.00.php
@@ -16,6 +16,14 @@ function getUpdates26_08_00(): array {
 		 ], //name*/
 
 		//mark n
+		'increase_user_username_column' => [
+			'title' => 'Increase username column in user table',
+			'description' => 'Increase username column in user table',
+			'continueOnError' => false,
+			'sql' => [
+				'ALTER TABLE user CHANGE COLUMN username username VARCHAR(255) NOT NULL',
+			]
+		], //name
 
 		//kirstien
 

--- a/code/web/sys/UserAccount.php
+++ b/code/web/sys/UserAccount.php
@@ -682,7 +682,7 @@ class UserAccount {
 			if(!$localAuthOnly) {
 				$tempUser = $authN->authenticate($validatedViaSSO, $accountProfile);
 			} else {
-				$tempUser = UserAccount::findNewAspenUser('username', $_POST['username']);
+				$tempUser = UserAccount::findNewAspenUser('username', $_POST['username'], $accountProfile->name);
 			}
 
 			// If we authenticated, store the user in the session:
@@ -1141,12 +1141,16 @@ class UserAccount {
 	 *
 	 * @param string $key The column in the User table to search
 	 * @param string $value Value needed to match the given key to find the user
+	 * @param ?string $source the source of the user (from account profile name)
 	 *
 	 * @return false|User
 	 */
-	public static function findNewAspenUser(string $key, string $value) {
+	public static function findNewAspenUser(string $key, string $value, ?string $source = null) : User|false {
 		$newUser = new User();
 		$newUser->$key = $value;
+		if ($source != null) {
+			$newUser->source = $source;
+		}
 		if($newUser->find(true)) {
 			return $newUser;
 		}


### PR DESCRIPTION
- increase username column length to accommodate using email as username
- properly load account profile based on SSO Settings linked
- When getting access token send information in post body rather than query string
- When loading resource owner information send access token in headers rather than as url parameter
- Update to find users based on username rather than non-existent user_id column
- Update searchArray to properly handle nesting of array
- Properly link users to the correct account profile
- Fix adding administrators based on username field for add administrator