### PR TITLE
DIS-1202: Fix OverDrive Products to Reindex 

### DIFF
--- a/code/overdrive_extract/src/com/turning_leaf_technologies/overdrive/ExtractOverDriveInfo.java
+++ b/code/overdrive_extract/src/com/turning_leaf_technologies/overdrive/ExtractOverDriveInfo.java
@@ -183,14 +183,13 @@ class ExtractOverDriveInfo implements AutoCloseable {
 					logEntry.addNote("There are " + numProductsToUpdate + " products that need to be checked for updates");
 					logEntry.saveResults();
 
+					addProductsToUpdate();
+
 					//Do some counts of the records that will be updated for logging purposes
 					int numRecordsToUpdate = 0;
 					int numNewRecords = 0;
 					int totalRecordsWithChanges = 0;
 					for (OverDriveRecordInfo curRecord : allProductsInOverDrive.values()) {
-						if (settings.getProductsToUpdate().contains(curRecord.getId().toLowerCase())){
-							curRecord.hasChanges = true;
-						}
 						//Extract data from Libby and update the database
 						if (curRecord.isNew){
 							numNewRecords++;
@@ -1133,6 +1132,24 @@ class ExtractOverDriveInfo implements AutoCloseable {
 		} catch (SQLException e) {
 			logEntry.incErrors("Error updating last seen for " + curRecord.getId());
 		}
+	}
+
+
+	private void addProductsToUpdate() {
+		for (String productId : settings.getProductsToUpdate()) {
+			OverDriveRecordInfo recordInfo = allProductsInOverDrive.get(productId);
+
+			if (recordInfo == null) {
+				recordInfo = new OverDriveRecordInfo();
+				recordInfo.setId(productId);
+				getExistingRecordInformationForProduct(recordInfo);
+				allProductsInOverDrive.put(recordInfo.getId(), recordInfo);
+			}
+
+			recordInfo.hasChanges = true;
+			logEntry.addNote("Added record " + productId + " to process queue");
+		}
+		logEntry.saveResults();
 	}
 
 	private synchronized void getExistingRecordInformationForProduct(OverDriveRecordInfo curRecord) {

--- a/code/web/release_notes/26.09.00.MD
+++ b/code/web/release_notes/26.09.00.MD
@@ -40,6 +40,7 @@
 #### Materials Request
 #### New York Times API
 #### OverDrive
+- Fix an issue where manually entered OverDrive product IDs in OverDrive Setting > Products to Reindex are not processed.([DIS-1202](https://aspen-discovery.atlassian.net/browse/DIS-1202)) (*YL*)
 #### Palace Project
 #### Permissions and Roles
 #### Placards

--- a/code/web/sys/OverDrive/OverDriveSetting.php
+++ b/code/web/sys/OverDrive/OverDriveSetting.php
@@ -181,8 +181,8 @@ class OverDriveSetting extends DataObject {
 			'productsToUpdate' => [
 				'property' => 'productsToUpdate',
 				'type' => 'textarea',
-				'label' => 'Products To Reindex',
-				'description' => 'A list of products to update on the next index',
+				'label' => 'Records To Reindex',
+				'description' => 'A list of records to update on the next index. Enter one record ID per line.',
 				'canBatchUpdate' => false,
 				'hideInLists' => true,
 			],


### PR DESCRIPTION
There is a field in OverDrive settings called “Products to Reindex”, where you should be able to list the OverDrive IDs and force specific updates for those records on the next index, but it’s not currently working. When entering OverDrive GUIDs into the "Products To Reindex" text field, the corresponding OverDrive records did not appear to reindex (no status change, no change in update/availability info/time in staff view) although the indexing pass did take/clear the entered GUIDs. 

To test:
1. Apply the PR.
2. Go to OverDrive Settings > Products to Reindex and enter the OverDrive record IDs.
3. Wait for the next indexing run.
4. Check the log for: `Added record <productId> to process queue`
5. Go to the record pages and verify that Staff View > Last Update has changed.
