### PR TITLE
DIS-2791: Add 'translateParameters' flag across login-related pages 

### DIFF
--- a/code/web/interface/themes/responsive/MyAccount/addAccountLink.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/addAccountLink.tpl
@@ -18,7 +18,7 @@
 			<div class='col-xs-12 col-sm-offset-4 col-sm-8'>
 				<label for="showPwd" class="checkbox">
 					<input type="checkbox" id="showPwd" name="showPwd" onclick="return AspenDiscovery.pwdToText('password')"/>
-					{translate text="Reveal %1%" 1=$passwordLabel isPublicFacing=true}
+					{translate text="Reveal %1%" 1=$passwordLabel translateParameters=true isPublicFacing=true}
 				</label>
 			</div>
 		</div>

--- a/code/web/interface/themes/responsive/MyAccount/ajax-login.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/ajax-login.tpl
@@ -36,17 +36,17 @@
 					<p class="text-muted help-block">
 						<strong>{translate text="Forgot %1%?" 1=$passwordLabel isPublicFacing=true translateParameters=true}</strong>&nbsp;
 						{if $forgotPasswordType == 'emailAspenResetLink'}
-							<a href="/MyAccount/InitiateResetPin">{translate text="Reset My %1%" 1=$passwordLabel isPublicFacing=true}</a>
+							<a href="/MyAccount/InitiateResetPin">{translate text="Reset My %1%" 1=$passwordLabel translateParameters=true isPublicFacing=true}</a>
 						{elseif $forgotPasswordType == 'emailResetLink'}
-							<a href="/MyAccount/EmailResetPin">{translate text="Reset My %1%" 1=$passwordLabel isPublicFacing=true}</a>
+							<a href="/MyAccount/EmailResetPin">{translate text="Reset My %1%" 1=$passwordLabel translateParameters=true isPublicFacing=true}</a>
 						{else}
-							<a href="/MyAccount/EmailPin">{translate text="Email my %1%" 1=$passwordLabel isPublicFacing=true}</a>
+							<a href="/MyAccount/EmailPin">{translate text="Email my %1%" 1=$passwordLabel translateParameters=true isPublicFacing=true}</a>
 						{/if}
 					</p>
 				{/if}
 				{if $enableForgotBarcode}
 					 <p class="text-muted help-block">
-						<strong>{translate text="Forgot %1%?" 1=$usernameLabel isPublicFacing=true}</strong>&nbsp;&nbsp;<a href="/MyAccount/ForgotBarcode">{translate text="Send My %1% by Text" 1=$usernameLabel isPublicFacing=true}</a>
+						<strong>{translate text="Forgot %1%?" 1=$usernameLabel translateParameters=true isPublicFacing=true}</strong>&nbsp;&nbsp;<a href="/MyAccount/ForgotBarcode">{translate text="Send My %1% by Text" 1=$usernameLabel translateParameters=true isPublicFacing=true}</a>
 					 </p>
 				{/if}
 				{if $enableSelfRegistration == 1}
@@ -79,7 +79,7 @@
 			<div class="col-xs-12 col-sm-offset-4 col-sm-8">
 				<label for="showPwd" class="checkbox">
 					<input type="checkbox" id="showPwd" name="showPwd" onclick="return AspenDiscovery.pwdToText('password')">
-					{translate text="Reveal %1%" 1=$passwordLabel isPublicFacing=true}
+					{translate text="Reveal %1%" 1=$passwordLabel translateParameters=true isPublicFacing=true}
 				</label>
 
 				{if empty($isOpac)}

--- a/code/web/interface/themes/responsive/MyAccount/forgotBarcode.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/forgotBarcode.tpl
@@ -17,7 +17,7 @@
 			</div>
 			<div class="form-group">
 				<div class="col-xs-12 col-sm-offset-4 col-sm-8">
-					<input id="emailPinSubmit" name="submit" class="btn btn-primary" type="submit" value="{translate text='Send My %1%' 1=$usernameLabel isPublicFacing=true}">
+					<input id="emailPinSubmit" name="submit" class="btn btn-primary" type="submit" value="{translate text='Send My %1%' 1=$usernameLabel translateParameters=true isPublicFacing=true}">
 				</div>
 			</div>
 		</form>

--- a/code/web/interface/themes/responsive/MyAccount/login-staff.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/login-staff.tpl
@@ -47,13 +47,13 @@
 							{* disable forgot password if sso only since its managed else where *}
 								{if $forgotPasswordType != 'null' && $forgotPasswordType != 'none'}
 									<p class="text-muted help-block">
-										<strong>{translate text="Forgot %1%?" 1=$passwordLabel isPublicFacing=true}</strong>&nbsp;&nbsp;
+										<strong>{translate text="Forgot %1%?" 1=$passwordLabel translateParameters=true isPublicFacing=true}</strong>&nbsp;&nbsp;
 										{if $forgotPasswordType == 'emailAspenResetLink'}
