### PR TITLE
DIS-2608: Unit test portability

### DIFF
--- a/code/web/index.php
+++ b/code/web/index.php
@@ -121,7 +121,7 @@ global $translator;
 $activeLanguage = $validLanguages[$language];
 $interface->assign('validLanguages', $validLanguages);
 if ($translator == null) {
-	$translator = new Translator('lang', $language);
+	$translator = new Translator(ROOT_DIR . '/lang', $language);
 }
 $timer->logTime('Translator setup');
 $interface->assign('translationModeActive', $translator->translationModeActive());

--- a/code/web/interface/plugins/function.translate.php
+++ b/code/web/interface/plugins/function.translate.php
@@ -12,7 +12,7 @@ function smarty_function_translate($params, Smarty_Internal_Template &$smarty) :
 		} else {
 			$code = $activeLanguage->code;
 		}
-		$translator = new Translator('lang', $code);
+		$translator = new Translator(ROOT_DIR . '/lang', $code);
 	}
 	if (is_array($params)) {
 		$defaultText = $params['defaultText'] ?? '';

--- a/code/web/release_notes/26.09.00.MD
+++ b/code/web/release_notes/26.09.00.MD
@@ -25,6 +25,9 @@
 
 </div>
 
+#### Automated Testing
+- Resolve the unit test site name from the SITE_NAME environment variable. ([DIS-2608](https://aspen-discovery.atlassian.net/browse/DIS-2608)) (*JOM*)
+
 #### Code Maintenance
 - Introduce PSR-4 autoloading through Composer. Can now begin namespacing code under AspenDiscovery\ root directory. ([DIS-2854](https://aspen-discovery.atlassian.net/browse/DIS-2854)) (*JW*)
 
@@ -119,8 +122,11 @@
 
 #### Automated Testing
 - Add PHPStan to dev dependencies in Composer.json. Once deps. are updated, tool can be used by all devs across branches. ([DIS-2798](https://aspen-discovery.atlassian.net/browse/DIS-2798))
+- Allow the unit test suite to run on Linux and docker setups as well as Windows. ([DIS-2608](https://aspen-discovery.atlassian.net/browse/DIS-2608)) (*JOM*)
+- Stop the unit test run with a clear message when the test database import fails. ([DIS-2608](https://aspen-discovery.atlassian.net/browse/DIS-2608)) (*JOM*)
 
 #### Code Maintenance
+- Load translation files from the installation directory regardless of the working directory. ([DIS-2608](https://aspen-discovery.atlassian.net/browse/DIS-2608)) (*JOM*)
 - Added `generatePalette` to ColorUtils to generate a small palette of colors based on a given background and text color, while keeping minimum 4.5 contrast ratio. ([DIS-2711](https://aspen-discovery.atlassian.net/browse/DIS-2711)) (*KK*)
 - Added `readOnly` option to color property. ([DIS-2711](https://aspen-discovery.atlassian.net/browse/DIS-2711)) (*KK*)
 - Added the ability to set configuration to rate limit requests to the same host within a CurlWrapper. Sample configuration is in default/conf/config.ini commented out ([DIS-2192](https://aspen-discovery.atlassian.net/browse/DIS-2192)) (*IT*)
@@ -134,6 +140,9 @@
 
 #### eCommerce & Donations
 - Fix rounding error with Stripe payments ([DIS-2817](https://aspen-discovery.atlassian.net/browse/DIS-2817)) (*SW*)
+
+#### Events
+- Fix an error when staff look up an unknown barcode for event registration and no ILS connection is available. ([DIS-2608](https://aspen-discovery.atlassian.net/browse/DIS-2608)) (*JOM*)
 
 #### Evergreen
 - Fix issue preventing user login when password contains embedded spaces. ([DIS-2410](https://aspen-discovery.atlassian.net/browse/DIS-2410)) (*GMC*)
@@ -163,6 +172,7 @@
 
 #### Server Setup
 - Remove a redundant background process check from the backend container's startup script. ([DIS-2867](https://aspen-discovery.atlassian.net/browse/DIS-2867)) (*LM*)
+- Detect the operating system during site creation when the answer file does not specify it. ([DIS-2608](https://aspen-discovery.atlassian.net/browse/DIS-2608)) (*JOM*)
 
 #### Sierra ILS
 - Fix a bug specific to retrieving holds from Sierra with an unknown format. ([DIS-2742](https://aspen-discovery.atlassian.net/browse/DIS-2742))
@@ -172,6 +182,7 @@
 - Fix debug message when renewing non-renewable Symphony items. ([DIS-2837](https://aspen-discovery.atlassian.net/browse/DIS-2837)) (*MDN*)
 
 #### User Account
+- Fix a crash when the two-factor authentication method status is checked with no active user. ([DIS-2608](https://aspen-discovery.atlassian.net/browse/DIS-2608)) (*JOM*)
 - Fix issue where holds were being incorrectly filtered after bulk freezing/thawing actions ([DIS-2702](https://aspen-discovery.atlassian.net/browse/DIS-2702)) (*KL*)
 - Fix hold filtering in MyAccount to account for holds that are marked as unavailable ([DIS-2776](https://aspen-discovery.atlassian.net/browse/DIS-2776)) (*JW*)
 - Fix holds filter clear button ([DIS-2823](https://aspen-discovery.atlassian.net/browse/DIS-2823)) (*SW*)
@@ -204,6 +215,7 @@
 
 ### Open Fifth
 - Chloe Zermatten (CZ)
+- Jacob O'Mara (JOM)
 - Olivia Reynolds (OR)
 
 ### Theke Solutions

--- a/code/web/services/API/AbstractAPI.php
+++ b/code/web/services/API/AbstractAPI.php
@@ -435,7 +435,7 @@ abstract class AbstractAPI extends Action{
 			if ($userLanguage->find(true)) {
 				if ($userLanguage->code != $activeLanguage->code) {
 					$activeLanguage = $userLanguage;
-					$translator = new Translator('lang', $userLanguage->code);
+					$translator = new Translator(ROOT_DIR . '/lang', $userLanguage->code);
 				}
 			}
 		}

--- a/code/web/services/EventRegistrationService.php
+++ b/code/web/services/EventRegistrationService.php
@@ -597,8 +597,7 @@ class EventRegistrationService {
 
 		require_once ROOT_DIR . '/CatalogFactory.php';
 		$catalog = CatalogFactory::getCatalogConnectionInstance(null, null);
-		$catalogSupportsNewUsers = $catalog != null && method_exists($catalog, 'findNewUser');
-		if ($catalogSupportsNewUsers) {
+		if ($catalog != null) {
 			$newUser = $catalog->findNewUser($barcode, '');
 			if ($newUser && !($newUser instanceof AspenError)) {
 				$newUser->getDisplayName();

--- a/code/web/services/EventRegistrationService.php
+++ b/code/web/services/EventRegistrationService.php
@@ -597,7 +597,8 @@ class EventRegistrationService {
 
 		require_once ROOT_DIR . '/CatalogFactory.php';
 		$catalog = CatalogFactory::getCatalogConnectionInstance(null, null);
-		if (method_exists($catalog, 'findNewUser')) {
+		$catalogSupportsNewUsers = $catalog != null && method_exists($catalog, 'findNewUser');
+		if ($catalogSupportsNewUsers) {
 			$newUser = $catalog->findNewUser($barcode, '');
 			if ($newUser && !($newUser instanceof AspenError)) {
 				$newUser->getDisplayName();

--- a/code/web/sys/Interface.php
+++ b/code/web/sys/Interface.php
@@ -1238,7 +1238,7 @@ function translate($params) {
 		} else {
 			$code = $activeLanguage->code;
 		}
-		$translator = new Translator('lang', $code);
+		$translator = new Translator(ROOT_DIR . '/lang', $code);
 	}
 	if (is_array($params)) {
 		$defaultText = $params['defaultText'] ?? '';

--- a/code/web/sys/UserAccount.php
+++ b/code/web/sys/UserAccount.php
@@ -61,85 +61,82 @@ class UserAccount {
 
 	public static function get2FAMethodStatus(): array {
 		$user = UserAccount::getActiveUserObj();
-		if ($user !== null) {
+		$twoFactorAuthSetting = empty($user) ? null : $user->getTwoFactorAuthenticationSetting();
+		if ($twoFactorAuthSetting != null) {
+			$userTwoFactorMethods = ($user->twoFactorMethod ?? '');
 
-			$twoFactorAuthSetting = $user->getTwoFactorAuthenticationSetting();
-			if ($twoFactorAuthSetting != null) {
-				$userTwoFactorMethods = ($user->twoFactorMethod ?? '');
+			$setupMethods = array_values(array_filter(array_map('trim', explode(',', $userTwoFactorMethods)), static function ($method) {
+				return $method !== '';
+			}));
 
-				$setupMethods = array_values(array_filter(array_map('trim', explode(',', $userTwoFactorMethods)), static function ($method) {
-					return $method !== '';
-				}));
+			$allowEmail = (int)$twoFactorAuthSetting->allowEmail === 1;
+			$allowTotp = (int)$twoFactorAuthSetting->allowTotp === 1;
 
-				$allowEmail = (int)$twoFactorAuthSetting->allowEmail === 1;
-				$allowTotp = (int)$twoFactorAuthSetting->allowTotp === 1;
+			$validMethods = [
+				'email',
+				'totp'
+			];
+			$setupMethods = array_values(array_unique(array_filter($setupMethods, static function ($method) use ($validMethods) {
+				return in_array($method, $validMethods, true);
+			})));
 
-				$validMethods = [
-					'email',
-					'totp'
-				];
-				$setupMethods = array_values(array_unique(array_filter($setupMethods, static function ($method) use ($validMethods) {
-					return in_array($method, $validMethods, true);
-				})));
-
-				$filteredMethods = array_values(array_filter($setupMethods, static function ($method) use ($allowEmail, $allowTotp) {
-					if ($method === 'email' && !$allowEmail) {
-						return false;
-					}
-					if ($method === 'totp' && !$allowTotp) {
-						return false;
-					}
-					return true;
-				}));
-
-				$methodsChanged = $filteredMethods !== $setupMethods;
-				$setupMethods = $filteredMethods;
-				$updatedTwoFactorMethod = implode(',', $setupMethods);
-
-				if ($methodsChanged) {
-					// remove 2FA methods the user has set up which the library no longer allows
-					$user->twoFactorMethod = $updatedTwoFactorMethod;
-					$user->update();
+			$filteredMethods = array_values(array_filter($setupMethods, static function ($method) use ($allowEmail, $allowTotp) {
+				if ($method === 'email' && !$allowEmail) {
+					return false;
 				}
-
-				$hasEmail = in_array('email', $setupMethods, true);
-				$hasTotp = in_array('totp', $setupMethods, true);
-
-				$showSetupEmail = !$hasEmail && $allowEmail;
-				$showSetupTotp = !$hasTotp && $allowTotp;
-				$showDisableEmail = $hasEmail;
-				$showDisableTotp = $hasTotp;
-
-				$canDisableEmail = $showDisableEmail;
-				$canDisableTotp = $showDisableTotp;
-
-				if (UserAccount::isRequired2FA()) {
-					$configuredAllowedCount = 0;
-					if ($hasEmail && $allowEmail) {
-						$configuredAllowedCount++;
-					}
-					if ($hasTotp && $allowTotp) {
-						$configuredAllowedCount++;
-					}
-					if ($configuredAllowedCount <= 1) {
-						$canDisableEmail = false;
-						$canDisableTotp = false;
-					}
+				if ($method === 'totp' && !$allowTotp) {
+					return false;
 				}
+				return true;
+			}));
 
-				$requiredSetupWarning = null;
-				if (!$hasEmail && !$hasTotp) {
-					if ($allowEmail && !$allowTotp) {
-						$requiredSetupWarning = translate([
-							'text' => 'You must set up email two-factor authentication to keep using two-factor authentication.',
-							'isPublicFacing' => true
-						]);
-					} elseif (!$allowEmail && $allowTotp) {
-						$requiredSetupWarning = translate([
-							'text' => 'You must set up authenticator app (TOTP) to keep using two-factor authentication.',
-							'isPublicFacing' => true
-						]);
-					}
+			$methodsChanged = $filteredMethods !== $setupMethods;
+			$setupMethods = $filteredMethods;
+			$updatedTwoFactorMethod = implode(',', $setupMethods);
+
+			if ($methodsChanged) {
+				// remove 2FA methods the user has set up which the library no longer allows
+				$user->twoFactorMethod = $updatedTwoFactorMethod;
+				$user->update();
+			}
+
+			$hasEmail = in_array('email', $setupMethods, true);
+			$hasTotp = in_array('totp', $setupMethods, true);
+
+			$showSetupEmail = !$hasEmail && $allowEmail;
+			$showSetupTotp = !$hasTotp && $allowTotp;
+			$showDisableEmail = $hasEmail;
+			$showDisableTotp = $hasTotp;
+
+			$canDisableEmail = $showDisableEmail;
+			$canDisableTotp = $showDisableTotp;
+
+			if (UserAccount::isRequired2FA()) {
+				$configuredAllowedCount = 0;
+				if ($hasEmail && $allowEmail) {
+					$configuredAllowedCount++;
+				}
+				if ($hasTotp && $allowTotp) {
+					$configuredAllowedCount++;
+				}
+				if ($configuredAllowedCount <= 1) {
+					$canDisableEmail = false;
+					$canDisableTotp = false;
+				}
+			}
+
+			$requiredSetupWarning = null;
+			if (!$hasEmail && !$hasTotp) {
+				if ($allowEmail && !$allowTotp) {
+					$requiredSetupWarning = translate([
+						'text' => 'You must set up email two-factor authentication to keep using two-factor authentication.',
+						'isPublicFacing' => true
+					]);
+				} elseif (!$allowEmail && $allowTotp) {
+					$requiredSetupWarning = translate([
+						'text' => 'You must set up authenticator app (TOTP) to keep using two-factor authentication.',
+						'isPublicFacing' => true
+					]);
 				}
 			}
 		}

--- a/install/createSite.php
+++ b/install/createSite.php
@@ -16,6 +16,49 @@ if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN'){
 $linuxOS = null;
 $linuxArray = ['centos', 'debian'];
 
+function detectLinuxOS(array $linuxArray): string {
+	$osRelease = @parse_ini_file('/etc/os-release');
+	if ($osRelease === false) {
+		return 'debian';
+	}
+	$osIds = array_merge([$osRelease['ID'] ?? ''], explode(' ', $osRelease['ID_LIKE'] ?? ''));
+	$knownIds = array_values(array_intersect($osIds, $linuxArray));
+	if ($knownIds !== []) {
+		return $knownIds[0];
+	}
+	$isRhelFamily = count(array_intersect(['rhel', 'fedora'], $osIds)) > 0;
+	if ($isRhelFamily) {
+		return 'centos';
+	}
+	return 'debian';
+}
+
+function resolveConfiguredSiteOS(array $siteConfig, string $operatingSystemSetting, string $siteOnWindowsSetting): array {
+	$siteOnWindows = $siteOnWindowsSetting == 'Y' || $siteOnWindowsSetting == 'y';
+	$siteOnMacSetting = $siteConfig['siteOnMac'] ?? '';
+	$siteOnMac = $siteOnMacSetting == 'Y' || $siteOnMacSetting == 'y';
+	$siteOnLinux = !$siteOnWindows && !$siteOnMac;
+	$linuxOS = $siteOnLinux ? $operatingSystemSetting : null;
+	return [$siteOnWindows, $siteOnMac, $linuxOS, $operatingSystemSetting];
+}
+
+function resolveSiteOS(array $siteConfig, bool $runningOnWindows, array $linuxArray, string $detectedOS): array {
+	$operatingSystemSetting = $siteConfig['operatingSystem'] ?? '';
+	$siteOnWindowsSetting = $siteConfig['siteOnWindows'] ?? '';
+	$autoDetectOS = $operatingSystemSetting === '' && $siteOnWindowsSetting === '';
+	if (!$autoDetectOS) {
+		return resolveConfiguredSiteOS($siteConfig, $operatingSystemSetting, $siteOnWindowsSetting);
+	}
+	if ($runningOnWindows) {
+		return [true, false, null, 'windows'];
+	}
+	if (PHP_OS === 'Darwin') {
+		return [false, true, null, $detectedOS];
+	}
+	$linuxOS = detectLinuxOS($linuxArray);
+	return [false, false, $linuxOS, $linuxOS];
+}
+
 $foundConfig = false;
 $variables = [];
 $siteOnWindows = false;
@@ -106,13 +149,7 @@ if (count($_SERVER['argv']) > 1){
 		}else{
 			$variables['ilsDriver'] = $configArray['ILS']['ilsDriver'];
 		}
-		$siteOnWindows = $configArray['Site']['siteOnWindows'] == 'Y' || $configArray['Site']['siteOnWindows'] == 'y';
-		$siteOnMac = !empty($configArray['Site']['siteOnMac']) && ($configArray['Site']['siteOnMac'] == 'Y' || $configArray['Site']['siteOnMac'] == 'y');
-
-		if (!$siteOnWindows && !$siteOnMac){
-			$linuxOS = $configArray['Site']['operatingSystem'];
-		}
-		$operatingSystem = $configArray['Site']['operatingSystem'];
+		[$siteOnWindows, $siteOnMac, $linuxOS, $operatingSystem] = resolveSiteOS($configArray['Site'], $runningOnWindows, $linuxArray, $operatingSystem);
 	} else {
 		echo "Invalid configuration file ($siteConfigFile) specified";
 		exit();

--- a/install/unit_tests.ini
+++ b/install/unit_tests.ini
@@ -1,10 +1,10 @@
 [Site]
 sitename = unit_tests.localhost
-operatingSystem = windows
+operatingSystem =
 library = Unit Tests
 title = Unit Tests
 url = http://unit_tests.localhost
-siteOnWindows = y
+siteOnWindows =
 solrPort = 8083
 ils = MockILS
 ; timezone of the library (e.g. America/Los_Angeles, check http://www.php.net/manual/en/timezones.php)

--- a/tests/phpunit/phpUnitBootstrap.php
+++ b/tests/phpunit/phpUnitBootstrap.php
@@ -36,15 +36,22 @@ foreach ($allTables as $table) {
 	$aspen_db->exec("DROP TABLE {$table['TABLE_NAME']}");
 }
 
+function importSqlFile(string $sqlFile, string $dbUser, string $dbHost, string $dbPort, string $dbName): void {
+	$importOutput = [];
+	exec("mysql -u$dbUser -h$dbHost -P$dbPort $dbName < $sqlFile 2>&1", $importOutput, $exitCode);
+	if ($exitCode !== 0) {
+		die("Failed to import $sqlFile (exit code $exitCode):\n" . implode("\n", $importOutput) . "\n");
+	}
+}
+
+putenv("MYSQL_PWD=$dbPassword");
+
 //Import blank database
-$importCommand = "mysql -u$dbUser -p$dbPassword -h$dbHost -P$dbPort $dbName < $baseAspenSQL";
-exec($importCommand);
+importSqlFile($baseAspenSQL, $dbUser, $dbHost, $dbPort, $dbName);
 
 ////Import unit test specific data
 $unitTestsSQL = "$curDir/../../tests/unit_tests.sql";
-$importCommand = "mysql -u$dbUser -p$dbPassword -h$dbHost -P$dbPort $dbName < $unitTestsSQL";
-$results = [];
-exec($importCommand, $results);
+importSqlFile($unitTestsSQL, $dbUser, $dbHost, $dbPort, $dbName);
 
 //Make sure solr is running?
 

--- a/tests/phpunit/phpUnitBootstrap.php
+++ b/tests/phpunit/phpUnitBootstrap.php
@@ -62,4 +62,13 @@ require_once __DIR__ . '/../../code/web/bootstrap_aspen.php';
 global $interface;
 $interface = new UInterface();
 
+//Setup translation like index.php does for web requests
+global $activeLanguage;
+global $translator;
+$validLanguages = Language::getValidLanguages();
+$defaultLanguageCode = Language::getDefaultLanguageCode();
+$activeLanguage = $validLanguages[$defaultLanguageCode];
+$translator = new Translator(ROOT_DIR . '/lang', $defaultLanguageCode);
+$interface->setLanguage($activeLanguage);
+
 echo "Aspen Discovery PHPUnit tests starting\n";

--- a/tests/phpunit/phpUnitBootstrap.php
+++ b/tests/phpunit/phpUnitBootstrap.php
@@ -1,7 +1,7 @@
 <?php
 $_SERVER['aspen_server'] = 'unit_tests.localhost';
 
-require_once '../../code/web/bootstrap.php';
+require_once __DIR__ . '/../../code/web/bootstrap.php';
 //Load a clean database at the start of unit testing?
 global $configArray;
 global $aspen_db;
@@ -49,7 +49,7 @@ exec($importCommand, $results);
 //Make sure solr is running?
 
 
-require_once '../../code/web/bootstrap_aspen.php';
+require_once __DIR__ . '/../../code/web/bootstrap_aspen.php';
 
 //Setup interface
 global $interface;

--- a/tests/phpunit/phpUnitBootstrap.php
+++ b/tests/phpunit/phpUnitBootstrap.php
@@ -1,5 +1,5 @@
 <?php
-$_SERVER['aspen_server'] = 'unit_tests.localhost';
+$_SERVER['aspen_server'] = getenv('SITE_NAME') ?: 'unit_tests.localhost';
 
 require_once __DIR__ . '/../../code/web/bootstrap.php';
 //Load a clean database at the start of unit testing?

--- a/tests/phpunit/tests/FinalizationTests.php
+++ b/tests/phpunit/tests/FinalizationTests.php
@@ -3,6 +3,12 @@ use PHPUnit\Framework\TestCase;
 
 class FinalizationTests extends TestCase {
 	public function test_stoppingSolr() {
+		global $configArray;
+		$solrHost = $configArray['Index']['solrHost'] ?? 'localhost';
+		$solrIsRemote = !in_array($solrHost, ['localhost', '127.0.0.1']);
+		if ($solrIsRemote) {
+			$this->markTestSkipped("Solr runs remotely on $solrHost and cannot be stopped locally");
+		}
 		require_once __DIR__ . '/../../../code/web/sys/SolrUtils.php';
 		SolrUtils::stopSolr();
 		sleep(15);

--- a/tests/phpunit/tests/InitializationTests.php
+++ b/tests/phpunit/tests/InitializationTests.php
@@ -8,7 +8,7 @@ class InitializationTests extends TestCase {
 	}
 
 	public function test_rootDir() {
-		$this->assertEquals('C:\web\aspen-discovery\code\web', ROOT_DIR);
+		$this->assertEquals(realpath(__DIR__ . '/../../../code/web'), realpath(ROOT_DIR));
 	}
 
 	public function test_getAspenVersion() {

--- a/tests/phpunit/tests/InitializationTests.php
+++ b/tests/phpunit/tests/InitializationTests.php
@@ -18,9 +18,13 @@ class InitializationTests extends TestCase {
 	}
 
 	public function test_solrRunning() {
+		global $configArray;
 		require_once __DIR__ . '/../../../code/web/sys/SolrUtils.php';
-		SolrUtils::startSolr();
-		sleep(45);
+		$solrIsLocal = in_array($configArray['Index']['solrHost'] ?? 'localhost', ['localhost', '127.0.0.1']);
+		if ($solrIsLocal) {
+			SolrUtils::startSolr();
+			sleep(45);
+		}
 
 		$solrSearcher = SearchObjectFactory::initSearchObject('GroupedWork');
 		$pingResult = $solrSearcher->ping(true);

--- a/tests/phpunit/tests/sys/ECommerce/HeyCentricUrlBuilderTests.php
+++ b/tests/phpunit/tests/sys/ECommerce/HeyCentricUrlBuilderTests.php
@@ -1,7 +1,9 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
-define('PATH_TO_ROOT', __DIR__ . '/../../../../../');
+if (!defined('PATH_TO_ROOT')) {
+	define('PATH_TO_ROOT', __DIR__ . '/../../../../../');
+}
 
 require_once PATH_TO_ROOT . 'code/web/sys/ECommerce/HeyCentricUrlBuilder.php';
 

--- a/tests/phpunit/tests/sys/Events/EventAttendeeCategoryTests.php
+++ b/tests/phpunit/tests/sys/Events/EventAttendeeCategoryTests.php
@@ -435,7 +435,7 @@ class EventAttendeeCategoryTests extends TestCase {
 		$instance->id = $this->eventInstance->id;
 		$instance->find(true);
 
-		$breakdown = EventRegistrationService::getAttendeeCategoryBreakdown((int)$instance->id);
+		$breakdown = EventRegistrationService::getAttendeeCategoryBreakdownForInstance((int)$instance->id);
 
 		$this->assertCount(2, $breakdown);
 
@@ -455,7 +455,7 @@ class EventAttendeeCategoryTests extends TestCase {
 		$instance->id = $this->eventInstance->id;
 		$instance->find(true);
 
-		$breakdown = EventRegistrationService::getAttendeeCategoryBreakdown((int)$instance->id);
+		$breakdown = EventRegistrationService::getAttendeeCategoryBreakdownForInstance((int)$instance->id);
 		$this->assertCount(2, $breakdown);
 
 		foreach ($breakdown as $entry) {

--- a/tests/phpunit/tests/sys/Events/EventStaffRegistrationTests.php
+++ b/tests/phpunit/tests/sys/Events/EventStaffRegistrationTests.php
@@ -175,9 +175,11 @@ class EventStaffRegistrationTests extends TestCase {
 
 	public function testRegisterUserAllowsInvitedUserWhenFull(): void {
 		// Fill all seats
+		$firstUser = null;
 		for ($i = 0; $i < 3; $i++) {
 			$u = $this->insertUser(40060 + $i);
 			$this->insertRegistration((int)$u->id);
+			$firstUser ??= $u;
 		}
 
 		// Put user on waitlist as invited
@@ -192,7 +194,7 @@ class EventStaffRegistrationTests extends TestCase {
 
 		// Unregister one to make room — invited user should be allowed through
 		$firstReg = new UserAspenEventInstanceRegistration();
-		$firstReg->userId = 40060;
+		$firstReg->userId = $firstUser->id;
 		$firstReg->eventInstanceId = $this->eventInstance->id;
 		$firstReg->find(true);
 		$firstReg->delete();

--- a/tests/phpunit/tests/sys/Events/EventWaitingListTests.php
+++ b/tests/phpunit/tests/sys/Events/EventWaitingListTests.php
@@ -1,7 +1,9 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
-define('PATH_TO_ROOT', __DIR__ . '/../../../../../');
+if (!defined('PATH_TO_ROOT')) {
+	define('PATH_TO_ROOT', __DIR__ . '/../../../../../');
+}
 
 /**
  * Tests for the waiting list model on UserAspenEventInstanceRegistration and


### PR DESCRIPTION
@mdnoble73 This should not change functionality for your test system. This is just to allow the test suite to be run more universally on other systems. 
Stuff like:
 - Removing the hard coded windows paths
 - Making the distro/os detection dynamic
 - Making the bootstrap paths relative to the file, not where you ran it from
 - Allowing an optional env var to override the site name when the site you're running tests  on isn't "unit_tests.localhost"
 - Skipping the solr shutdown test if solr isn't running on localhost (will probably only be relevant for docker instances as solr runs in a different container)
 
To test:
 - Run the test suite as usual.
 
 The last 6 commits are me fixing the currently failing tests to ensure we start with a bare passing state.