### PR TITLE
DIS-2823 Fix holds filter clear button

### DIFF
--- a/code/web/interface/themes/responsive/MyAccount/holdsFilters.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/holdsFilters.tpl
@@ -117,7 +117,7 @@
 				AspenDiscovery.Account.loadHolds('all', $('#availableHoldSort_{/literal}{$source}{literal} option:selected').val(), $('#unavailableHoldSort_{/literal}{$source}{literal} option:selected').val(), null, null, filters);
 			});
 			$('#clearHoldsFilters').on('click', function() {
-				AspenDiscovery.Account.loadHolds('all', $('#availableHoldSort_{/literal}{$source}{literal} option:selected').val(), $('#unavailableHoldSort_{/literal}{$source}{literal} option:selected').val());
+				AspenDiscovery.Account.loadHolds('all', $('#availableHoldSort_{/literal}{$source}{literal} option:selected').val(), $('#unavailableHoldSort_{/literal}{$source}{literal} option:selected').val(), null, null, {});
 			});
 		});
 		{/literal}

--- a/code/web/release_notes/26.09.00.MD
+++ b/code/web/release_notes/26.09.00.MD
@@ -132,6 +132,7 @@
 #### Genealogy
 #### Grouped Works
 #### Holds
+- Fix holds filter clear button ([DIS-2823](https://aspen-discovery.atlassian.net/browse/DIS-2823)) (*SW*)
 #### Hoopla
 #### ILL
 #### Indexing


### PR DESCRIPTION
https://aspen-discovery.atlassian.net/browse/DIS-2823

Fixes the Clear Filters button on the holds page.

This ticket has a lot more to it that we can get into the next release.