### PR TITLE
DIS-2666: Headers should be case insensitive

### DIFF
--- a/code/web/release_notes/26.08.00.MD
+++ b/code/web/release_notes/26.08.00.MD
@@ -88,6 +88,7 @@
 - Continue to check non-ILS accounts (such as administrator users) against the Aspen database when the ILS returns no match, so their password reset and email resend requests are still handled. ([DIS-2375](https://aspen-discovery.atlassian.net/browse/DIS-2375)) (*CZ*)
 
 // jacob
+- Check the Expo-Signature header case-insensitively when validating Expo EAS Build and Submit webhook requests. ([DIS-2666](https://aspen-discovery.atlassian.net/browse/DIS-2666)) (*JOM*)
 
 // pedro
 

--- a/code/web/services/webhooks/ExpoEASBuild.php
+++ b/code/web/services/webhooks/ExpoEASBuild.php
@@ -110,7 +110,7 @@ class webhooks_ExpoEASBuild extends Action {
 
 		if($expoEASBuildWebhook && $hash) {
 			foreach (getallheaders() as $name => $value) {
-				if($name == 'Expo-Signature' || $name == 'expo-signature') {
+				if(strcasecmp($name, 'Expo-Signature') === 0) {
 					$logger->log($value, Logger::LOG_ERROR);
 					if(hash_equals($hash, $value)) {
 						$logger->log('Keys match. Request validated.', Logger::LOG_ERROR);

--- a/code/web/services/webhooks/ExpoEASSubmit.php
+++ b/code/web/services/webhooks/ExpoEASSubmit.php
@@ -74,7 +74,7 @@ class webhooks_ExpoEASSubmit extends Action {
 
 		if ($expoEASSubmitWebhook && $hash) {
 			foreach (getallheaders() as $name => $value) {
-				if ($name == 'Expo-Signature' || $name == 'expo-signature') {
+				if (strcasecmp($name, 'Expo-Signature') === 0) {
 					$logger->log($value, Logger::LOG_ERROR);
 					if (hash_equals($hash, $value)) {
 						$logger->log('Keys match. Request validated.', Logger::LOG_ERROR);


### PR DESCRIPTION
I believe these were the only ones that weren’t resolved by DIS-2214’s follow up work for endpoints.

To Test:

Check the 2 webhooks that have been changed work with any case combination.

