### PR TITLE
DIS-2857: E-Content Call Number Sorting

### DIFF
--- a/code/reindexer/src/org/aspen_discovery/reindexer/GroupedWorkSolr2.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/GroupedWorkSolr2.java
@@ -435,6 +435,7 @@ public class GroupedWorkSolr2 extends AbstractGroupedWorkSolr implements Cloneab
 
 
 				String sortableCallNumberForScope = null;
+				boolean hasBookCallNumberForScope = false;
 				Long daysSinceAddedForScope = null;
 				long libBoost = 1;
 
@@ -595,8 +596,13 @@ public class GroupedWorkSolr2 extends AbstractGroupedWorkSolr implements Cloneab
 
 						if (locallyOwned || libraryOwned || !scopingInfo.getScope().isRestrictOwningLibraryAndLocationFacets()) {
 							localCallNumbersForScope.add(curItem.getCallNumber());
-							if (sortableCallNumberForScope == null) {
+							String format = curItem.getPrimaryFormat();
+							if (sortableCallNumberForScope == null && !isEContent
+								|| (!hasBookCallNumberForScope && format != null && (format.equalsIgnoreCase("book") || format.equalsIgnoreCase("large print")))) {
 								sortableCallNumberForScope = curItem.getSortableCallNumber();
+								if (format != null && format.equalsIgnoreCase("book")) {
+									hasBookCallNumberForScope = true;
+								}
 							}
 						}
 					}catch (Exception e){

--- a/code/web/RecordDrivers/GroupedWorkDriver.php
+++ b/code/web/RecordDrivers/GroupedWorkDriver.php
@@ -3996,8 +3996,8 @@ class GroupedWorkDriver extends IndexRecordDriver {
 
 	private function getCallNumber() {
 		foreach (array_keys(($this->fields)) as $key) {
-			if (str_contains($key, 'callnumber')) {
-				return $this->fields[$key][0] ?? null;
+			if (str_contains($key, 'callnumber_sort')) {
+				return $this->fields[$key] ?? null;
 			}
 		}
 		return null;

--- a/code/web/release_notes/26.09.00.MD
+++ b/code/web/release_notes/26.09.00.MD
@@ -72,7 +72,9 @@
 #### Searching
 - Allow customization of number of sample titles in saved search email. ([DIS-2818](https://aspen-discovery.atlassian.net/browse/DIS-2818)) (*MJ*)
 - Link publishers in search results so that clicking on them will do a blank search with the Publisher facet selected. ([DIS-2822](https://aspen-discovery.atlassian.net/browse/DIS-2822)) (*KL*)
-
+- Update call number sorting logic. ([DIS-2857](https://aspen-discovery.atlassian.net/browse/DIS-2857)) (*KL*)
+  - Update callnumber_sort to prefer book/large print over other formats and no longer use eContent for this value.
+  - Update the display of call number when sorting by call number to use the callnumber_sort value.
 ### Self Check Updates
 - Add setting for checked-out override locations to allow self-check-out of items already checked out to these locations. Symphony Only. ([DIS-2646](https://aspen-discovery.atlassian.net/browse/DIS-2646)) (*KL*)
 

--- a/code/web/sys/SearchObject/GroupedWorkSearcher2.php
+++ b/code/web/sys/SearchObject/GroupedWorkSearcher2.php
@@ -651,10 +651,12 @@ class SearchObject_GroupedWorkSearcher2 extends SearchObject_AbstractGroupedWork
 				$fieldsToReturn .= ',local_days_since_added_' . $solrScope;
 				$fieldsToReturn .= ',local_time_since_added_' . $solrScope;
 				$fieldsToReturn .= ',local_callnumber_' . $solrScope;
+				$fieldsToReturn .= ',callnumber_sort_' . $solrScope;
 				$fieldsToReturn .= ',scoping_details_' . $solrScope;
 			} else {
 				$fieldsToReturn .= ',days_since_added';
 				$fieldsToReturn .= ',local_callnumber';
+				$fieldsToReturn .= ',callnumber_sort';
 			}
 			$fieldsToReturn .= ',collection';
 			$fieldsToReturn .= ',detailed_location';

--- a/code/web/sys/SolrConnector/GroupedWorksSolrConnector2.php
+++ b/code/web/sys/SolrConnector/GroupedWorksSolrConnector2.php
@@ -428,7 +428,9 @@ class GroupedWorksSolrConnector2 extends Solr {
 		// Break apart sort into field name and sort direction (note error
 		// suppression to prevent notice when direction is left blank):
 		$sort = trim($sort);
-		@list($sortField, $sortDirection) = explode(' ', $sort);
+		$parts = explode(' ', $sort, 2);
+		$sortField = $parts[0];
+		$sortDirection = $parts[1] ?? '';
 
 		// Default sort order (may be overridden by switch below):
 		$defaultSortDirection = 'asc';


### PR DESCRIPTION
- Update GroupedWorkSolr2.java to prefer book/large print formats over others when determining callnumber_sort (book is preferred over large print) 
- Update GroupedWorkDriver.php and GroupedWorkSearcher2 to use callnumber_sort value instead of local_callnumber value when displaying call number to users who are sorting by call number 
- Update GroupedWorkSolrConnector2 to fix error: PHP Warning: Undefined array key 1 in /C:/web/aspen-discovery/code/web/sys/SolrConnector/GroupedWorksSolrConnector2.php on line 431
- Update release notes

Tested on my local instance of Aspen