### PR TITLE
DIS-2753: Run fewer cronjobs as root

### DIFF
--- a/code/web/release_notes/26.09.00.MD
+++ b/code/web/release_notes/26.09.00.MD
@@ -69,6 +69,7 @@
 #### Administration
 #### Aspen API
 #### Aspen Cron
+- Run fewer cronjobs as root ([DIS-2753](https://aspen-discovery.atlassian.net/browse/DIS-2753)) (*OR*)
 #### Aspen LiDA
 #### Automated Testing
 #### Boundless

--- a/docker/files/cron/crontab
+++ b/docker/files/cron/crontab
@@ -46,12 +46,12 @@
 */5 * * * * php /usr/local/aspen-discovery/code/web/cron/runScheduledUpdate.php {sitename} >/proc/1/fd/1 2>/proc/1/fd/2
 
 #   Update Translations from Community 
-15 1 * * *  php /usr/local/aspen-discovery/code/web/cron/updateCommunityTranslations.php {sitename} >/proc/1/fd/1 2>/proc/1/fd/2
+15 1 * * *    sudo -u www-data    php /usr/local/aspen-discovery/code/web/cron/updateCommunityTranslations.php {sitename} >/proc/1/fd/1 2>/proc/1/fd/2
 
 #   Run Clam AV Scans 
 00 3 * * *  truncate -s0 /var/log/aspen-discovery/clam_av.log; /bin/clamscan --recursive=yes --quiet -i --exclude-dir=/var/lib/mysql --exclude-dir=/sys --exclude-dir=/data/aspen-discovery/{sitename}/solr7/ --exclude-dir=/var/log/aspen-discovery/{sitename} --exclude-dir=/data/aspen-discovery/{sitename}/covers/small --exclude-dir=/data/aspen-discovery/{sitename}/covers/medium --exclude-dir=/data/aspen-discovery/{sitename}/covers/large --log=/var/log/aspen-discovery/clam_av.log
 
 #   Generate Materials Request Hold Candidates 
-0 9 * * *   php /usr/local/aspen-discovery/code/web/cron/generateMaterialRequestHoldCandidates.php template.linux >/proc/1/fd/1 2>/proc/1/fd/2
+0 9 * * *    sudo -u www-data    php /usr/local/aspen-discovery/code/web/cron/generateMaterialRequestHoldCandidates.php template.linux >/proc/1/fd/1 2>/proc/1/fd/2
 
 ## Cron needs a new line at the EOF to work properly

--- a/install/updateCron_26.09.00.php
+++ b/install/updateCron_26.09.00.php
@@ -1,0 +1,111 @@
+<?php
+
+$jobsToChange = [
+	'updateCommunityTranslations.php',
+	'generateMaterialRequestHoldCandidates.php',
+	'dismissYearInReviewMessages.php',
+	'cleanupSharedSessions.php',
+	'talpaWorksCron.php',
+	'talpaRecalculationCron.php',
+	'sendCampaignEmails.php',
+	'sendCampaignEndingEmails.php',
+	'loadInitialReadingHistory.php',
+	'fetchILSMessages.php',
+	'sendILSMessages.php',
+	'purgeSoftDeleted.php',
+	'updateCommunityEngagementMilestones.php',
+	'purgeUserAppRequestLogs.php'
+];
+
+# Match a possible comment delimiter and indent as well as the {5} timing
+# sections of a cron line in a group to retain them, followed by "root" which we
+# replace with "aspen".
+$pattern = '/^((?:#\\s*)?(?:\\S+\\s+){5})root(\\s)/';
+$replacement = '\\1aspen\\2';
+
+function validateCron($crontab) {
+	$proc = proc_open(
+		'crontab -n -',
+		[
+			0 => ['pipe', 'r'],
+			1 => ['pipe', 'w'],
+			2 => ['pipe', 'w'],
+		],
+		$pipes
+	);
+
+	if(!$proc) {
+		// Error creating process, assume the crontab is valid
+		return true;
+	}
+
+	fwrite($pipes[0], $crontab);
+	fclose($pipes[0]);
+
+	$stderr = stream_get_contents($pipes[2]);
+
+	# 0 return code on success
+	if(proc_close($proc) == 0) {
+		return true;
+	}
+
+	echo $stderr;
+
+	return false;
+}
+
+if (count($_SERVER['argv']) > 1) {
+	$serverName = $_SERVER['argv'][1];
+
+	// Check to see if the update already exists properly.
+	$fhnd = fopen("/usr/local/aspen-discovery/sites/$serverName/conf/crontab_settings.txt", 'r');
+
+	if ($fhnd) {
+		$lines = [];
+		$changed = false;
+
+		// Go through each line of the cron settings file
+		while (($line = fgets($fhnd)) !== false) {
+			// Detect if this is a line we should update
+			$matched = false;
+			foreach($jobsToChange as $needle) {
+				if(strpos($line, $needle) > 0) {
+					$matched = true;
+					break;
+				}
+			}
+
+			if($matched) {
+				$changed = true;
+				$original_line = $line;
+				$line = preg_replace($pattern, $replacement, $line);
+
+				$original_prefix = '# Before DIS-2753 update: ';
+				if($original_line != $line && !str_starts_with($original_line, $original_prefix)) {
+					// Keep original line in a comment for reference
+					$lines[] = $original_prefix . $original_line;
+				}
+
+			}
+			$lines[] = $line;
+		}
+
+		fclose($fhnd);
+		// Write the updated content back into the crontab settings file
+		if ($changed) {
+			$newContent = implode('', $lines);
+
+			if(validateCron($newContent)) {
+				file_put_contents("/usr/local/aspen-discovery/sites/$serverName/conf/crontab_settings.txt", $newContent);
+			} else {
+				echo "Resulting crontab was invalid, not overwriting\n";
+			}
+		}
+	} else {
+		echo("- Could not find cron settings file\n");
+	}
+
+} else {
+	echo 'Must provide server name as the first argument';
+	exit();
+}

--- a/sites/template.linux/conf/crontab_settings.txt
+++ b/sites/template.linux/conf/crontab_settings.txt
@@ -94,7 +94,7 @@
 #########################
 # Update Translations from Community #
 #########################
-15 1 * * * root php /usr/local/aspen-discovery/code/web/cron/updateCommunityTranslations.php {sitename}
+15 1 * * * aspen php /usr/local/aspen-discovery/code/web/cron/updateCommunityTranslations.php {sitename}
 
 ######################################
 # Run Clam AV Scans                  #
@@ -104,63 +104,63 @@
 ##############################################
 # Generate Materials Request Hold Candidates #
 ##############################################
-0 9 * * * root php /usr/local/aspen-discovery/code/web/cron/generateMaterialRequestHoldCandidates.php {sitename}
+0 9 * * * aspen php /usr/local/aspen-discovery/code/web/cron/generateMaterialRequestHoldCandidates.php {sitename}
 
 #######################################
 # Dismiss old Year in Review messages #
 #######################################
-0 3 * * * root php /usr/local/aspen-discovery/code/web/cron/dismissYearInReviewMessages.php {sitename}
+0 3 * * * aspen php /usr/local/aspen-discovery/code/web/cron/dismissYearInReviewMessages.php {sitename}
 
 ###########################
 # Cleanup Shared Sessions #
 ###########################
-15 * * * * root php /usr/local/aspen-discovery/code/web/cron/cleanupSharedSessions.php {sitename}
+15 * * * * aspen php /usr/local/aspen-discovery/code/web/cron/cleanupSharedSessions.php {sitename}
 
 ####################################
 # Update grouped works for TalpaAI #
 ####################################
-0 1 * * * root php /usr/local/aspen-discovery/code/web/cron/talpaWorksCron.php {sitename}
+0 1 * * * aspen php /usr/local/aspen-discovery/code/web/cron/talpaWorksCron.php {sitename}
 
 ###################################################
 # Recalculate grouped works for TalpaAI (monthly) #
 ###################################################
-0 2 1 * * root php /usr/local/aspen-discovery/code/web/cron/talpaRecalculationCron.php {sitename}
+0 2 1 * * aspen php /usr/local/aspen-discovery/code/web/cron/talpaRecalculationCron.php {sitename}
 
 ########################
 # Send Campaign Emails #
 ########################
-0 6 * * * root php /usr/local/aspen-discovery/code/web/cron/sendCampaignEmails.php {sitename}
-0 6 * * * root php /usr/local/aspen-discovery/code/web/cron/sendCampaignEndingEmails.php {sitename}
+0 6 * * * aspen php /usr/local/aspen-discovery/code/web/cron/sendCampaignEmails.php {sitename}
+0 6 * * * aspen php /usr/local/aspen-discovery/code/web/cron/sendCampaignEndingEmails.php {sitename}
 
 ##########################################
 # Load Initial Reading History for Users #
 ##########################################
-*/5 * * * * root php /usr/local/aspen-discovery/code/web/cron/loadInitialReadingHistory.php {sitename}
+*/5 * * * * aspen php /usr/local/aspen-discovery/code/web/cron/loadInitialReadingHistory.php {sitename}
 
 ######################
 # Fetch ILS Messages #
 ######################
-*/40 8-19 * * * root php /usr/local/aspen-discovery/code/web/cron/fetchILSMessages.php {sitename}
+*/40 8-19 * * * aspen php /usr/local/aspen-discovery/code/web/cron/fetchILSMessages.php {sitename}
 
 ######################
 # Send ILS Messages  #
 ######################
-*/59 8-19 * * * root php /usr/local/aspen-discovery/code/web/cron/sendILSMessages.php {sitename}
+*/59 8-19 * * * aspen php /usr/local/aspen-discovery/code/web/cron/sendILSMessages.php {sitename}
 
 #######################################
 # Purge Soft-Deleted Database Objects #
 #######################################
-59 23 * * * root php /usr/local/aspen-discovery/code/web/cron/purgeSoftDeleted.php {sitename}
+59 23 * * * aspen php /usr/local/aspen-discovery/code/web/cron/purgeSoftDeleted.php {sitename}
 
 #######################################################
 # Update holds and checkouts for Community Engagement #
 #######################################################
-59 23 * * * root php /usr/local/aspen-discovery/code/web/cron/updateCommunityEngagementMilestones.php {sitename}
+59 23 * * * aspen php /usr/local/aspen-discovery/code/web/cron/updateCommunityEngagementMilestones.php {sitename}
 
 #######################################
 # Purge User App Request Logs #
 #######################################
-0 */12 * * * root php /usr/local/aspen-discovery/code/web/cron/purgeUserAppRequestLogs.php {sitename}
+0 */12 * * * aspen php /usr/local/aspen-discovery/code/web/cron/purgeUserAppRequestLogs.php {sitename}
 
 ##################################################
 # Update Expired Registration Invites for Events #

--- a/sites/template.mac/conf/crontab_settings.txt
+++ b/sites/template.mac/conf/crontab_settings.txt
@@ -92,43 +92,43 @@
 #########################
 # Update Translations from Community #
 #########################
-15 1 * * * root php /usr/local/aspen-discovery/code/web/cron/updateCommunityTranslations.php {sitename}
+15 1 * * * aspen php /usr/local/aspen-discovery/code/web/cron/updateCommunityTranslations.php {sitename}
 
 ##############################################
 # Generate Materials Request Hold Candidates #
 ##############################################
-0 9 * * * root php /usr/local/aspen-discovery/code/web/cron/generateMaterialRequestHoldCandidates.php template.linux
+0 9 * * * aspen php /usr/local/aspen-discovery/code/web/cron/generateMaterialRequestHoldCandidates.php template.linux
 
 #######################################
 # Dismiss old Year in Review messages #
 #######################################
-0 3 * * * root php /usr/local/aspen-discovery/code/web/cron/dismissYearInReviewMessages.php {sitename}
+0 3 * * * aspen php /usr/local/aspen-discovery/code/web/cron/dismissYearInReviewMessages.php {sitename}
 
 ###########################
 # Cleanup Shared Sessions #
 ###########################
-15 * * * * root php /usr/local/aspen-discovery/code/web/cron/cleanupSharedSessions.php {sitename}
+15 * * * * aspen php /usr/local/aspen-discovery/code/web/cron/cleanupSharedSessions.php {sitename}
 
 ####################################
 # Update grouped works for TalpaAI #
 ####################################
-0 1 * * * root php /usr/local/aspen-discovery/code/web/cron/talpaWorksCron.php {sitename}
+0 1 * * * aspen php /usr/local/aspen-discovery/code/web/cron/talpaWorksCron.php {sitename}
 
 ##############################################
 # Send Campaign Emails #
 ##############################################
-0 6 * * * root php /usr/local/aspen-discovery/code/web/cron/sendCampaignEmails.php {sitename}
-0 6 * * * root php /usr/local/aspen-discovery/code/web/cron/sendCampaignEndingEmails.php {sitename}
+0 6 * * * aspen php /usr/local/aspen-discovery/code/web/cron/sendCampaignEmails.php {sitename}
+0 6 * * * aspen php /usr/local/aspen-discovery/code/web/cron/sendCampaignEndingEmails.php {sitename}
 
 ##########################################
 # Load Initial Reading History for Users #
 ##########################################
-*/5 * * * * root php /usr/local/aspen-discovery/code/web/cron/loadInitialReadingHistory.php {sitename}
+*/5 * * * * aspen php /usr/local/aspen-discovery/code/web/cron/loadInitialReadingHistory.php {sitename}
 
 #######################
 "# Fetch ILS Messages #
 #######################
-*/40 8-19 * * * root php /usr/local/aspen-discovery/code/web/cron/fetchILSMessages.php {sitename}
+*/40 8-19 * * * aspen php /usr/local/aspen-discovery/code/web/cron/fetchILSMessages.php {sitename}
 
 #######################
 # Send ILS Messages  #
@@ -138,12 +138,12 @@
 #######################################################
 # Update holds and checkouts for Community Engagement #
 #######################################################
-59 23 * * * root php /usr/local/aspen-discovery/code/web/cron/updateCommunityEngagementMilestones.php {sitename}
+59 23 * * * aspen php /usr/local/aspen-discovery/code/web/cron/updateCommunityEngagementMilestones.php {sitename}
 
 #######################################
 # Purge User App Request Logs #
 #######################################
-0 */12 * * * root php /usr/local/aspen-discovery/code/web/cron/purgeUserAppRequestLogs.php {sitename}
+0 */12 * * * aspen php /usr/local/aspen-discovery/code/web/cron/purgeUserAppRequestLogs.php {sitename}
 
 ##################################################
 # Update Expired Registration Invites for Events #


### PR DESCRIPTION
This PR updates several cronjobs to run as the `aspen` user, rather than `root`. I believe that one cronjob was added which required `root`, and then future cronjobs used this as a template.

I've marked this as draft to indicate that this is worthy of more intensive review. I've audited every cronjob I've changed the user of, but I may have missed portions of them that do require `root`. Similarly, I've tested the migration script and tried to make it robust, but there is still a chance it could break existing installations.