### PR TITLE
DIS-2622: QA Changes

### DIFF
--- a/code/web/interface/themes/responsive/Search/advanced.tpl
+++ b/code/web/interface/themes/responsive/Search/advanced.tpl
@@ -238,6 +238,8 @@
 	var searchFields = {ldelim}
 	{foreach from=$advSearchTypes item=searchDesc key=searchVal}
 	"{$searchVal}" : "{translate text=$searchDesc inAttribute=true isPublicFacing=true}",
+	{foreachelse}
+	"Keyword" : "{translate text="Keyword" inAttribute=true isPublicFacing=true}",
 	{/foreach}
 	{rdelim};
 	var searchJoins = {ldelim}


### PR DESCRIPTION
Fix issue where, if all search types are disabled, no search type showed in the advanced search page. It will now show "Keyword"

Tested on my local instance of Aspen