### PR TITLE
DIS-2877: Fix Hoopla v2 SingleWork Extraction

### DIFF
--- a/code/hoopla_export/src/com/turning_leaf_technologies/hoopla/HooplaExporter2.java
+++ b/code/hoopla_export/src/com/turning_leaf_technologies/hoopla/HooplaExporter2.java
@@ -1237,7 +1237,7 @@ public class HooplaExporter2 {
 					}
 					// We don't know if this title is instant or flex for the current library, so we try instant first
 					if (librarySetting.isInstantEnabled()) {
-						String entitlementUrl = hooplaAPIBaseURL + "/api/v1/libraries/" + librarySetting.getHooplaLibraryId() + "/entitlements?purchaseModel=Instant&limit=1&status=active&startToken=" + (numericSingleWorkId - 1);
+						String entitlementUrl = hooplaAPIBaseURL + "/api/v1/libraries/" + librarySetting.getHooplaLibraryId() + "/entitlements?purchaseModel=Instant&limit=1&startToken=" + (numericSingleWorkId - 1);
 						WebServiceResponse entitlementResponse = NetworkUtils.getURL(entitlementUrl, logger, headers);
 						if (!entitlementResponse.isSuccess()) {
 							logEntry.incErrors("Could not get entitlements from " + entitlementUrl + " " + entitlementResponse.getMessage());
@@ -1250,14 +1250,14 @@ public class HooplaExporter2 {
 
 									// Verify contentId is the same as the given hoopla Id
 									if (entitlement.has("contentId") && entitlement.getLong("contentId") == numericSingleWorkId) {
-										if (entitlement.has("active") && entitlement.getBoolean("active")) {
+										if (entitlement.has("active")) {
 											// Only update the entitlement if it is active
 											updateEntitlementsInDB(responseEntitlements, null, false, HOOPLA_TYPE_INSTANT, librarySetting.getLibraryId());
-											logger.warn("Updated entitlement for Hoopla Library ID " + librarySetting.getHooplaLibraryId() + " for Instant.");
+											logger.warn("Updated entitlement for Hoopla Library ID " + librarySetting.getHooplaLibraryId() + " for Instant. Entitlement active = " + entitlement.getBoolean("active"));
 											updatesRun = true;
 											continue;
 										} else {
-											logger.warn("Entitlement is not active for Hoopla Library ID " + librarySetting.getHooplaLibraryId() + " for Instant.");
+											logger.warn("Error returning enttlement status for Hoopla Library ID " + librarySetting.getHooplaLibraryId() + " for Instant.");
 										}
 									} else {
 										logger.warn("Content ID for entitlement does not match the given hoopla ID, this record might not be active for Hoopla Library ID " + librarySetting.getHooplaLibraryId() + " for Instant.");
@@ -1268,7 +1268,7 @@ public class HooplaExporter2 {
 					}
 
 					if (librarySetting.isFlexEnabled()) {
-						String entitlementUrl = hooplaAPIBaseURL + "/api/v1/libraries/" + librarySetting.getHooplaLibraryId() + "/entitlements?purchaseModel=Flex&limit=1&status=active&startToken=" + (numericSingleWorkId - 1);
+						String entitlementUrl = hooplaAPIBaseURL + "/api/v1/libraries/" + librarySetting.getHooplaLibraryId() + "/entitlements?purchaseModel=Flex&limit=1&startToken=" + (numericSingleWorkId - 1);
 						WebServiceResponse entitlementResponse = NetworkUtils.getURL(entitlementUrl, logger, headers);
 						if (!entitlementResponse.isSuccess()) {
 							logEntry.incErrors("Could not get entitlements from " + entitlementUrl + " " + entitlementResponse.getMessage());
@@ -1281,25 +1281,27 @@ public class HooplaExporter2 {
 
 									// Verify contentId is the same as the given hoopla ID
 									if (entitlement.has("contentId") && entitlement.getLong("contentId") == numericSingleWorkId) {
-										if (entitlement.has("active") && entitlement.getBoolean("active")) {
-											// Only update the entitlement if it is active
+										if (entitlement.has("active")) {
+											boolean activeStatus = entitlement.getBoolean("active");
 											updateEntitlementsInDB(responseEntitlements, null, false, HOOPLA_TYPE_FLEX, librarySetting.getLibraryId());
-											logger.warn("Updated entitlement for Hoopla Library ID " + librarySetting.getHooplaLibraryId() + " for Flex.");
-
-											// This is an active fle entitlement, so we need to update the availability
-											String availabilityUrl = hooplaAPIBaseURL + "/api/v1/libraries/" + librarySetting.getHooplaLibraryId() + "/content/info?contentIds=" + numericSingleWorkId;
-											WebServiceResponse availabilityResponse = NetworkUtils.getURL(availabilityUrl, logger, headers);
-											if (!availabilityResponse.isSuccess()) {
-												logEntry.incErrors("Could not get availability from " + availabilityUrl + " " + availabilityResponse.getMessage());
-											} else {
-												JSONArray availabilityArray = new JSONArray(availabilityResponse.getMessage());
-												updateFlexAvailabilityInDB(availabilityArray, librarySetting.getLibraryId());
-												logger.warn("Updated availability for Hoopla Library ID " + librarySetting.getHooplaLibraryId() + " for Flex.");
-												updatesRun = true;
-												continue;
+											logger.warn("Updated entitlement for Hoopla Library ID " + librarySetting.getHooplaLibraryId() + " for Flex. Entitlement active = " + activeStatus);
+											if (activeStatus) {
+												// This is an active flex entitlement, so we need to update the availability
+												// If this is an inactive flex entitlement, updateEntitlementsInDB() will remove flex availability
+												String availabilityUrl = hooplaAPIBaseURL + "/api/v1/libraries/" + librarySetting.getHooplaLibraryId() + "/content/info?contentIds=" + numericSingleWorkId;
+												WebServiceResponse availabilityResponse = NetworkUtils.getURL(availabilityUrl, logger, headers);
+												if (!availabilityResponse.isSuccess()) {
+													logEntry.incErrors("Could not get availability from " + availabilityUrl + " " + availabilityResponse.getMessage());
+												} else {
+													JSONArray availabilityArray = new JSONArray(availabilityResponse.getMessage());
+													updateFlexAvailabilityInDB(availabilityArray, librarySetting.getLibraryId());
+													logger.warn("Updated availability for Hoopla Library ID " + librarySetting.getHooplaLibraryId() + " for Flex.");
+													continue;
+												}
+											updatesRun = true;
 											}
 										} else {
-											logger.warn("Entitlement is not active for Hoopla Library ID " + librarySetting.getHooplaLibraryId() + " for Flex.");
+											logger.warn("Error returning enttlement status for Hoopla Library ID " + librarySetting.getHooplaLibraryId() + " for Flex.");
 										}
 									} else {
 										logger.warn("Content ID for entitlement " + entitlement.getLong("contentId") + " does not match the given hoopla ID, this record might not be active for Hoopla Library ID " + librarySetting.getHooplaLibraryId() + " for Flex.");

--- a/code/web/release_notes/26.09.00.MD
+++ b/code/web/release_notes/26.09.00.MD
@@ -32,6 +32,7 @@
 #### Grouped Works
 #### Holds
 #### Hoopla
+- Fix an issue where Hoopla Version 2 singleWork extraction could not remove records with an inactive entitlement. ([DIS-2877](https://aspen-discovery.atlassian.net/browse/DIS-2877)) (*YL*)
 #### ILL
 #### Indexing
 #### Interface Updates and Usability


### PR DESCRIPTION
If a Hoopla record appears in the Aspen catalog but is actually inactive for the library, running the singlework extraction command cannot remove or update the record because the current singlework extraction logic only checks entitlement where status=active.

To test:
1. Apply the PR 
2. Confirm Hoopla Version 2 is enabled and has both Instant and Flex enabled.
3. Find one active one inactive Instant titles and one active one inactive Flex titles.
4. Run the following DB queries and run reindexer.jar for reindexing grouped work. 
(1) Restore an active Instant title
     `DELETE FROM hoopla_entitlement_scopes WHERE entitlementId = (SELECT id FROM hoopla_entitlements WHERE hooplaId = <Instant A ID> AND hooplaType = 'Instant') AND scopeLibraryId = <scopeLibraryId>;`
     Reindex the grouped work; confirm Instant title is removed. 
     Run Hoopla singlework extraction; confirm Instant title appears. 
 (2) Remove an inactive Instant title
`INSERT IGNORE INTO hoopla_entitlements (hooplaId, hooplaType) VALUES (<Instant B ID>, 'Instant');`
`INSERT IGNORE INTO hoopla_entitlement_scopes (entitlementId, scopeLibraryId) VALUES ((SELECT id FROM hoopla_entitlements WHERE hooplaId = <Instant B ID> AND hooplaType = 'Instant'), <scopeLibraryId>);`
    Reindex the grouped work, confirm Instant title appears. 
    Run Hoopla singlework extraction, confirm Instant is removed. 
 (3) Restore an active Flex title
`DELETE FROM hoopla_entitlement_scopes WHERE entitlementId = (SELECT id FROM hoopla_entitlements WHERE hooplaId = <Flex A ID> AND hooplaType = 'Flex') AND scopeLibraryId = <scopeLibraryId>;`
`DELETE FROM hoopla_flex_availability WHERE hooplaId = <Flex A ID> AND scopeLibraryId = <scopeLibraryId>;`
   Reindex the grouped work; confirm Flex title is removed. 
   Run hoopla singlework extraction; confirm Flex title appears. 
 (4) Remove an inactive Flex title
   `INSERT IGNORE INTO hoopla_entitlements (hooplaId, hooplaType) VALUES (<Flex B ID>, 'Flex');`
   `INSERT IGNORE INTO hoopla_entitlement_scopes (entitlementId, scopeLibraryId) VALUES ((SELECT id FROM hoopla_entitlements WHERE hooplaId = <Flex B ID> AND hooplaType = 'Flex'), <scopeLibraryId>);`
   `INSERT INTO hoopla_flex_availability (hooplaId, holdsQueueSize, availableCopies, totalCopies, status, scopeLibraryId) VALUES (<Flex B ID>, 0, 1, 1, 'BORROW', <scopeLibraryId>) ON DUPLICATE KEY UPDATE holdsQueueSize = VALUES(holdsQueueSize), availableCopies = VALUES(availableCopies), totalCopies = VALUES(totalCopies), status = VALUES(status);`
    Reindex the grouped work; confirm Flex title appears. 
    Run Hoopla singlework extraction, confirm Flex is removed. 
   