### PR TITLE
DIS-2668: Add checkbox list to Custom Form

### DIFF
--- a/code/web/interface/themes/responsive/DataObjectUtil/multiSelect.tpl
+++ b/code/web/interface/themes/responsive/DataObjectUtil/multiSelect.tpl
@@ -28,7 +28,7 @@
 			<div class="checkbox">
 				{*this assumes a simple array, eg list *}
 				{foreach from=$property.values item=propertyName}
-					<input name='{$propName}[]' type="checkbox" value='{$propertyName}' {if is_array($propValue) && in_array($propertyName, $propValue)}checked='checked'{/if} {if !empty($property.readOnly)}readonly disabled{/if}> {if !empty($property.translateValues)}{translate text=$propertyName|escape inAttribute=true isPublicFacing=$property.isPublicFacing isAdminFacing=$property.isAdminFacing }{else}{$propertyName|escape}{/if}<br>
+					<input name='{$propName}[]' type="checkbox" value='{$propertyName}' {if !empty($property.required)}required{/if} {if is_array($propValue) && in_array($propertyName, $propValue)}checked='checked'{/if} {if !empty($property.readOnly)}readonly disabled{/if}> {if !empty($property.translateValues)}{translate text=$propertyName|escape inAttribute=true isPublicFacing=$property.isPublicFacing isAdminFacing=$property.isAdminFacing }{else}{$propertyName|escape}{/if}<br>
 				{/foreach}
 			</div>
 		{elseif $property.listStyle == 'checkboxWithOptions'}

--- a/code/web/release_notes/26.09.00.MD
+++ b/code/web/release_notes/26.09.00.MD
@@ -68,6 +68,7 @@
 #### User Account
 #### User Lists
 #### Web Builder
+- Add a Checkbox List field type to Web Builder Custom Forms. Patrons can now select multiple options from a list of checkboxes. ([DIS-2668](https://aspen-discovery.atlassian.net/browse/DIS-2668)) (*YL*)
 #### Website Indexing
 
 ### Bug Fixes and Code Maintenance

--- a/code/web/services/WebBuilder/SubmitForm.php
+++ b/code/web/services/WebBuilder/SubmitForm.php
@@ -157,6 +157,9 @@ class WebBuilder_SubmitForm extends Action {
 			$submissionSelection = new CustomFormSubmissionSelection();
 			$submissionSelection->formSubmissionId = $formSubmissionId;
 			$submissionSelection->submissionFieldId = $fieldId;
+			if (is_array($formFieldContent)) {
+				$formFieldContent = implode(', ', $formFieldContent);
+			}
 			$submissionSelection->formFieldContent = $formFieldContent;
 			$submissionSelection->insert();
 		}

--- a/code/web/sys/DB/UnsavedDataObject.php
+++ b/code/web/sys/DB/UnsavedDataObject.php
@@ -19,6 +19,9 @@ class UnsavedDataObject extends DataObject {
 	function getPrintableHtmlData($structure) : string {
 		$printableData = '';
 		foreach ($this->_data as $fieldId => $value) {
+			if (is_array($value)) {
+				$value = implode(', ', $value);
+			}
 			$fieldLabel = $structure[$fieldId]['label'];
 			$printableData .= "<div><b>$fieldLabel</b></div><div>$value</div><br/>";
 		}

--- a/code/web/sys/WebBuilder/CustomForm.php
+++ b/code/web/sys/WebBuilder/CustomForm.php
@@ -252,9 +252,12 @@ class CustomForm extends DB_LibraryLinkedObject {
 				'required' => $field->required,
 				'default' => $field->defaultValue,
 			];
-			if ($fieldType == 'enum') {
-				$enumValues = explode(',', $field->enumValues);
+			if ($fieldType == 'enum' || $fieldType == 'multiSelect') {
+				$enumValues = array_map('trim', explode(',', $field->enumValues));
 				$fieldStructure['values'] = $enumValues;
+			}
+			if ($fieldType == 'multiSelect') {
+				$fieldStructure['listStyle'] = 'checkboxList';
 			}
 			$structure[$field->id] = $fieldStructure;
 		}

--- a/code/web/sys/WebBuilder/CustomFormField.php
+++ b/code/web/sys/WebBuilder/CustomFormField.php
@@ -29,7 +29,8 @@ class CustomFormField extends DataObject {
         12 => 'Address 2 (prefill)',
         13 => 'City (prefill)',
         14 => 'State (prefill)',
-        15 => 'Zip (prefill)'
+		15 => 'Zip (prefill)',
+		16 => 'Checkbox List'
 	];
 
 	public static $fieldTypes = [
@@ -48,7 +49,8 @@ class CustomFormField extends DataObject {
         12 => 'address2_prefill',
         13 => 'city_prefill',
         14 => 'state_prefill',
-        15 => 'zip_prefill'
+		15 => 'zip_prefill',
+		16 => 'multiSelect'
 	];
 
 	static $_objectStructure = [];
@@ -98,8 +100,8 @@ class CustomFormField extends DataObject {
 			'enumValues' => [
 				'property' => 'enumValues',
 				'type' => 'textarea',
-				'label' => 'Select List Values (separate values with commas)',
-				'description' => 'A list of valid values for the select list',
+				'label' => 'Select List / Checkbox List Values (separate values with commas)',
+				'description' => 'A list of valid values for the select list or checkbox list',
 				'autoResizeTextArea' => true,
 				'required' => false,
 			],


### PR DESCRIPTION
Custom Forms in Web Builder has a Field Type “Select List” which lets patrons select only one option from a dropdown list. Adding a “Checkbox” Field Type so that patrons can select multiple options at the same time.

To Test:
1. Apply the PR.
2. Go to Web Builder > Custom Forms and create or edit a custom form.
3. Add a new field and select Checkbox List.
4. Enter options such as Red, Blue, and Green, and mark the field as Required.
5. Save the form and open the public link.
6. Confirm that all three checkbox options appear.
7. Select multiple options and submit the form.
8. Confirm that the submission succeeds.
9. Submit the form again without selecting any options and confirm that the browser prevents submission.