### PR TITLE
DIS-2647: QA Changes

### DIFF
--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -18794,7 +18794,12 @@ AspenDiscovery.WebBuilder = function () {
 			const params = { method: "getWebResource", resourceId: id };
 
 			$.getJSON(url, params, (data) => {
-				const { openInNewTab, url: resourceUrl } = data;
+				const { canView, openInNewTab, url: resourceUrl, userNoAccessTitle, userNoAccessMessage } = data;
+
+				if (!canView) {
+					AspenDiscovery.showMessage(userNoAccessTitle, userNoAccessMessage);
+					return;
+				}
 
 				const trackParams = { method: "trackWebResourceUsage", id, authType: "user" };
 				if (fromPlacard) trackParams.fromPlacard = 1;

--- a/code/web/interface/themes/responsive/js/aspen/web-builder.js
+++ b/code/web/interface/themes/responsive/js/aspen/web-builder.js
@@ -530,7 +530,12 @@ AspenDiscovery.WebBuilder = function () {
 			const params = { method: "getWebResource", resourceId: id };
 
 			$.getJSON(url, params, (data) => {
-				const { openInNewTab, url: resourceUrl } = data;
+				const { canView, openInNewTab, url: resourceUrl, userNoAccessTitle, userNoAccessMessage } = data;
+
+				if (!canView) {
+					AspenDiscovery.showMessage(userNoAccessTitle, userNoAccessMessage);
+					return;
+				}
 
 				const trackParams = { method: "trackWebResourceUsage", id, authType: "user" };
 				if (fromPlacard) trackParams.fromPlacard = 1;


### PR DESCRIPTION
Ensure users without access get shown the same "userNoAccessMessage" if they aren't already logged in when clicking a resource & logging in through that modal

Tested on my local instance of Aspen