### PR TITLE
DIS-2647: Opening a Web Resource takes an extra click if not logged in

### DIFF
--- a/code/web/RecordDrivers/WebResourceRecordDriver.php
+++ b/code/web/RecordDrivers/WebResourceRecordDriver.php
@@ -41,6 +41,7 @@ class WebResourceRecordDriver extends IndexRecordDriver {
 		global $interface;
 
 		$interface->assign('id', $this->getId());
+		$interface->assign('idNumber', $this->getNumericId());
 		$interface->assign('bookCoverUrl', $this->getBookcoverUrl('small'));
 		$interface->assign('pageUrl', $this->getLinkUrl());
 		$interface->assign('website_name', $this->fields['website_name']);
@@ -118,7 +119,7 @@ class WebResourceRecordDriver extends IndexRecordDriver {
 				$libraryId = $activeLibrary->libraryId;
 			}
 
-			return $webResource->getUrlForLibrary($libraryId);
+			return $webResource->getUrlForLibrary($libraryId, $this->fields['source_url']);
 		}
 
 		return $this->fields['source_url'];

--- a/code/web/interface/themes/responsive/RecordDrivers/WebPage/result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/WebPage/result.tpl
@@ -13,13 +13,18 @@
 
 	<div class="{if empty($showCovers)}col-xs-12{else}col-xs-9 col-sm-9 col-md-9 col-lg-10{/if}">{* May turn out to be more than one situation to consider here *}
 		{* Title Row *}
-
 		<div class="row">
 			<div class="col-xs-12">
 				<span class="result-index">{$resultIndex})</span>&nbsp;
-				<a href="{$pageUrl}" class="result-title notranslate" onclick="AspenDiscovery.Websites.trackUsage('{$id}')">
+				{if preg_match('/webresource/i', $id)}
+				<a href="{$resourceUrl}" class="result-title notranslate" onclick="return AspenDiscovery.WebBuilder.getWebResource('{$idNumber}');" aria-label="{translate text='Open Resource' isPublicFacing=true}{if $openInNewTab} ({translate text='opens in new tab' isPublicFacing=true}){/if}">
 					{if !$title|removeTrailingPunctuation} {translate text='Title not available' isPublicFacing=true}{else}{$title|removeTrailingPunctuation|highlight|truncate:180:"..."}{/if}
 				</a>
+				{else}
+					<a href="{$pageUrl}" class="result-title notranslate" onclick="AspenDiscovery.Websites.trackUsage('{$id}')">
+						{if !$title|removeTrailingPunctuation} {translate text='Title not available' isPublicFacing=true}{else}{$title|removeTrailingPunctuation|highlight|truncate:180:"..."}{/if}
+					</a>
+				{/if}
 				{if isset($summScore)}
 					&nbsp;(<a href="#" onclick="return AspenDiscovery.showElementInPopup('Score Explanation', '#scoreExplanationValue{$summId|escape}');">{$summScore}</a>)
 				{/if}

--- a/code/web/sys/WebBuilder/WebResource.php
+++ b/code/web/sys/WebBuilder/WebResource.php
@@ -590,8 +590,8 @@ class WebResource extends DB_LibraryLinkedObject {
 	 * @param int|null $libraryId The library ID to get the URL for. If null, returns base URL.
 	 * @return string The URL for the library.
 	 */
-	public function getUrlForLibrary(int $libraryId = null): string {
-		$url = $this->url;
+	public function getUrlForLibrary(int $libraryId = null, $url = null): string {
+		$url ??= $this->url;
 		if ($libraryId !== null) {
 			$libraries = $this->getLibraries();
 			if (isset($libraries[$libraryId]) && !empty($libraries[$libraryId]['url'])) {


### PR DESCRIPTION
- Update logic for clicking a web resource in search results to follow the same logic as the A to Z resource page 
- Update more info button to use the /WebBuilder/WebResource?id= url link unless a different url is supplied by the library within the web resource settings
- Additionally test functionality in explore more and placards where "open in new tab" is selected and unselected - nothing seemed to need updating here