### PR TITLE
DIS-2649: Avoid matching names from two separate people when doing author searches

### DIFF
--- a/code/web/release_notes/26.09.00.MD
+++ b/code/web/release_notes/26.09.00.MD
@@ -118,6 +118,7 @@
 #### Reports and Statistics
 #### SSO
 #### Searching
+- Update search specifications for author and contributor searches to help prevent matching on shared first or last names from different authors/contributors. ([DIS-2649](https://aspen-discovery.atlassian.net/browse/DIS-2649)) (*KL*)
 #### Series
 #### Server Setup
 #### Side Loading

--- a/code/web/sys/SolrConnector/Solr.php
+++ b/code/web/sys/SolrConnector/Solr.php
@@ -737,9 +737,11 @@ abstract class Solr {
 			$values['onephrase'] = '"' . str_replace('"', '', implode(' ', $tokenized)) . '"';
 			if (count($tokenized) > 1) {
 				$values['proximal'] = $values['onephrase'] . '~10';
+				$values['proximal2'] = $values['onephrase'] . '~2';
 				$values['single_word'] = null;
 			} else {
 				$values['proximal'] = null;
+				$values['proximal2'] = null;
 				if (!array_key_exists(0, $tokenized)) {
 					$values['single_word'] = '';
 				} else {
@@ -804,6 +806,7 @@ abstract class Solr {
 				'and' => $cleanedQuery,
 				'or' => $cleanedQuery,
 				'proximal' => $cleanedQuery,
+				'proximal2' => $cleanedQuery,
 				'single_word' => $cleanedQuery,
 				'single_word_removal' => $onephrase,
 				'exact_quoted' => $onephrase,

--- a/sites/default/conf/groupedWorksSearchSpecs2.yaml
+++ b/sites/default/conf/groupedWorksSearchSpecs2.yaml
@@ -119,10 +119,10 @@ Author:
       - [proximal, 200]
     - author2:
       - [onephrase, 25]
-      - [proximal, 1]
+      - [proximal2, 1]
     - author_additional:
       - [onephrase, 25]
-      - [proximal, 1]
+      - [proximal2, 1]
 
 AuthorProper:
   QueryFields:


### PR DESCRIPTION
- Update search specs yaml and solr.php functions to have a proximal2 value where slop is set to ~2 instead of ~10. This helps match authors based on firstname lastname searches. "Firstname Lastname" will still match "Lastname, Firstname" but will no longer match with contributors who share the same first or last name
- Update release notes

Tested on my local instance of Aspen