### PR TITLE
DIS-2752: Check TV ratings before movie ratings

### DIFF
--- a/code/reindexer/src/org/aspen_discovery/reindexer/MarcRecordProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/MarcRecordProcessor.java
@@ -663,15 +663,17 @@ abstract class MarcRecordProcessor {
 			return "Not Rated";
 		}
 
+		// Check TV ratings first
+		String tvRating = getRatingFromPatterns(val, tvRatingRegex1, tvRatingRegex2, tvRatingRegex3, tvRatingRegex4);
+		if (tvRating != null) {
+			return normalizeTvRating(tvRating) + " Rated";
+		}
+
 		String mpaaRating = getRatingFromPatterns(val, mpaaRatingRegex1, mpaaRatingRegex2, mpaaRatingRegex3, mpaaRatingRegex4);
 		if (mpaaRating != null) {
 			return mpaaRating + " Rated";
 		}
 
-		String tvRating = getRatingFromPatterns(val, tvRatingRegex1, tvRatingRegex2, tvRatingRegex3, tvRatingRegex4);
-		if (tvRating != null) {
-			return normalizeTvRating(tvRating) + " Rated";
-		}
 		return null;
 	}
 

--- a/code/web/release_notes/26.08.00.MD
+++ b/code/web/release_notes/26.08.00.MD
@@ -113,6 +113,9 @@
 ### Series Updates
 - Fix an issue where grouped work series names could display with lowercase when series data came from MARC records. ([DIS-2689](https://aspen-discovery.atlassian.net/browse/DIS-2689)) (*YL*)
 
+### Other Updates
+- Update MARC 521$a content rating parsing so TV ratings are checked before movie ratings, preventing values like TV-PG from displaying as PR Rated. ([DIS-2752](https://aspen-discovery.atlassian.net/browse/DIS-2752)) (*YL*)
+
 // lucas
 ### Docker Updates
 - Replace `TIMEZONE` env var with `TZ` and set timezone via PHP-FPM pool config instead of `timedatectl`, which requires systemd and fails silently in containers. ([DIS-2296](https://aspen-discovery.atlassian.net/browse/DIS-2296)) (*LM*)


### PR DESCRIPTION
MARC 521 $a TV ratings like TV-PG and TV-G can be displayed as PG and G, which are MPAA ratings.

Update content rating parsing to check TV rating patterns before MPAA rating patterns so ratings with “TV” are treated as TV ratings.

To Test:
1. Go to Grouped Work Facets and enable "Show on Results Page" for Content Ratings.
2. Create record A with MARC 521 $a "TV-PG" and record B with MARC 521 $a "TVPG".
3. Index the records and search for them.
4. Confirm record A shows "PG Rated" and record B shows "TV-PG Rated".
5. Apply the PR.
6. Reindex the records and search again.
7. Confirm both records show "TV-PG Rated".
