### PR TITLE
Dis-1506: Add Display Order to Staff Members

### DIFF
--- a/code/web/release_notes/26.09.00.MD
+++ b/code/web/release_notes/26.09.00.MD
@@ -70,6 +70,14 @@
 #### Web Builder
 #### Website Indexing
 
+- Add configurable Staff Directory ordering. Administrators can assign display order values, with lower numbers appearing first. Staff members sharing the same order are sorted alphabetically by name, and unassigned members use order 0. ([DIS-1506](https://aspen-discovery.atlassian.net/browse/DIS-1506)) (*YL*)
+- Update the Staff Members administration sort so Display Order results are grouped by library. ([DIS-1506](https://aspen-discovery.atlassian.net/browse/DIS-1506)) (*YL*)
+<div markdown="1" class="settings">
+
+##### New Settings
+- Staff Members > Display Order
+
+</div>
 ### Bug Fixes and Code Maintenance
 #### Accessibility
 - Make several buttons in My Account Checked Out Titles and Lists keyboard-accessible. ([DIS-2573](https://aspen-discovery.atlassian.net/browse/DIS-2573)) (*GMC*)

--- a/code/web/services/WebBuilder/StaffDirectory.php
+++ b/code/web/services/WebBuilder/StaffDirectory.php
@@ -11,7 +11,7 @@ class StaffDirectory extends Action {
 
 		require_once ROOT_DIR . '/sys/WebBuilder/StaffMember.php';
 		$staffMember = new StaffMember();
-		$staffMember->orderBy('name');
+		$staffMember->orderBy('CASE WHEN displayOrder = 0 THEN 1 ELSE 0 END, displayOrder ASC, name ASC, id ASC');
 		$staffMember->libraryId = $library->libraryId;
 		$staffMember->find();
 		$staffMembers = [];

--- a/code/web/services/WebBuilder/StaffMembers.php
+++ b/code/web/services/WebBuilder/StaffMembers.php
@@ -40,6 +40,29 @@ class WebBuilder_StaffMembers extends ObjectEditor {
 		return 'name asc';
 	}
 
+	function getSort(): string {
+		$sort = parent::getSort();
+		$normalizedSort = strtolower($sort);
+
+		if ($normalizedSort === 'displayorder asc') {
+			return 'libraryId asc,
+					CASE WHEN displayOrder = 0 THEN 1 ELSE 0 END,
+					displayOrder asc,
+					name asc,
+					id asc';
+		}
+
+		if ($normalizedSort === 'displayorder desc') {
+			return 'libraryId asc,
+					CASE WHEN displayOrder = 0 THEN 1 ELSE 0 END,
+					displayOrder desc,
+					name asc,
+					id asc';
+		}
+
+		return $sort;
+	}
+
 	function getObjectStructure($context = ''): array {
 		return StaffMember::getObjectStructure($context);
 	}

--- a/code/web/services/WebBuilder/StaffMembers.php
+++ b/code/web/services/WebBuilder/StaffMembers.php
@@ -21,7 +21,8 @@ class WebBuilder_StaffMembers extends ObjectEditor {
 
 	function getAllObjects(int $page, int $recordsPerPage): array {
 		$object = new StaffMember();
-		$object->orderBy($this->getSort());
+		$sort = parent::getSort();
+		$object->orderBy($this->getStaffMemberOrderBy($sort));
 		$this->applyFilters($object);
 		$object->limit(($page - 1) * $recordsPerPage, $recordsPerPage);
 		if (!UserAccount::userHasPermission('Administer All Staff Members')) {
@@ -40,9 +41,8 @@ class WebBuilder_StaffMembers extends ObjectEditor {
 		return 'name asc';
 	}
 
-	function getSort(): string {
-		$sort = parent::getSort();
-		$normalizedSort = strtolower($sort);
+	private function getStaffMemberOrderBy(string $sort): string {
+		$normalizedSort = strtolower(trim($sort));
 
 		if ($normalizedSort === 'displayorder asc') {
 			return 'libraryId asc,

--- a/code/web/sys/DBMaintenance/version_updates/26.09.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/26.09.00.php
@@ -35,8 +35,16 @@ function getUpdates26_09_00(): array {
 				'ALTER TABLE `aspen_lida_self_check_settings` ADD COLUMN `checkedoutOverrideLocations` VARCHAR(255)',
 			]
 		], //self_check_location_overrides
-
 		//yanjun
+		'add_staff_members_display_order' => [
+			'title' => 'Add staff members display order column',
+			'description' => 'Add staff members display order',
+			'continueOnError' => false,
+			'sql' => [
+				'ALTER TABLE staff_members ADD COLUMN displayOrder INT UNSIGNED NOT NULL DEFAULT 0',
+				'UPDATE staff_members sm JOIN (SELECT id, ROW_NUMBER() OVER (PARTITION BY libraryId ORDER BY name ASC, id ASC) AS newDisplayOrder FROM staff_members) orderedStaff ON orderedStaff.id = sm.id SET sm.displayOrder = orderedStaff.newDisplayOrder'
+			]
+		],
 
 		//imani
 

--- a/code/web/sys/WebBuilder/StaffMember.php
+++ b/code/web/sys/WebBuilder/StaffMember.php
@@ -11,6 +11,7 @@ class StaffMember extends DataObject {
 	public $libraryId;
 	public $photo;
 	public $description;
+	public $displayOrder;
 
 	static $_objectStructure = [];
 	static function getObjectStructure(string $context = ''): array {
@@ -40,6 +41,14 @@ class StaffMember extends DataObject {
 				'description' => 'The name of the staffer',
 				'size' => '100',
 				'maxLength' => 100,
+			],
+			'displayOrder' => [
+				'property' => 'displayOrder',
+				'type' => 'integer',
+				'label' => 'Display Order',
+				'description' => 'Use 0 when no order is assigned. Otherwise, enter a number starting at 1; lower numbers appear first. Staff members in the same library with the same order are sorted alphabetically by name.',
+				'default' => 0,
+				'min' => 0,
 			],
 			'role' => [
 				'property' => 'role',


### PR DESCRIPTION
Add configurable Staff Directory ordering. Administrators can assign display order values, with lower numbers appearing first. Staff members sharing the same order are sorted alphabetically by name, and unassigned members use order 0. 
Update the Staff Members administration sort so Display Order results are grouped by library.


To Test:
1. Apply the PR.
2. Go to Web Builder > Staff Members and confirm the Display Order field is shown.
3. Go to /WebBuilder/StaffDirectory and confirm staff members still appear in their existing alphabetical order.
4. Return to Staff Members and assign different display order values to different staff member entries
5. Go back to /WebBuilder/StaffDirectory and confirm staff members appear according to the assigned order.
6. Assign the same order to multiple staff members and confirm they are sorted alphabetically by name.
7. In Staff Members, select Display Order Ascending and confirm results are grouped by library and ordered by display order.
8. Select Display Order Descending and confirm the selected sort remains displayed and the results update correctly.
9. Confirm unassigned staff members with order 0 appear after assigned staff members.