### PR TITLE
DIS 2867: Remove redundant background process check from backend startup

### DIFF
--- a/code/web/release_notes/26.09.00.MD
+++ b/code/web/release_notes/26.09.00.MD
@@ -120,6 +120,7 @@
 #### Searching
 #### Series
 #### Server Setup
+- Remove a redundant background process check from the backend container's startup script. ([DIS-2867](https://aspen-discovery.atlassian.net/browse/DIS-2867)) (*LM*)
 #### Side Loading
 #### Sierra ILS
 #### Summon

--- a/docker/files/scripts/start.sh
+++ b/docker/files/scripts/start.sh
@@ -114,7 +114,5 @@ done
 log_info "Running pending database updates..."
 php updateDatabase.php "$SITE_NAME"
 
-sudo -u www-data php /usr/local/aspen-discovery/docker/files/cron/checkBackgroundProcessesDocker.php $SITE_NAME >/proc/1/fd/1 2>/proc/1/fd/2
-
 log_info "Starting PHP-FPM in foreground mode..."
 php-fpm8.4 --test && exec php-fpm8.4 -F


### PR DESCRIPTION
The backend container's startup script made a one-time call to checkBackgroundProcessesDocker.php, which checks whether required background/indexing Java processes (like the reindexer) are running and relaunches any that aren't. That responsibility already belongs to the cron container, which runs the same check on a recurring schedule via crontab. The call in backend only ever ran once at boot with no follow-up, so it added no real supervision, just a duplicated startup step.

The fix removes that redundant call from backend's start.sh, leaving background-process supervision solely to the cron container, which is the intended owner per the project's own docker service documentation. This is a minor cleanup with no functional impact: backend continues serving PHP-FPM requests as before, and background-process monitoring continues uninterrupted via cron.