### PR TITLE
DIS-2648: Hold Edition Picker Enhancements

### DIFF
--- a/code/web/interface/themes/responsive/Record/hold-popup.tpl
+++ b/code/web/interface/themes/responsive/Record/hold-popup.tpl
@@ -278,15 +278,15 @@
 						<div id="editionSelectionOptions" class="form-group">
 							<label class="control-label">{translate text="Do you want to place a hold on the suggested edition or a specific edition?" isPublicFacing=true}</label>
 							<div class="btn-group btn-group-toggle edition-option-toggle" role="group" aria-label="{translate text="Edition hold option" isPublicFacing=true}">
+								<button type="button" class="btn btn-primary edition-option-btn{if $holdPromptForEditions == 1} active{/if}"
+								        aria-pressed="{if $holdPromptForEditions == 1}true{else}false{/if}"
+								        onclick="AspenDiscovery.GroupedWork.selectEditionOption(this, 1)">
+									{translate text="Place hold on suggested edition" isPublicFacing=true}
+								</button>
 								<button type="button" class="btn btn-primary edition-option-btn{if $holdPromptForEditions == 2} active{/if}"
 										aria-pressed="{if $holdPromptForEditions == 2}true{else}false{/if}"
 										onclick="AspenDiscovery.GroupedWork.selectEditionOption(this, 2)">
 									{translate text="Place hold on specific edition" isPublicFacing=true}
