### PR TITLE
 DIS-2519: Translate plural facet title above facet popup search bar

### DIFF
--- a/code/web/interface/themes/responsive/Search/advancedSearchFacetPopup.tpl
+++ b/code/web/interface/themes/responsive/Search/advancedSearchFacetPopup.tpl
@@ -1,7 +1,7 @@
 <form role="form" id="advancedSearchFacetValuesForm">
 	<input type="hidden" name="facetName" id="advFacetName" value="{$facetName}">
 	<div class="form-group">
-		<label for="advFacetSearchTerm">{translate text="Search %1%" isPublicFacing=true 1=$facetTitlePlural}</label>
+		<label for="advFacetSearchTerm">{translate text="Search %1%" isPublicFacing=true 1=$facetTitlePlural translateParameters=true}</label>
 		<div class="input-group input-group-sm">
 			<input type="text" name="facetSearchTerm" id="advFacetSearchTerm" class="form-control" onkeydown="AspenDiscovery.Searches.searchAdvancedFacetValuesKeyDown(event)"/>
 			<span class="btn btn-sm btn-primary input-group-addon" onclick="return AspenDiscovery.Searches.searchAdvancedFacetValues();">{translate text="Search" isPublicFacing=true}</span>

--- a/code/web/interface/themes/responsive/Search/searchFacetPopup.tpl
+++ b/code/web/interface/themes/responsive/Search/searchFacetPopup.tpl
@@ -15,7 +15,7 @@
 	<input type="hidden" name="searchId" id="searchId" value="{$searchId}">
 	<input type="hidden" name="facetName" id="facetName" value="{$facetName}">
 	<div class="form-group">
-		<label for="facetSearchTerm">{translate text="Search %1%" isPublicFacing=true 1=$facetTitlePlural}</label>
+		<label for="facetSearchTerm">{translate text="Search %1%" isPublicFacing=true 1=$facetTitlePlural translateParameters=true}</label>
 		<div class="input-group input-group-sm">
 			<input  type="text" name="facetSearchTerm" id="facetSearchTerm" class="form-control" onkeydown="AspenDiscovery.Searches.searchFacetValuesKeyDown(event)"/>
 			<span class="btn btn-sm btn-primary input-group-addon" onclick="return AspenDiscovery.Searches.searchFacetValues();">{translate text="Search" isPublicFacing=true}</span>

--- a/code/web/release_notes/26.09.00.MD
+++ b/code/web/release_notes/26.09.00.MD
@@ -51,6 +51,7 @@
 #### JavaScript Snippets
 #### Koha ILS
 #### Languages and Translations
+- Fix translating the plural facet name above the search bar in its popup ([DIS-2519](https://aspen-discovery.atlassian.net/browse/DIS-2836)) (*OR*)
 #### Materials Request
 #### New York Times API
 #### OverDrive


### PR DESCRIPTION
Pass `translateParameters` in both modals to ensure the facet title is translated too.