### PR TITLE
DIS-2875: Allow deleting Reading History entries containing apostrophes

### DIFF
--- a/code/web/interface/themes/responsive/MyAccount/readingHistoryEntry.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/readingHistoryEntry.tpl
@@ -131,7 +131,7 @@
 
 			<div class="col-xs-12 col-md-3">
 				<div class="btn-group btn-group-vertical btn-block">
-					<a href="#" onclick='return AspenDiscovery.Account.ReadingHistory.deleteGroupedEntry("{$selectedUser}", "{$record.permanentId}", "{$record.title|escape:"javascript"}", "{$record.author|escape:"javascript"}", "{$record.id}");' class="btn btn-sm btn-primary">{translate text='Delete' isPublicFacing=true}</a>
+					<a href="#" onclick="return AspenDiscovery.Account.ReadingHistory.deleteGroupedEntry('{$selectedUser}', '{$record.permanentId}', '{$record.title|escape:"javascript"}', '{$record.author|escape:"javascript"}', '{$record.id}');" class="btn btn-sm btn-primary">{translate text='Delete' isPublicFacing=true}</a>
 				</div>
 				{if !empty($showYouMightAlsoLike)}
 					{if !$record.isIll}

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -15810,13 +15810,15 @@ AspenDiscovery.Account.ReadingHistory = (function(){
 		},
 
 		deleteGroupedEntry(patronId, groupedWorkPermanentId, title, author, displayId) {
+                        const titleHtmlSafe = title.replace(/'/g, "&#39;");
+                        const authorHtmlSafe = author.replace(/'/g, "&#39;");
 			AspenDiscovery.confirm(
 				__('Delete Reading History Entry'),
 				__('All checkout records for this title will be irreversibly deleted from your reading history. Proceed?'),
 				__('Delete'),
 				__('Cancel'),
 				false,
-				`AspenDiscovery.Account.ReadingHistory.doDeleteGroupedEntry(&quot;${patronId}&quot;, &quot;${groupedWorkPermanentId}&quot;, &quot;${title}&quot;, &quot;${author}&quot;, &quot;${displayId}&quot;)`,
+				`AspenDiscovery.Account.ReadingHistory.doDeleteGroupedEntry(&quot;${patronId}&quot;, &quot;${groupedWorkPermanentId}&quot;, &quot;${titleHtmlSafe}&quot;, &quot;${authorHtmlSafe}&quot;, &quot;${displayId}&quot;)`,
 				'btn-danger'
 			);
 

--- a/code/web/release_notes/26.09.00.MD
+++ b/code/web/release_notes/26.09.00.MD
@@ -50,6 +50,7 @@
 #### Polaris ILS
 #### Ratings and Reviews
 #### Reading History
+- Fix issue where Reading History entries for titles or authors containing apostrophes could not be deleted. ([DIS-2875](https://aspen-discovery.atlassian.net/browse/DIS-2875)) (*SSP*)
 #### Record Grouping
 #### Reports and Statistics
 #### SSO


### PR DESCRIPTION
When trying to delete an entry from Reading history, clicking the “Delete” button does nothing if the title or author name has an apostrophe (e.g: The Winter’s tale). The confirmation popup does not show up and the page just jumps to the top.

Steps to Reproduce:
1. Go to the Account -> Reading History
2. Find an entry with an apostrophe in the title name
3. Click “Delete”
4. Popup does not show and page just jumps to the top
5. Apply the PR
6. Click “Delete” again and confirm the popup appears and the entry can be deleted successfully