### PR TITLE
DIS-2785: Bump Docker's Solr image to 9.10.1

### DIFF
--- a/code/web/release_notes/26.08.00.MD
+++ b/code/web/release_notes/26.08.00.MD
@@ -144,6 +144,11 @@
 - Update volumes for series to use normalized volume values for matching ([DIS-2656](https://aspen-discovery.atlassian.net/browse/DIS-2656)) (*KL*)
 - Fix an issue where grouped work series names could display with lowercase when series data came from MARC records. ([DIS-2689](https://aspen-discovery.atlassian.net/browse/DIS-2689)) (*YL*)
 
+### Server Setup
+- Bump Docker's Solr image from 8.11.2 to 9.10.1 to match the production install/upgrade version. ([DIS-2785](https://aspen-discovery.atlassian.net/browse/DIS-2785)) (*LM*)
+  - Copy the analysis-extras module into Solr's shared lib path so ICU-based text analysis keeps working under Solr 9's modularized classpath.
+  - Provision the grouped_works_v3 core in Docker so it's buildable locally alongside grouped_works_v2.
+
 ### SSO Updates
 - Update SSO Authentication using OAuth. ([DIS-2250](https://aspen-discovery.atlassian.net/browse/DIS-2250)) (*MDN*)
   - Fix loading Access Token and Resource Owner information for OAuth.  

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -106,6 +106,10 @@ services:
       precreate-core grouped_works_v2 /opt/solr/server/solr/configsets/grouped_works_v2
       cp -r /opt/solr/server/solr/configsets/grouped_works_v2/* grouped_works_v2
 
+      # Grouped Works v3 core
+      precreate-core grouped_works_v3 /opt/solr/server/solr/configsets/grouped_works_v3
+      cp -r /opt/solr/server/solr/configsets/grouped_works_v3/* grouped_works_v3
+
       # Lists core
       precreate-core lists /opt/solr/server/solr/configsets/lists
       cp -r /opt/solr/server/solr/configsets/lists/* lists

--- a/docker/files/solr/Dockerfile
+++ b/docker/files/solr/Dockerfile
@@ -1,4 +1,4 @@
-FROM solr:8.11.2
+FROM solr:9.10.1
 
 # Build arguments with defaults
 ARG SOLR_HOST=localhost
@@ -25,6 +25,7 @@ ENV SOLR_OPTS="-Dsolr.config.lib.enabled=true" \
     SERIES_CONFIGSET_PATH=/opt/solr/server/solr/configsets/series/conf \
     GENEALOGY_CONFIGSET_PATH=/opt/solr/server/solr/configsets/genealogy/conf \
     GROUPED_WORK_V2_CONFIGSET_PATH=/opt/solr/server/solr/configsets/grouped_works_v2/conf \
+    GROUPED_WORK_V3_CONFIGSET_PATH=/opt/solr/server/solr/configsets/grouped_works_v3/conf \
     LISTS_CONFIGSET_PATH=/opt/solr/server/solr/configsets/lists/conf \
     COURSE_RESERVES_CONFIGSET_PATH=/opt/solr/server/solr/configsets/course_reserves/conf \
     OPEN_ARCHIVES_CONFIGSET_PATH=/opt/solr/server/solr/configsets/open_archives/conf \
@@ -35,6 +36,7 @@ ENV SOLR_OPTS="-Dsolr.config.lib.enabled=true" \
 RUN mkdir -p $SERIES_CONFIGSET_PATH && \
     mkdir -p $GENEALOGY_CONFIGSET_PATH && \
     mkdir -p $GROUPED_WORK_V2_CONFIGSET_PATH && \
+    mkdir -p $GROUPED_WORK_V3_CONFIGSET_PATH && \
     mkdir -p $LISTS_CONFIGSET_PATH && \
     mkdir -p $COURSE_RESERVES_CONFIGSET_PATH && \
     mkdir -p $OPEN_ARCHIVES_CONFIGSET_PATH && \
@@ -45,6 +47,7 @@ RUN mkdir -p $SERIES_CONFIGSET_PATH && \
 COPY data_dir_setup/solr7/series/conf ${SERIES_CONFIGSET_PATH}
 COPY data_dir_setup/solr7/genealogy/conf ${GENEALOGY_CONFIGSET_PATH}
 COPY data_dir_setup/solr7/grouped_works_v2/conf ${GROUPED_WORK_V2_CONFIGSET_PATH}
+COPY data_dir_setup/solr7/grouped_works_v3/conf ${GROUPED_WORK_V3_CONFIGSET_PATH}
 COPY data_dir_setup/solr7/lists/conf ${LISTS_CONFIGSET_PATH}
 COPY data_dir_setup/solr7/course_reserves/conf ${COURSE_RESERVES_CONFIGSET_PATH}
 COPY data_dir_setup/solr7/open_archives/conf ${OPEN_ARCHIVES_CONFIGSET_PATH}
@@ -53,5 +56,13 @@ COPY data_dir_setup/solr7/events/conf ${EVENTS_CONFIGSET_PATH}
 
 # Copy solr.xml to SOLR_HOME
 COPY data_dir_setup/solr7/solr.xml ${SOLR_HOME}/solr.xml
+
+# Solr 9 moved ICU/analysis-extras (used by the text_general field type,
+# e.g. ICUFoldingFilterFactory) out of core into an optional module. Copy it
+# into SOLR_HOME/lib, which Solr auto-loads for every core, so schemas that
+# reference it keep working without per-core solrconfig.xml <lib> entries.
+RUN mkdir -p ${SOLR_HOME}/lib && \
+    cp /opt/solr/modules/analysis-extras/lib/*.jar ${SOLR_HOME}/lib/
+
 RUN set -eux; \
     chown -R ${SOLR_USER}:${SOLR_GROUP} ${SOLR_HOME}


### PR DESCRIPTION
Updates docker/files/solr/Dockerfile to build Solr's Docker image from solr:9.10.1 instead of solr:8.11.2, matching the version already used by the production install/upgrade scripts. Since Solr 9 moved ICU-based text analysis filters (used by every core's schema) out of core into an optional module, the Dockerfile now copies the analysis-extras module into Solr's shared library path so those filters keep loading correctly. Also adds Docker provisioning for the grouped_works_v3 core alongside the existing grouped_works_v2, so it's buildable locally in addition to production. docker/docker-compose.yml is updated accordingly to precreate the new core at container startup.