### PR TITLE
DIS-2521: Narrator/Reader, Contributor, etc Metadata Ingestion and Use for Hoopla Titles

### DIFF
--- a/code/reindexer/src/org/aspen_discovery/reindexer/HooplaProcessor2.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/HooplaProcessor2.java
@@ -409,7 +409,7 @@ class HooplaProcessor2 {
 					HashSet<String> artistsWithRoleToAdd = new HashSet<>();
 					for (int i = 0; i < artists.length(); i++) {
 						JSONObject curArtist = artists.getJSONObject(i);
-						String artistName = AspenStringUtils.swapFirstLastNames(curArtist.getString("name"));
+						String artistName = AspenStringUtils.swapFirstLastNames(curArtist.getString("name")).replaceAll("\\s+$", "");
 						artistsToAdd.add(artistName);
 						if (curArtist.getString("relationship").toLowerCase().equals("reader")) {
 							artistsToAdd.add(artistName);

--- a/code/reindexer/src/org/aspen_discovery/reindexer/MarcRecordProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/MarcRecordProcessor.java
@@ -1,5 +1,6 @@
 package org.aspen_discovery.reindexer;
 
+import org.apache.commons.lang3.StringUtils;
 import org.aspen_discovery.format_classification.MarcRecordFormatClassifier;
 import com.turning_leaf_technologies.indexing.BaseIndexingSettings;
 import com.turning_leaf_technologies.logging.BaseIndexingLogEntry;
@@ -16,6 +17,7 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
 
 abstract class MarcRecordProcessor {
 	protected Logger logger;
@@ -1634,14 +1636,25 @@ abstract class MarcRecordProcessor {
 				continue;
 			}
 			if (contributor.substring(contributor.length() - 1, contributor.length()).equals(",")){
-				contributor = new StringBuilder(contributor.substring(0, contributor.length() - 1));
+				contributor = new StringBuilder(contributor.substring(0, contributor.length() - 1).replaceAll("\\s+$", ""));
 			}
 			StringBuilder roles = MarcUtil.getSpecifiedSubfieldsAsString(contributorField, "e4", ",");
-			if (roles.length() > 0){
-				if (roles.toString().contains("nrt")) {
+			if (roles.length() > 0) {
+				List<String> roleList = Arrays.stream(roles.toString().split(","))
+					.map(role -> AspenStringUtils.trimTrailingPunctuation(role.trim()))
+					.collect(Collectors.toList());
+
+				boolean isNarrator = roleList.stream().anyMatch(role -> role.equalsIgnoreCase("nrt") || role.equalsIgnoreCase("reader"));
+
+				if (isNarrator) {
 					contributor.append("|Narrator");
 				} else {
-					contributor.append("|").append(roles.toString().replaceAll(",,", ","));
+					String normalizedRoles = roleList.stream()
+						.filter(role -> !role.isEmpty())
+						.map(role -> StringUtils.capitalize(role.toLowerCase()))
+						.collect(Collectors.joining(","));
+
+					contributor.append("|").append(normalizedRoles);
 				}
 			}
 			contributors.add(contributor.toString());

--- a/code/reindexer/src/org/aspen_discovery/reindexer/OverDriveProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/OverDriveProcessor.java
@@ -4,6 +4,7 @@ import com.turning_leaf_technologies.indexing.OverDriveScope;
 import com.turning_leaf_technologies.indexing.Scope;
 import com.turning_leaf_technologies.logging.BaseIndexingLogEntry;
 import com.turning_leaf_technologies.strings.AspenStringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -217,8 +218,10 @@ class OverDriveProcessor implements AutoCloseable {
 									HashSet<String> authorsWithRole = new HashSet<>();
 									for (int i = 0; i < creators.length(); i++) {
 										JSONObject creator = creators.getJSONObject(i);
-										authors.add(creator.getString("fileAs"));
-										authorsWithRole.add(creator.getString("fileAs") + "|" + creator.getString("role"));
+										String author = creator.getString("fileAs").replaceAll("\\s+$", "");
+										String role = StringUtils.capitalize(creator.getString("role").toLowerCase());
+										authors.add(author);
+										authorsWithRole.add(author + "|" + role);
 									}
 									groupedWork.addAuthor2(authors);
 									groupedWork.addAuthor2Role(authorsWithRole);

--- a/code/reindexer/src/org/aspen_discovery/reindexer/PalaceProjectProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/PalaceProjectProcessor.java
@@ -255,9 +255,9 @@ public class PalaceProjectProcessor {
 				if (metadata.has("narrator")) {
 					String narrator;
 					if (metadata.get("narrator") instanceof String) {
-						narrator = metadata.getString("narrator");
+						narrator = metadata.getString("narrator").replaceAll("\\s+$", "");
 					}else{
-						narrator = metadata.getJSONObject("narrator").getString("name");
+						narrator = metadata.getJSONObject("narrator").getString("name").replaceAll("\\s+$", "");
 					}
 					HashSet<String> artistsToAdd = new HashSet<>();
 					HashSet<String> artistsWithRoleToAdd = new HashSet<>();

--- a/code/web/RecordDrivers/GroupedWorkDriver.php
+++ b/code/web/RecordDrivers/GroupedWorkDriver.php
@@ -1035,7 +1035,7 @@ class GroupedWorkDriver extends IndexRecordDriver {
 						$roles = explode(',', $contributorInfo[1]);
 						foreach ($roles as &$role) {
 							$normalizedRole = strtolower(rtrim(trim($role), '.'));
-							if ($normalizedRole == "nrt" || $normalizedRole == "reader") {
+							if ($normalizedRole == "reader") {
 								$role = 'Narrator';
 							} else {
 								$role = ucfirst(strtolower(trim($role)));

--- a/code/web/RecordDrivers/GroupedWorkDriver.php
+++ b/code/web/RecordDrivers/GroupedWorkDriver.php
@@ -1032,9 +1032,19 @@ class GroupedWorkDriver extends IndexRecordDriver {
 				foreach ($contributorsInIndex as $contributor) {
 					if (strpos($contributor, '|')) {
 						$contributorInfo = explode('|', $contributor);
+						$roles = explode(',', $contributorInfo[1]);
+						foreach ($roles as &$role) {
+							$normalizedRole = strtolower(rtrim(trim($role), '.'));
+							if ($normalizedRole == "nrt" || $normalizedRole == "reader") {
+								$role = 'Narrator';
+							} else {
+								$role = ucfirst(strtolower(trim($role)));
+							}
+						}
+						unset($role);
 						$curContributor = [
 							'name' => $contributorInfo[0],
-							'roles' => explode(',', $contributorInfo[1]),
+							'roles' => $roles,
 						];
 						ksort($curContributor['roles']);
 					} else {

--- a/code/web/RecordDrivers/HooplaRecordDriver.php
+++ b/code/web/RecordDrivers/HooplaRecordDriver.php
@@ -67,9 +67,15 @@ class HooplaRecordDriver extends GroupedWorkSubDriver {
 			$rawData = $this->hooplaRawMetadata;
 			foreach ($rawData->artists as $artist) {
 				if (!array_key_exists($artist->name, $this->detailedContributors)) {
+					$normalizedRole = strtolower(trim($artist->relationship));
+					if ($normalizedRole == 'reader') {
+						$role = 'Narrator';
+					} else {
+						$role = ucfirst(strtolower($artist->relationship));
+					}
 					$this->detailedContributors[$artist->name] = [
 						'name' => $artist->name,
-						'role' =>  ucfirst(strtolower($artist->relationship)),
+						'role' => $role,
 					];
 				}
 			}

--- a/code/web/RecordDrivers/MarcRecordDriver.php
+++ b/code/web/RecordDrivers/MarcRecordDriver.php
@@ -945,7 +945,6 @@ class MarcRecordDriver extends GroupedWorkSubDriver {
 			$agrContributors = $this->get880Contributors();
 			/** @var File_MARC_Data_Field[] $sevenHundredFields */
 			$sevenHundredFields = $this->getMarcRecord()->getFields('700|710', true);
-			$narratorValues = ['nrt', 'reader', 'narrator'];
 			foreach ($sevenHundredFields as $field) {
 				$nameSubfieldArray = $this->getSubfieldArray($field, [
 					'a',
@@ -969,15 +968,11 @@ class MarcRecordDriver extends GroupedWorkSubDriver {
 				if ($field->getSubfield('4') != null) {
 					$contributorRole = $field->getSubfield('4')->getData();
 					$contributorRole = preg_replace('/[\s,.;]+$/', '', $contributorRole);
-					if (in_array(strtolower($contributorRole), $narratorValues, true)) {
-						$curContributor['roles'][] = 'Narrator';
-					} else {
-						$curContributor['roles'][] = mapValue('contributor_role', $contributorRole);
-					}
+					$curContributor['roles'][] = mapValue('contributor_role', $contributorRole);
 				} elseif ($field->getSubfield('e') != null) {
 					$contributorRole = $field->getSubfield('e')->getData();
 					$normalizedRole = strtolower(rtrim(trim($contributorRole), '.'));
-					if (in_array($normalizedRole, $narratorValues, true)) {
+					if ($normalizedRole == 'reader') {
 						$curContributor['roles'][] = 'Narrator';
 					} else {
 						$curContributor['roles'][] = ucfirst(strtolower(trim($contributorRole)));

--- a/code/web/RecordDrivers/MarcRecordDriver.php
+++ b/code/web/RecordDrivers/MarcRecordDriver.php
@@ -945,6 +945,7 @@ class MarcRecordDriver extends GroupedWorkSubDriver {
 			$agrContributors = $this->get880Contributors();
 			/** @var File_MARC_Data_Field[] $sevenHundredFields */
 			$sevenHundredFields = $this->getMarcRecord()->getFields('700|710', true);
+			$narratorValues = ['nrt', 'reader', 'narrator'];
 			foreach ($sevenHundredFields as $field) {
 				$nameSubfieldArray = $this->getSubfieldArray($field, [
 					'a',
@@ -968,9 +969,19 @@ class MarcRecordDriver extends GroupedWorkSubDriver {
 				if ($field->getSubfield('4') != null) {
 					$contributorRole = $field->getSubfield('4')->getData();
 					$contributorRole = preg_replace('/[\s,.;]+$/', '', $contributorRole);
-					$curContributor['roles'][] = mapValue('contributor_role', $contributorRole);
+					if (in_array(strtolower($contributorRole), $narratorValues, true)) {
+						$curContributor['roles'][] = 'Narrator';
+					} else {
+						$curContributor['roles'][] = mapValue('contributor_role', $contributorRole);
+					}
 				} elseif ($field->getSubfield('e') != null) {
-					$curContributor['roles'][] = $field->getSubfield('e')->getData();
+					$contributorRole = $field->getSubfield('e')->getData();
+					$normalizedRole = strtolower(rtrim(trim($contributorRole), '.'));
+					if (in_array($normalizedRole, $narratorValues, true)) {
+						$curContributor['roles'][] = 'Narrator';
+					} else {
+						$curContributor['roles'][] = ucfirst(strtolower(trim($contributorRole)));
+					}
 				}
 				//Try to match to an AGR Contributor
 				if ($field->getSubfield('6') != null) {

--- a/code/web/sys/SearchObject/BaseSearcher.php
+++ b/code/web/sys/SearchObject/BaseSearcher.php
@@ -387,7 +387,7 @@ abstract class SearchObject_BaseSearcher {
 					$endValue = $rangeValues[2] == '*' ? '*' : $rangeValues[2] / 60;
 					$display = translate(['text' => $facetLabel, 'isPublicFacing' => true]) . ' ' . "[$startValue TO $endValue]";
 				} elseif ($field == 'author2-role') {
-					$display = preg_replace('/\s*\|\s*/', ' - ', $value);
+					$display = preg_replace('/\s*\|\s*/', ', ', $value);
 				} else {
 					$display = $translate ? translate([
 						'text' => $value,


### PR DESCRIPTION
Use a , instead of a - when listing contributors + roles for the contributor facet 
Update indexing to normalize, strtolower, then capitalize contributor roles for more consistency 
Trim trailing white spaces for contributors so they aren't included multiple times as a contributor with the same role 
Update full record view to use "Narrator" instead of "reader" for consistency 
Ensure roles in full record view are also strtolower then capitalized

Tested on my local instance of Aspen