### PR TITLE
DIS-2815 Move Audience Indexing to Child Documents

### DIFF
--- a/code/java_shared_libraries/src/com/turning_leaf_technologies/indexing/InclusionRule.java
+++ b/code/java_shared_libraries/src/com/turning_leaf_technologies/indexing/InclusionRule.java
@@ -2,10 +2,7 @@ package com.turning_leaf_technologies.indexing;
 
 import com.turning_leaf_technologies.marc.MarcUtil;
 
-import java.util.HashMap;
-import java.util.Objects;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 import java.util.regex.Pattern;
 
 class InclusionRule {
@@ -115,7 +112,7 @@ class InclusionRule {
 
 	//TODO: We can potentially just pass in the ItemInfo object instead of all or most of these parameters
 	//		This would likely require creating an interface for ItemInfo under java_shared_libraries.
-	boolean isItemIncluded(String itemIdentifier, String recordType, String locationCode, String subLocationCode, String iType, TreeSet<String> audiences, String audiencesAsString, String format, String shelfLocation, String collectionCode, boolean isHoldable, boolean isOnOrder, boolean isEContent, org.marc4j.marc.Record marcRecord, DebugLogger debugLogger){
+	boolean isItemIncluded(String itemIdentifier, String recordType, String locationCode, String subLocationCode, String iType, HashSet<String> audiences, String audiencesAsString, String format, String shelfLocation, String collectionCode, boolean isHoldable, boolean isOnOrder, boolean isEContent, org.marc4j.marc.Record marcRecord, DebugLogger debugLogger){
 		if (lastIdentifier != null && lastIdentifier.equals(itemIdentifier)){
 			return lastIdentifierResult;
 		}

--- a/code/java_shared_libraries/src/com/turning_leaf_technologies/indexing/InclusionRuleDetails.java
+++ b/code/java_shared_libraries/src/com/turning_leaf_technologies/indexing/InclusionRuleDetails.java
@@ -2,10 +2,7 @@ package com.turning_leaf_technologies.indexing;
 
 import com.turning_leaf_technologies.marc.MarcUtil;
 
-import java.util.HashMap;
-import java.util.Objects;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 import java.util.regex.Pattern;
 
 /**
@@ -143,7 +140,7 @@ class InclusionRuleDetails {
 
 	//TODO: We can potentially just pass in the ItemInfo object instead of all or most of these parameters
 	//		This would likely require creating an interface for ItemInfo under java_shared_libraries.
-	boolean isItemIncluded(String itemIdentifier, String subLocationCode, String iType, TreeSet<String> audiences, String audiencesAsString, String format, String shelfLocation, String collectionCode, org.marc4j.marc.Record marcRecord, DebugLogger debugLogger){
+	boolean isItemIncluded(String itemIdentifier, String subLocationCode, String iType, HashSet<String> audiences, String audiencesAsString, String format, String shelfLocation, String collectionCode, org.marc4j.marc.Record marcRecord, DebugLogger debugLogger){
 		if (lastIdentifier != null && lastIdentifier.equals(itemIdentifier)){
 			return lastIdentifierResult;
 		}

--- a/code/java_shared_libraries/src/com/turning_leaf_technologies/indexing/Scope.java
+++ b/code/java_shared_libraries/src/com/turning_leaf_technologies/indexing/Scope.java
@@ -87,7 +87,7 @@ public class Scope implements Comparable<Scope>{
 	 * @param subLocationCode   The sub location code to check.  Set to blank if no sub location code
 	 * @return                  Whether the item is included within the scope
 	 */
-	public InclusionResult isItemPartOfScope(String itemIdentifier, String recordType, String locationCode, String subLocationCode, String iType, TreeSet<String> audiences, String audiencesAsString, String format, String shelfLocation, String collectionCode, boolean isHoldable, boolean isOnOrder, boolean isEContent, Record marcRecord, String econtentUrl, DebugLogger debugLogger){
+	public InclusionResult isItemPartOfScope(String itemIdentifier, String recordType, String locationCode, String subLocationCode, String iType, HashSet<String> audiences, String audiencesAsString, String format, String shelfLocation, String collectionCode, boolean isHoldable, boolean isOnOrder, boolean isEContent, Record marcRecord, String econtentUrl, DebugLogger debugLogger){
 		if (debugLogger != null && debugLogger.isDebugEnabled()) {
 			debugLogger.addDebugMessage("Checking scope '" + facetLabel + "' for item " + itemIdentifier, 2);
 		}
@@ -121,7 +121,7 @@ public class Scope implements Comparable<Scope>{
 	/**
 	 * Determine if the item is part of the current scope based on location code and other information
 	 */
-	public boolean isItemOwnedByScope(String itemIdentifier, String recordType, String locationCode, String subLocationCode, String iType, TreeSet<String> audiences, String audiencesAsString, String format, String shelfLocation, String collectionCode, boolean isHoldable, boolean isOnOrder, boolean isEContent, Record marcRecord, DebugLogger debugLogger){
+	public boolean isItemOwnedByScope(String itemIdentifier, String recordType, String locationCode, String subLocationCode, String iType, HashSet<String> audiences, String audiencesAsString, String format, String shelfLocation, String collectionCode, boolean isHoldable, boolean isOnOrder, boolean isEContent, Record marcRecord, DebugLogger debugLogger){
 		for (InclusionRule curRule: ownershipRules){
 			if (curRule.isItemIncluded(itemIdentifier, recordType, locationCode, subLocationCode, iType, audiences, audiencesAsString, format, shelfLocation, collectionCode, isHoldable, isOnOrder, isEContent, marcRecord, debugLogger)){
 				return true;

--- a/code/reindexer/src/org/aspen_discovery/reindexer/AbstractGroupedWorkSolr.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/AbstractGroupedWorkSolr.java
@@ -6,6 +6,7 @@ import com.turning_leaf_technologies.logging.BaseIndexingLogEntry;
 import com.turning_leaf_technologies.strings.AspenStringUtils;
 import org.apache.logging.log4j.Logger;
 import org.apache.solr.common.SolrInputDocument;
+import org.marc4j.marc.Record;
 
 import java.util.*;
 import java.util.regex.Matcher;
@@ -88,7 +89,7 @@ public abstract class AbstractGroupedWorkSolr implements DebugLogger {
 	protected HashMap<String, SeriesInfo> series = new HashMap<>();
 	protected String subTitle;
 	protected HashSet<String> targetAudienceFull = new HashSet<>();
-	protected TreeSet<String> targetAudience = new TreeSet<>();
+	protected HashSet<String> targetAudience = new HashSet<>();
 	protected String title;
 	protected HashSet<String> titleAlt = new HashSet<>();
 	protected HashSet<String> titleNew = new HashSet<>();
@@ -211,7 +212,7 @@ public abstract class AbstractGroupedWorkSolr implements DebugLogger {
 		// noinspection unchecked
 		clonedWork.targetAudienceFull = (HashSet<String>) targetAudienceFull.clone();
 		// noinspection unchecked
-		clonedWork.targetAudience = (TreeSet<String>) targetAudience.clone();
+		clonedWork.targetAudience = (HashSet<String>) targetAudience.clone();
 		// noinspection unchecked
 		clonedWork.titleAlt = (HashSet<String>) titleAlt.clone();
 		// noinspection unchecked
@@ -1219,64 +1220,20 @@ public abstract class AbstractGroupedWorkSolr implements DebugLogger {
 		this.addLiteraryFormFull(literaryForm, 1);
 	}
 
-	void addTargetAudiences(HashSet<String> target_audiences) {
-		for (String target_audience : target_audiences) {
-			this.addTargetAudience(target_audience);
-		}
+	void addTargetAudiences(HashSet<String> target_audiences, RecordInfo recordInfo) {
+		targetAudience.addAll(target_audiences);
 	}
 
-	void addTargetAudience(String target_audience) {
-		switch (target_audience){
-			case "Unknown":
-			case "Other":
-				if (targetAudience.isEmpty()){
-					targetAudience.add(target_audience);
-					targetAudiencesAsString = null;
-				}
-				break;
-			default:
-				if (!targetAudience.contains(target_audience)) {
-					if (targetAudience.contains("Unknown")) {
-						targetAudience.remove("Unknown");
-					} else {
-						targetAudience.remove("Other");
-					}
-					targetAudience.add(target_audience);
-					targetAudiencesAsString = null;
-				}
-				break;
-		}
+	void addTargetAudience(String target_audience, RecordInfo recordInfo) {
+		targetAudience.add(target_audience);
 	}
 
-	void addTargetAudiencesFull(HashSet<String> target_audiences_full) {
-		for (String target_audience : target_audiences_full) {
-			this.addTargetAudienceFull(target_audience);
-		}
+	void addTargetAudienceFull(String target_audience_full, RecordInfo recordInfo) {
+		targetAudienceFull.add(target_audience_full);
 	}
 
-	void addTargetAudienceFull(String target_audience) {
-		targetAudienceFull.add(target_audience);
-		switch (target_audience){
-			case "Unknown":
-			case "Other":
-			case "No Attempt To Code":
-				//noinspection ConstantConditions
-				if (targetAudienceFull.isEmpty()){
-					targetAudienceFull.add(target_audience);
-				}
-				break;
-			default:
-				if (targetAudienceFull.contains("Unknown")){
-					targetAudienceFull.remove("Unknown");
-				}else if (targetAudienceFull.contains("Other")){
-					targetAudienceFull.remove("Other");
-				}else //noinspection RedundantCollectionOperation
-					if (targetAudienceFull.contains("No Attempt To Code")){
-						targetAudienceFull.remove("No Attempt To Code");
-					}
-				targetAudienceFull.add(target_audience);
-				break;
-		}
+	void addTargetAudiencesFull(HashSet<String> target_audiences_full, RecordInfo recordInfo) {
+		targetAudienceFull.addAll(target_audiences_full);
 	}
 
 	protected Set<String> getRatingFacet(Float rating) {
@@ -1537,8 +1494,7 @@ public abstract class AbstractGroupedWorkSolr implements DebugLogger {
 		return this.relatedRecords.size();
 	}
 
-	TreeSet<String> getTargetAudiences() {
-
+	HashSet<String> getTargetAudiences() {
 		return targetAudience;
 	}
 
@@ -1768,10 +1724,8 @@ public abstract class AbstractGroupedWorkSolr implements DebugLogger {
 		if (targetAudiencesAsString == null) {
 			if (targetAudience.isEmpty()) {
 				targetAudiencesAsString = "";
-			} else if (targetAudience.size() == 1) {
-				targetAudiencesAsString = targetAudience.first();
 			} else {
-				targetAudiencesAsString = targetAudience.toString();
+				targetAudiencesAsString = String.join(", ", targetAudience);
 			}
 		}
 		return targetAudiencesAsString;

--- a/code/reindexer/src/org/aspen_discovery/reindexer/AbstractGroupedWorkSolr.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/AbstractGroupedWorkSolr.java
@@ -6,7 +6,6 @@ import com.turning_leaf_technologies.logging.BaseIndexingLogEntry;
 import com.turning_leaf_technologies.strings.AspenStringUtils;
 import org.apache.logging.log4j.Logger;
 import org.apache.solr.common.SolrInputDocument;
-import org.marc4j.marc.Record;
 
 import java.util.*;
 import java.util.regex.Matcher;

--- a/code/reindexer/src/org/aspen_discovery/reindexer/Axis360Processor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/Axis360Processor.java
@@ -97,7 +97,7 @@ class Axis360Processor {
 					groupedWork.addSeriesWithVolume(series, primaryAuthor, "", 2, true);
 				}
 
-				String targetAudience = loadAxis360Subjects(groupedWork, rawResponse);
+				String targetAudience = loadAxis360Subjects(groupedWork, rawResponse, axis360Record);
 
 				//Believe these are all
 				axis360Record.setPrimaryLanguage("English");
@@ -225,7 +225,7 @@ class Axis360Processor {
 	 *
 	 * @return String the targetAudience of the record
 	 */
-	private String loadAxis360Subjects(AbstractGroupedWorkSolr groupedWork, JSONObject titleData) throws JSONException {
+	private String loadAxis360Subjects(AbstractGroupedWorkSolr groupedWork, JSONObject titleData, RecordInfo recordInfo) throws JSONException {
 		//Load subject data
 
 		HashSet<String> topics = new HashSet<>();
@@ -277,8 +277,8 @@ class Axis360Processor {
 		}
 		if (groupedWork != null && groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target audience is " + targetAudience + " based on Boundless record", 2);}
 		if (groupedWork != null && groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Full target audience list is " + targetAudienceFull + " based on Boundless record", 2);}
-		groupedWork.addTargetAudience(targetAudience);
-		groupedWork.addTargetAudienceFull(targetAudienceFull);
+		groupedWork.addTargetAudience(targetAudience, recordInfo);
+		groupedWork.addTargetAudienceFull(targetAudienceFull, recordInfo);
 
 		return targetAudience;
 	}

--- a/code/reindexer/src/org/aspen_discovery/reindexer/CloudLibraryProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/CloudLibraryProcessor.java
@@ -133,7 +133,7 @@ class CloudLibraryProcessor extends MarcRecordProcessor {
 				cloudLibraryRecord.addFormat(primaryFormat);
 				cloudLibraryRecord.addFormatCategory(formatCategory);
 
-				updateGroupedWorkSolrDataBasedOnStandardMarcData(groupedWork, marcRecord, new ArrayList<>(), identifier, primaryFormat, formatCategory, false);
+				updateGroupedWorkSolrDataBasedOnStandardMarcData(groupedWork, marcRecord, cloudLibraryRecord, new ArrayList<>(), identifier, primaryFormat, formatCategory, false);
 
 				//Special processing for ILS Records
 				String fullDescription = Util.getCRSeparatedString(MarcUtil.getFieldList(marcRecord, "520a"));
@@ -152,7 +152,7 @@ class CloudLibraryProcessor extends MarcRecordProcessor {
 					targetAudience = "Adult";
 				}
 				if (groupedWork != null && groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target audience is " + targetAudience + " based on cloudLibrary record", 2);}
-				groupedWork.addTargetAudience(targetAudience);
+				groupedWork.addTargetAudience(targetAudience, cloudLibraryRecord);
 
 				boolean isAdult = targetAudience.equalsIgnoreCase("Adult");
 				boolean isTeen = targetAudience.equalsIgnoreCase("Young Adult");

--- a/code/reindexer/src/org/aspen_discovery/reindexer/GroupedWorkIndexer.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/GroupedWorkIndexer.java
@@ -1,6 +1,8 @@
 package org.aspen_discovery.reindexer;
 
-import org.apache.solr.client.solrj.impl.BinaryResponseParser;
+import org.apache.solr.client.solrj.request.CoreAdminRequest;
+import org.apache.solr.client.solrj.request.CoreStatus;
+import org.apache.solr.client.solrj.response.CoreAdminResponse;
 import org.aspen_discovery.grouping.*;
 import com.turning_leaf_technologies.indexing.*;
 import com.turning_leaf_technologies.logging.BaseIndexingLogEntry;
@@ -9,7 +11,6 @@ import com.turning_leaf_technologies.strings.AspenStringUtils;
 import com.turning_leaf_technologies.util.MaxSizeHashMap;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.ConcurrentUpdateHttp2SolrClient;
-import org.apache.solr.client.solrj.impl.BaseHttpSolrClient;
 import org.apache.solr.client.solrj.impl.Http2SolrClient;
 import org.apache.solr.client.solrj.response.UpdateResponse;
 import org.apache.solr.common.SolrInputDocument;
@@ -207,6 +208,8 @@ public class GroupedWorkIndexer implements AutoCloseable {
 	private int hooplaVersion;
 	private int solrThreadCount;
 	private int solrQueueSize;
+	private String solrPort;
+	private String solrHost;
 
 	public GroupedWorkIndexer(String serverName, Connection dbConn, Ini configIni, boolean fullReindex, boolean clearIndex, BaseIndexingLogEntry logEntry, Logger logger) {
 		this(serverName, dbConn, configIni, fullReindex, clearIndex, false, logEntry, logger);
@@ -223,14 +226,14 @@ public class GroupedWorkIndexer implements AutoCloseable {
 		this.clearIndex = clearIndex;
 		this.regroupAllRecords = regroupAllRecords;
 
-		String solrPort = configIni.get("Index", "solrPort");
+		solrPort = configIni.get("Index", "solrPort");
 		if (solrPort == null || solrPort.isEmpty()) {
 			solrPort = configIni.get("Reindex", "solrPort");
 			if (solrPort == null || solrPort.isEmpty()) {
 				solrPort = "8080";
 			}
 		}
-		String solrHost = configIni.get("Index", "solrHost");
+		solrHost = configIni.get("Index", "solrHost");
 		if (solrHost == null || solrHost.isEmpty()) {
 			solrHost = configIni.get("Reindex", "solrHost");
 			if (solrHost == null || solrHost.isEmpty()) {
@@ -432,9 +435,7 @@ public class GroupedWorkIndexer implements AutoCloseable {
 			.connectionTimeout(15000)
 			.build();
 		try {
-
-
-		updateServer = new ConcurrentUpdateHttp2SolrClient.Builder(solrUrl, http2Client)
+			updateServer = new ConcurrentUpdateHttp2SolrClient.Builder(solrUrl, http2Client)
 				.withThreadCount(solrThreadCount)
 				.withQueueSize(solrQueueSize)
 				.build();
@@ -736,20 +737,54 @@ public class GroupedWorkIndexer implements AutoCloseable {
 	}
 
 	private void clearIndex() {
-		//Check to see if we should clear the existing index
-		logger.info("Clearing existing MARC records from index");
-		try {
-			updateServer.deleteByQuery("recordtype:grouped_work");
-			if (indexVersion == 3) {
-				updateServer.deleteByQuery("recordtype:record_scoping");
-			}
-			//Make sure the delete gets processed.
-			updateServer.blockUntilFinished();
-		} catch (BaseHttpSolrClient.RemoteSolrException rse) {
-			logEntry.incErrors("Solr is not running properly, try restarting", rse);
-			System.exit(-1);
+		//Do a full clear of the index by stopping the core and deleting all records. This is needed when changing
+		//field definitions. The clear index is generally only called during development and is never called automatically
+		//by cron or other mechanism.
+		String solrAdminUrl = "http://" + solrHost + ":" + solrPort + "/solr";
+		try (Http2SolrClient adminClient =
+			 new Http2SolrClient.Builder(solrAdminUrl)
+				 .idleTimeout(60000)
+				 .connectionTimeout(15000)
+				 .build()) {
+
+				String coreName = "grouped_works_v2";
+				if (indexVersion != 2) {
+					coreName ="grouped_works_v3";
+				}
+
+				CoreStatus status = CoreAdminRequest.getCoreStatus(coreName, adminClient);
+
+				String instanceDir = status.getInstanceDirectory();
+
+				CoreAdminRequest.Unload unload = new CoreAdminRequest.Unload(true);
+				unload.setCoreName(coreName);
+
+				unload.setDeleteIndex(true);
+				unload.setDeleteDataDir(true);
+				unload.setDeleteInstanceDir(false);
+
+				CoreAdminResponse unloadResponse = unload.process(adminClient);
+
+				if (unloadResponse.getStatus() != 0) {
+					throw new IllegalStateException(
+						"Unable to unload core: " + unloadResponse
+					);
+				}
+
+				CoreAdminRequest.Create create = new CoreAdminRequest.Create();
+				create.setCoreName(coreName);
+				create.setInstanceDir(instanceDir);
+
+				CoreAdminResponse createResponse = create.process(adminClient);
+
+				if (createResponse.getStatus() != 0) {
+					throw new IllegalStateException(
+						"Unable to recreate core: " + createResponse
+					);
+				}
+
 		} catch (Exception e) {
-			logEntry.incErrors("Error deleting from index", e);
+			logEntry.incErrors("Could not clear core", e);
 		}
 	}
 
@@ -3648,7 +3683,7 @@ public class GroupedWorkIndexer implements AutoCloseable {
 	 */
 	public synchronized MarcStatus saveMarcRecordToDatabase(BaseIndexingSettings indexingProfile, String ilsId, Record marcRecord) {
 		// Filter out any private fields from the record
-		marcRecord = filterPrivateFields(marcRecord);
+		filterPrivateFields(marcRecord);
 
 		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 		MarcWriter writer = new MarcJsonWriter(outputStream);
@@ -3701,7 +3736,7 @@ public class GroupedWorkIndexer implements AutoCloseable {
 		return returnValue;
 	}
 
-	private Record filterPrivateFields(Record marcRecord){
+	private void filterPrivateFields(Record marcRecord){
 		String[] privateFields = {"541", "542", "561", "583"};
 		for (String tag : privateFields) {
 			List<VariableField> fields = new ArrayList<>(marcRecord.getVariableFields(tag));
@@ -3712,8 +3747,6 @@ public class GroupedWorkIndexer implements AutoCloseable {
 				}
 			}
 		}
-
-		return marcRecord;
 	}
 
 	//Create a small cache to hold recently used marc records to avoid time reloading them.
@@ -3767,5 +3800,25 @@ public class GroupedWorkIndexer implements AutoCloseable {
 
 	public int getSeriesVersion() {
 		return seriesVersion;
+	}
+
+	/**
+	 * Remove unneeded/undesired target audiences based on other values that are available.
+	 *
+	 * @param targetAudiences - The raw audiences that are supplied
+	 * @return The cleaned set
+	 */
+	public HashSet<String> cleanTargetAudiences(HashSet<String> targetAudiences) {
+		if (targetAudiences.size() > 1 || !this.isTreatUnknownAudienceAsUnknown()) {
+			targetAudiences.remove("Unknown");
+		}
+		if (targetAudiences.size() > 1) {
+			targetAudiences.remove("No Attempt To Code");
+			targetAudiences.remove("Other");
+		}
+		if (targetAudiences.isEmpty()) {
+			targetAudiences.add(this.getTreatUnknownAudienceAs());
+		}
+		return targetAudiences;
 	}
 }

--- a/code/reindexer/src/org/aspen_discovery/reindexer/GroupedWorkSolr2.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/GroupedWorkSolr2.java
@@ -184,26 +184,9 @@ public class GroupedWorkSolr2 extends AbstractGroupedWorkSolr implements Cloneab
 			if (this.debugEnabled) {this.addDebugMessage("Full literary form is " + literaryFormFull.keySet(), 2);}
 			doc.addField("literary_form_full", literaryFormFull.keySet());
 			doc.addField("literary_form", literaryForm.keySet());
-			if (targetAudienceFull.size() > 1 || !groupedWorkIndexer.isTreatUnknownAudienceAsUnknown()) {
-				targetAudienceFull.remove("Unknown");
-			}
-			if (targetAudienceFull.size() > 1) {
-				targetAudienceFull.remove("No Attempt To Code");
-				targetAudienceFull.remove("Other");
-			}
-			if (targetAudienceFull.isEmpty()) {
-				targetAudienceFull.add(groupedWorkIndexer.getTreatUnknownAudienceAs());
-			}
+			targetAudienceFull = groupedWorkIndexer.cleanTargetAudiences(targetAudienceFull);
 			doc.addField("target_audience_full", targetAudienceFull);
-			if (targetAudience.size() > 1 || !groupedWorkIndexer.isTreatUnknownAudienceAsUnknown()) {
-				targetAudience.remove("Unknown");
-			}
-			if (targetAudience.size() > 1) {
-				targetAudience.remove("Other");
-			}
-			if (targetAudience.isEmpty()) {
-				targetAudience.add(groupedWorkIndexer.getTreatUnknownAudienceAs());
-			}
+			targetAudience = groupedWorkIndexer.cleanTargetAudiences(targetAudience);
 			if (this.isDebugEnabled()) {this.addDebugMessage("Final target audience is " + targetAudience, 1);}
 			if (this.isDebugEnabled()) {this.addDebugMessage("Final full target audience is " + targetAudienceFull, 1);}
 			doc.addField("target_audience", targetAudience);

--- a/code/reindexer/src/org/aspen_discovery/reindexer/GroupedWorkSolr3.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/GroupedWorkSolr3.java
@@ -28,13 +28,29 @@ public class GroupedWorkSolr3 extends AbstractGroupedWorkSolr implements Cloneab
 		return clonedWork;
 	}
 
+	void addTargetAudiences(HashSet<String> target_audiences, RecordInfo recordInfo) {
+		recordInfo.addTargetAudiences(target_audiences);
+	}
+
+	void addTargetAudience(String target_audience, RecordInfo recordInfo) {
+		recordInfo.addTargetAudience(target_audience);
+	}
+
+	void addTargetAudienceFull(String target_audience_full, RecordInfo recordInfo) {
+		recordInfo.addTargetAudienceFull(target_audience_full);
+	}
+
+	void addTargetAudiencesFull(HashSet<String> target_audiences_full, RecordInfo recordInfo) {
+		recordInfo.addTargetAudiencesFull(target_audiences_full);
+	}
+
 	/**
 	 * Create a solr document to store the majority of the grouped work data.
 	 * There is also a child document that contains information about the scoped records which allows filtering by
 	 *
 	 *
-	 * @param logEntry
-	 * @return
+	 * @param logEntry The log entry used for logging
+	 * @return The fully built out document
 	 */
 	@SuppressWarnings("DuplicatedCode")
 	SolrInputDocument getSolrDocument(BaseIndexingLogEntry logEntry) {
@@ -187,30 +203,7 @@ public class GroupedWorkSolr3 extends AbstractGroupedWorkSolr implements Cloneab
 			groupedWorkDoc.addField("literary_form_full", literaryFormFull.keySet());
 			groupedWorkDoc.addField("literary_form", literaryForm.keySet());
 
-			//Target Audiences
-			if (targetAudienceFull.size() > 1 || !groupedWorkIndexer.isTreatUnknownAudienceAsUnknown()) {
-				targetAudienceFull.remove("Unknown");
-			}
-			if (targetAudienceFull.size() > 1) {
-				targetAudienceFull.remove("No Attempt To Code");
-				targetAudienceFull.remove("Other");
-			}
-			if (targetAudienceFull.isEmpty()) {
-				targetAudienceFull.add(groupedWorkIndexer.getTreatUnknownAudienceAs());
-			}
-			groupedWorkDoc.addField("target_audience_full", targetAudienceFull);
-			if (targetAudience.size() > 1 || !groupedWorkIndexer.isTreatUnknownAudienceAsUnknown()) {
-				targetAudience.remove("Unknown");
-			}
-			if (targetAudience.size() > 1) {
-				targetAudience.remove("Other");
-			}
-			if (targetAudience.isEmpty()) {
-				targetAudience.add(groupedWorkIndexer.getTreatUnknownAudienceAs());
-			}
-			if (this.isDebugEnabled()) {this.addDebugMessage("Final target audience is " + targetAudience, 1);}
-			if (this.isDebugEnabled()) {this.addDebugMessage("Final full target audience is " + targetAudienceFull, 1);}
-			groupedWorkDoc.addField("target_audience", targetAudience);
+			//Target Audiences - In V3 these are stored at the record level
 
 			//Date added to catalog
 			Date dateAdded = getDateAdded();
@@ -404,7 +397,7 @@ public class GroupedWorkSolr3 extends AbstractGroupedWorkSolr implements Cloneab
 		}
 
 		for (RecordInfo recordInfo : relatedRecords.values()) {
-			ArrayList<SolrInputDocument> recordDocuments = recordInfo.getRecordScopeSolrDocuments(groupedWorkIndexer, daysAddedSincePubDate);
+			ArrayList<SolrInputDocument> recordDocuments = recordInfo.getRecordScopeSolrDocuments(groupedWorkIndexer, this, daysAddedSincePubDate);
 			if (recordDocuments != null) {
 				groupedWorkDoc.addChildDocuments(recordDocuments);
 			}

--- a/code/reindexer/src/org/aspen_discovery/reindexer/HooplaProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/HooplaProcessor.java
@@ -152,8 +152,8 @@ class HooplaProcessor {
 				boolean isKids = false;
 				if (children){
 					isKids = true;
-					groupedWork.addTargetAudience("Juvenile");
-					groupedWork.addTargetAudienceFull("Juvenile");
+					groupedWork.addTargetAudience("Juvenile", hooplaRecord);
+					groupedWork.addTargetAudienceFull("Juvenile", hooplaRecord);
 					if ( groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target/full target audience is Juvenile based on Hoopla record", 2);}
 				}else {
 					//Todo: Also check the genres (Children's, Teen
@@ -163,21 +163,21 @@ class HooplaProcessor {
 						for (int i = 0; i < genres.length(); i++) {
 							if (genres.getString(i).equals("Teen") || genres.getString(i).startsWith("Young Adult")) {
 								isTeen = true;
-								groupedWork.addTargetAudience("Young Adult");
-								groupedWork.addTargetAudienceFull("Adolescent (14-17)");
+								groupedWork.addTargetAudience("Young Adult", hooplaRecord);
+								groupedWork.addTargetAudienceFull("Adolescent (14-17)", hooplaRecord);
 								if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target audience is Young Adult based on Hoopla genre", 2);}
 								if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Full target audience is Adolescent (14-17) based on Hoopla genre", 2);}
 								foundAudience = true;
 							} else if (genres.getString(i).equals("Children's")) {
 								isKids = true;
-								groupedWork.addTargetAudience("Juvenile");
-								groupedWork.addTargetAudienceFull("Juvenile");
+								groupedWork.addTargetAudience("Juvenile", hooplaRecord);
+								groupedWork.addTargetAudienceFull("Juvenile", hooplaRecord);
 								if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target/full target audience is Juvenile based on Hoopla genre", 2);}
 								foundAudience = true;
 							} else if (genres.getString(i).equals("Adult")) {
 								isAdult = true;
-								groupedWork.addTargetAudience("Adult");
-								groupedWork.addTargetAudienceFull("Adult");
+								groupedWork.addTargetAudience("Adult", hooplaRecord);
+								groupedWork.addTargetAudienceFull("Adult", hooplaRecord);
 								if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target/full target audience is Adult based on Hoopla genre", 2);}
 								foundAudience = true;
 							}
@@ -189,8 +189,8 @@ class HooplaProcessor {
 						//noinspection SpellCheckingInspection
 						if (rating.equals("TVMA") || rating.equals("M") || rating.equals("NC17")) {
 							isAdult = true;
-							groupedWork.addTargetAudience("Adult");
-							groupedWork.addTargetAudienceFull("Adult");
+							groupedWork.addTargetAudience("Adult", hooplaRecord);
+							groupedWork.addTargetAudienceFull("Adult", hooplaRecord);
 							if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target/full target audience is Adult based on Hoopla rating", 2);}
 						} else {
 							if (kind.equals("MOVIE") || kind.equals("TELEVISION")) {
@@ -201,8 +201,8 @@ class HooplaProcessor {
 									case "NRM":
 									case "NC-17":
 										isAdult = true;
-										groupedWork.addTargetAudience("Adult");
-										groupedWork.addTargetAudienceFull("Adult");
+										groupedWork.addTargetAudience("Adult", hooplaRecord);
+										groupedWork.addTargetAudienceFull("Adult", hooplaRecord);
 										if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target/full target audience is Adult based on Hoopla rating " + rating, 2);}
 										break;
 									case "PG-13":
@@ -214,20 +214,20 @@ class HooplaProcessor {
 									case "NRT":
 										isAdult = true;
 										isTeen = true;
-										groupedWork.addTargetAudience("Young Adult");
-										groupedWork.addTargetAudienceFull("Adolescent (14-17)");
+										groupedWork.addTargetAudience("Young Adult", hooplaRecord);
+										groupedWork.addTargetAudienceFull("Adolescent (14-17)", hooplaRecord);
 										if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target audience is Young Adult based on Hoopla rating " + rating, 2);}
 										if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Full target audience is Adolescent (14-17) based on Hoopla rating " + rating, 2);}
-										groupedWork.addTargetAudience("Adult");
-										groupedWork.addTargetAudienceFull("Adult");
+										groupedWork.addTargetAudience("Adult", hooplaRecord);
+										groupedWork.addTargetAudienceFull("Adult", hooplaRecord);
 										if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target/full target audience is Adult based on Hoopla rating " + rating, 2);}
 										break;
 									case "TVY":
 									case "TVY7":
 									case "NRC":
 										isKids = true;
-										groupedWork.addTargetAudience("Juvenile");
-										groupedWork.addTargetAudienceFull("Juvenile");
+										groupedWork.addTargetAudience("Juvenile", hooplaRecord);
+										groupedWork.addTargetAudienceFull("Juvenile", hooplaRecord);
 										if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target/full target audience is Juvenile based on Hoopla rating " + rating, 2);}
 										break;
 									case "TVG":
@@ -235,8 +235,8 @@ class HooplaProcessor {
 										isKids = true;
 										isTeen = true;
 										isAdult = true;
-										groupedWork.addTargetAudience("General");
-										groupedWork.addTargetAudienceFull("General");
+										groupedWork.addTargetAudience("General", hooplaRecord);
+										groupedWork.addTargetAudienceFull("General", hooplaRecord);
 										if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target/full target audience is General based on Hoopla rating " + rating, 2);}
 										break;
 									default:
@@ -248,21 +248,21 @@ class HooplaProcessor {
 								switch (rating) {
 									case "E":
 										isKids = true;
-										groupedWork.addTargetAudience("Juvenile");
-										groupedWork.addTargetAudienceFull("Juvenile");
+										groupedWork.addTargetAudience("Juvenile", hooplaRecord);
+										groupedWork.addTargetAudienceFull("Juvenile", hooplaRecord);
 										if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target/full target audience is Juvenile based on Hoopla rating " + rating, 2);}
 										break;
 									case "PA":
 									case "EX":
 										isAdult = true;
-										groupedWork.addTargetAudience("Adult");
-										groupedWork.addTargetAudienceFull("Adult");
+										groupedWork.addTargetAudience("Adult", hooplaRecord);
+										groupedWork.addTargetAudienceFull("Adult", hooplaRecord);
 										if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target/full target audience is Adult based on Hoopla rating " + rating, 2);}
 										break;
 									case "T":
 										isTeen = true;
-										groupedWork.addTargetAudience("Young Adult");
-										groupedWork.addTargetAudienceFull("Adolescent (14-17)");
+										groupedWork.addTargetAudience("Young Adult", hooplaRecord);
+										groupedWork.addTargetAudienceFull("Adolescent (14-17)", hooplaRecord);
 										if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target audience is Young Adult based on Hoopla rating " + rating, 2);}
 										if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Full target audience is Adolescent (14-17) based on Hoopla rating " + rating, 2);}
 										break;
@@ -270,22 +270,22 @@ class HooplaProcessor {
 									default:
 										isAdult = true;
 										isTeen = true;
-										groupedWork.addTargetAudience("Young Adult");
-										groupedWork.addTargetAudienceFull("Adolescent (14-17)");
+										groupedWork.addTargetAudience("Young Adult", hooplaRecord);
+										groupedWork.addTargetAudienceFull("Adolescent (14-17)", hooplaRecord);
 										if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target audience is Young Adult based on Hoopla rating " + rating, 2);}
 										if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Full target audience is Adolescent (14-17) based on Hoopla rating " + rating, 2);}
-										groupedWork.addTargetAudience("Adult");
-										groupedWork.addTargetAudienceFull("Adult");
+										groupedWork.addTargetAudience("Adult", hooplaRecord);
+										groupedWork.addTargetAudienceFull("Adult", hooplaRecord);
 										if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target/full target audience is Adult based on Hoopla rating " + rating, 2);}
 								}
 
 							} else {
 								isAdult = true;
 								isTeen = true;
-								groupedWork.addTargetAudience("Young Adult");
-								groupedWork.addTargetAudienceFull("Adolescent (14-17)");
-								groupedWork.addTargetAudience("Adult");
-								groupedWork.addTargetAudienceFull("Adult");
+								groupedWork.addTargetAudience("Young Adult", hooplaRecord);
+								groupedWork.addTargetAudienceFull("Adolescent (14-17)", hooplaRecord);
+								groupedWork.addTargetAudience("Adult", hooplaRecord);
+								groupedWork.addTargetAudienceFull("Adult", hooplaRecord);
 								if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target audience is Young Adult based on Hoopla rating " + rating, 2);}
 								if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Full target audience is Adolescent (14-17) based on Hoopla rating " + rating, 2);}
 								if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target/full target audience is Adult based on Hoopla rating " + rating, 2);}
@@ -293,8 +293,8 @@ class HooplaProcessor {
 						}
 					} else if (!foundAudience) {
 						isAdult = true;
-						groupedWork.addTargetAudience("Adult");
-						groupedWork.addTargetAudienceFull("Adult");
+						groupedWork.addTargetAudience("Adult", hooplaRecord);
+						groupedWork.addTargetAudienceFull("Adult", hooplaRecord);
 						if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target/full target audience is Adult based on Hoopla record", 2);}
 					}
 				}

--- a/code/reindexer/src/org/aspen_discovery/reindexer/HooplaProcessor2.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/HooplaProcessor2.java
@@ -200,8 +200,8 @@ class HooplaProcessor2 {
 				boolean isKids = false;
 				if (children){
 					isKids = true;
-					groupedWork.addTargetAudience("Juvenile");
-					groupedWork.addTargetAudienceFull("Juvenile");
+					groupedWork.addTargetAudience("Juvenile", hooplaRecord);
+					groupedWork.addTargetAudienceFull("Juvenile", hooplaRecord);
 					if ( groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target/full target audience is Juvenile based on Hoopla record", 2);}
 				} else {
 					boolean foundAudience = false;
@@ -211,32 +211,32 @@ class HooplaProcessor2 {
 							for (int i = 0; i < audiences.length(); i++) {
 								if (audiences.getString(i).equals("Juvenile")) {
 									isKids = true;
-									groupedWork.addTargetAudience("Juvenile");
-									groupedWork.addTargetAudienceFull("Juvenile");
+									groupedWork.addTargetAudience("Juvenile", hooplaRecord);
+									groupedWork.addTargetAudienceFull("Juvenile", hooplaRecord);
 								} else if (audiences.getString(i).equals("Young Adult")) {
 									isTeen = true;
-									groupedWork.addTargetAudience("Young Adult");
-									groupedWork.addTargetAudienceFull("Young Adult");
+									groupedWork.addTargetAudience("Young Adult", hooplaRecord);
+									groupedWork.addTargetAudienceFull("Young Adult", hooplaRecord);
 								} else if (audiences.getString(i).equals("General Adult") || audiences.getString(i).equals("Mature")) {
 									isAdult = true;
-									groupedWork.addTargetAudience("Adult");
-									groupedWork.addTargetAudienceFull("Adult");
+									groupedWork.addTargetAudience("Adult", hooplaRecord);
+									groupedWork.addTargetAudienceFull("Adult", hooplaRecord);
 								}
 								foundAudience = true;
 							}
 						} else {
 							if (rawResponse.getString("audience").equals("Juvenile")) {
 								isKids = true;
-								groupedWork.addTargetAudience("Juvenile");
-								groupedWork.addTargetAudienceFull("Juvenile");
+								groupedWork.addTargetAudience("Juvenile", hooplaRecord);
+								groupedWork.addTargetAudienceFull("Juvenile", hooplaRecord);
 							} else if (rawResponse.getString("audience").equals("Young Adult")) {
 								isTeen = true;
-								groupedWork.addTargetAudience("Young Adult");
-								groupedWork.addTargetAudienceFull("Young Adult");
+								groupedWork.addTargetAudience("Young Adult", hooplaRecord);
+								groupedWork.addTargetAudienceFull("Young Adult", hooplaRecord);
 							} else if (rawResponse.getString("audience").equals("General Adult") || rawResponse.getString("audience").equals("Mature")) {
 								isAdult = true;
-								groupedWork.addTargetAudience("Adult");
-								groupedWork.addTargetAudienceFull("Adult");
+								groupedWork.addTargetAudience("Adult", hooplaRecord);
+								groupedWork.addTargetAudienceFull("Adult", hooplaRecord);
 							}
 							foundAudience = true;
 						}
@@ -245,21 +245,21 @@ class HooplaProcessor2 {
 						for (int i = 0; i < genres.length(); i++) {
 							if (genres.getString(i).equals("Teen") || genres.getString(i).startsWith("Young Adult")) {
 								isTeen = true;
-								groupedWork.addTargetAudience("Young Adult");
-								groupedWork.addTargetAudienceFull("Adolescent (14-17)");
+								groupedWork.addTargetAudience("Young Adult", hooplaRecord);
+								groupedWork.addTargetAudienceFull("Adolescent (14-17)", hooplaRecord);
 								if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target audience is Young Adult based on Hoopla genre", 2);}
 								if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Full target audience is Adolescent (14-17) based on Hoopla genre", 2);}
 								foundAudience = true;
 							} else if (genres.getString(i).equals("Children's")) {
 								isKids = true;
-								groupedWork.addTargetAudience("Juvenile");
-								groupedWork.addTargetAudienceFull("Juvenile");
+								groupedWork.addTargetAudience("Juvenile", hooplaRecord);
+								groupedWork.addTargetAudienceFull("Juvenile", hooplaRecord);
 								if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target/full target audience is Juvenile based on Hoopla genre", 2);}
 								foundAudience = true;
 							} else if (genres.getString(i).equals("Adult")) {
 								isAdult = true;
-								groupedWork.addTargetAudience("Adult");
-								groupedWork.addTargetAudienceFull("Adult");
+								groupedWork.addTargetAudience("Adult", hooplaRecord);
+								groupedWork.addTargetAudienceFull("Adult", hooplaRecord);
 								if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target/full target audience is Adult based on Hoopla genre", 2);}
 								foundAudience = true;
 							}
@@ -270,8 +270,8 @@ class HooplaProcessor2 {
 						String rating = productRS.getString("rating");
 						if (rating.equals("TVMA") || rating.equals("M") || rating.equals("NC17")) {
 							isAdult = true;
-							groupedWork.addTargetAudience("Adult");
-							groupedWork.addTargetAudienceFull("Adult");
+							groupedWork.addTargetAudience("Adult", hooplaRecord);
+							groupedWork.addTargetAudienceFull("Adult", hooplaRecord);
 							if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target/full target audience is Adult based on Hoopla rating", 2);}
 						} else {
 							if (format.equals("MOVIE") || format.equals("TELEVISION")) {
@@ -282,8 +282,8 @@ class HooplaProcessor2 {
 									case "NRM":
 									case "NC-17":
 										isAdult = true;
-										groupedWork.addTargetAudience("Adult");
-										groupedWork.addTargetAudienceFull("Adult");
+										groupedWork.addTargetAudience("Adult", hooplaRecord);
+										groupedWork.addTargetAudienceFull("Adult", hooplaRecord);
 										if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target/full target audience is Adult based on Hoopla rating " + rating, 2);}
 										break;
 									case "PG-13":
@@ -294,20 +294,20 @@ class HooplaProcessor2 {
 									case "NRT":
 										isAdult = true;
 										isTeen = true;
-										groupedWork.addTargetAudience("Young Adult");
-										groupedWork.addTargetAudienceFull("Adolescent (14-17)");
+										groupedWork.addTargetAudience("Young Adult", hooplaRecord);
+										groupedWork.addTargetAudienceFull("Adolescent (14-17)", hooplaRecord);
 										if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target audience is Young Adult based on Hoopla rating " + rating, 2);}
 										if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Full target audience is Adolescent (14-17) based on Hoopla rating " + rating, 2);}
-										groupedWork.addTargetAudience("Adult");
-										groupedWork.addTargetAudienceFull("Adult");
+										groupedWork.addTargetAudience("Adult", hooplaRecord);
+										groupedWork.addTargetAudienceFull("Adult", hooplaRecord);
 										if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target/full target audience is Adult based on Hoopla rating " + rating, 2);}
 										break;
 									case "TVY":
 									case "TVY7":
 									case "NRC":
 										isKids = true;
-										groupedWork.addTargetAudience("Juvenile");
-										groupedWork.addTargetAudienceFull("Juvenile");
+										groupedWork.addTargetAudience("Juvenile", hooplaRecord);
+										groupedWork.addTargetAudienceFull("Juvenile", hooplaRecord);
 										if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target/full target audience is Juvenile based on Hoopla rating " + rating, 2);}
 										break;
 									case "TVG":
@@ -315,8 +315,8 @@ class HooplaProcessor2 {
 										isKids = true;
 										isTeen = true;
 										isAdult = true;
-										groupedWork.addTargetAudience("General");
-										groupedWork.addTargetAudienceFull("General");
+										groupedWork.addTargetAudience("General", hooplaRecord);
+										groupedWork.addTargetAudienceFull("General", hooplaRecord);
 										if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target/full target audience is General based on Hoopla rating " + rating, 2);}
 										break;
 									default:
@@ -328,21 +328,21 @@ class HooplaProcessor2 {
 								switch (rating) {
 									case "E":
 										isKids = true;
-										groupedWork.addTargetAudience("Juvenile");
-										groupedWork.addTargetAudienceFull("Juvenile");
+										groupedWork.addTargetAudience("Juvenile", hooplaRecord);
+										groupedWork.addTargetAudienceFull("Juvenile", hooplaRecord);
 										if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target/full target audience is Juvenile based on Hoopla rating " + rating, 2);}
 										break;
 									case "PA":
 									case "EX":
 										isAdult = true;
-										groupedWork.addTargetAudience("Adult");
-										groupedWork.addTargetAudienceFull("Adult");
+										groupedWork.addTargetAudience("Adult", hooplaRecord);
+										groupedWork.addTargetAudienceFull("Adult", hooplaRecord);
 										if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target/full target audience is Adult based on Hoopla rating " + rating, 2);}
 										break;
 									case "T":
 										isTeen = true;
-										groupedWork.addTargetAudience("Young Adult");
-										groupedWork.addTargetAudienceFull("Adolescent (14-17)");
+										groupedWork.addTargetAudience("Young Adult", hooplaRecord);
+										groupedWork.addTargetAudienceFull("Adolescent (14-17)", hooplaRecord);
 										if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target audience is Young Adult based on Hoopla rating " + rating, 2);}
 										if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Full target audience is Adolescent (14-17) based on Hoopla rating " + rating, 2);}
 										break;
@@ -350,22 +350,22 @@ class HooplaProcessor2 {
 									default:
 										isAdult = true;
 										isTeen = true;
-										groupedWork.addTargetAudience("Young Adult");
-										groupedWork.addTargetAudienceFull("Adolescent (14-17)");
+										groupedWork.addTargetAudience("Young Adult", hooplaRecord);
+										groupedWork.addTargetAudienceFull("Adolescent (14-17)", hooplaRecord);
 										if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target audience is Young Adult based on Hoopla rating " + rating, 2);}
 										if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Full target audience is Adolescent (14-17) based on Hoopla rating " + rating, 2);}
-										groupedWork.addTargetAudience("Adult");
-										groupedWork.addTargetAudienceFull("Adult");
+										groupedWork.addTargetAudience("Adult", hooplaRecord);
+										groupedWork.addTargetAudienceFull("Adult", hooplaRecord);
 										if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target/full target audience is Adult based on Hoopla rating " + rating, 2);}
 								}
 
 							} else {
 								isAdult = true;
 								isTeen = true;
-								groupedWork.addTargetAudience("Young Adult");
-								groupedWork.addTargetAudienceFull("Adolescent (14-17)");
-								groupedWork.addTargetAudience("Adult");
-								groupedWork.addTargetAudienceFull("Adult");
+								groupedWork.addTargetAudience("Young Adult", hooplaRecord);
+								groupedWork.addTargetAudienceFull("Adolescent (14-17)", hooplaRecord);
+								groupedWork.addTargetAudience("Adult", hooplaRecord);
+								groupedWork.addTargetAudienceFull("Adult", hooplaRecord);
 								if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target audience is Young Adult based on Hoopla rating " + rating, 2);}
 								if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Full target audience is Adolescent (14-17) based on Hoopla rating " + rating, 2);}
 								if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target/full target audience is Adult based on Hoopla rating " + rating, 2);}
@@ -373,8 +373,8 @@ class HooplaProcessor2 {
 						}
 					} else if (!foundAudience) {
 						isAdult = true;
-						groupedWork.addTargetAudience("Adult");
-						groupedWork.addTargetAudienceFull("Adult");
+						groupedWork.addTargetAudience("Adult", hooplaRecord);
+						groupedWork.addTargetAudienceFull("Adult", hooplaRecord);
 						if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target/full target audience is Adult based on Hoopla record", 2);}
 					}
 				}

--- a/code/reindexer/src/org/aspen_discovery/reindexer/IlsRecordProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/IlsRecordProcessor.java
@@ -321,7 +321,7 @@ abstract class IlsRecordProcessor extends MarcRecordProcessor {
 				primaryFormatCategory = "Unknown";
 				//logger.info("No primary format for " + recordInfo.getRecordIdentifier() + " found setting to unknown to load standard marc data");
 			}
-			updateGroupedWorkSolrDataBasedOnStandardMarcData(groupedWork, record, recordInfo.getRelatedItems(), identifier, primaryFormat, primaryFormatCategory, firstParentId != null);
+			updateGroupedWorkSolrDataBasedOnStandardMarcData(groupedWork, record, recordInfo, recordInfo.getRelatedItems(), identifier, primaryFormat, primaryFormatCategory, firstParentId != null);
 
 			//Special processing for ILS Records
 			String fullDescription = Util.getCRSeparatedString(MarcUtil.getFieldList(record, "520ac"));
@@ -671,7 +671,7 @@ abstract class IlsRecordProcessor extends MarcRecordProcessor {
 		return true;
 	}
 
-	private void loadScopeInfoForOrderItem(AbstractGroupedWorkSolr groupedWork, String location, String format, TreeSet<String> audiences, String audiencesAsString, ItemInfo itemInfo, org.marc4j.marc.Record record) {
+	private void loadScopeInfoForOrderItem(AbstractGroupedWorkSolr groupedWork, String location, String format, HashSet<String> audiences, String audiencesAsString, ItemInfo itemInfo, org.marc4j.marc.Record record) {
 		//Shelf Location also include the name of the ordering branch if possible
 		boolean hasLocationBasedShelfLocation = false;
 		boolean hasSystemBasedShelfLocation = false;
@@ -1099,7 +1099,7 @@ abstract class IlsRecordProcessor extends MarcRecordProcessor {
 
 	}
 
-	private void loadScopeInfoForPrintIlsItem(AbstractGroupedWorkSolr groupedWork, RecordInfo recordInfo, TreeSet<String> audiences, String audiencesAsString, ItemInfo itemInfo, org.marc4j.marc.Record record) {
+	private void loadScopeInfoForPrintIlsItem(AbstractGroupedWorkSolr groupedWork, RecordInfo recordInfo, HashSet<String> audiences, String audiencesAsString, ItemInfo itemInfo, org.marc4j.marc.Record record) {
 		//Determine status, need to do this before determining if it is available since that is part of the check.
 		String recordIdentifier = recordInfo.getRecordIdentifier();
 		String displayStatus = getDisplayStatus(itemInfo, recordIdentifier);
@@ -1893,10 +1893,10 @@ abstract class IlsRecordProcessor extends MarcRecordProcessor {
 		return translatedValues;
 	}
 
-	protected void loadTargetAudiences(AbstractGroupedWorkSolr groupedWork, org.marc4j.marc.Record record, ArrayList<ItemInfo> printItems, String identifier) {
+	protected void loadTargetAudiences(AbstractGroupedWorkSolr groupedWork, org.marc4j.marc.Record record, RecordInfo recordInfo, ArrayList<ItemInfo> printItems, String identifier) {
 		if (settings.getDetermineAudienceBy() == 0) {
 			if (groupedWork != null && groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Determining target audience by bib record data", 1);}
-			super.loadTargetAudiences(groupedWork, record, printItems, identifier, settings.getTreatUnknownAudienceAs());
+			super.loadTargetAudiences(groupedWork, record, recordInfo, printItems, identifier, settings.getTreatUnknownAudienceAs());
 		}else{
 			HashSet<String> targetAudiences = new HashSet<>();
 			if (settings.getDetermineAudienceBy() == 1) {
@@ -1944,11 +1944,11 @@ abstract class IlsRecordProcessor extends MarcRecordProcessor {
 			if (translatedAudiences.isEmpty()){
 				//We didn't get anything from the items (including Unknown), check the bib record
 				if (groupedWork != null && groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Could not find target audience based on item - checking the bib record", 1);}
-				super.loadTargetAudiences(groupedWork, record, printItems, identifier,  settings.getTreatUnknownAudienceAs());
+				super.loadTargetAudiences(groupedWork, record, recordInfo, printItems, identifier,  settings.getTreatUnknownAudienceAs());
 			}else {
 				if (groupedWork != null) {
-					groupedWork.addTargetAudiences(translatedAudiences);
-					groupedWork.addTargetAudiencesFull(translatedAudiences);
+					groupedWork.addTargetAudiences(translatedAudiences, recordInfo);
+					groupedWork.addTargetAudiencesFull(translatedAudiences, recordInfo);
 				}
 			}
 		}

--- a/code/reindexer/src/org/aspen_discovery/reindexer/ItemInfo.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/ItemInfo.java
@@ -563,6 +563,7 @@ public class ItemInfo{
 		locationOwnedNames = new HashSet<>();
 		libraryOwnedNames = new HashSet<>();
 		ArrayList<ScopingInfo> scopes = new ArrayList<>(scopingInfo.values());
+		scopes.sort(Comparator.comparingLong(scope -> scope.getScope().getId()));
 		for (ScopingInfo scope : scopes){
 			Scope curScope = scope.getScope();
 			if (scope.isLocallyOwned()){

--- a/code/reindexer/src/org/aspen_discovery/reindexer/MarcRecordProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/MarcRecordProcessor.java
@@ -372,7 +372,7 @@ abstract class MarcRecordProcessor {
 
 	}
 
-	void updateGroupedWorkSolrDataBasedOnStandardMarcData(AbstractGroupedWorkSolr groupedWork, org.marc4j.marc.Record record, ArrayList<ItemInfo> printItems, String identifier, String format, String formatCategory, boolean hasParentRecord) {
+	void updateGroupedWorkSolrDataBasedOnStandardMarcData(AbstractGroupedWorkSolr groupedWork, org.marc4j.marc.Record record, RecordInfo recordInfo, ArrayList<ItemInfo> printItems, String identifier, String format, String formatCategory, boolean hasParentRecord) {
 		loadTitles(groupedWork, record, formatCategory, hasParentRecord, identifier);
 		loadAuthors(groupedWork, record, identifier, formatCategory);
 		loadSubjects(groupedWork, record);
@@ -488,7 +488,7 @@ abstract class MarcRecordProcessor {
 		loadAwards(groupedWork, record);
 		loadBibCallNumbers(groupedWork, record, identifier);
 		loadLiteraryForms(groupedWork, record, printItems, identifier);
-		loadTargetAudiences(groupedWork, record, printItems, identifier);
+		loadTargetAudiences(groupedWork, record, recordInfo, printItems, identifier);
 		loadAcceleratedReader(groupedWork, record);
 		loadFountasPinnell(groupedWork, record);
 		loadLexileScore(groupedWork, record);
@@ -712,12 +712,12 @@ abstract class MarcRecordProcessor {
 		}
 	}
 
-	protected void loadTargetAudiences(AbstractGroupedWorkSolr groupedWork, org.marc4j.marc.Record record, ArrayList<ItemInfo> printItems, String identifier) {
-		loadTargetAudiences(groupedWork, record, printItems, identifier, "Unknown");
+	protected void loadTargetAudiences(AbstractGroupedWorkSolr groupedWork, org.marc4j.marc.Record record, RecordInfo recordInfo, ArrayList<ItemInfo> printItems, String identifier) {
+		loadTargetAudiences(groupedWork, record, recordInfo, printItems, identifier, "Unknown");
 	}
 
 	@SuppressWarnings("unused")
-	protected void loadTargetAudiences(AbstractGroupedWorkSolr groupedWork, org.marc4j.marc.Record record, ArrayList<ItemInfo> printItems, String identifier, String unknownAudienceLabel) {
+	protected void loadTargetAudiences(AbstractGroupedWorkSolr groupedWork, org.marc4j.marc.Record record, RecordInfo recordInfo, ArrayList<ItemInfo> printItems, String identifier, String unknownAudienceLabel) {
 		Set<String> targetAudiences = new LinkedHashSet<>();
 		try {
 			String leader = record.getLeader().toString();
@@ -784,7 +784,7 @@ abstract class MarcRecordProcessor {
 			translatedAudiences.add(unknownAudienceLabel);
 			if (groupedWork != null && groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Updating unknown target audience to " + unknownAudienceLabel, 2);}
 		}
-		groupedWork.addTargetAudiences(translatedAudiences);
+		groupedWork.addTargetAudiences(translatedAudiences, recordInfo);
 		LinkedHashSet<String> translatedAudiencesFull;
 		if (settings == null) {
 			translatedAudiencesFull = indexer.translateSystemCollection("target_audience_full", targetAudiences, identifier);
@@ -798,7 +798,7 @@ abstract class MarcRecordProcessor {
 			translatedAudiencesFull.add(unknownAudienceLabel);
 			if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Updating unknown full target audience to " + unknownAudienceLabel, 2);}
 		}
-		groupedWork.addTargetAudiencesFull(translatedAudiencesFull);
+		groupedWork.addTargetAudiencesFull(translatedAudiencesFull, recordInfo);
 	}
 
 	protected void loadLiteraryForms(AbstractGroupedWorkSolr groupedWork, org.marc4j.marc.Record record, ArrayList<ItemInfo> printItems, String identifier) {

--- a/code/reindexer/src/org/aspen_discovery/reindexer/OverDriveProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/OverDriveProcessor.java
@@ -249,7 +249,7 @@ class OverDriveProcessor implements AutoCloseable {
 								String targetAudience = "Adult";
 								if (rawMetadataDecoded != null) {
 									primaryLanguage = loadOverDriveLanguages(groupedWork, rawMetadataDecoded, identifier, overDriveRecord);
-									targetAudience = loadOverDriveSubjects(groupedWork, rawMetadataDecoded);
+									targetAudience = loadOverDriveSubjects(groupedWork, rawMetadataDecoded, overDriveRecord);
 								}
 
 								//Load the formats for the record.  For Libby, we will create a separate item for each format.
@@ -644,7 +644,7 @@ class OverDriveProcessor implements AutoCloseable {
 	 * @return The target audience for use later in scoping
 	 * @throws JSONException Exception if something goes horribly wrong
 	 */
-	private String loadOverDriveSubjects(AbstractGroupedWorkSolr groupedWork, JSONObject productMetadata) throws JSONException {
+	private String loadOverDriveSubjects(AbstractGroupedWorkSolr groupedWork, JSONObject productMetadata, RecordInfo recordInfo) throws JSONException {
 		//Load subject data
 		assert groupedWork != null;
 
@@ -720,8 +720,8 @@ class OverDriveProcessor implements AutoCloseable {
 			}
 		}
 
-		groupedWork.addTargetAudience(targetAudience);
-		groupedWork.addTargetAudienceFull(targetAudienceFull);
+		groupedWork.addTargetAudience(targetAudience, recordInfo);
+		groupedWork.addTargetAudienceFull(targetAudienceFull, recordInfo);
 
 		return targetAudience;
 	}

--- a/code/reindexer/src/org/aspen_discovery/reindexer/PalaceProjectProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/PalaceProjectProcessor.java
@@ -243,12 +243,12 @@ public class PalaceProjectProcessor {
 				}
 				if (audience == null) {
 					audience = "Unknown";
-					groupedWork.addTargetAudience("Unknown");
-					groupedWork.addTargetAudienceFull("Unknown");
+					groupedWork.addTargetAudience("Unknown", palaceProjectRecord);
+					groupedWork.addTargetAudienceFull("Unknown", palaceProjectRecord);
 					if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target/full target audience is unknown based on Palace Project record", 2);}
 				}else {
-					groupedWork.addTargetAudience(audience);
-					groupedWork.addTargetAudienceFull(audience);
+					groupedWork.addTargetAudience(audience, palaceProjectRecord);
+					groupedWork.addTargetAudienceFull(audience, palaceProjectRecord);
 					if (groupedWork.isDebugEnabled()) {groupedWork.addDebugMessage("Target/full target audience is " + audience + " based on Palace Project record", 2);}
 				}
 

--- a/code/reindexer/src/org/aspen_discovery/reindexer/RecordInfo.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/RecordInfo.java
@@ -24,10 +24,12 @@ public class RecordInfo {
 	private long formatBoost = 1;
 
 	private String edition;
+	// The raw audience from the 521a
 	private String audience;
+
+	private HashSet<String> targetAudience = new HashSet<>();
+	private HashSet<String> targetAudienceFull = new HashSet<>();
 	private String primaryLanguage;
-	private final HashSet<String> languages = new HashSet<>();
-	protected HashSet<String> translations = new HashSet<>();
 	protected Long languageBoost = 1L;
 	protected Long languageBoostSpanish = 1L;
 	private String publisher;
@@ -86,6 +88,30 @@ public class RecordInfo {
 		return audience;
 	}
 
+	void addTargetAudiences(HashSet<String> targetAudiences) {
+		this.targetAudience.addAll(targetAudiences);
+	}
+
+	void addTargetAudience(String targetAudiences) {
+		this.targetAudience.add(targetAudiences);
+	}
+
+	public String getTargetAudience() {
+		return String.join(", ", targetAudience);
+	}
+
+	void addTargetAudiencesFull(HashSet<String> targetAudiencesFull) {
+		this.targetAudienceFull.addAll(targetAudiencesFull);
+	}
+
+	void addTargetAudienceFull(String targetAudiencesFull) {
+		this.targetAudienceFull.add(targetAudiencesFull);
+	}
+
+	public String getTargetAudienceFull() {
+		return String.join(", ", targetAudienceFull);
+	}
+
 	void setPrimaryLanguage(String primaryLanguage) {
 		this.primaryLanguage = primaryLanguage;
 	}
@@ -107,14 +133,12 @@ public class RecordInfo {
 	}
 
 	public void addLanguage(String language) {
-		this.languages.add(language);
 		if (this.primaryLanguage == null) {
 			this.setPrimaryLanguage(language);
 		}
 	}
 
 	void setLanguages(HashSet<String> languages) {
-		this.languages.addAll(languages);
 		if (this.primaryLanguage == null) {
 			setPrimaryLanguage(languages.iterator().next());
 		}
@@ -397,6 +421,10 @@ public class RecordInfo {
 		this.formatBoost = recordInfo.formatBoost;
 		this.edition = recordInfo.edition;
 		this.audience = recordInfo.audience;
+		//noinspection unchecked
+		this.targetAudience = (HashSet<String>)recordInfo.targetAudience.clone();
+		//noinspection unchecked
+		this.targetAudienceFull = (HashSet<String>)recordInfo.targetAudienceFull.clone();
 		this.primaryLanguage = recordInfo.primaryLanguage;
 		this.publisher = recordInfo.publisher;
 		this.placeOfPublication = recordInfo.placeOfPublication;
@@ -495,7 +523,7 @@ public class RecordInfo {
 	}
 
 	@SuppressWarnings("DuplicatedCode")
-	public ArrayList<SolrInputDocument> getRecordScopeSolrDocuments(GroupedWorkIndexer groupedWorkIndexer, Long daysAddedSincePubDate) {
+	public ArrayList<SolrInputDocument> getRecordScopeSolrDocuments(GroupedWorkIndexer groupedWorkIndexer, AbstractGroupedWorkSolr parentWork, Long daysAddedSincePubDate) {
 		if (databaseId == -1) {
 			//This did not save for some reason
 			return null;
@@ -520,6 +548,11 @@ public class RecordInfo {
 			formatCategoriesForRecord.add("Books");
 			formatCategoriesForRecord.add("Audio Books");
 		}
+		HashSet<String> filteredTargetAudiences = groupedWorkIndexer.cleanTargetAudiences(targetAudience);
+		HashSet<String> filteredTargetAudiencesFull = groupedWorkIndexer.cleanTargetAudiences(targetAudienceFull);
+		if (parentWork.isDebugEnabled()) {parentWork.addDebugMessage("Final target audience for " + this.recordIdentifier + " is " + targetAudience, 1);}
+		if (parentWork.isDebugEnabled()) {parentWork.addDebugMessage("Final full target audience " + this.recordIdentifier + " is " + targetAudienceFull, 1);}
+
 
 		for (String scopeName : relatedScopes) {
 			Scope curScope = groupedWorkIndexer.getScopes().get(scopeName);
@@ -533,6 +566,8 @@ public class RecordInfo {
 			recordDoc.setField("scope", scopeName);
 			recordDoc.setField("format", formatsForRecord);
 			recordDoc.setField("format_category", formatCategoriesForRecord);
+			recordDoc.setField("target_audience", filteredTargetAudiences);
+			recordDoc.setField("target_audience_full", filteredTargetAudiencesFull);
 
 			AvailabilityToggleInfo availabilityToggleValuesForScope = new AvailabilityToggleInfo();
 			int availableCopiesForScope = 0;

--- a/code/reindexer/src/org/aspen_discovery/reindexer/SideLoadedEContentProcessor.java
+++ b/code/reindexer/src/org/aspen_discovery/reindexer/SideLoadedEContentProcessor.java
@@ -47,7 +47,7 @@ class SideLoadedEContentProcessor extends MarcRecordProcessor{
 			if (primaryFormat == null) primaryFormat = "Unknown";
 			String primaryFormatCategory = recordInfo.getPrimaryFormatCategory();
 			if (primaryFormatCategory == null) primaryFormatCategory = "Unknown";
-			updateGroupedWorkSolrDataBasedOnStandardMarcData(groupedWork, record, recordInfo.getRelatedItems(), identifier, primaryFormat, primaryFormatCategory, false);
+			updateGroupedWorkSolrDataBasedOnStandardMarcData(groupedWork, record, recordInfo, recordInfo.getRelatedItems(), identifier, primaryFormat, primaryFormatCategory, false);
 
 			String fullDescription = Util.getCRSeparatedString(MarcUtil.getFieldList(record, "520a"));
 			groupedWork.addDescription(fullDescription, primaryFormatCategory);

--- a/code/web/release_notes/26.09.00.MD
+++ b/code/web/release_notes/26.09.00.MD
@@ -62,6 +62,9 @@
 #### ILL
 #### Indexing
 - Add an option in indexing profiles to determine if publisher info is excluded from the keyword index or not. ([DIS-2821](https://aspen-discovery.atlassian.net/browse/DIS-2821)) (*KL*)
+- Add version 3 for Grouped Work indexing and searching utilizing child documents. ([DIS-2535](https://aspen-discovery.atlassian.net/browse/DIS-2535)) (*MDN*)
+- When clearing a solr core (unusual) fully drop the core and rebuild to allow for changes in field definitions. ([DIS-2815](https://aspen-discovery.atlassian.net/browse/DIS-2815)) (*MDN*)
+- Sort scopes when determining scoping strings so they are in a known order. ([DIS-2815](https://aspen-discovery.atlassian.net/browse/DIS-2815)) (*MDN*)
 
 <div markdown="1" class="settings">
 
@@ -97,11 +100,12 @@
 - Update call number sorting logic. ([DIS-2857](https://aspen-discovery.atlassian.net/browse/DIS-2857)) (*KL*)
   - Update callnumber_sort to prefer book/large print over other formats and no longer use eContent for this value.
   - Update the display of call number when sorting by call number to use the callnumber_sort value.
-- Improved searching of "record level" facets. ([DIS-2535](https://aspen-discovery.atlassian.net/browse/DIS-2535)) (*MDN*)
+- Improved searching of "record level" facets (requires grouped works v3 indexer and searcher). ([DIS-2535](https://aspen-discovery.atlassian.net/browse/DIS-2535)) (*MDN*)
     - Create nested documents within solr to hold scoped information by record during indexing.
     - Update searching to handle nested documents.
     - Remove prefixing of faceted fields.
-  
+- Index audiences at the record level to avoid scoping issues with audience. ([DIS-2815](https://aspen-discovery.atlassian.net/browse/DIS-2815)) (*MDN*)
+
 ### Self Check Updates
 - Add setting for checked-out override locations to allow self-check-out of items already checked out to these locations. Symphony Only. ([DIS-2646](https://aspen-discovery.atlassian.net/browse/DIS-2646)) (*KL*)
 

--- a/code/web/release_notes/26.09.00.MD
+++ b/code/web/release_notes/26.09.00.MD
@@ -97,6 +97,11 @@
 - Update call number sorting logic. ([DIS-2857](https://aspen-discovery.atlassian.net/browse/DIS-2857)) (*KL*)
   - Update callnumber_sort to prefer book/large print over other formats and no longer use eContent for this value.
   - Update the display of call number when sorting by call number to use the callnumber_sort value.
+- Improved searching of "record level" facets. ([DIS-2535](https://aspen-discovery.atlassian.net/browse/DIS-2535)) (*MDN*)
+    - Create nested documents within solr to hold scoped information by record during indexing.
+    - Update searching to handle nested documents.
+    - Remove prefixing of faceted fields.
+  
 ### Self Check Updates
 - Add setting for checked-out override locations to allow self-check-out of items already checked out to these locations. Symphony Only. ([DIS-2646](https://aspen-discovery.atlassian.net/browse/DIS-2646)) (*KL*)
 

--- a/code/web/sys/SearchObject/GroupedWorkSearcher3.php
+++ b/code/web/sys/SearchObject/GroupedWorkSearcher3.php
@@ -113,7 +113,9 @@ class SearchObject_GroupedWorkSearcher3 extends SearchObject_GroupedWorkSearcher
 			'lib_boost',
 			'owning_library',
 			'owning_location',
-			'shelf_location'
+			'shelf_location',
+			'target_audience',
+			'target_audience_full'
 		];
 		foreach ($this->filterList as $field => $filter) {
 			$multiSelect = false;
@@ -455,7 +457,7 @@ class SearchObject_GroupedWorkSearcher3 extends SearchObject_GroupedWorkSearcher
 			$fieldsToReturn .= ',itype';
 			$fieldsToReturn .= ',score';
 			if ($solrScope !== false) {
-				$fieldsToReturn .= ' [child childFilter="scope:' . $solrScope . '"]';
+				$fieldsToReturn .= ',[child childFilter="scope:' . $solrScope . '"]';
 			}
 		}
 		return $fieldsToReturn;

--- a/code/web/sys/SystemVariables.php
+++ b/code/web/sys/SystemVariables.php
@@ -189,7 +189,7 @@ class SystemVariables extends DataObject {
 						'type' => 'enum',
 						'values' => [
 							2 => 'Version 2 (Edition information)',
-							//3 => 'Version 3 (Optimization of solr fields)'
+							3 => 'Version 3 (Optimization of solr fields)'
 						],
 						'label' => 'Grouped Work Indexing Version',
 						'description' => 'The Solr Core Version to index with.  In 26.08 and above this should be version 3 in most cases.',
@@ -201,7 +201,7 @@ class SystemVariables extends DataObject {
 						'type' => 'enum',
 						'values' => [
 							2 => 'Version 2 (Edition information)',
-							//3 => 'Version 3 (Optimization of solr fields)'
+							3 => 'Version 3 (Optimization of solr fields)'
 						],
 						'label' => 'Grouped Work Search Version',
 						'description' => 'The Solr Core Version to search with.  In 26.08 and above this should be version 3 in most cases.',


### PR DESCRIPTION
- Index audience within child docs with grouped works v3
- When clearing a solr core (unusual) fully drop the core and rebuild to allow for changes in field definitions
- Optimize determining the correct audiences to show
- Sort scopes when determining scoping strings so they are in a known order