### PR TITLE
DIS-2370: External materials request url length to 512

### DIFF
--- a/code/web/release_notes/26.08.00.MD
+++ b/code/web/release_notes/26.08.00.MD
@@ -88,6 +88,7 @@
 - Continue to check non-ILS accounts (such as administrator users) against the Aspen database when the ILS returns no match, so their password reset and email resend requests are still handled. ([DIS-2375](https://aspen-discovery.atlassian.net/browse/DIS-2375)) (*CZ*)
 
 // jacob
+- Allow External Materials Request URLs up to 512 characters. ([DIS-2370](https://aspen-discovery.atlassian.net/browse/DIS-2370)) (*JOM*)
 
 // pedro
 

--- a/code/web/sys/DBMaintenance/version_updates/26.08.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/26.08.00.php
@@ -134,5 +134,15 @@ function getUpdates26_08_00(): array {
 
 		//other
 
+		//jacob - OpenFifth
+		'external_materials_request_url_length' => [
+			'title' => 'Increase External Materials Request URL length',
+			'description' => 'Allow External Materials Request URLs longer than 255 characters',
+			'continueOnError' => false,
+			'sql' => [
+				'ALTER TABLE library CHANGE COLUMN externalMaterialsRequestUrl externalMaterialsRequestUrl VARCHAR(512)',
+			]
+		], //external_materials_request_url_length
+
 	];
 }

--- a/code/web/sys/LibraryLocation/Library.php
+++ b/code/web/sys/LibraryLocation/Library.php
@@ -4080,6 +4080,7 @@ class Library extends DataObject {
 						'type' => 'text',
 						'label' => 'External Materials Request URL',
 						'description' => 'A link to an external Materials Request System to be used instead of the built in Aspen Discovery system',
+						'maxLength' => 512,
 						'hideInList' => true,
 					],
 					'maxRequestsPerYear' => [


### PR DESCRIPTION
This is a trivial fix as we were having issues with some urls being longer than 256 chars
To test:
apply patch and run db update,
check column is of type VARCHAR(512)