### PR TITLE
DIS-1871: fix crash when attempting payment of certain fines from Evergreen

### DIFF
--- a/code/web/Drivers/Evergreen.php
+++ b/code/web/Drivers/Evergreen.php
@@ -1597,7 +1597,7 @@ class Evergreen extends AbstractIlsDriver {
 							'date' => date('M j, Y', strtotime($transactionObj['xact_start'])),
 							'type' => $transactionObj['xact_type'],
 							'reason' => $transactionObj['last_billing_type'],
-							'message' => $reason,
+							'message' => $reason ?? '',
 							'amountVal' => $transactionObj['total_owed'],
 							'amountOutstandingVal' => $transactionObj['balance_owed'],
 							'amount' => $currencyFormatter->formatCurrency($transactionObj['total_owed'], $currencyCode),

--- a/code/web/release_notes/26.09.00.MD
+++ b/code/web/release_notes/26.09.00.MD
@@ -24,6 +24,7 @@
 #### eCommerce & Donations
 #### Events
 #### Evergreen
+- Fix issue that could prevent Aspen from recording payments of fines that have a null billing note. ([DIS-1871](https://aspen-discovery.atlassian.net/browse/DIS-1871)) (*GMC*)
 #### Evolve ILS
 #### Facets
 #### Gale
@@ -135,6 +136,9 @@
 - Imani Thomas (IT)
 - Nick Clemens (NC)
 - Shipra Poojary (SSP)
+
+### Equinox Open Library Initaitive
+- Galen Charlton (GMC)
 
 ### Grove For Libraries
 - Mark Noble (MDN)

--- a/code/web/sys/Utils/StringUtils.php
+++ b/code/web/sys/Utils/StringUtils.php
@@ -12,7 +12,7 @@ class StringUtils {
 				$string .= '...';
 			}
 		}
-		return $string;
+		return $string ?? '';
 	}
 
 	static function getCurrencyFormatter() : NumberFormatter {


### PR DESCRIPTION
Two changes:

* Make trimStringToLengthAtWordBoundary() return the empty string if given a null value to trim
* Update the Evergreen driver to use the empty string as the fine reason if the billing note happens to be null