### PR TITLE
DIS-2648: QA Changes

### DIFF
--- a/code/web/services/Record/AJAX.php
+++ b/code/web/services/Record/AJAX.php
@@ -991,7 +991,8 @@ class Record_AJAX extends JSON_Action {
 					}else{
 						//Placing a hold on the suggested edition
 						$rememberUserEditionPreference = isset($_REQUEST['rememberUserEditionPreference']) ? filter_var($_REQUEST['rememberUserEditionPreference'], FILTER_VALIDATE_BOOLEAN) : false;
-						if ($rememberUserEditionPreference !== $patron->rememberHoldPromptForEdition) {
+						//don't update rememberHoldPromptForEdition from here if it is already set to 1 for the patron, they can update from their preferences
+						if ($rememberUserEditionPreference !== $patron->rememberHoldPromptForEdition && $patron->rememberHoldPromptForEdition != 1) {
 							$patron->setRememberHoldPromptForEdition($rememberUserEditionPreference);
 							$patron->update();
 						}
@@ -1962,7 +1963,7 @@ class Record_AJAX extends JSON_Action {
 		}
 
 		//If it is a non-fiction work, we will prompt the user for the edition if they aren't placing a hold on the latest
-		if ($isNonFiction) {
+		if ($isNonFiction && $holdPromptForEditions != 0) {
 			$selectedRecordLatestPubDate = 0;
 			$hasHoldEditionPromptMessage = false;
 			foreach ($marcRecord->getPublicationDates() as $selectedRecordPubDate) {
@@ -1976,9 +1977,6 @@ class Record_AJAX extends JSON_Action {
 					foreach ($relatedRecord->getDriver()->getPublicationDates() as $relatedRecordPubDate) {
 						if (preg_match('/(\d{4})/', $relatedRecordPubDate, $matches)) {
 							if ($matches[1] > $selectedRecordLatestPubDate) {
-								if ($holdPromptForEditions != 1) {
-									$holdPromptForEditions = 2;
-								}
 								$promptForEdition = true;
 								$hasHoldEditionPromptMessage = true;
 								$interface->assign('holdEditionPromptMessage', 'You are placing a hold on an earlier version of this title. If you need the latest information, you can request the newer edition instead, though wait times may be longer.');


### PR DESCRIPTION
- Update the isNonFiction check to also check if holdPromptForEditions is not 0 
- Update logic for updating rememberHoldPromptForEdition for users/patrons so that it doesn't get reset when placing a hold if it is already set to 1

Tested on my local instance of Aspen