-											<a href="/MyAccount/InitiateResetPin">{translate text="Reset My %1%" 1=$passwordLabel isPublicFacing=true}</a>
+											<a href="/MyAccount/InitiateResetPin">{translate text="Reset My %1%" 1=$passwordLabel translateParameters=true isPublicFacing=true}</a>
 										{elseif $forgotPasswordType == 'emailResetLink'}
-											<a href="/MyAccount/EmailResetPin">{translate text="Reset My %1%" 1=$passwordLabel isPublicFacing=true}</a>
+											<a href="/MyAccount/EmailResetPin">{translate text="Reset My %1%" 1=$passwordLabel translateParameters=true isPublicFacing=true}</a>
 										{else}
-											<a href="/MyAccount/EmailPin">{translate text="Email my %1%" 1=$passwordLabel isPublicFacing=true}</a>
+											<a href="/MyAccount/EmailPin">{translate text="Email my %1%" 1=$passwordLabel translateParameters=true isPublicFacing=true}</a>
 										{/if}
 									</p>
 								{/if}
@@ -61,13 +61,13 @@
 								{if $ssoLoginOptions != 1 && empty($ssoService)}
 									{if $forgotPasswordType != 'null' && $forgotPasswordType != 'none'}
 										<p class="text-muted help-block">
-											<strong>{translate text="Forgot %1%?" 1=$passwordLabel isPublicFacing=true}</strong>&nbsp;&nbsp;
+											<strong>{translate text="Forgot %1%?" 1=$passwordLabel translateParameters=true isPublicFacing=true}</strong>&nbsp;&nbsp;
 											{if $forgotPasswordType == 'emailAspenResetLink'}
-												<a href="/MyAccount/InitiateResetPin">{translate text="Reset My %1%" 1=$passwordLabel isPublicFacing=true}</a>
+												<a href="/MyAccount/InitiateResetPin">{translate text="Reset My %1%" 1=$passwordLabel translateParameters=true isPublicFacing=true}</a>
 											{elseif $forgotPasswordType == 'emailResetLink'}
-												<a href="/MyAccount/EmailResetPin">{translate text="Reset My %1%" 1=$passwordLabel isPublicFacing=true}</a>
+												<a href="/MyAccount/EmailResetPin">{translate text="Reset My %1%" 1=$passwordLabel translateParameters=true isPublicFacing=true}</a>
 											{else}
-												<a href="/MyAccount/EmailPin">{translate text="Email my %1%" 1=$passwordLabel isPublicFacing=true}</a>
+												<a href="/MyAccount/EmailPin">{translate text="Email my %1%" 1=$passwordLabel translateParameters=true isPublicFacing=true}</a>
 											{/if}
 										</p>
 									{/if}
@@ -86,7 +86,7 @@
 						<div class="col-xs-12 col-sm-offset-4 col-sm-8">
 							<label for="showPwd" class="checkbox">
 								<input type="checkbox" id="showPwd" name="showPwd" onclick="return AspenDiscovery.pwdToText('password')">
-								{translate text="Reveal %1%" 1=$passwordLabel isPublicFacing=true}
+								{translate text="Reveal %1%" 1=$passwordLabel translateParameters=true isPublicFacing=true}
 							</label>
 
 							{if !$canLoginSSO}
@@ -112,7 +112,7 @@
 					<div id="loginActions" class="form-group">
 						<div class="col-xs-12 col-sm-offset-4 col-sm-8">
 						{if !empty($ldapLabel) && $canLoginSSO}
-							<input type="submit" name="submit" value="{translate text="Sign in with %1%" 1=$ldapLabel isPublicFacing=true}" id="loginFormSubmit" class="btn btn-primary" onclick="return AspenDiscovery.Account.preProcessLogin();">
+							<input type="submit" name="submit" value="{translate text="Sign in with %1%" 1=$ldapLabel translateParameters=true isPublicFacing=true}" id="loginFormSubmit" class="btn btn-primary" onclick="return AspenDiscovery.Account.preProcessLogin();">
 						{else}
 							<input type="submit" name="submit" value="{translate text="Login" isPublicFacing=true}" id="loginFormSubmit" class="btn btn-primary" onclick="return AspenDiscovery.Account.preProcessLogin();">
 						{/if}

--- a/code/web/interface/themes/responsive/MyAccount/login.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/login.tpl
@@ -44,19 +44,19 @@
 							<input type="password" name="password" id="password" size="28" onkeypress="return AspenDiscovery.submitOnEnter(event, '#loginForm');" class="form-control" maxlength="70">
 							{if $forgotPasswordType != 'null' && $forgotPasswordType != 'none'}
 								<p class="text-muted help-block">
