### PR TITLE
DIS-2888: Tests run db updates

### DIFF
--- a/code/web/release_notes/26.09.00.MD
+++ b/code/web/release_notes/26.09.00.MD
@@ -26,6 +26,7 @@
 </div>
 
 #### Code Maintenance
+- PHPUnit test bootstrap optionally runs pending database updates before tests when `ASPEN_TESTS_RUN_DB_UPDATES` is set, keeping the test database in sync with migrations. ([DIS-2888](https://aspen-discovery.atlassian.net/browse/DIS-2888)) (*JOM*)
 - Introduce PSR-4 autoloading through Composer. Can now begin namespacing code under AspenDiscovery\ root directory. ([DIS-2854](https://aspen-discovery.atlassian.net/browse/DIS-2854)) (*JW*)
 
 #### eCommerce & Donations
@@ -204,6 +205,7 @@
 
 ### Open Fifth
 - Chloe Zermatten (CZ)
+- Jacob O'Mara (JOM)
 - Olivia Reynolds (OR)
 
 ### Theke Solutions

--- a/tests/phpunit/phpUnitBootstrap.php
+++ b/tests/phpunit/phpUnitBootstrap.php
@@ -55,4 +55,27 @@ require_once '../../code/web/bootstrap_aspen.php';
 global $interface;
 $interface = new UInterface();
 
+function applyPendingDatabaseUpdates() : void {
+	require_once ROOT_DIR . '/services/API/SystemAPI.php';
+	$systemAPI = new SystemAPI();
+	$pendingUpdates = $systemAPI->getPendingDatabaseUpdates();
+	$numFailed = 0;
+	foreach (array_keys($pendingUpdates) as $updateKey) {
+		$updateResult = $systemAPI->runDatabaseUpdate($pendingUpdates, $updateKey);
+		if ($updateResult['success']) {
+			continue;
+		}
+		$numFailed++;
+		$updateMessage = strip_tags(str_replace('<br/>', "\n", $updateResult['message']));
+		echo "Database update $updateKey failed: $updateMessage\n";
+	}
+	$numApplied = count($pendingUpdates) - $numFailed;
+	echo "Applied $numApplied pending database updates, $numFailed failed\n";
+}
+
+$runPendingDatabaseUpdates = !empty(getenv('ASPEN_TESTS_RUN_DB_UPDATES'));
+if ($runPendingDatabaseUpdates) {
+	applyPendingDatabaseUpdates();
+}
+
 echo "Aspen Discovery PHPUnit tests starting\n";


### PR DESCRIPTION
We should allow the ability optionally run pending db updates at the beginning of the test suite setup.
This allows you to test your new features while developing without having to regenerate the aspen.sql.

To test:
Set this env variable to true: "ASPEN_TESTS_RUN_DB_UPDATES" and then run test suite with tests in it that require tables that are not yet in aspen.sql but have db updates created.