### PR TITLE
DIS-2743: Make panel heading fully clickable

### DIFF
--- a/code/web/interface/themes/responsive/DataObjectUtil/property.tpl
+++ b/code/web/interface/themes/responsive/DataObjectUtil/property.tpl
@@ -172,7 +172,7 @@
 					<div id="panelStatus_{$property.label|escapeCSS}" class="panel panel-default {if !empty($property.expandByDefault)}active{/if}">
 						<div class="panel-heading row">
 							<div class="panel-title col-xs-11">
-								<a id="panelToggle_{$property.property}" data-toggle="collapse" data-parent="#accordion_{$property.label|escapeCSS}" href="#accordion_body_{$property.label|escapeCSS}" aria-expanded="{if !empty($property.expandByDefault)}true{else}false{/if}" class="{if !empty($property.expandByDefault)}expanded{else}collapsed{/if}">
+								<a id="panelToggle_{$property.property}" data-toggle="collapse" data-parent="#accordion_{$property.label|escapeCSS}" href="#accordion_body_{$property.label|escapeCSS}" aria-expanded="{if !empty($property.expandByDefault)}true{else}false{/if}" class="panel-toggle-full {if !empty($property.expandByDefault)}expanded{else}collapsed{/if}">
 									{translate text=$property.label isAdminFacing=true}
 								</a>
 							</div>
@@ -200,8 +200,14 @@
 				<script type="text/javascript">
 					{* Initiate any checkbox with a data attribute set to data-switch=""  as a bootstrap switch *}
 					{literal}
-					$("#panelToggle_{/literal}{$property.property}{literal}").on('click', function() {
+					$("#panelToggle_{/literal}{$property.property}{literal}").on('click keydown', function(event) {
 						var toggleButton = $(this);
+						if (event.type === 'keydown' && event.key !== 'Enter' && event.key !== ' ') {
+							return;
+						}
+						if (event.type === 'keydown') {
+							event.preventDefault();
+						}
 						$(this).toggleClass('expanded');
 						$(this).toggleClass('collapsed');
 						var panelStatus = $("#panelStatus_{/literal}{$property.label|escapeCSS}{literal}");
@@ -216,6 +222,15 @@
 						}
 						return false;
 					})
+					{/literal}
+				</script>
+				<script type="text/javascript">
+					{literal}
+					$("#panelStatus_{/literal}{$property.label|escapeCSS}{literal} .panel-heading").on('click', function(e) {
+						if ($(e.target).closest('.col-xs-1, a, button, img').length === 0) {
+							$("#panelToggle_{/literal}{$property.property}{literal}").trigger('click');
+						}
+					});
 					{/literal}
 				</script>
 			{/if}

--- a/code/web/interface/themes/responsive/DataObjectUtil/property.tpl
+++ b/code/web/interface/themes/responsive/DataObjectUtil/property.tpl
@@ -202,11 +202,13 @@
 					{literal}
 					$("#panelToggle_{/literal}{$property.property}{literal}").on('click keydown', function(event) {
 						var toggleButton = $(this);
-						if (event.type === 'keydown' && event.key !== 'Enter' && event.key !== ' ') {
+						var key = event.key || event.which;
+						if (event.type === 'keydown' && key !== 'Enter' && key !== ' ' && key !== 'Spacebar' && key !== 13 && key !== 32) {
 							return;
 						}
 						if (event.type === 'keydown') {
 							event.preventDefault();
+							event.stopPropagation();
 						}
 						$(this).toggleClass('expanded');
 						$(this).toggleClass('collapsed');

--- a/code/web/interface/themes/responsive/theme.css.tpl
+++ b/code/web/interface/themes/responsive/theme.css.tpl
@@ -262,6 +262,12 @@ div.striped > div:nth-child(odd), div.striped > div:nth-child(odd){ldelim}
 	border-color: {$closedPanelForegroundColor}70;
 {rdelim}
 
+/* Make panel title links fill the available heading area for easier clicking */
+.panel-title > a.panel-toggle-full, .panel-toggle-full{ldelim}
+    display: block;
+    width: 100%;
+{rdelim}
+
 .facetTitle, .exploreMoreTitle,.panel-title,.panel-default > .panel-heading, .sidebar-links .panel-heading, #account-link-accordion .panel .panel-title, #account-settings-accordion .panel .panel-title, .panel-title > a,.panel-default > .panel-heading{ldelim}
     color: {$closedPanelForegroundColor};
 {rdelim}

--- a/code/web/release_notes/26.09.00.MD
+++ b/code/web/release_notes/26.09.00.MD
@@ -73,6 +73,7 @@
 #### Interface Updates and Usability
 - Add data attributes for grouped work ids, formats, and record ids in grouped work view, full record view, Titles on Hold, and Checked Out Titles. ([DIS-2836](https://aspen-discovery.atlassian.net/browse/DIS-2836)) (*MAF*)
 
+- Add ability to click anywhere on a collapsable header to make it drop down. ([DIS-2743](https://aspen-discovery.atlassian.net/browse/DIS-2743)) (*SY*)
 #### JavaScript Snippets
 #### Koha ILS
 - Fixed an issue where patrons could not update their primary contact method. ([DIS-1320](https://aspen-discovery.atlassian.net/browse/DIS-1320)) (*CZ*)
@@ -238,6 +239,7 @@
 
 ## This release includes code contributions from
 ### ByWater Solutions
+- Sam Young (SY)
 - Yanjun Li (YL)
 - Imani Thomas (IT)
 - Nick Clemens (NC)


### PR DESCRIPTION
## Testing Instructions

1. Open an admin settings page containing expandable property panels.
2. Confirm the panel title, plus icon, and surrounding heading area display a pointer cursor.
3. Click the panel title area outside the text.
4. Verify the panel expands and collapses.
5. Click the plus/minus icon area and verify it toggles.
6. Click the help icon, if present, and verify it opens the help link instead of toggling the panel.
7. Test keyboard navigation:
   - Focus the panel title with `Tab`
   - Press `Enter` or `Space`
   - Verify the panel toggles
8. Verify panels configured to expand by default still open correctly.