-									<strong>{translate text="Forgot %1%?" 1=$passwordLabel isPublicFacing=true}</strong>&nbsp;&nbsp;
+									<strong>{translate text="Forgot %1%?" 1=$passwordLabel translateParameters=true isPublicFacing=true}</strong>&nbsp;&nbsp;
 									{if $forgotPasswordType == 'emailAspenResetLink'}
-										<a href="/MyAccount/InitiateResetPin">{translate text="Reset My %1%" 1=$passwordLabel isPublicFacing=true}</a>
+										<a href="/MyAccount/InitiateResetPin">{translate text="Reset My %1%" 1=$passwordLabel translateParameters=true isPublicFacing=true}</a>
 									{elseif $forgotPasswordType == 'emailResetLink'}
-										<a href="/MyAccount/EmailResetPin">{translate text="Reset My %1%" 1=$passwordLabel isPublicFacing=true}</a>
+										<a href="/MyAccount/EmailResetPin">{translate text="Reset My %1%" 1=$passwordLabel translateParameters=true isPublicFacing=true}</a>
 									{else}
-										<a href="/MyAccount/EmailPin">{translate text="Email my %1%" 1=$passwordLabel isPublicFacing=true}</a>
+										<a href="/MyAccount/EmailPin">{translate text="Email my %1%" 1=$passwordLabel translateParameters=true isPublicFacing=true}</a>
 									{/if}
 								</p>
 							{/if}
 							{if $enableForgotBarcode}
 								 <p class="text-muted help-block">
-									<strong>{translate text="Forgot %1%?" 1=$usernameLabel isPublicFacing=true}</strong>&nbsp;&nbsp;<a href="/MyAccount/ForgotBarcode">{translate text="Send My %1% by Text" 1=$usernameLabel isPublicFacing=true}</a>
+									<strong>{translate text="Forgot %1%?" 1=$usernameLabel translateParameters=true isPublicFacing=true}</strong>&nbsp;&nbsp;<a href="/MyAccount/ForgotBarcode">{translate text="Send My %1% by Text" 1=$usernameLabel translateParameters=true isPublicFacing=true}</a>
 								 </p>
 							{/if}
 
@@ -90,7 +90,7 @@
 						<div class="col-xs-12 col-sm-offset-4 col-sm-8">
 							<label for="showPwd" class="checkbox">
 								<input type="checkbox" id="showPwd" name="showPwd" onclick="return AspenDiscovery.pwdToText('password')">
-								{translate text="Reveal %1%" 1=$passwordLabel isPublicFacing=true}
+								{translate text="Reveal %1%" 1=$passwordLabel translateParameters=true isPublicFacing=true}
 							</label>
 
 							{if empty($inLibrary) && empty($isOpac) && empty($isStandalonePage)}
@@ -105,7 +105,7 @@
 					<div id="loginActions" class="form-group">
 						<div class="col-xs-12 col-sm-offset-4 col-sm-8">
 							{if !$ssoStaffOnly && $ssoService == 'ldap' && !empty($ldapLabel)}
-								<input type="submit" name="submit" value="{translate text="Sign in with %1%" 1=$ldapLabel isPublicFacing=true}" id="loginFormSubmit" class="btn btn-primary" onclick="return AspenDiscovery.Account.preProcessLogin();">
+								<input type="submit" name="submit" value="{translate text="Sign in with %1%" 1=$ldapLabel translateParameters=true isPublicFacing=true}" id="loginFormSubmit" class="btn btn-primary" onclick="return AspenDiscovery.Account.preProcessLogin();">
 							{else}
 								<input type="submit" name="submit" value="{translate text="Login" isPublicFacing=true}" id="loginFormSubmit" class="btn btn-primary" onclick="return AspenDiscovery.Account.preProcessLogin();">
 							{/if}

--- a/code/web/interface/themes/responsive/MyAccount/resetPinPage.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/resetPinPage.tpl
@@ -13,7 +13,7 @@
 				{include file='ilsMessages.tpl' messages=$ilsMessages}
 			{/if}
 
-			<h1>{translate text='Reset %1%' 1=$passwordLabel isPublicFacing=true}</h1>
+			<h1>{translate text='Reset %1%' 1=$passwordLabel translateParameters=true isPublicFacing=true}</h1>
 			{if !empty($offline)}
 				<div class="alert alert-warning"><strong>{translate text=$offlineMessage isPublicFacing=true}</strong></div>
 			{else}
@@ -31,9 +31,9 @@
 					{if !empty($pinValidationRules.requireStrongPassword)}
 						{translate text="A strong password from 12 to 50 characters including at least one uppercase, lowercase, number, and special character (-_~!@#$%^&*.+)." isPublicFacing=true 1=$pinValidationRules.minLength 2=$pinValidationRules.maxLength}
 					{elseif !empty($pinValidationRules.onlyDigitsAllowed)}
