### PR TITLE
DIS-2784: Add Hoopla Records to Include

### DIFF
--- a/code/hoopla_export/src/com/turning_leaf_technologies/hoopla/HooplaExportMain.java
+++ b/code/hoopla_export/src/com/turning_leaf_technologies/hoopla/HooplaExportMain.java
@@ -181,7 +181,7 @@ public class HooplaExportMain {
 					if (singleWorkId == null) {
 						updatesRun = exporter2.exportHooplaData();
 					} else {
-						updatesRun = exporter2.exportSingleHooplaTitle(singleWorkId);
+						updatesRun = exporter2.exportSingleHooplaTitle(singleWorkId, true);
 					}
 					exporter2.exporter2CleanUp();
 					numChanges = logEntry2.getNumChanges();

--- a/code/hoopla_export/src/com/turning_leaf_technologies/hoopla/HooplaExporter2.java
+++ b/code/hoopla_export/src/com/turning_leaf_technologies/hoopla/HooplaExporter2.java
@@ -400,7 +400,7 @@ public class HooplaExporter2 {
 				}
 
 				// Process Records to Reindex
-				updatesRun |= processProductsToUpdate(settings);
+				processProductsToUpdate(settings);
 
 				// Extract Global Content
 				if (!globalContentUpdated) {
@@ -1333,9 +1333,9 @@ public class HooplaExporter2 {
 		return updatesRun;
 	}
 
-	private boolean processProductsToUpdate(HooplaSettings2 settings) {
+	private void processProductsToUpdate(HooplaSettings2 settings) {
 		if (settings.getProductsToUpdate().isEmpty()) {
-			return false;
+			return;
 		}
 
 		boolean updatesRun = false;
@@ -1344,9 +1344,7 @@ public class HooplaExporter2 {
 			try {
 				Long.parseLong(hooplaId);
 
-				if (exportSingleHooplaTitle(hooplaId, false)) {
-					updatesRun = true;
-				} else {
+				if (!exportSingleHooplaTitle(hooplaId, false)) {
 					logEntry.addNote("Failed to retrieve Hoopla record " + hooplaId + ".");
 				}
 			} catch (NumberFormatException e) {
@@ -1361,8 +1359,6 @@ public class HooplaExporter2 {
 		} catch (SQLException e) {
 			logEntry.incErrors("Error clearing Hoopla Products To Reindex", e);
 		}
-
-		return updatesRun;
 	}
 
 	private void updateTitlesInDB(JSONArray responseTitles, boolean forceRegrouping, boolean doFullReload) {

--- a/code/hoopla_export/src/com/turning_leaf_technologies/hoopla/HooplaExporter2.java
+++ b/code/hoopla_export/src/com/turning_leaf_technologies/hoopla/HooplaExporter2.java
@@ -399,6 +399,9 @@ public class HooplaExporter2 {
 					continue;
 				}
 
+				// Process Records to Reindex
+				updatesRun |= processProductsToUpdate(settings);
+
 				// Extract Global Content
 				if (!globalContentUpdated) {
 					globalContentUpdated = exportHooplaContent(settings);
@@ -1180,7 +1183,7 @@ public class HooplaExporter2 {
 		return Collections.emptySet();
 	}
 
-	public boolean exportSingleHooplaTitle(String singleWorkId) {
+	public boolean exportSingleHooplaTitle(String singleWorkId, boolean flushAfterRetrieve) {
 		boolean updatesRun = false;
 		try{
 			logEntry.addNote("Doing extract of single work " + singleWorkId);
@@ -1313,7 +1316,9 @@ public class HooplaExporter2 {
 				if (updatesRun) {
 					// Add the title to the list regardless
 					titlesNeedingReindex.add(numericSingleWorkId);
-					flushRecordsToReindex();
+					if (flushAfterRetrieve) {
+						flushRecordsToReindex();
+					}
 				}
 				logEntry.addNote("Completed extract of single work " + singleWorkId + " for setting " + settings.getSettingsId());
 				logEntry.saveResults();
@@ -1325,6 +1330,42 @@ public class HooplaExporter2 {
 		}catch (Exception e){
 			logEntry.incErrors("Error exporting single hoopla title", e);
 		}
+		return updatesRun;
+	}
+
+	private boolean processProductsToUpdate(HooplaSettings2 settings) {
+		if (settings.getProductsToUpdate().isEmpty()) {
+			return false;
+		}
+
+		boolean updatesRun = false;
+
+		for (String hooplaId : settings.getProductsToUpdate()) {
+			try {
+				Long.parseLong(hooplaId);
+
+				if (exportSingleHooplaTitle(hooplaId, false)) {
+					updatesRun = true;
+				} else {
+					logEntry.addNote("Failed to retrieve Hoopla record " + hooplaId + ".");
+				}
+			} catch (NumberFormatException e) {
+				logEntry.addNote("Skipped invalid Hoopla record ID " + hooplaId);
+			}
+		}
+		logEntry.saveResults();
+
+		if (updatesRun) {
+			flushRecordsToReindex();
+		}
+
+		try (PreparedStatement clearProductsToUpdateStmt = aspenConn.prepareStatement("UPDATE hoopla_settings SET productsToUpdate = '' WHERE id = ?")) {
+			clearProductsToUpdateStmt.setLong(1, settings.getSettingsId());
+			clearProductsToUpdateStmt.executeUpdate();
+		} catch (SQLException e) {
+			logEntry.incErrors("Error clearing Hoopla Products To Reindex", e);
+		}
+
 		return updatesRun;
 	}
 

--- a/code/hoopla_export/src/com/turning_leaf_technologies/hoopla/HooplaExporter2.java
+++ b/code/hoopla_export/src/com/turning_leaf_technologies/hoopla/HooplaExporter2.java
@@ -1355,10 +1355,6 @@ public class HooplaExporter2 {
 		}
 		logEntry.saveResults();
 
-		if (updatesRun) {
-			flushRecordsToReindex();
-		}
-
 		try (PreparedStatement clearProductsToUpdateStmt = aspenConn.prepareStatement("UPDATE hoopla_settings SET productsToUpdate = '' WHERE id = ?")) {
 			clearProductsToUpdateStmt.setLong(1, settings.getSettingsId());
 			clearProductsToUpdateStmt.executeUpdate();

--- a/code/hoopla_export/src/com/turning_leaf_technologies/hoopla/HooplaSettings2.java
+++ b/code/hoopla_export/src/com/turning_leaf_technologies/hoopla/HooplaSettings2.java
@@ -2,6 +2,8 @@ package com.turning_leaf_technologies.hoopla;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.Set;
 
 class HooplaSettings2 {
 	private final long settingsId;
@@ -18,6 +20,7 @@ class HooplaSettings2 {
 	private final long lastUpdateOfAllRecords;
 	private final String lastRecordProcessed;
 	private final int hooplaFlexBatchSize;
+	private final Set<String> productsToUpdate = new HashSet<>();
 
 	// Token settings
 	private final String accessToken;
@@ -44,6 +47,15 @@ class HooplaSettings2 {
 		tokenExpirationTime = settingsRS.getLong("tokenExpirationTime");
 
 		regroupAllRecords = settingsRS.getBoolean("regroupAllRecords");
+		String productsToUpdateStr = settingsRS.getString("productsToUpdate");
+		if (productsToUpdateStr != null) {
+			for (String productId : productsToUpdateStr.split("\\R")) {
+				productId = productId.trim();
+				if (!productId.isEmpty()) {
+					productsToUpdate.add(productId);
+				}
+			}
+		}
 	}
 
 	public long getSettingsId() {
@@ -104,6 +116,10 @@ class HooplaSettings2 {
 
 	public int getHooplaFlexBatchSize() {
 		return hooplaFlexBatchSize;
+	}
+
+	public Set<String> getProductsToUpdate() {
+		return productsToUpdate;
 	}
 
 }

--- a/code/web/release_notes/26.09.00.MD
+++ b/code/web/release_notes/26.09.00.MD
@@ -32,6 +32,15 @@
 #### Grouped Works
 #### Holds
 #### Hoopla
+- Add a Records To Reindex setting for Hoopla. Entering Hoopla record IDs refreshes their metadata, entitlements, and Flex availability from Hoopla. ([DIS-2784](https://aspen-discovery.atlassian.net/browse/DIS-2784)) (*YL*)
+
+<div markdown="1" class="settings">
+
+##### New Settings
+- Hoopla Settings > Records to Reindex
+
+</div>
+
 #### ILL
 #### Indexing
 #### Interface Updates and Usability

--- a/code/web/sys/DBMaintenance/version_updates/26.09.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/26.09.00.php
@@ -22,6 +22,13 @@ function getUpdates26_09_00(): array {
 		//kodi
 
 		//yanjun
+		'add_hoopla_products_to_update' => [
+			'title' => 'Add Records To Reindex to Hoopla Settings',
+			'description' => 'Add a queue of Hoopla record IDs to refresh and reindex.',
+			'sql' => [
+				'ALTER TABLE hoopla_settings ADD COLUMN productsToUpdate MEDIUMTEXT NULL',
+			],
+		],
 
 		//imani
 

--- a/code/web/sys/Hoopla/HooplaSetting.php
+++ b/code/web/sys/Hoopla/HooplaSetting.php
@@ -23,6 +23,7 @@ class HooplaSetting extends DataObject {
 	public $recordExtractionBatchSize;
 	public $hooplaFlexBatchSize;
 	public $indexingTime;
+	public $productsToUpdate;
 	// Legacy Hoopla v1 columns
 	public $libraryId;
 	public $runFullUpdateInstant;
@@ -377,6 +378,13 @@ class HooplaSetting extends DataObject {
 		];
 		if ($isVersion2) {
 			$indexingProperties += [
+				'productsToUpdate' => [
+					'property' => 'productsToUpdate',
+					'type' => 'textarea',
+					'label' => 'Records To Reindex',
+					'description' => 'A list of Hoopla record IDs to update on the next export run. Enter one record ID per line.',
+					'default' => '',
+				],
 				'lastUpdateOfChangedRecords' => [
 					'property' => 'lastUpdateOfChangedRecords',
 					'type' => 'timestamp',


### PR DESCRIPTION
For Hoopla version 2, add a Records To Reindex setting that allows admins to enter Hoopla record IDs, one per line, to refresh metadata, entitlements, and Flex availability before reindexing.

To test:
1. Apply the PR.
2. Go to Hoopla Settings > Record to Reindex and enter the Hoopla record IDs.
3. Wait for the next indexing run.
4. Check the log for: Doing extract of single work <recordID>
5. Go to the record pages and verify that Staff View > Last Update has changed.
6. Repeat step 2 but enter invalid IDs, for letters or special characters 
7. Wait for the next indexing run, check the logs for: Skipped invalid Hoopla record ID <invalid ID> 