### PR TITLE
DIS-2878: Add support for Force Reindex to retrieve data from eContents

### DIFF
--- a/code/cloud_library_export/src/com/turning_leaf_technologies/cloud_library/CloudLibraryExportMain.java
+++ b/code/cloud_library_export/src/com/turning_leaf_technologies/cloud_library/CloudLibraryExportMain.java
@@ -169,7 +169,9 @@ public class CloudLibraryExportMain {
 				CloudLibrarySettings settings = new CloudLibrarySettings(getSettingsRS);
 				numSettings++;
 				CloudLibraryExporter exporter = new CloudLibraryExporter(serverName, configIni, settings, logger, aspenConn);
-				numChanges += exporter.extractSingleRecord(singleRecordId);
+				if (exporter.extractSingleRecord(singleRecordId)) {
+					numChanges++;
+				}
 			}
 			if (numSettings == 0) {
 				logger.error("Unable to find settings for CloudLibrary; please add settings to the database.");

--- a/code/cloud_library_export/src/com/turning_leaf_technologies/cloud_library/CloudLibraryExporter.java
+++ b/code/cloud_library_export/src/com/turning_leaf_technologies/cloud_library/CloudLibraryExporter.java
@@ -266,8 +266,9 @@ public class CloudLibraryExporter {
 	 * @param singleRecordId The CloudLibrary ID of the record to extract.
 	 * @return Number of changes made.
 	 */
-	public int extractSingleRecord(String singleRecordId) {
-		int numChanges = 0;
+	public boolean extractSingleRecord(String singleRecordId) {
+		boolean marcLoaded = false;
+		boolean availabilityLoaded = false;
 
 		loadExistingTitles(settings.getSettingsId());
 
@@ -303,9 +304,7 @@ public class CloudLibraryExporter {
 					SAXParserFactory saxParserFactory = SAXParserFactory.newInstance();
 					SAXParser saxParser = saxParserFactory.newSAXParser();
 					saxParser.parse(new ByteArrayInputStream(response.getMessage().getBytes(StandardCharsets.UTF_8)), handler);
-
-					numChanges += handler.getNumDocuments();
-					logEntry.saveResults();
+					marcLoaded = true;
 				} catch (SAXException | ParserConfigurationException | IOException e) {
 					logger.error("Error parsing response:", e);
 					logEntry.incErrors("Error parsing response: ", e);
@@ -313,13 +312,10 @@ public class CloudLibraryExporter {
 				break;
 			}
 		}
+		logEntry.saveResults();
 
 		CloudLibraryAvailability availability = loadAvailabilityForRecord(singleRecordId);
-		if (availability != null) {
-			numChanges++;
-		}
-
-		processRecordsToReload(logEntry);
+		availabilityLoaded = !availability.getRawResponse().isEmpty();
 
 		if (recordGroupingProcessorSingleton != null) {
 			recordGroupingProcessorSingleton.close();
@@ -333,10 +329,9 @@ public class CloudLibraryExporter {
 			existingRecords = null;
 		}
 
-		logger.info("Finished extracting single record: {} change(s).", numChanges);
 		logEntry.setFinished();
 
-		return numChanges;
+		return marcLoaded && availabilityLoaded;
 	}
 
 	private void createDbLogEntry(Date startTime, Connection aspenConn) {

--- a/code/cloud_library_export/src/com/turning_leaf_technologies/cloud_library/CloudLibraryExporter.java
+++ b/code/cloud_library_export/src/com/turning_leaf_technologies/cloud_library/CloudLibraryExporter.java
@@ -267,13 +267,33 @@ public class CloudLibraryExporter {
 	 * @return Number of changes made.
 	 */
 	public boolean extractSingleRecord(String singleRecordId) {
-		boolean marcLoaded = false;
-		boolean availabilityLoaded = false;
-
 		loadExistingTitles(settings.getSettingsId());
 
 		logEntry.addNote("Extracting single CloudLibrary record: " + singleRecordId + ".");
 		logEntry.saveResults();
+
+		boolean updatesRun = reloadSingleRecordFromApi(singleRecordId);
+
+		if (recordGroupingProcessorSingleton != null) {
+			recordGroupingProcessorSingleton.close();
+			recordGroupingProcessorSingleton = null;
+		}
+
+		if (groupedWorkIndexer != null) {
+			groupedWorkIndexer.finishIndexingFromExtract(logEntry);
+			groupedWorkIndexer.close();
+			groupedWorkIndexer = null;
+			existingRecords = null;
+		}
+
+		logEntry.setFinished();
+
+		return updatesRun;
+	}
+
+	private boolean reloadSingleRecordFromApi(String singleRecordId) {
+		boolean marcLoaded = false;
+		boolean availabilityLoaded = false;
 
 		CloudLibraryMarcHandler handler = new CloudLibraryMarcHandler(this, settings.getSettingsId(), existingRecords, true, startTimeForLogging, aspenConn, getRecordGroupingProcessor(), getGroupedWorkIndexer(), logEntry, logger, settings.shouldRunSundayReindex());
 		String apiPath = "/cirrus/library/" + settings.getLibraryId() + "/data/marc/" + singleRecordId;
@@ -316,20 +336,6 @@ public class CloudLibraryExporter {
 
 		CloudLibraryAvailability availability = loadAvailabilityForRecord(singleRecordId);
 		availabilityLoaded = !availability.getRawResponse().isEmpty();
-
-		if (recordGroupingProcessorSingleton != null) {
-			recordGroupingProcessorSingleton.close();
-			recordGroupingProcessorSingleton = null;
-		}
-
-		if (groupedWorkIndexer != null) {
-			groupedWorkIndexer.finishIndexingFromExtract(logEntry);
-			groupedWorkIndexer.close();
-			groupedWorkIndexer = null;
-			existingRecords = null;
-		}
-
-		logEntry.setFinished();
 
 		return marcLoaded && availabilityLoaded;
 	}
@@ -441,43 +447,31 @@ public class CloudLibraryExporter {
 	}
 
 	private void processRecordsToReload(CloudLibraryExtractLogEntry logEntry) {
-		try {
+		try (
 			PreparedStatement getRecordsToReloadStmt = aspenConn.prepareStatement("SELECT * FROM record_identifiers_to_reload WHERE processed = 0 AND type='cloud_library'", ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
 			PreparedStatement markRecordToReloadAsProcessedStmt = aspenConn.prepareStatement("UPDATE record_identifiers_to_reload SET processed = 1 WHERE id = ?");
-
 			ResultSet getRecordsToReloadRS = getRecordsToReloadStmt.executeQuery();
+		) {
 			int numRecordsToReloadProcessed = 0;
 			while (getRecordsToReloadRS.next()){
 				long recordToReloadId = getRecordsToReloadRS.getLong("id");
 				String cloudLibraryId = getRecordsToReloadRS.getString("identifier");
-				// Regroup the record.
-				String groupedWorkId = getRecordGroupingProcessor().groupCloudLibraryRecord(cloudLibraryId);
-				if (groupedWorkId != null) {
-					logEntry.incRecordsRegrouped();
-					getGroupedWorkIndexer().processGroupedWork(groupedWorkId);
+				if (reloadSingleRecordFromApi(cloudLibraryId)) {
+					markRecordToReloadAsProcessedStmt.setLong(1, recordToReloadId);
+					markRecordToReloadAsProcessedStmt.executeUpdate();
+					numRecordsToReloadProcessed++;
+					logEntry.addNote("Refreshed CloudLibrary record " + cloudLibraryId + " from Force Reindex.");
 				} else {
-					logEntry.incErrors("Could not get details for record to reload " + cloudLibraryId + ", as it has likely been deleted.");
-					RemoveRecordFromWorkResult result = getRecordGroupingProcessor().removeRecordFromGroupedWork("cloud_library", cloudLibraryId);
-					if (result.reindexWork) {
-						getGroupedWorkIndexer().processGroupedWork(result.permanentId);
-					} else if (result.deleteWork) {
-						// Delete the work from Solr and the database.
-						logEntry.incDeleted();
-						getGroupedWorkIndexer().deleteRecord(result.permanentId, result.groupedWorkId);
-					}
-
+					logEntry.addNote("Failed to refresh CloudLibrary record " + cloudLibraryId + " from Force Reindex.");
 				}
-				markRecordToReloadAsProcessedStmt.setLong(1, recordToReloadId);
-				markRecordToReloadAsProcessedStmt.executeUpdate();
-				numRecordsToReloadProcessed++;
 			}
 			if (numRecordsToReloadProcessed > 0){
-				logEntry.addNote("Regrouped " + numRecordsToReloadProcessed + " records marked for reprocessing.");
+				logEntry.addNote("Processed " + numRecordsToReloadProcessed + " records from Force Reindex.");
 			}
-			getRecordsToReloadRS.close();
 		} catch (Exception e){
 			logEntry.incErrors("Error processing records to reload ", e);
 		}
+		logEntry.saveResults();
 	}
 
 	private GroupedWorkIndexer getGroupedWorkIndexer() {

--- a/code/hoopla_export/src/com/turning_leaf_technologies/hoopla/HooplaExportMain.java
+++ b/code/hoopla_export/src/com/turning_leaf_technologies/hoopla/HooplaExportMain.java
@@ -181,7 +181,7 @@ public class HooplaExportMain {
 					if (singleWorkId == null) {
 						updatesRun = exporter2.exportHooplaData();
 					} else {
-						updatesRun = exporter2.exportSingleHooplaTitle(singleWorkId);
+						updatesRun = exporter2.exportSingleHooplaTitle(singleWorkId, true);
 					}
 					exporter2.exporter2CleanUp();
 					numChanges = logEntry2.getNumChanges();

--- a/code/hoopla_export/src/com/turning_leaf_technologies/hoopla/HooplaExporter2.java
+++ b/code/hoopla_export/src/com/turning_leaf_technologies/hoopla/HooplaExporter2.java
@@ -399,6 +399,9 @@ public class HooplaExporter2 {
 					continue;
 				}
 
+				// Process Records to Reindex
+				updatesRun |= processProductsToUpdate(settings);
+
 				// Extract Global Content
 				if (!globalContentUpdated) {
 					globalContentUpdated = exportHooplaContent(settings);
@@ -1180,7 +1183,7 @@ public class HooplaExporter2 {
 		return Collections.emptySet();
 	}
 
-	public boolean exportSingleHooplaTitle(String singleWorkId) {
+	public boolean exportSingleHooplaTitle(String singleWorkId, boolean flushAfterRetrieve) {
 		boolean updatesRun = false;
 		try{
 			logEntry.addNote("Doing extract of single work " + singleWorkId);
@@ -1313,7 +1316,9 @@ public class HooplaExporter2 {
 				if (updatesRun) {
 					// Add the title to the list regardless
 					titlesNeedingReindex.add(numericSingleWorkId);
-					flushRecordsToReindex();
+					if (flushAfterRetrieve) {
+						flushRecordsToReindex();
+					}
 				}
 				logEntry.addNote("Completed extract of single work " + singleWorkId + " for setting " + settings.getSettingsId());
 				logEntry.saveResults();
@@ -1325,6 +1330,42 @@ public class HooplaExporter2 {
 		}catch (Exception e){
 			logEntry.incErrors("Error exporting single hoopla title", e);
 		}
+		return updatesRun;
+	}
+
+	private boolean processProductsToUpdate(HooplaSettings2 settings) {
+		if (settings.getProductsToUpdate().isEmpty()) {
+			return false;
+		}
+
+		boolean updatesRun = false;
+
+		for (String hooplaId : settings.getProductsToUpdate()) {
+			try {
+				Long.parseLong(hooplaId);
+
+				if (exportSingleHooplaTitle(hooplaId, false)) {
+					updatesRun = true;
+				} else {
+					logEntry.addNote("Failed to retrieve Hoopla record " + hooplaId + ".");
+				}
+			} catch (NumberFormatException e) {
+				logEntry.addNote("Skipped invalid Hoopla record ID " + hooplaId);
+			}
+		}
+		logEntry.saveResults();
+
+		if (updatesRun) {
+			flushRecordsToReindex();
+		}
+
+		try (PreparedStatement clearProductsToUpdateStmt = aspenConn.prepareStatement("UPDATE hoopla_settings SET productsToUpdate = '' WHERE id = ?")) {
+			clearProductsToUpdateStmt.setLong(1, settings.getSettingsId());
+			clearProductsToUpdateStmt.executeUpdate();
+		} catch (SQLException e) {
+			logEntry.incErrors("Error clearing Hoopla Products To Reindex", e);
+		}
+
 		return updatesRun;
 	}
 

--- a/code/hoopla_export/src/com/turning_leaf_technologies/hoopla/HooplaExporter2.java
+++ b/code/hoopla_export/src/com/turning_leaf_technologies/hoopla/HooplaExporter2.java
@@ -106,11 +106,12 @@ public class HooplaExporter2 {
 	}
 
 	private void processRecordsToReload(HooplaExtractLogEntry2 logEntry) {
-		try {
+		try (
 			PreparedStatement getRecordsToReloadStmt = aspenConn.prepareStatement("SELECT * from record_identifiers_to_reload WHERE processed = 0 and type='hoopla'", ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
 			PreparedStatement markRecordToReloadAsProcessedStmt = aspenConn.prepareStatement("UPDATE record_identifiers_to_reload SET processed = 1 where id = ?");
 			PreparedStatement getItemDetailsForRecordStmt = aspenConn.prepareStatement("SELECT UNCOMPRESS(rawResponse) as rawResponse FROM hoopla_export where hooplaId = ?", ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
 			ResultSet getRecordsToReloadRS = getRecordsToReloadStmt.executeQuery();
+		) {
 			int numRecordsToReloadProcessed = 0;
 			while (getRecordsToReloadRS.next()){
 				long recordToReloadId = getRecordsToReloadRS.getLong("id");
@@ -126,7 +127,6 @@ public class HooplaExporter2 {
 			if (numRecordsToReloadProcessed > 0){
 				logEntry.addNote("Added " + numRecordsToReloadProcessed + " records from Force Reindex to the update queue.");
 			}
-			getRecordsToReloadRS.close();
 		}catch (Exception e){
 			logEntry.incErrors("Error processing records to reload ", e);
 		}

--- a/code/hoopla_export/src/com/turning_leaf_technologies/hoopla/HooplaExporter2.java
+++ b/code/hoopla_export/src/com/turning_leaf_technologies/hoopla/HooplaExporter2.java
@@ -103,7 +103,6 @@ public class HooplaExporter2 {
 		//Get a list of all existing records in the database
 		loadExistingTitles();
 
-		processRecordsToReload(logEntry);
 	}
 
 	private void processRecordsToReload(HooplaExtractLogEntry2 logEntry) {
@@ -115,36 +114,17 @@ public class HooplaExporter2 {
 			int numRecordsToReloadProcessed = 0;
 			while (getRecordsToReloadRS.next()){
 				long recordToReloadId = getRecordsToReloadRS.getLong("id");
-				String recordId = getRecordsToReloadRS.getString("identifier");
-				long hooplaId = Long.parseLong(StringUtils.replace(recordId,"MWT", ""));
-				//Regroup the record
-				getItemDetailsForRecordStmt.setLong(1, hooplaId);
-				ResultSet getItemDetailsForRecordRS = getItemDetailsForRecordStmt.executeQuery();
-				if (getItemDetailsForRecordRS.next()){
-					String rawResponse = getItemDetailsForRecordRS.getString("rawResponse");
-					try {
-						JSONObject itemDetails = new JSONObject(rawResponse);
-						String groupedWorkId =  getRecordGroupingProcessor().groupHooplaRecord(itemDetails, hooplaId);
-						//Reindex the record
-						getGroupedWorkIndexer().processGroupedWork(groupedWorkId);
-
+				String hooplaId = StringUtils.replace(getRecordsToReloadRS.getString("identifier"), "MWT", "");
+				if (exportSingleHooplaTitle(hooplaId, false)) {
 						markRecordToReloadAsProcessedStmt.setLong(1, recordToReloadId);
 						markRecordToReloadAsProcessedStmt.executeUpdate();
 						numRecordsToReloadProcessed++;
-					}catch (JSONException e){
-						logEntry.incErrors("Could not parse item details for record to reload " + hooplaId, e);
-					}
-				}else{
-					//The record has likely been deleted
-					logEntry.addNote("Could not get details for Hoopla record to reload " + hooplaId + " it has been deleted");
-					markRecordToReloadAsProcessedStmt.setLong(1, recordToReloadId);
-					markRecordToReloadAsProcessedStmt.executeUpdate();
-					numRecordsToReloadProcessed++;
+				} else {
+					logEntry.addNote("Failed to retrieve Hoopla record " + hooplaId + " from Force Reindex.");
 				}
-				getItemDetailsForRecordRS.close();
 			}
 			if (numRecordsToReloadProcessed > 0){
-				logEntry.addNote("Regrouped " + numRecordsToReloadProcessed + " records marked for reprocessing");
+				logEntry.addNote("Added " + numRecordsToReloadProcessed + " records from Force Reindex to the update queue.");
 			}
 			getRecordsToReloadRS.close();
 		}catch (Exception e){
@@ -398,6 +378,9 @@ public class HooplaExporter2 {
 					logEntry.saveResults();
 					continue;
 				}
+
+				// Process records that have been marked for Force Reindex
+				processRecordsToReload(logEntry);
 
 				// Process Records to Reindex
 				updatesRun |= processProductsToUpdate(settings);

--- a/code/hoopla_export/src/com/turning_leaf_technologies/hoopla/HooplaSettings2.java
+++ b/code/hoopla_export/src/com/turning_leaf_technologies/hoopla/HooplaSettings2.java
@@ -2,6 +2,8 @@ package com.turning_leaf_technologies.hoopla;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.Set;
 
 class HooplaSettings2 {
 	private final long settingsId;
@@ -18,6 +20,7 @@ class HooplaSettings2 {
 	private final long lastUpdateOfAllRecords;
 	private final String lastRecordProcessed;
 	private final int hooplaFlexBatchSize;
+	private final Set<String> productsToUpdate = new HashSet<>();
 
 	// Token settings
 	private final String accessToken;
@@ -44,6 +47,15 @@ class HooplaSettings2 {
 		tokenExpirationTime = settingsRS.getLong("tokenExpirationTime");
 
 		regroupAllRecords = settingsRS.getBoolean("regroupAllRecords");
+		String productsToUpdateStr = settingsRS.getString("productsToUpdate");
+		if (productsToUpdateStr != null) {
+			for (String productId : productsToUpdateStr.split("\\R")) {
+				productId = productId.trim();
+				if (!productId.isEmpty()) {
+					productsToUpdate.add(productId);
+				}
+			}
+		}
 	}
 
 	public long getSettingsId() {
@@ -104,6 +116,10 @@ class HooplaSettings2 {
 
 	public int getHooplaFlexBatchSize() {
 		return hooplaFlexBatchSize;
+	}
+
+	public Set<String> getProductsToUpdate() {
+		return productsToUpdate;
 	}
 
 }

--- a/code/overdrive_extract/src/com/turning_leaf_technologies/overdrive/ExtractOverDriveInfo.java
+++ b/code/overdrive_extract/src/com/turning_leaf_technologies/overdrive/ExtractOverDriveInfo.java
@@ -183,14 +183,13 @@ class ExtractOverDriveInfo implements AutoCloseable {
 					logEntry.addNote("There are " + numProductsToUpdate + " products that need to be checked for updates");
 					logEntry.saveResults();
 
+					addProductsToUpdate();
+
 					//Do some counts of the records that will be updated for logging purposes
 					int numRecordsToUpdate = 0;
 					int numNewRecords = 0;
 					int totalRecordsWithChanges = 0;
 					for (OverDriveRecordInfo curRecord : allProductsInOverDrive.values()) {
-						if (settings.getProductsToUpdate().contains(curRecord.getId().toLowerCase())){
-							curRecord.hasChanges = true;
-						}
 						//Extract data from Libby and update the database
 						if (curRecord.isNew){
 							numNewRecords++;
@@ -1133,6 +1132,24 @@ class ExtractOverDriveInfo implements AutoCloseable {
 		} catch (SQLException e) {
 			logEntry.incErrors("Error updating last seen for " + curRecord.getId());
 		}
+	}
+
+
+	private void addProductsToUpdate() {
+		for (String productId : settings.getProductsToUpdate()) {
+			OverDriveRecordInfo recordInfo = allProductsInOverDrive.get(productId);
+
+			if (recordInfo == null) {
+				recordInfo = new OverDriveRecordInfo();
+				recordInfo.setId(productId);
+				getExistingRecordInformationForProduct(recordInfo);
+				allProductsInOverDrive.put(recordInfo.getId(), recordInfo);
+			}
+
+			recordInfo.hasChanges = true;
+			logEntry.addNote("Added record " + productId + " to process queue");
+		}
+		logEntry.saveResults();
 	}
 
 	private synchronized void getExistingRecordInformationForProduct(OverDriveRecordInfo curRecord) {

--- a/code/overdrive_extract/src/com/turning_leaf_technologies/overdrive/ExtractOverDriveInfo.java
+++ b/code/overdrive_extract/src/com/turning_leaf_technologies/overdrive/ExtractOverDriveInfo.java
@@ -183,6 +183,10 @@ class ExtractOverDriveInfo implements AutoCloseable {
 					logEntry.addNote("There are " + numProductsToUpdate + " products that need to be checked for updates");
 					logEntry.saveResults();
 
+					// Add any records that have been marked for Force Reindex
+					processRecordsToReload(logEntry);
+
+					// Add any records entered in Records To Reindex
 					addProductsToUpdate();
 
 					//Do some counts of the records that will be updated for logging purposes
@@ -317,9 +321,6 @@ class ExtractOverDriveInfo implements AutoCloseable {
 						saveProductsToUpdateStmt.setLong(2, settings.getId());
 						saveProductsToUpdateStmt.executeUpdate();
 					}
-
-					//For any records that have been marked to reload, regroup and reindex the records
-					processRecordsToReload(logEntry);
 
 					//Finally, process any records that seem to be unlinked
 					//MDN 3/6/24 - This is no longer needed.
@@ -460,23 +461,22 @@ class ExtractOverDriveInfo implements AutoCloseable {
 					while (getRecordsToReloadRS.next()) {
 						long recordToReloadId = getRecordsToReloadRS.getLong("id");
 						String overDriveId = getRecordsToReloadRS.getString("identifier");
-						//Regroup the record
-						String groupedWorkId = getRecordGroupingProcessor().processOverDriveRecord(overDriveId);
-						//Reindex the record
-						getGroupedWorkIndexer().processGroupedWork(groupedWorkId);
+
+						settings.addProductToUpdate(overDriveId);
 
 						markRecordToReloadAsProcessedStmt.setLong(1, recordToReloadId);
 						markRecordToReloadAsProcessedStmt.executeUpdate();
 						numRecordsToReloadProcessed++;
 					}
 					if (numRecordsToReloadProcessed > 0) {
-						logEntry.addNote("Regrouped " + numRecordsToReloadProcessed + " records marked for reprocessing");
+						logEntry.addNote("Added " + numRecordsToReloadProcessed + " records from Force Reindex to the update queue.");
 					}
 				}
 			}
 		}catch (Exception e){
 			logEntry.incErrors("Error processing records to reload ", e);
 		}
+		logEntry.saveResults();
 	}
 
 	private void initOverDriveExtract(Connection dbConn, OverDriveExtractLogEntry logEntry) throws SQLException {

--- a/code/overdrive_extract/src/com/turning_leaf_technologies/overdrive/OverDriveSetting.java
+++ b/code/overdrive_extract/src/com/turning_leaf_technologies/overdrive/OverDriveSetting.java
@@ -97,6 +97,10 @@ public class OverDriveSetting {
 		return productsToUpdate;
 	}
 
+	public void addProductToUpdate(String overDriveId) {
+		productsToUpdate.add(overDriveId);
+	}
+
 	public synchronized void addProductToUpdateNextTime(String overDriveId){
 		productsToUpdateNextTime.add(overDriveId);
 	}

--- a/code/web/release_notes/26.09.00.MD
+++ b/code/web/release_notes/26.09.00.MD
@@ -34,6 +34,7 @@
 #### Hoopla
 #### ILL
 #### Indexing
+- Add support for Force Reindex to refresh record metadata and availability from the OverDrive, Hoopla, and CloudLibrary APIs. ([DIS-2878](https://aspen-discovery.atlassian.net/browse/DIS-2878)) (*YL*)
 #### Interface Updates and Usability
 #### JavaScript Snippets
 #### Koha ILS

--- a/code/web/sys/DBMaintenance/version_updates/26.09.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/26.09.00.php
@@ -22,6 +22,13 @@ function getUpdates26_09_00(): array {
 		//kodi
 
 		//yanjun
+		'add_hoopla_products_to_update' => [
+			'title' => 'Add Records To Reindex to Hoopla Settings',
+			'description' => 'Add a queue of Hoopla record IDs to refresh and reindex.',
+			'sql' => [
+				'ALTER TABLE hoopla_settings ADD COLUMN productsToUpdate MEDIUMTEXT NULL',
+			],
+		],
 
 		//imani
 

--- a/code/web/sys/Hoopla/HooplaSetting.php
+++ b/code/web/sys/Hoopla/HooplaSetting.php
@@ -23,6 +23,7 @@ class HooplaSetting extends DataObject {
 	public $recordExtractionBatchSize;
 	public $hooplaFlexBatchSize;
 	public $indexingTime;
+	public $productsToUpdate;
 	// Legacy Hoopla v1 columns
 	public $libraryId;
 	public $runFullUpdateInstant;
@@ -377,6 +378,13 @@ class HooplaSetting extends DataObject {
 		];
 		if ($isVersion2) {
 			$indexingProperties += [
+				'productsToUpdate' => [
+					'property' => 'productsToUpdate',
+					'type' => 'textarea',
+					'label' => 'Records To Reindex',
+					'description' => 'A list of Hoopla record IDs to update on the next export run. Enter one record ID per line.',
+					'default' => '',
+				],
 				'lastUpdateOfChangedRecords' => [
 					'property' => 'lastUpdateOfChangedRecords',
 					'type' => 'timestamp',

--- a/code/web/sys/OverDrive/OverDriveSetting.php
+++ b/code/web/sys/OverDrive/OverDriveSetting.php
@@ -181,8 +181,8 @@ class OverDriveSetting extends DataObject {
 			'productsToUpdate' => [
 				'property' => 'productsToUpdate',
 				'type' => 'textarea',
-				'label' => 'Products To Reindex',
-				'description' => 'A list of products to update on the next index',
+				'label' => 'Records To Reindex',
+				'description' => 'A list of records to update on the next index. Enter one record ID per line.',
 				'canBatchUpdate' => false,
 				'hideInLists' => true,
 			],


### PR DESCRIPTION
Currently, Staff View > Force Reindex retrieves ILS records from their source system, but eContent records are generally reindexed using data already stored in Aspen. It does not make a vendor API request to retrieve the latest eContent metadata or availability first.

Add source update support for Force Reindex for OverDrive, Hoopla, CloudLibrary

Palace Project currently does not support single work extraction. 
Boundless (Axis 360) is not included in this work.

To Test:
1. Apply the PR.
2. Force reindex grouped works containing Hoopla, OverDrive, and CloudLibrary records.
3. Wait for the eContent records to refresh and reindex.
4. Review the Hoopla, OverDrive, and CloudLibrary logs to confirm that each Force Reindex request was processed.