-						{translate text="%3% must be between %1% and %2% digits." isPublicFacing=true 1=$pinValidationRules.minLength 2=$pinValidationRules.maxLength 3=$passwordLabel}
+						{translate text="%3% must be between %1% and %2% digits." isPublicFacing=true translateParameters=true 1=$pinValidationRules.minLength 2=$pinValidationRules.maxLength 3=$passwordLabel}
 					{else}
-						{translate text="%3% must be between %1% and %2% characters." isPublicFacing=true 1=$pinValidationRules.minLength 2=$pinValidationRules.maxLength 3=$passwordLabel}
+						{translate text="%3% must be between %1% and %2% characters." isPublicFacing=true translateParameters=true 1=$pinValidationRules.minLength 2=$pinValidationRules.maxLength 3=$passwordLabel}
 					{/if}
 				</div>
 

--- a/code/web/interface/themes/responsive/MyAccount/sso-login.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/sso-login.tpl
@@ -24,11 +24,11 @@
 					color: {$oAuthButtonTextColor};
 					border-color: {$oAuthButtonBackgroundColor}
 					">
-					{translate text="Sign in With %1%" 1=$oAuthCustomGatewayLabel isPublicFacing=true}
+					{translate text="Sign in With %1%" 1=$oAuthCustomGatewayLabel translateParameters=true isPublicFacing=true}
 				</a>
 			{else}
 				<a href="/init_oauth.php" class="btn btn-default btn-lg" style="background-color: {$oAuthButtonBackgroundColor}; color: {$oAuthButtonTextColor}">
-					{translate text="Sign in with %1%" 1=$oAuthCustomGatewayLabel isPublicFacing=true}
+					{translate text="Sign in with %1%" 1=$oAuthCustomGatewayLabel translateParameters=true isPublicFacing=true}
 				</a>
 			{/if}
 		{/if}
@@ -46,11 +46,11 @@
 				color: {$samlBtnTextColor};
 				border-color: {$samlBtnBgColor}
 				">
-				{translate text="Sign in With %1%" 1=$samlBtnLabel isPublicFacing=true}
+				{translate text="Sign in With %1%" 1=$samlBtnLabel translateParameters=true isPublicFacing=true}
 			</a>
 		{else}
 			<a href="/Authentication/SAML2?init" class="btn btn-default btn-lg" style="background-color: {$samlBtnBgColor}; color: {$samlBtnTextColor}">
-				{translate text="Sign in with %1%" 1=$samlBtnLabel isPublicFacing=true}
+				{translate text="Sign in with %1%" 1=$samlBtnLabel translateParameters=true isPublicFacing=true}
 			</a>
 		{/if}
 	{/if}

--- a/code/web/release_notes/26.09.00.MD
+++ b/code/web/release_notes/26.09.00.MD
@@ -102,6 +102,7 @@
 #### JavaScript Snippets
 #### Koha ILS
 #### Languages and Translations
+- Add translateParameters flag to login page messages so admin-configurable labels (e.g. "Library Card Number") translate correctly instead of appearing in English on non-English interfaces. ([DIS-2791](https://aspen-discovery.atlassian.net/browse/DIS-2791)) (*LM*)
 #### Materials Request
 #### New York Times API
 #### OverDrive


### PR DESCRIPTION
Admin-configurable login labels (e.g. "Library Card Number") weren't translated when substituted into surrounding translated text on login pages, so non-English interfaces showed a mix of translated and untranslated text (e.g. Spanish: "¿Olvidaste Número de carnet de biblioteca? Restablecer mi Library Card Number"). Fixed by adding translateParameters=true to the affected {translate} calls (~25 sites) across login.tpl, login-staff.tpl, ajax-login.tpl, sso-login.tpl, resetPinPage.tpl, addAccountLink.tpl, and forgotBarcode.tpl, so the label values are translated recursively instead of inserted verbatim.

Test Plan:

Before:
- Switch the interface language to a non-English language with translations available (e.g. Spanish) using ?myLang=es or the language selector.
- Visit the login page, staff login page, and the "Forgot password/username" / "Reset PIN" / "Reveal password" / "Sign in with SSO" flows. 
- Observe that admin-configured labels ("Library Card Number", "PIN or Password", SSO/LDAP button labels) appear untranslated in English, mixed into otherwise-translated sentences.

After:
- Repeat the same navigation on the same non-English interface.
- Confirm the labels now render translated wherever a translation exists for that term, consistently across all affected pages: login, staff login, ajax login modal, SSO login, reset PIN page, add account link, and forgot barcode.
- Confirm English interface behavior is unchanged (labels still show correctly in English).
- Confirm no untranslated term shows a raw %1%/placeholder artifact.