### PR TITLE
DIS-2851: Solr Docker volume freezes config across image upgrades, breaking analysis-extras after the Solr 9 bump

### DIFF
--- a/code/web/release_notes/26.08.00.MD
+++ b/code/web/release_notes/26.08.00.MD
@@ -18,6 +18,7 @@
 - Replace `TIMEZONE` env var with `TZ` and set timezone via PHP-FPM pool config instead of `timedatectl`, which requires systemd and fails silently in containers. ([DIS-2296](https://aspen-discovery.atlassian.net/browse/DIS-2296)) (*LM*)
 - Replace `exec()` shell calls in container scripts with PHP native functions and fix retry logic, hardcoded constants, and a dead signal trap in Apache startup. ([DIS-2296](https://aspen-discovery.atlassian.net/browse/DIS-2296)) (*LM*)
 - Consolidate Docker database update script to delegate to SystemAPI, eliminating a duplicate implementation that had diverged from the authoritative version used by the web admin UI and nightly cron job ([DIS-2670](https://aspen-discovery.atlassian.net/browse/DIS-2670)) (*LM*)
+- Stop persisting all of `/var/solr` in the Solr container's volume, which froze config and libraries (schema, solrconfig, `lib`) at whichever image first created it and silently shadowed updates from later image bumps; only the index data is now persisted, via Solr's own `SOLR_DATA_HOME` mechanism ([DIS-2851](https://aspen-discovery.atlassian.net/browse/DIS-2851)) (*LM*)
 
 ### eCommerce Updates
 - Allow the statuses within an eCommerce Report to be edited ([DIS-2537](https://aspen-discovery.atlassian.net/browse/DIS-2537)) (*SW*)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ networks:
   net-aspen:
 
 volumes:
-  solr:
+  solr-index-data:
 
 services:
   backend:
@@ -83,10 +83,12 @@ services:
       - .env
     environment:
       - SOLR_PORT=${SOLR_PORT:-8983}
+      - SOLR_HOST=${SOLR_HOST:-solr}
+      - SOLR_DATA_HOME=/var/solr/index-data
     ports:
       - "${SOLR_PORT}:${SOLR_PORT:-8983}"
     volumes:
-      - solr:/var/solr
+      - solr-index-data:/var/solr/index-data
     networks:
       - net-aspen
     entrypoint:
@@ -94,42 +96,15 @@ services:
     - '-c'
     - |
       init-var-solr
-      # Series core
-      precreate-core series /opt/solr/server/solr/configsets/series
-      cp -r /opt/solr/server/solr/configsets/series/* series
 
-      # Genealogy core
-      precreate-core genealogy /opt/solr/server/solr/configsets/genealogy
-      cp -r /opt/solr/server/solr/configsets/genealogy/* genealogy
-
-      # Grouped Works v2 core
-      precreate-core grouped_works_v2 /opt/solr/server/solr/configsets/grouped_works_v2
-      cp -r /opt/solr/server/solr/configsets/grouped_works_v2/* grouped_works_v2
-
-      # Grouped Works v3 core
-      precreate-core grouped_works_v3 /opt/solr/server/solr/configsets/grouped_works_v3
-      cp -r /opt/solr/server/solr/configsets/grouped_works_v3/* grouped_works_v3
-
-      # Lists core
-      precreate-core lists /opt/solr/server/solr/configsets/lists
-      cp -r /opt/solr/server/solr/configsets/lists/* lists
-
-      # Course Reserves core
-      precreate-core course_reserves /opt/solr/server/solr/configsets/course_reserves
-      cp -r /opt/solr/server/solr/configsets/course_reserves/* course_reserves
-
-      # Open Archives core
-      precreate-core open_archives /opt/solr/server/solr/configsets/open_archives
-      cp -r /opt/solr/server/solr/configsets/open_archives/* open_archives
-
-      # Website Pages core
-      precreate-core website_pages /opt/solr/server/solr/configsets/website_pages
-      cp -r /opt/solr/server/solr/configsets/website_pages/* website_pages
-
-      # Events core
-      precreate-core events /opt/solr/server/solr/configsets/events
-      cp -r /opt/solr/server/solr/configsets/events/* events
-
+      # Only the index data itself is persisted, on solr-index-data (via the
+      # solr.data.home mechanism, set through SOLR_DATA_HOME above). Everything
+      # else under /var/solr/data (conf, core.properties, solr.xml, lib) is not
+      # volume-mounted, so it always comes fresh from whatever image is running
+      # instead of being frozen at whichever image first created the volume.
+      for core in series genealogy grouped_works_v2 grouped_works_v3 lists course_reserves open_archives website_pages events; do
+        precreate-core "$$core" "/opt/solr/server/solr/configsets/$$core"
+      done
 
       chown -R solr:solr /var/solr
       runuser -u solr -- solr-foreground


### PR DESCRIPTION
Solr's Docker volume was mounting all of /var/solr, so config and libraries got frozen at whichever image first created the volume — later image updates were silently shadowed. This broke analysis-extras after the Solr 9 bump. Fix: only the index data is now persisted (via Solr's native SOLR_DATA_HOME), so config always loads fresh from the running image.

Test plan

Before:
- Bump the Solr image and confirm analysis-extras (ICU filters) isn't picked up without manually copying jars into the volume.

After:
- Start the stack; confirm all 9 cores respond to admin/ping.
- Confirm analysis-extras jars load automatically, no manual copy step.
- Write a marker file to the volume, run down/up (full container recreation), confirm it survives.
- Run a real Koha extraction + reindex; confirm records are indexed and searchable in Solr.