-								</button>
-								<button type="button" class="btn btn-primary edition-option-btn{if $holdPromptForEditions == 1} active{/if}"
-										aria-pressed="{if $holdPromptForEditions == 1}true{else}false{/if}"
-										onclick="AspenDiscovery.GroupedWork.selectEditionOption(this, 1)">
-									{translate text="Place hold on suggested edition" isPublicFacing=true}
 								</button>
 							</div>
 							<input type="hidden" name="selectedEditionOption" id="selectedEditionOption" value="{$holdPromptForEditions|default:1}">

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -1858,6 +1858,29 @@ var AspenDiscovery = (function(){
 			var slides = wrapper.querySelectorAll('.slider-slide');
 			let currentIndex = 0;
 
+			var scrollEdgeThreshold = 2; // px slack for subpixel/rounding differences for scroll boundary
+
+			function updateNavButtons() {
+				var maxScrollLeft = wrapper.scrollWidth - wrapper.clientWidth;
+				var atStart = wrapper.scrollLeft <= scrollEdgeThreshold;
+				var atEnd = wrapper.scrollLeft >= maxScrollLeft - scrollEdgeThreshold;
+				var noOverflow = maxScrollLeft <= scrollEdgeThreshold;
+
+				var hidePrev = atStart || noOverflow;
+				var hideNext = atEnd || noOverflow;
+
+				prevBtn.style.visibility = hidePrev ? 'hidden' : '';
+				nextBtn.style.visibility = hideNext ? 'hidden' : '';
+
+				// Prevent keyboard users from tabbing into an invisible button
+				prevBtn.tabIndex = hidePrev ? -1 : 0;
+				nextBtn.tabIndex = hideNext ? -1 : 0;
+
+				// Let screen readers know the control isn't currently actionable
+				prevBtn.setAttribute('aria-disabled', hidePrev ? 'true' : 'false');
+				nextBtn.setAttribute('aria-disabled', hideNext ? 'true' : 'false');
+			}
+
 			// Compute slide width fresh each time instead of caching it once at init,
 			// since offsetWidth is 0 while this is inside a display:none modal.
 			function getSlideWidth() {
@@ -1878,7 +1901,7 @@ var AspenDiscovery = (function(){
 			// --- Accessibility ARIA setup ---
 			if (hasInnerControls) {
 				// Native controls (e.g. a radio group) provide semantics and keyboard behavior.
-				//  Don't add a redundant listbox pattern on top of them.
+				// Don't add a redundant listbox pattern on top of them.
 				wrapper.removeAttribute('role');
 				wrapper.removeAttribute('aria-activedescendant');
 				slides.forEach(function (slide) {
@@ -1986,13 +2009,34 @@ var AspenDiscovery = (function(){
 				e.preventDefault();
 			});
 
+			// Keep buttons in sync with actual scroll position
+			wrapper.addEventListener('scroll', function () {
+				if (!wrapper._navRAF) {
+					wrapper._navRAF = requestAnimationFrame(function () {
+						wrapper._navRAF = null;
+						updateNavButtons();
+					});
+				}
+			});
+
+			// Also recheck on resize, since clientWidth/scrollWidth can change
+			if (window.ResizeObserver) {
+				new ResizeObserver(function () { updateNavButtons(); }).observe(wrapper);
+			} else {
+				window.addEventListener('resize', updateNavButtons);
+			}
+
+			// Initial check. Deferred to a rAF (same reasoning as getSlideWidth's comment above:
+			// scrollWidth/clientWidth are unreliable while inside a display:none modal).
+			requestAnimationFrame(updateNavButtons);
+
 			// --- Pointer-based drag-to-scroll with momentum (mouse, touch, and pen) ---
 			(function enableDragScroll() {
 				var isDown = false;
 				var pointerId = null;
 				var startX = 0;
 				var startScrollLeft = 0;
-				var DRAG_THRESHOLD = 10; // px before a press counts as a drag, not a click
+				var dragThreshold = 10; // px before a press counts as a drag, not a click
 
 				// Velocity tracking
 				var lastX = 0;
@@ -2000,30 +2044,30 @@ var AspenDiscovery = (function(){
 				var velocity = 0; // px per ms
 
 				// Momentum animation
-				var momentumRAF = null;
-				var FRICTION = 0.95;      // lower = stops sooner, higher = coasts longer
-				var MIN_VELOCITY = 0.02;  // px/ms threshold to stop the animation
+				var momentum = null;
+				var friction = 0.95;      // lower = stops sooner, higher = coasts longer
+				var minVelocity = 0.02;  // px/ms threshold to stop the animation
 
 				function stopMomentum() {
-					if (momentumRAF) {
-						cancelAnimationFrame(momentumRAF);
-						momentumRAF = null;
+					if (momentum) {
+						cancelAnimationFrame(momentum);
+						momentum = null;
 					}
 				}
 
 				function runMomentum() {
 					wrapper.scrollLeft -= velocity * 16; // approximate px for a ~16ms frame
-					velocity *= FRICTION;
+					velocity *= friction;
 
 					// Stop at the natural scroll boundaries too, rather than fighting them
 					if (wrapper.scrollLeft <= 0 || wrapper.scrollLeft >= wrapper.scrollWidth - wrapper.clientWidth) {
 						velocity = 0;
 					}
 
-					if (Math.abs(velocity) > MIN_VELOCITY) {
-						momentumRAF = requestAnimationFrame(runMomentum);
+					if (Math.abs(velocity) > minVelocity) {
+						momentum = requestAnimationFrame(runMomentum);
 					} else {
-						momentumRAF = null;
+						momentum = null;
 					}
 				}
 
@@ -2050,7 +2094,7 @@ var AspenDiscovery = (function(){
 
 					var dx = e.clientX - startX;
 
-					if (Math.abs(dx) > DRAG_THRESHOLD && wrapper.dataset.dragMoved !== 'true') {
+					if (Math.abs(dx) > dragThreshold && wrapper.dataset.dragMoved !== 'true') {
 						wrapper.dataset.dragMoved = 'true';
 						wrapper.classList.add('dragging');
 						wrapper.setPointerCapture(pointerId); // capture only now that it's a real drag
@@ -2080,8 +2124,8 @@ var AspenDiscovery = (function(){
 					}
 					pointerId = null;
 
-					if (Math.abs(velocity) > MIN_VELOCITY) {
-						momentumRAF = requestAnimationFrame(runMomentum);
+					if (Math.abs(velocity) > minVelocity) {
+						momentum = requestAnimationFrame(runMomentum);
 					}
 
 					setTimeout(function () { wrapper.dataset.dragMoved = 'false'; }, 0);

--- a/code/web/interface/themes/responsive/js/aspen/base.js
+++ b/code/web/interface/themes/responsive/js/aspen/base.js
@@ -899,6 +899,29 @@ var AspenDiscovery = (function(){
 			var slides = wrapper.querySelectorAll('.slider-slide');
 			let currentIndex = 0;
 
+			var scrollEdgeThreshold = 2; // px slack for subpixel/rounding differences for scroll boundary
+
+			function updateNavButtons() {
+				var maxScrollLeft = wrapper.scrollWidth - wrapper.clientWidth;
+				var atStart = wrapper.scrollLeft <= scrollEdgeThreshold;
+				var atEnd = wrapper.scrollLeft >= maxScrollLeft - scrollEdgeThreshold;
+				var noOverflow = maxScrollLeft <= scrollEdgeThreshold;
+
+				var hidePrev = atStart || noOverflow;
+				var hideNext = atEnd || noOverflow;
+
+				prevBtn.style.visibility = hidePrev ? 'hidden' : '';
+				nextBtn.style.visibility = hideNext ? 'hidden' : '';
+
+				// Prevent keyboard users from tabbing into an invisible button
+				prevBtn.tabIndex = hidePrev ? -1 : 0;
+				nextBtn.tabIndex = hideNext ? -1 : 0;
+
+				// Let screen readers know the control isn't currently actionable
+				prevBtn.setAttribute('aria-disabled', hidePrev ? 'true' : 'false');
+				nextBtn.setAttribute('aria-disabled', hideNext ? 'true' : 'false');
+			}
+
 			// Compute slide width fresh each time instead of caching it once at init,
 			// since offsetWidth is 0 while this is inside a display:none modal.
 			function getSlideWidth() {
@@ -919,7 +942,7 @@ var AspenDiscovery = (function(){
 			// --- Accessibility ARIA setup ---
 			if (hasInnerControls) {
 				// Native controls (e.g. a radio group) provide semantics and keyboard behavior.
-				//  Don't add a redundant listbox pattern on top of them.
+				// Don't add a redundant listbox pattern on top of them.
 				wrapper.removeAttribute('role');
 				wrapper.removeAttribute('aria-activedescendant');
 				slides.forEach(function (slide) {
@@ -1027,13 +1050,34 @@ var AspenDiscovery = (function(){
 				e.preventDefault();
 			});
 
+			// Keep buttons in sync with actual scroll position
+			wrapper.addEventListener('scroll', function () {
+				if (!wrapper._navRAF) {
+					wrapper._navRAF = requestAnimationFrame(function () {
+						wrapper._navRAF = null;
+						updateNavButtons();
+					});
+				}
+			});
+
+			// Also recheck on resize, since clientWidth/scrollWidth can change
+			if (window.ResizeObserver) {
+				new ResizeObserver(function () { updateNavButtons(); }).observe(wrapper);
+			} else {
+				window.addEventListener('resize', updateNavButtons);
+			}
+
+			// Initial check. Deferred to a rAF (same reasoning as getSlideWidth's comment above:
+			// scrollWidth/clientWidth are unreliable while inside a display:none modal).
+			requestAnimationFrame(updateNavButtons);
+
 			// --- Pointer-based drag-to-scroll with momentum (mouse, touch, and pen) ---
 			(function enableDragScroll() {
 				var isDown = false;
 				var pointerId = null;
 				var startX = 0;
 				var startScrollLeft = 0;
-				var DRAG_THRESHOLD = 10; // px before a press counts as a drag, not a click
+				var dragThreshold = 10; // px before a press counts as a drag, not a click
 
 				// Velocity tracking
 				var lastX = 0;
@@ -1041,30 +1085,30 @@ var AspenDiscovery = (function(){
 				var velocity = 0; // px per ms
 
 				// Momentum animation
-				var momentumRAF = null;
-				var FRICTION = 0.95;      // lower = stops sooner, higher = coasts longer
-				var MIN_VELOCITY = 0.02;  // px/ms threshold to stop the animation
+				var momentum = null;
+				var friction = 0.95;      // lower = stops sooner, higher = coasts longer
+				var minVelocity = 0.02;  // px/ms threshold to stop the animation
 
 				function stopMomentum() {
-					if (momentumRAF) {
-						cancelAnimationFrame(momentumRAF);
-						momentumRAF = null;
+					if (momentum) {
+						cancelAnimationFrame(momentum);
+						momentum = null;
 					}
 				}
 
 				function runMomentum() {
 					wrapper.scrollLeft -= velocity * 16; // approximate px for a ~16ms frame
-					velocity *= FRICTION;
+					velocity *= friction;
 
 					// Stop at the natural scroll boundaries too, rather than fighting them
 					if (wrapper.scrollLeft <= 0 || wrapper.scrollLeft >= wrapper.scrollWidth - wrapper.clientWidth) {
 						velocity = 0;
 					}
 
-					if (Math.abs(velocity) > MIN_VELOCITY) {
-						momentumRAF = requestAnimationFrame(runMomentum);
+					if (Math.abs(velocity) > minVelocity) {
+						momentum = requestAnimationFrame(runMomentum);
 					} else {
-						momentumRAF = null;
+						momentum = null;
 					}
 				}
 
@@ -1091,7 +1135,7 @@ var AspenDiscovery = (function(){
 
 					var dx = e.clientX - startX;
 
-					if (Math.abs(dx) > DRAG_THRESHOLD && wrapper.dataset.dragMoved !== 'true') {
+					if (Math.abs(dx) > dragThreshold && wrapper.dataset.dragMoved !== 'true') {
 						wrapper.dataset.dragMoved = 'true';
 						wrapper.classList.add('dragging');
 						wrapper.setPointerCapture(pointerId); // capture only now that it's a real drag
@@ -1121,8 +1165,8 @@ var AspenDiscovery = (function(){
 					}
 					pointerId = null;
 
-					if (Math.abs(velocity) > MIN_VELOCITY) {
-						momentumRAF = requestAnimationFrame(runMomentum);
+					if (Math.abs(velocity) > minVelocity) {
+						momentum = requestAnimationFrame(runMomentum);
 					}
 
 					setTimeout(function () { wrapper.dataset.dragMoved = 'false'; }, 0);

--- a/code/web/services/Record/AJAX.php
+++ b/code/web/services/Record/AJAX.php
@@ -1964,6 +1964,7 @@ class Record_AJAX extends JSON_Action {
 		//If it is a non-fiction work, we will prompt the user for the edition if they aren't placing a hold on the latest
 		if ($isNonFiction) {
 			$selectedRecordLatestPubDate = 0;
+			$hasHoldEditionPromptMessage = false;
 			foreach ($marcRecord->getPublicationDates() as $selectedRecordPubDate) {
 				if (preg_match('/(\d{4})/', $selectedRecordPubDate, $matches)) {
 					$selectedRecordLatestPubDate = max($selectedRecordLatestPubDate, $matches[1]);
@@ -1975,15 +1976,18 @@ class Record_AJAX extends JSON_Action {
 					foreach ($relatedRecord->getDriver()->getPublicationDates() as $relatedRecordPubDate) {
 						if (preg_match('/(\d{4})/', $relatedRecordPubDate, $matches)) {
 							if ($matches[1] > $selectedRecordLatestPubDate) {
-								$holdPromptForEditions = 2;
+								if ($holdPromptForEditions != 1) {
+									$holdPromptForEditions = 2;
+								}
 								$promptForEdition = true;
+								$hasHoldEditionPromptMessage = true;
 								$interface->assign('holdEditionPromptMessage', 'You are placing a hold on an earlier version of this title. If you need the latest information, you can request the newer edition instead, though wait times may be longer.');
 								break;
 							}
 						}
 					}
 				}
-				if ($promptForEdition && $holdPromptForEditions == 2) {
+				if ($promptForEdition && $hasHoldEditionPromptMessage) {
 					break;
 				}
 			}


### PR DESCRIPTION
- Swap buttons so "suggested" edition is first
- Update Record/AJAX.php to not override $holdPromptForEditions if libraries have it set to 1, but still show the holdEditionPromptMessage if the suggested isn't the most recent version 
- Update initializeHorizontalSwiper function in base.js to hide scroller buttons when applicable

Tested on my local instance of Aspen