### PR TITLE
DIS-2894: Upgrade Docker image to Debian trixie, OpenJDK 25, and native PHP 8.4

### DIFF
--- a/code/web/release_notes/26.10.00.MD
+++ b/code/web/release_notes/26.10.00.MD
@@ -103,6 +103,7 @@
 #### Series
 
 #### Server Setup
+- Upgrade the Docker image's base OS to Debian trixie, Java runtime to OpenJDK 25, and PHP to trixie's native 8.4 package. ([DIS-2894](https://aspen-discovery.atlassian.net/browse/DIS-2894)) (*LM*)
 
 #### Side Loading
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm
+FROM debian:trixie
 
 # Install deps
 RUN apt -y update \
@@ -15,9 +15,7 @@ RUN apt -y update \
 	  vim \
 	  bind9 \
 	  bind9utils \
-	  software-properties-common \
-	  default-jdk \
-	  openjdk-17-jdk \
+	  openjdk-25-jdk \
 	  unzip \
 	  rng-tools \
 	  python3-certbot-apache \
@@ -42,30 +40,24 @@ RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
 ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
 
-# Add sury's repo
-RUN wget -O- -q https://packages.sury.org/php/apt.gpg \
-      | gpg --dearmor \
-      | tee /usr/share/keyrings/sury.gpg >/dev/null \
-   && echo "deb [signed-by=/usr/share/keyrings/sury.gpg] https://packages.sury.org/php/ bookworm main" > /etc/apt/sources.list.d/sury.list
-
-# Install php deps
+# Install php deps (trixie ships PHP 8.4 as the default version natively, no third-party repo needed)
 RUN apt -y update \
 	&& apt install -y \
-	  php8.4 \
-	  php8.4-fpm \
-	  php8.4-mcrypt \
-	  php8.4-gd \
-	  php8.4-imagick \
-	  php8.4-curl \
-	  php8.4-zip \
-	  php8.4-xml \
-	  php8.4-intl \
-	  php8.4-mbstring \
-	  php8.4-soap \
-	  php8.4-pgsql \
-	  php8.4-ssh2 \
-	  php8.4-ldap \
-	  php8.4-mysql \
+	  php \
+	  php-fpm \
+	  php-mcrypt \
+	  php-gd \
+	  php-imagick \
+	  php-curl \
+	  php-zip \
+	  php-xml \
+	  php-intl \
+	  php-mbstring \
+	  php-soap \
+	  php-pgsql \
+	  php-ssh2 \
+	  php-ldap \
+	  php-mysql \
 	&& rm -rf /var/cache/apt/archives/* \
 	&& rm -rf /var/lib/apt/lists/*
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -48,6 +48,7 @@ Access Aspen at http://localhost:85 (default credentials: `aspen_admin` / `secre
 | `DATABASE_USER` | `aspenusr` | Database user |
 | `DATABASE_PASSWORD` | `aspenpasswd` | Database password |
 | `DATABASE_ROOT_PASSWORD` | `password` | MariaDB root password |
+| `DATABASE_SSL_MODE` | `DISABLED` | When `DISABLED`, the mariadb CLI client connects with `--skip-ssl` (needed since mariadb-client 11.x defaults to requiring TLS). Set to `REQUIRED` only when the db service has TLS configured, e.g. via a compose overlay adding certs. |
 
 ### Services
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     image: ${BACKEND_IMAGE_TAG:-aspendiscovery/aspen}
     env_file:
       - .env
+    environment:
+      - DATABASE_SSL_MODE=${DATABASE_SSL_MODE:-DISABLED}
     networks:
       - net-aspen
     tty: true

--- a/docker/files/scripts/initDatabase.php
+++ b/docker/files/scripts/initDatabase.php
@@ -22,6 +22,9 @@ $mysqlConnectionCommand = "mariadb -u$databaseUser -p$databasePassword -h$databa
 if ($databasePort != "3306") {
 	$mysqlConnectionCommand .= " --port=$databasePort";
 }
+if ((getenv('DATABASE_SSL_MODE') ?: 'DISABLED') === 'DISABLED') {
+	$mysqlConnectionCommand .= " --skip-ssl";
+}
 
 DockerLogger::info("Checking database connection to: {$databaseHost}:{$databasePort}");
 


### PR DESCRIPTION
Upgrades the base OS from debian:bookworm to debian:trixie, the JVM from JDK 17 to OpenJDK 25 (24 was targeted but was never packaged in Debian), and PHP from the sury.org 8.4 repo to trixie's native 8.4 package. Trixie's mariadb-client (11.8) defaults to requiring TLS, which broke the fresh-DB init script against a non-TLS-configured database server; fixed by adding a DATABASE_SSL_MODE env var (default DISABLED) that makes the init script's mariadb client connect with --skip-ssl, rather than provisioning server-side certificates.

  Test plan:
  - Before: on trixie without the SSL fix, the mariadb client invoked by the init script fails immediately with ERROR 2026 (HY000): TLS/SSL error: SSL is required, but the server does not support it, and database initialization never completes.
  - After: the mariadb client connects and initializes the database with no TLS-related error in its output; inside the container, confirm php -v reports 8.4.24 and java -version/javac -version report 25.0.4.1.