### PR TITLE
DIS-2893: Fix updateDatabase.php Smarty init order

### DIFF
--- a/code/web/release_notes/26.09.00.MD
+++ b/code/web/release_notes/26.09.00.MD
@@ -132,6 +132,7 @@
 
 #### Docker
 - Remove a redundant background process check from the backend container's startup script. ([DIS-2867](https://aspen-discovery.atlassian.net/browse/DIS-2867)) (*LM*)
+- Fix a fatal error during database migrations on a fresh install, caused by Smarty theme variables being uninitialized before an update script that renders theme CSS. ([DIS-2893](https://aspen-discovery.atlassian.net/browse/DIS-2893)) (*LM*)
 
 #### EBSCO
 - If all EBSCOhost default databases are being searched in Combined Results do list them as facets when linking to all results. ([DIS-2858](https://aspen-discovery.atlassian.net/browse/DIS-2858)) (*MDN*)

--- a/docker/files/scripts/updateDatabase.php
+++ b/docker/files/scripts/updateDatabase.php
@@ -26,6 +26,11 @@ if (!checkDatabaseConnection($aspen_db) || !isDatabaseInitialized($aspen_db)) {
 	exit(1);
 }
 
+// Some update scripts render theme CSS as part of the update itself (e.g. 26.09.00.php),
+// so $interface must exist before updates run, not just before updateCssForAllThemes().
+global $interface;
+$interface = new UInterface();
+
 DockerLogger::info("Running pending database updates");
 
 $systemAPI = new SystemAPI();
@@ -39,8 +44,6 @@ if (!$completedUpdates['success']) {
 }
 
 DockerLogger::info("Updating CSS for all themes");
-global $interface;
-$interface = new UInterface();
 $result = $systemAPI->updateCssForAllThemes();
 if ($result['success'] != true) {
 	DockerLogger::warn("Error updating CSS: " . $result['message']);


### PR DESCRIPTION
Some database migration scripts (e.g. 26.09.00.php, via regenerateThemeCssForFontSize()) render theme CSS as part of the migration itself, which reads global $interface. updateDatabase.php only initialized $interface right before its own later, separate CSS-update call, after runPendingDatabaseUpdates() had already run. On a fresh database, this left $interface null while migrations executed, throwing a fatal error and hanging the entire backend startup. Fix moves the $interface initialization to before the migrations run.

Test plan

Before: starting the backend against a fresh, empty database never completes; backend logs show PHP Fatal error: Uncaught Error: Call to a member function assign() on null in Theme.php:3171, and the container never reaches a ready state.
After: same fresh-database startup completes; backend logs show migrations running to completion (or failing only on unrelated, pre-existing issues, not this crash), CSS updates succeed, and the backend reaches a ready state normally.