### PR TITLE
DIS-2748: Fix WebBuilder image viewer hardcoding Content-Type to image/png

### DIFF
--- a/code/web/release_notes/26.08.00.MD
+++ b/code/web/release_notes/26.08.00.MD
@@ -101,6 +101,7 @@
 
 ### Web Builder Updates
 - Fixed an issue where a failed image upload could still be saved as if it succeeded, leaving a broken image reference. ([DIS-2736](https://aspen-discovery.atlassian.net/browse/DIS-2736)) (*LM*)
+- Fix Web Builder images being served with an incorrect content type, which could cause GIF and JPEG images to be mislabeled as PNG. ([DIS-2748](https://aspen-discovery.atlassian.net/browse/DIS-2748)) (*LM*)
 
 ## This release includes code contributions from
 ### ByWater Solutions

--- a/code/web/services/WebBuilder/ViewImage.php
+++ b/code/web/services/WebBuilder/ViewImage.php
@@ -42,11 +42,14 @@ class WebBuilder_ViewImage extends Action {
 
 			$size = intval(sprintf("%u", filesize($fullPath)));
 
-			if ($extension == 'svg') {
-				header('Content-Type: image/svg+xml');
-			} else {
-				header('Content-Type: image/png');
-			}
+			$mimeTypesByExtension = [
+				'svg' => 'image/svg+xml',
+				'gif' => 'image/gif',
+				'jpg' => 'image/jpeg',
+				'jpeg' => 'image/jpeg',
+				'png' => 'image/png',
+			];
+			header('Content-Type: ' . ($mimeTypesByExtension[strtolower($extension)] ?? 'application/octet-stream'));
 			header('Content-Transfer-Encoding: binary');
 			header('Content-Length: ' . $size);
 


### PR DESCRIPTION
ViewImage.php (the WebBuilder image-serving endpoint) hardcoded Content-Type: image/png for every non-SVG uploaded image, regardless of the file's actual format. This meant GIF and JPEG images uploaded through Web Builder were served with an incorrect MIME type, which can cause browsers or downstream consumers to mishandle or refuse to render them correctly. The fix derives the Content-Type from the file's extension using a mime-type map (svg, gif, jpg/jpeg, png), falling back to application/octet-stream for unrecognized extensions.

Test Plan:

Before:
- Upload a GIF image via Web Builder (Images section) and view it through WebBuilder_ViewImage (e.g. /WebBuilder/ViewImage?id=<id>).
- Inspect the response headers: Content-Type is "image/png" regardless of the file being a GIF.
- Same result for a JPEG upload: Content-Type incorrectly reports "image/png".
- Only SVG uploads correctly report "image/svg+xml".

After:
- Upload and view a GIF image: Content-Type correctly reports "image/gif".
- Upload and view a JPEG image (.jpg and .jpeg): Content-Type correctly reports "image/jpeg".
- Upload and view a PNG image: Content-Type still correctly reports "image/png".
- Upload and view an SVG image: Content-Type still correctly reports "image/svg+xml" (unchanged behavior).
- Image bytes are unchanged and render correctly in-browser for all formats; no regression in the chunked-download path for large images.