### PR TITLE
DIS-2897: Add S3/CDN storage driver for uploaded images and files

### DIFF
--- a/code/web/composer.lock
+++ b/code/web/composer.lock
@@ -4,8 +4,145 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4118c04316d243cf71aaf6fe91d95187",
+    "content-hash": "2e0d9b9700a5d32a82f5a26b6d6141d7",
     "packages": [
+        {
+            "name": "async-aws/core",
+            "version": "1.29.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/async-aws/core.git",
+                "reference": "aefe81449ea19f6ed43944bbb29874a0a5e54d18"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/async-aws/core/zipball/aefe81449ea19f6ed43944bbb29874a0a5e54d18",
+                "reference": "aefe81449ea19f6ed43944bbb29874a0a5e54d18",
+                "shasum": ""
+            },
+            "require": {
+                "ext-hash": "*",
+                "ext-simplexml": "*",
+                "php": "^8.2",
+                "psr/cache": "^1.0 || ^2.0 || ^3.0",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
+                "symfony/deprecation-contracts": "^2.1 || ^3.0",
+                "symfony/http-client": "^4.4.16 || ^5.1.7 || ^6.0 || ^7.0 || ^8.0",
+                "symfony/http-client-contracts": "^1.1.8 || ^2.0 || ^3.0",
+                "symfony/service-contracts": "^1.0 || ^2.0 || ^3.0"
+            },
+            "conflict": {
+                "async-aws/s3": "<1.1",
+                "symfony/http-client": "5.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5.42",
+                "symfony/error-handler": "^7.3.2 || ^8.0",
+                "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.29-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "AsyncAws\\Core\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Core package to integrate with AWS. This is a lightweight AWS SDK provider by AsyncAws.",
+            "keywords": [
+                "amazon",
+                "async-aws",
+                "aws",
+                "sdk",
+                "sts"
+            ],
+            "support": {
+                "source": "https://github.com/async-aws/core/tree/1.29.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/jderusse",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nyholm",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-07-29T12:54:05+00:00"
+        },
+        {
+            "name": "async-aws/s3",
+            "version": "3.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/async-aws/s3.git",
+                "reference": "5df1ad51e02f489cf1b78e59890b40632b4a5a42"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/async-aws/s3/zipball/5df1ad51e02f489cf1b78e59890b40632b4a5a42",
+                "reference": "5df1ad51e02f489cf1b78e59890b40632b4a5a42",
+                "shasum": ""
+            },
+            "require": {
+                "async-aws/core": "^1.22",
+                "ext-dom": "*",
+                "ext-filter": "*",
+                "ext-hash": "*",
+                "ext-simplexml": "*",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5.42",
+                "symfony/error-handler": "^7.3.2 || ^8.0",
+                "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "AsyncAws\\S3\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "S3 client, part of the AWS SDK provided by AsyncAws.",
+            "keywords": [
+                "amazon",
+                "async-aws",
+                "aws",
+                "s3",
+                "sdk"
+            ],
+            "support": {
+                "source": "https://github.com/async-aws/s3/tree/3.4.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/jderusse",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nyholm",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-07-29T12:54:05+00:00"
+        },
         {
             "name": "defuse/php-encryption",
             "version": "v2.4.0",
@@ -686,6 +823,55 @@
             "time": "2020-10-15T08:29:30+00:00"
         },
         {
+            "name": "psr/cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/3.0.0"
+            },
+            "time": "2021-02-03T23:26:27+00:00"
+        },
+        {
             "name": "psr/clock",
             "version": "1.0.0",
             "source": {
@@ -732,6 +918,59 @@
                 "source": "https://github.com/php-fig/clock/tree/1.0.0"
             },
             "time": "2022-11-25T14:36:26+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
+            },
+            "time": "2021-11-05T16:47:00+00:00"
         },
         {
             "name": "psr/event-dispatcher",
@@ -1003,6 +1242,477 @@
                 "source": "https://github.com/php-fig/http-server-middleware/tree/1.0.2"
             },
             "time": "2023-04-11T06:14:47+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
+            },
+            "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-05T06:23:12+00:00"
+        },
+        {
+            "name": "symfony/http-client",
+            "version": "v7.4.17",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client.git",
+                "reference": "d0aca330a822fe40376cd04c335cb48a24743d0c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/d0aca330a822fe40376cd04c335cb48a24743d0c",
+                "reference": "d0aca330a822fe40376cd04c335cb48a24743d0c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/log": "^1|^2|^3",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/http-client-contracts": "~3.4.4|^3.5.2",
+                "symfony/polyfill-php83": "^1.29",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "amphp/amp": "<2.5",
+                "amphp/socket": "<1.1",
+                "php-http/discovery": "<1.15",
+                "symfony/http-foundation": "<6.4"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "*",
+                "php-http/client-implementation": "*",
+                "psr/http-client-implementation": "1.0",
+                "symfony/http-client-implementation": "3.0"
+            },
+            "require-dev": {
+                "amphp/http-client": "^4.2.1|^5.0",
+                "amphp/http-tunnel": "^1.0|^2.0",
+                "guzzlehttp/promises": "^1.4|^2.0",
+                "nyholm/psr7": "^1.0",
+                "php-http/httplug": "^1.0|^2.0",
+                "psr/http-client": "^1.0",
+                "symfony/amphp-http-client-meta": "^1.0|^2.0",
+                "symfony/cache": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/rate-limiter": "^6.4|^7.0|^8.0",
+                "symfony/stopwatch": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpClient\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides powerful methods to fetch HTTP resources synchronously or asynchronously",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "http"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/http-client/tree/v7.4.17"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-08-21T17:40:08+00:00"
+        },
+        {
+            "name": "symfony/http-client-contracts",
+            "version": "v3.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client-contracts.git",
+                "reference": "41fc42d276aeff21192465331ebbab7d83a743c0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/41fc42d276aeff21192465331ebbab7d83a743c0",
+                "reference": "41fc42d276aeff21192465331ebbab7d83a743c0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\HttpClient\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to HTTP clients",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/http-client-contracts/tree/v3.7.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-05T06:23:12+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php83",
+            "version": "v1.41.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php83.git",
+                "reference": "5ea99087fb99c273a9b9236ed4c31e78b16103c6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/5ea99087fb99c273a9b9236ed4c31e78b16103c6",
+                "reference": "5ea99087fb99c273a9b9236ed4c31e78b16103c6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php83\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.41.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-01T12:47:55+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v3.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/c0a284bab1ed8aa0417e3d69250ab437739563a0",
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-16T09:55:08+00:00"
         }
     ],
     "packages-dev": [

--- a/code/web/interface/themes/responsive/Admin/propertiesList.tpl
+++ b/code/web/interface/themes/responsive/Admin/propertiesList.tpl
@@ -201,9 +201,17 @@
 								{elseif $property.type == 'checkbox' || $property.type == 'calculatedBoolean'}
 									{if ($propValue == 1)}{translate text="Yes" isAdminFacing=true}{elseif ($propValue == 0)}{translate text="No" isAdminFacing=true}{else}{$propValue}{/if}
 								{elseif $property.type == 'image'}
-									<img src="{$property.displayUrl}{$dataItem->id}"
-										 onerror="this.onerror=null; this.src='/interface/themes/responsive/images/imageUnavailable.svg';"
-										 class="img-responsive" alt="{$propName}">
+									{* TEMPORARY: same instanceof special-case as
+									   DataObjectUtil/property.tpl's edit-form preview; keep in sync. *}
+									{if $dataItem instanceof ImageUpload}
+										<img src="{$dataItem->getDisplayUrl($propName)}"
+											 onerror="this.onerror=null; this.src='/interface/themes/responsive/images/imageUnavailable.svg';"
+											 class="img-responsive" alt="{$propName}">
+									{else}
+										<img src="{$property.displayUrl}{$dataItem->id}"
+											 onerror="this.onerror=null; this.src='/interface/themes/responsive/images/imageUnavailable.svg';"
+											 class="img-responsive" alt="{$propName}">
+									{/if}
 								{elseif $property.type == 'html'}
 									{$propValue|strip_tags|truncate:255:'...'}
 								{elseif $property.type == 'textarea'}

--- a/code/web/interface/themes/responsive/Admin/propertiesList.tpl
+++ b/code/web/interface/themes/responsive/Admin/propertiesList.tpl
@@ -201,7 +201,9 @@
 								{elseif $property.type == 'checkbox' || $property.type == 'calculatedBoolean'}
 									{if ($propValue == 1)}{translate text="Yes" isAdminFacing=true}{elseif ($propValue == 0)}{translate text="No" isAdminFacing=true}{else}{$propValue}{/if}
 								{elseif $property.type == 'image'}
-									<img src="{$property.displayUrl}{$dataItem->id}" class="img-responsive" alt="{$propName}">
+									<img src="{$property.displayUrl}{$dataItem->id}"
+										 onerror="this.onerror=null; this.src='/interface/themes/responsive/images/imageUnavailable.svg';"
+										 class="img-responsive" alt="{$propName}">
 								{elseif $property.type == 'html'}
 									{$propValue|strip_tags|truncate:255:'...'}
 								{elseif $property.type == 'textarea'}

--- a/code/web/interface/themes/responsive/DataObjectUtil/property.tpl
+++ b/code/web/interface/themes/responsive/DataObjectUtil/property.tpl
@@ -584,7 +584,13 @@
 				{if !empty($property.thumbWidth)}
 					<img src='/files/thumbnail/{$propValue}' style="display: block" alt="Selected Image for {$property.label}">
 				{else}
-					{if !empty($property.displayUrl)}
+					{* TEMPORARY: ImageUpload is the only object type on StorageDriver
+					   so far, hence the instanceof check. Replace with a shared
+					   interface if a second type is migrated; keep in sync with
+					   the same check in Admin/propertiesList.tpl until then. *}
+					{if $object instanceof ImageUpload}
+						<img src='{$object->getDisplayUrl($propName)}' style="display: block; max-width: 100%;" alt="Selected Image for {$property.label}">
+					{elseif !empty($property.displayUrl)}
 						<img src='{$property.displayUrl}{$object->id}' style="display: block; max-width: 100%;" alt="Selected Image for {$property.label}">
 					{else}
 						<img src='/files/original/{$propValue}' style="display: block; max-width: 100%" alt="Selected Image for {$property.label}">

--- a/code/web/interface/themes/responsive/HeroSlider/heroSliderDigitalSignage.tpl
+++ b/code/web/interface/themes/responsive/HeroSlider/heroSliderDigitalSignage.tpl
@@ -13,7 +13,7 @@
 		{foreach from=$slides item=slide name=slideLoop}
 			<div class="signage-slide"
 				 data-duration="{$slide.duration}">
-				<img src="/WebBuilder/ViewImage?id={$slide.image->id}&size=full"
+				<img src="{$slide.image->getDisplayUrl('full')}"
 					 alt="{$slide.image->altText|escape}" />
 			</div>
 		{/foreach}

--- a/code/web/interface/themes/responsive/HeroSlider/heroSliderWebsite.tpl
+++ b/code/web/interface/themes/responsive/HeroSlider/heroSliderWebsite.tpl
@@ -17,11 +17,11 @@
 					<div class="swiper-slide hero-slide" data-duration="{$slide.duration}">
 						{if $slide.image->pageLink}
 							<a href="{$slide.image->pageLink}" target="_blank">
-								<img src="/WebBuilder/ViewImage?id={$slide.image->id}&size=full"
+								<img src="{$slide.image->getDisplayUrl('full')}"
 									 alt="{$slide.image->altText|escape}" />
 							</a>
 						{else}
-							<img src="/WebBuilder/ViewImage?id={$slide.image->id}&size=full"
+							<img src="{$slide.image->getDisplayUrl('full')}"
 								 alt="{$slide.image->altText|escape}" />
 						{/if}
 					</div>

--- a/code/web/interface/themes/responsive/images/imageUnavailable.svg
+++ b/code/web/interface/themes/responsive/images/imageUnavailable.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 150">
+	<rect width="200" height="150" fill="#e0e0e0"/>
+	<path d="M70 55 L90 80 L105 65 L130 95 H70 Z" fill="#b0b0b0"/>
+	<circle cx="80" cy="50" r="8" fill="#b0b0b0"/>
+	<rect x="70" y="45" width="60" height="50" fill="none" stroke="#999999" stroke-width="3"/>
+	<text x="100" y="120" font-family="sans-serif" font-size="14" fill="#777777" text-anchor="middle">Image unavailable</text>
+</svg>

--- a/code/web/migrations/migrateLocalFilesToS3.php
+++ b/code/web/migrations/migrateLocalFilesToS3.php
@@ -1,0 +1,259 @@
+<?php
+
+/**
+ * Migrates uploaded files from local storage to an S3-compatible backend.
+ *
+ * Usage:
+ *   php migrateLocalFilesToS3.php --setting-id=<id> [--dry-run] [--path=<subpath>]
+ *
+ * Options:
+ *   --setting-id=N   ID of the StorageSetting record to use as the target.
+ *   --dry-run        List what would be migrated without uploading anything.
+ *   --path=<subpath> Only migrate files under uploads/web_builder_image/<subpath>
+ *                    (e.g. --path=full, or --path=full/some_image.png) instead of
+ *                    everything. Useful for migrating in batches or retrying a
+ *                    single file.
+ */
+
+require_once __DIR__ . '/../bootstrap.php';
+require_once __DIR__ . '/../bootstrap_aspen.php';
+
+set_time_limit(-1);
+ini_set('memory_limit', '1G');
+
+// =============================================================================
+// Parse arguments
+// =============================================================================
+
+$args = [];
+foreach ($_SERVER['argv'] ?? [] as $arg) {
+	if (preg_match('/^--([^=]+)(?:=(.*))?$/', $arg, $m)) {
+		$args[$m[1]] = $m[2] ?? true;
+	}
+}
+
+$dryRun    = isset($args['dry-run']);
+$settingId = isset($args['setting-id']) ? (int)$args['setting-id'] : null;
+$subPath   = isset($args['path']) ? trim($args['path'], '/') : '';
+
+if (!$settingId) {
+	echo "Usage: php migrateLocalFilesToS3.php --setting-id=<id> [--dry-run] [--path=<subpath>]\n";
+	echo "       Run without --setting-id to list available configurations:\n\n";
+	listSettings();
+	exit(1);
+}
+
+if ($dryRun) {
+	echo "DRY RUN: no files will be uploaded.\n\n";
+}
+
+// =============================================================================
+// Load and validate target StorageSetting
+// =============================================================================
+
+require_once ROOT_DIR . '/sys/Storage/StorageSetting.php';
+
+$setting = new StorageSetting();
+$setting->id = $settingId;
+if (!$setting->find(true)) {
+	echo "Error: No storage setting found with id={$settingId}.\n";
+	listSettings();
+	exit(1);
+}
+
+if ($setting->driver !== 's3') {
+	echo "Error: Setting '{$setting->name}' uses driver '{$setting->driver}', not 's3'.\n";
+	exit(1);
+}
+
+if (empty($setting->bucket) || empty($setting->accessKeyId) || empty($setting->accessKeySecret)) {
+	echo "Error: Setting '{$setting->name}' is missing bucket or credentials.\n";
+	exit(1);
+}
+
+// =============================================================================
+// Set up source (local) and target (S3) drivers
+// =============================================================================
+
+global $configArray, $serverName;
+$dataRoot = rtrim($configArray['Site']['dataPath'] ?? '/data/aspen-discovery/' . $serverName, '/');
+
+require_once ROOT_DIR . '/sys/Storage/LocalStorageDriver.php';
+$source = new LocalStorageDriver($dataRoot);
+
+require_once ROOT_DIR . '/sys/Storage/S3StorageDriver.php';
+// Explicit httpClient avoids AsyncAws probing for the optional amphp/http-client
+// package, which crashes under this codebase's autoloader when it's not installed.
+$httpClient = new \Symfony\Component\HttpClient\CurlHttpClient(['timeout' => 5, 'max_duration' => 15]);
+$client = new AsyncAws\S3\S3Client(
+	[
+		'accessKeyId'      => $setting->accessKeyId,
+		'accessKeySecret'  => $setting->accessKeySecret,
+		'region'           => $setting->region ?: 'us-east-1',
+		'endpoint'         => $setting->endpoint ?: null,
+		'pathStyleEndpoint' => !empty($setting->endpoint),
+	],
+	null,
+	$httpClient
+);
+$target = new S3StorageDriver($client, $setting->bucket, $setting->baseUrl);
+
+// =============================================================================
+// Walk the image uploads directory and migrate
+// =============================================================================
+
+// ImageUpload/S3StorageDriver only ever read/write keys under this prefix
+// (see ImageUpload::generateDerivatives()). $dataRoot also holds unrelated
+// site data (MARC records, SQL backups, fonts, etc.) that must never be
+// walked or uploaded here.
+$imagesRoot = $dataRoot . '/uploads/web_builder_image';
+$walkRoot = $subPath !== '' ? $imagesRoot . '/' . $subPath : $imagesRoot;
+
+if (!file_exists($walkRoot)) {
+	echo "Error: {$walkRoot} does not exist.\n";
+	exit(1);
+}
+
+echo "Source : {$walkRoot}\n";
+echo "Target : s3://{$setting->bucket}  (setting: {$setting->name})\n\n";
+
+$migrated = 0;
+$skipped  = 0;
+$failed   = 0;
+
+if (is_file($walkRoot)) {
+	$files = [new SplFileInfo($walkRoot)];
+} else {
+	$files = new RecursiveIteratorIterator(
+		new RecursiveDirectoryIterator($walkRoot, FilesystemIterator::SKIP_DOTS)
+	);
+}
+
+foreach ($files as $file) {
+	if (!$file->isFile()) {
+		continue;
+	}
+
+	$absolutePath = $file->getPathname();
+	$key = ltrim(substr($absolutePath, strlen($dataRoot)), '/');
+
+	if ($target->exists($key)) {
+		echo "  SKIP  {$key}\n";
+		$skipped++;
+		continue;
+	}
+
+	if ($dryRun) {
+		echo "  WOULD UPLOAD  {$key}\n";
+		$migrated++;
+		continue;
+	}
+
+	$mimeType = mime_content_type($absolutePath) ?: 'application/octet-stream';
+
+	if ($target->write($key, $absolutePath, $mimeType)) {
+		echo "  OK    {$key}\n";
+		$migrated++;
+	} else {
+		echo "  FAIL  {$key}\n";
+		$failed++;
+	}
+}
+
+// =============================================================================
+// Summary
+// =============================================================================
+
+$label = $dryRun ? 'Would migrate' : 'Migrated';
+echo "\nDone.\n";
+echo "  {$label} : {$migrated}\n";
+echo "  Skipped  : {$skipped}\n";
+if (!$dryRun) {
+	echo "  Failed   : {$failed}\n";
+}
+
+// =============================================================================
+// Repoint image_uploads rows whose files are now fully present in the target
+// bucket; copying the bytes doesn't change storageSettingId, which is what
+// getDisplayUrl()/generateDerivatives() actually read from.
+// =============================================================================
+
+require_once ROOT_DIR . '/sys/File/ImageUpload.php';
+
+$repointed = 0;
+$incomplete = 0;
+
+$imageUpload = new ImageUpload();
+$imageUpload->find();
+while ($imageUpload->fetch()) {
+	if ((int)$imageUpload->storageSettingId === $settingId || empty($imageUpload->fullSizePath)) {
+		continue;
+	}
+
+	$variantProperties = [
+		'full'    => 'fullSizePath',
+		'x-large' => 'xLargeSizePath',
+		'large'   => 'largeSizePath',
+		'medium'  => 'mediumSizePath',
+		'small'   => 'smallSizePath',
+	];
+	$complete = true;
+	foreach ($variantProperties as $variant => $property) {
+		$path = $imageUpload->$property;
+		if (empty($path)) {
+			continue;
+		}
+		if (!$target->exists('uploads/web_builder_image/' . $variant . '/' . $path)) {
+			$complete = false;
+			break;
+		}
+	}
+
+	if (!$complete) {
+		$incomplete++;
+		continue;
+	}
+
+	if ($dryRun) {
+		echo "  WOULD REPOINT  image_uploads id={$imageUpload->id}\n";
+	} else {
+		global $aspen_db;
+		$aspen_db->query('UPDATE image_uploads SET storageSettingId = ' . $settingId . ' WHERE id = ' . (int)$imageUpload->id);
+	}
+	$repointed++;
+}
+
+$repointLabel = $dryRun ? 'Would repoint' : 'Repointed';
+echo "\n{$repointLabel} : {$repointed} image_uploads row(s) to setting id={$settingId}\n";
+if ($incomplete > 0) {
+	echo "Left alone  : {$incomplete} row(s) with files not yet fully present in the target bucket\n";
+}
+
+if ($failed > 0) {
+	exit(1);
+}
+
+// =============================================================================
+// Helper
+// =============================================================================
+
+function listSettings(): void {
+	require_once ROOT_DIR . '/sys/Storage/StorageSetting.php';
+	$setting = new StorageSetting();
+	$setting->find();
+	$rows = [];
+	while ($setting->fetch()) {
+		$rows[] = sprintf('  id=%-4d  driver=%-6s  active=%-3s  %s',
+			$setting->id,
+			$setting->driver,
+			$setting->isActive ? 'yes' : 'no',
+			$setting->name
+		);
+	}
+	if (empty($rows)) {
+		echo "No storage configurations found. Add one via Admin > Storage Settings.\n";
+	} else {
+		echo "Available storage configurations:\n";
+		echo implode("\n", $rows) . "\n";
+	}
+}

--- a/code/web/release_notes/26.10.00.MD
+++ b/code/web/release_notes/26.10.00.MD
@@ -108,6 +108,9 @@
 
 #### Sierra ILS
 
+#### Storage
+- Add an S3-compatible/CDN storage backend for uploaded files ([DIS-2897](https://aspen-discovery.atlassian.net/browse/DIS-2897)) (*LM*)
+
 #### Summon
 
 #### Symphony ILS

--- a/code/web/services/API/HeroSliderAPI.php
+++ b/code/web/services/API/HeroSliderAPI.php
@@ -107,7 +107,7 @@ class API_HeroSliderAPI extends Action {
 		foreach ($activeImages as $slide) {
 			$slides[] = [
 				'imageId' => $slide['image']->id,
-				'imageUrl' => '/WebBuilder/ViewImage?id=' . $slide['image']->id . '&size=full',
+				'imageUrl' => $slide['image']->getDisplayUrl('full'),
 				'altText' => $slide['image']->altText ?? '',
 				'duration' => $slide['duration'],
 				'pageLink' => $slide['image']->pageLink ?? ''

--- a/code/web/services/API/SearchAPI.php
+++ b/code/web/services/API/SearchAPI.php
@@ -700,6 +700,22 @@ class SearchAPI extends AbstractAPI {
 			}
 		}
 
+		require_once ROOT_DIR . '/sys/Storage/StorageDriverFactory.php';
+		$activeStorageSetting = StorageDriverFactory::getActiveSetting();
+		if ($activeStorageSetting !== null && $activeStorageSetting->driver === 's3' && !empty($activeStorageSetting->baseUrl)) {
+			// Live check, not a cached read of the last saved verifiedStatus --
+			// this is what actually keeps the status current, since nothing else
+			// re-checks the public URL between admin form saves. Only relevant
+			// when a CDN/public URL is actually configured; S3 without one is a
+			// valid setup (proxy-only reads) and isn't a failure to report.
+			$activeStorageSetting->checkAndPersistPublicUrlStatus();
+			if ($activeStorageSetting->verifiedStatus === 'verified') {
+				$this->addCheck($checks, 'CDN Storage');
+			} else {
+				$this->addCheck($checks, 'CDN Storage', self::STATUS_CRITICAL, $activeStorageSetting->verifiedMessage);
+			}
+		}
+
 		$hasCriticalErrors = false;
 		$hasWarnings = false;
 		foreach ($checks as $check) {

--- a/code/web/services/WebBuilder/AJAX.php
+++ b/code/web/services/WebBuilder/AJAX.php
@@ -578,24 +578,13 @@ class WebBuilder_AJAX extends JSON_Action {
 				$image->generateLargeSize = true;
 				$image->generateMediumSize = true;
 				$image->generateSmallSize = true;
-				$destFileName = $file['name'];
-				$destFolder = $structure['fullSizePath']['path'];
-				if (!is_dir($destFolder)) {
-					if (!mkdir($destFolder, 0755, true)) {
-						$result['message'] = 'Could not create directory to upload files';
-						if (IPAddress::showDebuggingInformation()) {
-							$result['message'] .= " " . $destFolder;
-						}
-					}
-				}
-				$destFullPath = $destFolder . '/' . $destFileName;
-				if (file_exists($destFullPath)) {
-					$image->find(true);
-				}
-
 				$image->title = $file['name'];
-				$copyResult = copy($file["tmp_name"], $destFullPath);
-				if ($copyResult) {
+				//Insert the image so we can name images based on the id of the image
+				$image->insert();
+				//Upload the image
+				$imageUploaded = DataObjectUtil::processUploadedImageProperty($image, 'fullSizePath', $structure['fullSizePath'], $file);
+				if ($imageUploaded) {
+					//resize to save the image and generate derivatives
 					$image->update();
 					$result = [
 						'success' => true,

--- a/code/web/services/WebBuilder/ViewImage.php
+++ b/code/web/services/WebBuilder/ViewImage.php
@@ -38,7 +38,23 @@ class WebBuilder_ViewImage extends Action {
 		} else {
 			$size = 'full';
 		}
-		$storageKey = 'uploads/web_builder_image/' . $size . '/' . $this->uploadedImage->fullSizePath;
+
+		// Each size has its own filename column; a manual derivative upload
+		// can differ in extension, so resolve from that size's own column.
+		$filenameBySize = [
+			'x-large' => $this->uploadedImage->xLargeSizePath,
+			'large'   => $this->uploadedImage->largeSizePath,
+			'medium'  => $this->uploadedImage->mediumSizePath,
+			'small'   => $this->uploadedImage->smallSizePath,
+		];
+		$filename = $filenameBySize[$size] ?? $this->uploadedImage->fullSizePath;
+		if (empty($filename)) {
+			$filename = $this->uploadedImage->fullSizePath;
+		}
+		$extension = pathinfo($filename, PATHINFO_EXTENSION);
+		$contentType = $mimeTypesByExtension[strtolower($extension)] ?? 'application/octet-stream';
+
+		$storageKey = 'uploads/web_builder_image/' . $size . '/' . $filename;
 
 		require_once ROOT_DIR . '/sys/Storage/StorageDriverFactory.php';
 		$storage = StorageDriverFactory::getById($this->uploadedImage->storageSettingId);

--- a/code/web/sys/DBMaintenance/version_updates/26.08.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/26.08.00.php
@@ -184,6 +184,21 @@ function getUpdates26_08_00(): array {
 			],
 		], //image_uploads_storage_setting_id
 
+		'storage_settings_s3_columns' => [
+			'title' => 'Add S3 columns to storage settings table',
+			'description' => 'Extend the storage settings table with S3 connection fields and add s3 as a supported driver.',
+			'continueOnError' => false,
+			'sql' => [
+				"ALTER TABLE storage_settings MODIFY COLUMN driver ENUM('local','s3') NOT NULL DEFAULT 'local'",
+				"ALTER TABLE storage_settings ADD COLUMN bucket VARCHAR(255) NOT NULL DEFAULT ''",
+				"ALTER TABLE storage_settings ADD COLUMN accessKeyId VARCHAR(255) NOT NULL DEFAULT ''",
+				"ALTER TABLE storage_settings ADD COLUMN accessKeySecret VARCHAR(255) NOT NULL DEFAULT ''",
+				"ALTER TABLE storage_settings ADD COLUMN region VARCHAR(64) NOT NULL DEFAULT 'us-east-1'",
+				"ALTER TABLE storage_settings ADD COLUMN endpoint VARCHAR(512) NOT NULL DEFAULT ''",
+				"ALTER TABLE storage_settings ADD COLUMN baseUrl VARCHAR(512) NOT NULL DEFAULT ''",
+			],
+		], //storage_settings_s3_columns
+
 		//tomas
 
 		// stephen

--- a/code/web/sys/DBMaintenance/version_updates/26.08.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/26.08.00.php
@@ -199,6 +199,16 @@ function getUpdates26_08_00(): array {
 			],
 		], //storage_settings_s3_columns
 
+		'storage_settings_verified_status' => [
+			'title' => 'Track S3 public access verification status',
+			'description' => 'Add verifiedStatus/verifiedMessage to storage_settings so the admin UI can show whether the configured public base URL has actually been confirmed reachable, instead of assuming it works.',
+			'continueOnError' => false,
+			'sql' => [
+				"ALTER TABLE storage_settings ADD COLUMN verifiedStatus ENUM('unverified','verified','failed') NOT NULL DEFAULT 'unverified'",
+				"ALTER TABLE storage_settings ADD COLUMN verifiedMessage VARCHAR(255) NULL DEFAULT NULL",
+			],
+		], //storage_settings_verified_status
+
 		//tomas
 
 		// stephen

--- a/code/web/sys/DataObjectUtil.php
+++ b/code/web/sys/DataObjectUtil.php
@@ -381,8 +381,186 @@ class DataObjectUtil {
 				$object->setProperty($propertyName, '', $property);
 
 			} elseif (isset($_FILES[$propertyName])) {
-				$fileForProperty = $_FILES[$propertyName];
-				self::processUploadedImageProperty($object, $propertyName, $property, $fileForProperty);
+				if (isset($_FILES[$propertyName]["error"]) && $_FILES[$propertyName]["error"] == 4) {
+					$logger->log("No file was uploaded for $propertyName", Logger::LOG_DEBUG);
+					//No image supplied, use the existing value
+				} elseif (isset($_FILES[$propertyName]["error"]) && $_FILES[$propertyName]["error"] > 0) {
+					require_once ROOT_DIR . '/sys/Utils/SystemUtils.php';
+					$uploadError = $_FILES[$propertyName]["error"];
+					$logger->log("Error in file upload for $propertyName (code $uploadError)", Logger::LOG_ERROR);
+					AspenError::raiseError(SystemUtils::getUploadErrorMessage($uploadError));
+				} elseif ((!empty($property['validTypes']) && !in_array($_FILES[$propertyName]["type"], $property['validTypes'])) ||
+					(empty($property['validTypes']) && !in_array($_FILES[$propertyName]["type"], ['image/gif', 'image/jpeg', 'image/png', 'image/svg+xml']))) {
+					$allowedTypes = !empty($property['validTypes']) ? implode(', ', $property['validTypes']) : 'image/gif, image/jpeg, image/png, image/svg+xml';
+					AspenError::raiseError(translate([
+						'text' => 'Invalid file type: %1%. Allowed types: %2%.',
+						1 => $_FILES[$propertyName]["type"],
+						2 => $allowedTypes,
+						'isAdminFacing' => true
+					]));
+				} else {
+					$logger->log("Processing uploaded file for $propertyName", Logger::LOG_DEBUG);
+					//Copy the full image to the files directory
+					//Filename is the name of the object + the original filename
+					global $configArray;
+					$fileType = $_FILES[$propertyName]["type"];
+					$fileType = match ($fileType) {
+						'image/gif' => ".gif",
+						'image/png' => ".png",
+						'image/svg+xml' => ".svg",
+						default => ".jpg",
+					};
+					if (!empty($object->type)){
+						$objectType = $object->type;
+					} else {
+						$objectType = $property['property'];
+						$objectType = match ($objectType) {
+							'logoName' => 'discovery_logo',
+							'defaultCover' => 'default_cover',
+							'headerBackgroundImage' => 'header_background_image',
+							'footerLogo' => 'footer_logo',
+							'logoApp' => 'logo_app',
+							'headerLogoApp' => 'header_logo_app',
+							'booksImage' => 'books_image',
+							'booksImageSelected' => 'books_image_selected',
+							'eBooksImage' => 'eBooks_image',
+							'eBooksImageSelected' => 'eBooks_image_selected',
+							'audioBooksImage' => 'audioBooks_image',
+							'audioBooksImageSelected' => 'audioBooks_image_selected',
+							'musicImage' => 'music_image',
+							'musicImageSelected' => 'music_image_selected',
+							'moviesImage' => 'movies_image',
+							'moviesImageSelected' => 'movies_image_selected',
+							'catalogImage' => 'catalog_image',
+							'genealogyImage' => 'genealogy_image',
+							'articlesDBImage' => 'articles_db_image',
+							'eventsImage' => 'events_image',
+							'listsImage' => 'lists_image',
+							'seriesImage' => 'series_image',
+							'libraryWebsiteImage' => 'library_website_image',
+							'historyArchivesImage' => 'history_archives_image',
+							default => get_class($object) . '_' . $property['property'],
+						};
+						if (isset($_REQUEST['action']) && $_REQUEST['action'] == 'Placards') {
+							$objectType = 'placard_image';
+						}
+						if (isset($_REQUEST['action']) && $_REQUEST['action'] == 'WebResources') {
+							$objectType = 'web_resource_image';
+						}
+					}
+					global $serverName;
+					if (isset($property['storagePath']) || isset($property['path'])) {
+						$destFileName = ($object->getPrimaryKeyValue() != null) ? $objectType."_".$serverName."_".$object->getPrimaryKeyValue().$fileType : "Temp_".$_FILES[$propertyName]["name"];
+						$destFolder = $property['storagePath'] ?? $property['path'];
+						$destFullPath = $destFolder . '/' . $destFileName;
+						$copyResult = copy($_FILES[$propertyName]["tmp_name"], $destFullPath);
+						$logger->log("Copied file to $destFullPath result: $copyResult", Logger::LOG_DEBUG);
+					} elseif (isset($property['storageKey'])) {
+						$logger->log("Creating thumbnails for $propertyName", Logger::LOG_DEBUG);
+						$storageKey = $property['storageKey'];
+						$destFileName = ($object->getPrimaryKeyValue() != null) ? $objectType."_".$serverName."_".$object->getPrimaryKeyValue().$fileType : "Temp_".$_FILES[$propertyName]["name"];
+						$storage = StorageDriverFactory::get();
+						$resolvedStorageSettingId = StorageDriverFactory::getActiveSettingId();
+
+						$uploadTmp = $_FILES[$propertyName]["tmp_name"];
+
+						//check for previous upload that needs to be overwritten to new naming convention
+						$prevKey = $storageKey . '/Temp_' . $_FILES[$propertyName]["name"];
+						if ($storage->exists($prevKey)) {
+							$storage->delete($prevKey);
+						}
+
+						require_once ROOT_DIR . '/sys/Covers/CoverImageUtils.php';
+
+						if (isset($property['maxWidth'])) {
+							$width = $property['maxWidth'];
+							$height = isset($property['maxHeight']) ? $property['maxHeight'] : $property['maxWidth'];
+							$resizedTmp = tempnam(sys_get_temp_dir(), 'aspen_img_');
+							resizeImage($uploadTmp, $resizedTmp, $width, $height);
+							$storeSource = $resizedTmp;
+						} else {
+							$storeSource = $uploadTmp;
+						}
+
+						$copyResult = $storage->write($storageKey . '/' . $destFileName, $storeSource);
+
+						if (!$copyResult) {
+							$logger->log("Failed to write $propertyName to storageSettingId=" . var_export($resolvedStorageSettingId, true), Logger::LOG_ERROR);
+							AspenError::raiseError(translate([
+								'text' => "Could not upload %1% -- the storage backend did not accept the file.",
+								1 => $propertyName,
+								'isAdminFacing' => true,
+							]));
+						}
+
+						if (isset($resizedTmp)) {
+							unlink($resizedTmp);
+							unset($resizedTmp);
+						}
+
+						if ($copyResult) {
+							if (property_exists($object, 'storageSettingId')) {
+								$object->storageSettingId = $resolvedStorageSettingId;
+							}
+							$derivativeBase = dirname($storageKey);
+							if (isset($property['thumbWidth'])) {
+								$thumbTmp = tempnam(sys_get_temp_dir(), 'aspen_img_');
+								resizeImage($uploadTmp, $thumbTmp, $property['thumbWidth'], $property['thumbWidth']);
+								$storage->write($derivativeBase . '/thumbnail/' . $destFileName, $thumbTmp);
+								unlink($thumbTmp);
+							}
+							if (isset($property['mediumWidth'])) {
+								$medTmp = tempnam(sys_get_temp_dir(), 'aspen_img_');
+								resizeImage($uploadTmp, $medTmp, $property['mediumWidth'], $property['mediumWidth']);
+								$storage->write($derivativeBase . '/medium/' . $destFileName, $medTmp);
+								unlink($medTmp);
+							}
+						}
+					} else {
+						global $configArray;
+						$destFileName = ($object->getPrimaryKeyValue() != null) ? $serverName."_".$objectType."_".$object->getPrimaryKeyValue().$fileType : "Temp_".$_FILES[$propertyName]["name"];
+						$destFolder = $configArray['Site']['local'] . '/files/original';
+						$pathToThumbs = $configArray['Site']['local'] . '/files/thumbnail';
+						$pathToMedium = $configArray['Site']['local'] . '/files/medium';
+						$destFullPath = $destFolder . '/' . $destFileName;
+						$prevUpload = $destFolder . '/' . 'Temp_' . $_FILES[$propertyName]['name'];
+						if (file_exists($prevUpload)) {
+							rename($prevUpload, $destFullPath);
+						}
+						$copyResult = copy($_FILES[$propertyName]["tmp_name"], $destFullPath);
+						if ($copyResult) {
+							require_once ROOT_DIR . '/sys/Covers/CoverImageUtils.php';
+							if (isset($property['thumbWidth'])) {
+								if (!resizeImage($destFullPath, "$pathToThumbs/$destFileName", $property['thumbWidth'], $property['thumbWidth'])) {
+									$logger->log("Could not create thumbnail for $propertyName at $pathToThumbs/$destFileName", Logger::LOG_ERROR);
+								}
+							}
+							if (isset($property['mediumWidth'])) {
+								//Create a thumbnail if needed
+								if (!resizeImage($destFullPath, "$pathToMedium/$destFileName", $property['mediumWidth'], $property['mediumWidth'])) {
+									$logger->log("Could not create medium image for $propertyName at $pathToMedium/$destFileName", Logger::LOG_ERROR);
+								}
+							}
+							if (isset($property['maxWidth'])) {
+								$width = $property['maxWidth'];
+								$height = $property['maxWidth'];
+								if (isset($property['maxHeight'])) {
+									$height = $property['maxHeight'];
+								}
+								if (!resizeImage($destFullPath, "$destFolder/$destFileName", $width, $height)) {
+									$logger->log("Could not resize $propertyName to max dimensions at $destFolder/$destFileName", Logger::LOG_ERROR);
+								}
+							}
+						}
+					}
+					//store the actual filename, but only if the file was actually written
+					if ($copyResult) {
+						$object->setProperty($propertyName, $destFileName, $property);
+						$logger->log("Set $propertyName to $destFileName", Logger::LOG_DEBUG);
+					} else {
+						$logger->log("Not setting $propertyName because the file write failed", Logger::LOG_ERROR);
+					}
+				}
 			}
 
 		} elseif ($property['type'] == 'file') {

--- a/code/web/sys/DataObjectUtil.php
+++ b/code/web/sys/DataObjectUtil.php
@@ -72,6 +72,15 @@ class DataObjectUtil {
 					$validationResults['errors'][] = $property['property'] . ' is required.';
 				}
 			}
+			if (in_array($property['type'], ['image', 'file']) && !empty($property['required']) && empty($object->getPrimaryKeyValue())) {
+				// Scoped to inserts only (no primary key yet): on an update,
+				// the object already has a valid stored file, so a failed
+				// re-upload should just  warn and leave the existing file in place,
+				// not block the rest of the save.
+				if (empty($object->{$property['property']})) {
+					$validationResults['errors'][] = ($property['label'] ?? $property['property']) . ' could not be saved, the storage backend rejected the file. Please try again.';
+				}
+			}
 			if ($property['type'] == 'password' || $property['type'] == 'storedPassword') {
 				$valueRepeat = $_REQUEST[$property['property'] . 'Repeat'] ?? null;
 				if ($value != $valueRepeat) {

--- a/code/web/sys/DataObjectUtil.php
+++ b/code/web/sys/DataObjectUtil.php
@@ -482,7 +482,7 @@ class DataObjectUtil {
 							$storeSource = $uploadTmp;
 						}
 
-						$copyResult = $storage->write($storageKey . '/' . $destFileName, $storeSource);
+						$copyResult = $storage->write($storageKey . '/' . $destFileName, $storeSource, mime_content_type($storeSource));
 
 						if (isset($resizedTmp)) {
 							unlink($resizedTmp);
@@ -500,7 +500,7 @@ class DataObjectUtil {
 							$user = UserAccount::getActiveUserObj();
 							if ($user) {
 								$warning = translate([
-									'text' => "Could not upload %1% -- the storage backend did not accept the file.",
+									'text' => "Could not upload %1%, the storage backend did not accept the file.",
 									1 => $propertyName,
 									'isAdminFacing' => true,
 								]);
@@ -518,13 +518,13 @@ class DataObjectUtil {
 							if (isset($property['thumbWidth'])) {
 								$thumbTmp = tempnam(sys_get_temp_dir(), 'aspen_img_');
 								resizeImage($uploadTmp, $thumbTmp, $property['thumbWidth'], $property['thumbWidth']);
-								$storage->write($derivativeBase . '/thumbnail/' . $destFileName, $thumbTmp);
+								$storage->write($derivativeBase . '/thumbnail/' . $destFileName, $thumbTmp, mime_content_type($thumbTmp));
 								unlink($thumbTmp);
 							}
 							if (isset($property['mediumWidth'])) {
 								$medTmp = tempnam(sys_get_temp_dir(), 'aspen_img_');
 								resizeImage($uploadTmp, $medTmp, $property['mediumWidth'], $property['mediumWidth']);
-								$storage->write($derivativeBase . '/medium/' . $destFileName, $medTmp);
+								$storage->write($derivativeBase . '/medium/' . $destFileName, $medTmp, mime_content_type($medTmp));
 								unlink($medTmp);
 							}
 						}
@@ -652,8 +652,8 @@ class DataObjectUtil {
 					//return an error to the browser
 					$logger->log("Error uploading file " . $fileForProperty["error"], Logger::LOG_ERROR);
 				} elseif (true) { //TODO: validate the file type
-					$destFileName = $fileForProperty["name"];
-					$copyResult = StorageDriverFactory::get()->write('fonts/' . $destFileName, $fileForProperty["tmp_name"]);
+					$destFileName = $_FILES[$propertyName]["name"];
+					$copyResult = StorageDriverFactory::get()->write('fonts/' . $destFileName, $_FILES[$propertyName]["tmp_name"], mime_content_type($_FILES[$propertyName]["tmp_name"]));
 					if ($copyResult) {
 						$logger->log("Stored font file: fonts/{$destFileName}", Logger::LOG_NOTICE);
 					} else {

--- a/code/web/sys/DataObjectUtil.php
+++ b/code/web/sys/DataObjectUtil.php
@@ -484,18 +484,30 @@ class DataObjectUtil {
 
 						$copyResult = $storage->write($storageKey . '/' . $destFileName, $storeSource);
 
-						if (!$copyResult) {
-							$logger->log("Failed to write $propertyName to storageSettingId=" . var_export($resolvedStorageSettingId, true), Logger::LOG_ERROR);
-							AspenError::raiseError(translate([
-								'text' => "Could not upload %1% -- the storage backend did not accept the file.",
-								1 => $propertyName,
-								'isAdminFacing' => true,
-							]));
-						}
-
 						if (isset($resizedTmp)) {
 							unlink($resizedTmp);
 							unset($resizedTmp);
+						}
+
+						if (!$copyResult) {
+							// Skip this property rather than aborting the whole request:
+							// AspenError::raiseError() would exit() immediately, discarding
+							// every other property on this form (title, dates, unrelated
+							// fields) along with it. Flash an admin-facing warning instead,
+							// the same pattern ImageUpload::generateDerivatives() uses for a
+							// failed derivative, and let the rest of the save proceed.
+							$logger->log("Failed to write $propertyName to storageSettingId=" . var_export($resolvedStorageSettingId, true), Logger::LOG_ERROR);
+							$user = UserAccount::getActiveUserObj();
+							if ($user) {
+								$warning = translate([
+									'text' => "Could not upload %1% -- the storage backend did not accept the file.",
+									1 => $propertyName,
+									'isAdminFacing' => true,
+								]);
+								$user->updateMessage = !empty($user->updateMessage) ? $user->updateMessage . '<br/>' . $warning : $warning;
+								$user->updateMessageIsError = true;
+								$user->update();
+							}
 						}
 
 						if ($copyResult) {

--- a/code/web/sys/File/ImageUpload.php
+++ b/code/web/sys/File/ImageUpload.php
@@ -302,7 +302,19 @@ class ImageUpload extends DataObject {
 		} else {
 			$size = 'full';
 		}
-		return '/WebBuilder/ViewImage?size=' . $size . '&id=' . $this->id;
+		$proxyUrl = '/WebBuilder/ViewImage?size=' . $size . '&id=' . $this->id;
+		if (empty($this->fullSizePath)) {
+			return $proxyUrl;
+		}
+		// Mirrors ViewImage.php's redirect-vs-proxy decision, but made at
+		// render time so a configured CDN is embedded directly in the <img>
+		// tag instead of paying a redirect round-trip on every view. Falls
+		// back to the proxy URL only when no public base URL is configured
+		// at all (e.g. Local Storage) -- see StorageDriver::url()'s docblock.
+		$storage = StorageDriverFactory::getById($this->storageSettingId);
+		$storageKey = 'uploads/web_builder_image/' . $size . '/' . $this->fullSizePath;
+		$directUrl = $storage->url($storageKey);
+		return $directUrl !== '' ? $directUrl : $proxyUrl;
 	}
 
 	public function insert(string $context = '') : int|bool {

--- a/code/web/sys/File/ImageUpload.php
+++ b/code/web/sys/File/ImageUpload.php
@@ -287,32 +287,40 @@ class ImageUpload extends DataObject {
 		return self::$_objectStructure[$context];
 	}
 
-	function getDisplayUrl($property) : string {
+	// Accepts either a short size name ('full', 'large', ...) or the
+	// underlying property name ('fullSizePath', ...); each size stores its
+	// own filename since a manual derivative upload can differ in extension.
+	private const SIZE_TO_PROPERTY = [
+		'full'    => 'fullSizePath',
+		'x-large' => 'xLargeSizePath',
+		'large'   => 'largeSizePath',
+		'medium'  => 'mediumSizePath',
+		'small'   => 'smallSizePath',
+	];
+
+	function getDisplayUrl($sizeOrProperty) : string {
 		if (empty($this->id)) {
 			return '';
 		}
-		if ($property == 'xLargeSizePath') {
-			$size = 'x-large';
-		} elseif ($property == 'largeSizePath') {
-			$size = 'large';
-		} elseif ($property == 'mediumSizePath') {
-			$size = 'medium';
-		} elseif ($property == 'smallSizePath') {
-			$size = 'small';
+		if (isset(self::SIZE_TO_PROPERTY[$sizeOrProperty])) {
+			$size = $sizeOrProperty;
+			$property = self::SIZE_TO_PROPERTY[$sizeOrProperty];
+		} elseif (in_array($sizeOrProperty, self::SIZE_TO_PROPERTY, true)) {
+			$property = $sizeOrProperty;
+			$size = array_search($sizeOrProperty, self::SIZE_TO_PROPERTY, true);
 		} else {
 			$size = 'full';
+			$property = 'fullSizePath';
 		}
 		$proxyUrl = '/WebBuilder/ViewImage?size=' . $size . '&id=' . $this->id;
-		if (empty($this->fullSizePath)) {
+		$filename = $this->$property;
+		if (empty($filename)) {
 			return $proxyUrl;
 		}
-		// Mirrors ViewImage.php's redirect-vs-proxy decision, but made at
-		// render time so a configured CDN is embedded directly in the <img>
-		// tag instead of paying a redirect round-trip on every view. Falls
-		// back to the proxy URL only when no public base URL is configured
-		// at all (e.g. Local Storage) -- see StorageDriver::url()'s docblock.
+		// Mirrors ViewImage.php's redirect-vs-proxy decision, but resolved at
+		// render time so a configured CDN goes straight into the <img> tag.
 		$storage = StorageDriverFactory::getById($this->storageSettingId);
-		$storageKey = 'uploads/web_builder_image/' . $size . '/' . $this->fullSizePath;
+		$storageKey = 'uploads/web_builder_image/' . $size . '/' . $filename;
 		$directUrl = $storage->url($storageKey);
 		return $directUrl !== '' ? $directUrl : $proxyUrl;
 	}

--- a/code/web/sys/File/ImageUpload.php
+++ b/code/web/sys/File/ImageUpload.php
@@ -406,7 +406,7 @@ class ImageUpload extends DataObject {
 				$destTmp = tempnam(sys_get_temp_dir(), 'aspen_dst_');
 				if (resizeImage($srcTmp, $destTmp, $cfg['size'], $cfg['size'])) {
 					$destKey = 'uploads/web_builder_image/' . $variant . '/' . $this->fullSizePath;
-					$wrote = $storage->write($destKey, $destTmp);
+					$wrote = $storage->write($destKey, $destTmp, mime_content_type($destTmp));
 					if ($wrote) {
 						$this->{$cfg['prop']} = $this->fullSizePath;
 						$logger->log("generateDerivatives: wrote $variant derivative for image id=$this->id", Logger::LOG_DEBUG);
@@ -424,7 +424,7 @@ class ImageUpload extends DataObject {
 
 			// The full-size image (handled separately in DataObjectUtil::processProperty)
 			// was already saved successfully by the time we get here, so a derivative
-			// failure shouldn't fail the whole object save -- but it also shouldn't be
+			// failure shouldn't fail the whole object save, but it also shouldn't be
 			// silent or silently retried elsewhere. Surface it as an admin-facing warning
 			// instead of only a log line.
 			if (!empty($failedVariants)) {

--- a/code/web/sys/File/ImageUpload.php
+++ b/code/web/sys/File/ImageUpload.php
@@ -335,9 +335,46 @@ class ImageUpload extends DataObject {
 	}
 
 	public function update(string $context = '') : int|bool {
+		$this->cleanUpReplacedFiles();
 		$this->calculateAspectRatio();
 		$this->generateDerivatives();
 		return parent::update();
+	}
+
+	// Filename is recomputed from the upload's extension; a same-extension
+	// replacement overwrites in place, but a different-extension one orphans
+	// the old key unless deleted here. Verified live on S3 (.png -> .jpg).
+	private function cleanUpReplacedFiles() : void {
+		global $logger;
+		if (empty($this->id)) {
+			return;
+		}
+		$old = new ImageUpload();
+		$old->id = $this->id;
+		if (!$old->find(true)) {
+			return;
+		}
+		if (empty($old->fullSizePath) || $old->fullSizePath === $this->fullSizePath) {
+			// Nothing uploaded before, or the file wasn't replaced this save.
+			return;
+		}
+
+		$oldStorage = StorageDriverFactory::getById($old->storageSettingId);
+		foreach ([
+			'full'    => $old->fullSizePath,
+			'x-large' => $old->xLargeSizePath,
+			'large'   => $old->largeSizePath,
+			'medium'  => $old->mediumSizePath,
+			'small'   => $old->smallSizePath,
+		] as $size => $filename) {
+			if (empty($filename)) {
+				continue;
+			}
+			$key = 'uploads/web_builder_image/' . $size . '/' . $filename;
+			if ($oldStorage->delete($key)) {
+				$logger->log("cleanUpReplacedFiles: deleted stale $key for image id=$this->id after file replacement", Logger::LOG_DEBUG);
+			}
+		}
 	}
 
 	private function calculateAspectRatio() : void {

--- a/code/web/sys/File/ImageUpload.php
+++ b/code/web/sys/File/ImageUpload.php
@@ -363,8 +363,9 @@ class ImageUpload extends DataObject {
 		global $logger;
 		if (!empty($this->fullSizePath) && !empty($this->id)) {
 			require_once ROOT_DIR . '/sys/Covers/CoverImageUtils.php';
-			$storage = StorageDriverFactory::getById($this->storageSettingId);
-			$logger->log("generateDerivatives: image id=$this->id storageSettingId=" . var_export($this->storageSettingId, true), Logger::LOG_DEBUG);
+			$activeStorageSettingId = $this->storageSettingId;
+			$storage = StorageDriverFactory::getById($activeStorageSettingId);
+			$logger->log("generateDerivatives: image id=$this->id storageSettingId=" . var_export($activeStorageSettingId, true), Logger::LOG_DEBUG);
 
 			$sourceContents = $storage->read('uploads/web_builder_image/full/' . $this->fullSizePath);
 			if ($sourceContents === false) {
@@ -374,6 +375,7 @@ class ImageUpload extends DataObject {
 			$srcTmp = tempnam(sys_get_temp_dir(), 'aspen_src_');
 			file_put_contents($srcTmp, $sourceContents);
 
+			$failedVariants = [];
 			foreach ([
 				'x-large' => ['flag' => 'generateXLargeSize', 'prop' => 'xLargeSizePath', 'size' => ImageUpload::$xLargeSize],
 				'large'   => ['flag' => 'generateLargeSize',   'prop' => 'largeSizePath',   'size' => ImageUpload::$largeSize],
@@ -391,16 +393,37 @@ class ImageUpload extends DataObject {
 				}
 				$destTmp = tempnam(sys_get_temp_dir(), 'aspen_dst_');
 				if (resizeImage($srcTmp, $destTmp, $cfg['size'], $cfg['size'])) {
-					if ($storage->write('uploads/web_builder_image/' . $variant . '/' . $this->fullSizePath, $destTmp)) {
+					$destKey = 'uploads/web_builder_image/' . $variant . '/' . $this->fullSizePath;
+					$wrote = $storage->write($destKey, $destTmp);
+					if ($wrote) {
 						$this->{$cfg['prop']} = $this->fullSizePath;
 						$logger->log("generateDerivatives: wrote $variant derivative for image id=$this->id", Logger::LOG_DEBUG);
 					} else {
 						$logger->log('Failed to write ' . $variant . ' derivative image to storage for fullSizePath ' . $this->fullSizePath, Logger::LOG_ERROR);
+						$failedVariants[] = $variant;
 					}
+				} else {
+					$logger->log("generateDerivatives: failed to resize $variant derivative for image id=$this->id", Logger::LOG_ERROR);
+					$failedVariants[] = $variant;
 				}
 				unlink($destTmp);
 			}
 			unlink($srcTmp);
+
+			// The full-size image (handled separately in DataObjectUtil::processProperty)
+			// was already saved successfully by the time we get here, so a derivative
+			// failure shouldn't fail the whole object save -- but it also shouldn't be
+			// silent or silently retried elsewhere. Surface it as an admin-facing warning
+			// instead of only a log line.
+			if (!empty($failedVariants)) {
+				$user = UserAccount::getActiveUserObj();
+				if ($user) {
+					$warning = 'Could not generate the following image size(s) for "' . $this->title . '": ' . implode(', ', $failedVariants) . '. The full-size image was saved, but these sizes are missing.';
+					$user->updateMessage = !empty($user->updateMessage) ? $user->updateMessage . '<br/>' . $warning : $warning;
+					$user->updateMessageIsError = true;
+					$user->update();
+				}
+			}
 		}
 	}
 

--- a/code/web/sys/Storage/S3StorageDriver.php
+++ b/code/web/sys/Storage/S3StorageDriver.php
@@ -21,10 +21,7 @@ class S3StorageDriver implements StorageDriver {
 
 	public function url(string $key, array $transforms = []): string {
 		if (empty($this->baseUrl)) {
-			// No public base URL configured -- caller must proxy via read() instead.
-			// Reads always go through the CDN when one is configured; there is no
-			// fallback to reading the bucket directly if the CDN request fails --
-			// see StorageSetting::verifiedStatus for connectivity/health reporting.
+			// No public base URL configured; caller must proxy via read() instead.
 			return '';
 		}
 		$url = $this->baseUrl . '/' . ltrim($key, '/');
@@ -71,10 +68,11 @@ class S3StorageDriver implements StorageDriver {
 		}
 		try {
 			$this->client->putObject(new PutObjectRequest([
-				'Bucket'      => $this->bucket,
-				'Key'         => ltrim($key, '/'),
-				'Body'        => $handle,
-				'ContentType' => $mimeType ?: 'application/octet-stream',
+				'Bucket'       => $this->bucket,
+				'Key'          => ltrim($key, '/'),
+				'Body'         => $handle,
+				'ContentType'  => $mimeType ?: 'application/octet-stream',
+				'CacheControl' => 'no-cache',
 			]));
 			return true;
 		} catch (\Exception $e) {

--- a/code/web/sys/Storage/S3StorageDriver.php
+++ b/code/web/sys/Storage/S3StorageDriver.php
@@ -1,0 +1,102 @@
+<?php
+
+require_once ROOT_DIR . '/sys/Storage/StorageDriver.php';
+
+use AsyncAws\S3\S3Client;
+use AsyncAws\S3\Input\GetObjectRequest;
+use AsyncAws\S3\Input\PutObjectRequest;
+use AsyncAws\S3\Input\DeleteObjectRequest;
+use AsyncAws\S3\Input\HeadObjectRequest;
+
+class S3StorageDriver implements StorageDriver {
+	private S3Client $client;
+	private string $bucket;
+	private string $baseUrl;
+
+	public function __construct(S3Client $client, string $bucket, string $baseUrl) {
+		$this->client  = $client;
+		$this->bucket  = $bucket;
+		$this->baseUrl = rtrim($baseUrl, '/');
+	}
+
+	public function url(string $key, array $transforms = []): string {
+		if (empty($this->baseUrl)) {
+			// No public base URL configured; caller must proxy via read().
+			return '';
+		}
+		$url = $this->baseUrl . '/' . ltrim($key, '/');
+		if (!empty($transforms)) {
+			$url .= '?' . http_build_query($transforms);
+		}
+		return $url;
+	}
+
+	public function read(string $key): string|false {
+		try {
+			$result = $this->client->getObject(new GetObjectRequest([
+				'Bucket' => $this->bucket,
+				'Key'    => ltrim($key, '/'),
+			]));
+			return $result->getBody()->getContentAsString();
+		} catch (\Exception $e) {
+			global $logger;
+			$logger->log("S3StorageDriver: failed to read $key from bucket $this->bucket: " . $e->getMessage(), Logger::LOG_ERROR);
+			return false;
+		}
+	}
+
+	public function write(string $key, string $tmpPath, string $mimeType = ''): bool {
+		$handle = fopen($tmpPath, 'rb');
+		if ($handle === false) {
+			global $logger;
+			$logger->log("S3StorageDriver: could not open local file $tmpPath for upload to $key", Logger::LOG_ERROR);
+			return false;
+		}
+		try {
+			$this->client->putObject(new PutObjectRequest([
+				'Bucket'      => $this->bucket,
+				'Key'         => ltrim($key, '/'),
+				'Body'        => $handle,
+				'ContentType' => $mimeType ?: 'application/octet-stream',
+			]));
+			return true;
+		} catch (\Exception $e) {
+			global $logger;
+			$logger->log("S3StorageDriver: failed to write $key to bucket $this->bucket: " . $e->getMessage(), Logger::LOG_ERROR);
+			return false;
+		} finally {
+			fclose($handle);
+		}
+	}
+
+	public function delete(string $key): bool {
+		try {
+			$this->client->deleteObject(new DeleteObjectRequest([
+				'Bucket' => $this->bucket,
+				'Key'    => ltrim($key, '/'),
+			]));
+			return true;
+		} catch (\Exception $e) {
+			global $logger;
+			$logger->log("S3StorageDriver: failed to delete $key from bucket $this->bucket: " . $e->getMessage(), Logger::LOG_ERROR);
+			return false;
+		}
+	}
+
+	public function exists(string $key): bool {
+		try {
+			$result = $this->client->headObject(new HeadObjectRequest([
+				'Bucket' => $this->bucket,
+				'Key'    => ltrim($key, '/'),
+			]));
+			$result->resolve();
+			return true;
+		} catch (\Exception $e) {
+			// A missing key is routine (e.g. existence checks before overwrite);
+			// only log at debug level to avoid flooding the error log.
+			global $logger;
+			$logger->log("S3StorageDriver: $key not found in bucket $this->bucket: " . $e->getMessage(), Logger::LOG_DEBUG);
+			return false;
+		}
+	}
+}

--- a/code/web/sys/Storage/S3StorageDriver.php
+++ b/code/web/sys/Storage/S3StorageDriver.php
@@ -45,6 +45,20 @@ class S3StorageDriver implements StorageDriver {
 		}
 	}
 
+	public function readStream(string $key) {
+		try {
+			$result = $this->client->getObject(new GetObjectRequest([
+				'Bucket' => $this->bucket,
+				'Key'    => ltrim($key, '/'),
+			]));
+			return $result->getBody()->getContentAsResource();
+		} catch (\Exception $e) {
+			global $logger;
+			$logger->log("S3StorageDriver: failed to read $key from bucket $this->bucket: " . $e->getMessage(), Logger::LOG_ERROR);
+			return false;
+		}
+	}
+
 	public function write(string $key, string $tmpPath, string $mimeType = ''): bool {
 		$handle = fopen($tmpPath, 'rb');
 		if ($handle === false) {

--- a/code/web/sys/Storage/S3StorageDriver.php
+++ b/code/web/sys/Storage/S3StorageDriver.php
@@ -21,7 +21,10 @@ class S3StorageDriver implements StorageDriver {
 
 	public function url(string $key, array $transforms = []): string {
 		if (empty($this->baseUrl)) {
-			// No public base URL configured; caller must proxy via read().
+			// No public base URL configured -- caller must proxy via read() instead.
+			// Reads always go through the CDN when one is configured; there is no
+			// fallback to reading the bucket directly if the CDN request fails --
+			// see StorageSetting::verifiedStatus for connectivity/health reporting.
 			return '';
 		}
 		$url = $this->baseUrl . '/' . ltrim($key, '/');

--- a/code/web/sys/Storage/StorageDriverFactory.php
+++ b/code/web/sys/Storage/StorageDriverFactory.php
@@ -50,10 +50,29 @@ class StorageDriverFactory {
 	}
 
 	private static function create(): StorageDriver {
-		return self::getLocalDriver();
+		$setting = self::loadActiveSetting();
+		return self::buildDriver($setting);
 	}
 
 	private static function createFromId(int $id): StorageDriver {
+		$setting = self::loadSettingById($id);
+		return self::buildDriver($setting);
+	}
+
+	private static function buildDriver(?StorageSetting $setting): StorageDriver {
+		if ($setting !== null && $setting->driver === 's3' && !empty($setting->bucket)) {
+			require_once ROOT_DIR . '/sys/Storage/S3StorageDriver.php';
+
+			$client = new AsyncAws\S3\S3Client([
+				'accessKeyId'     => $setting->accessKeyId,
+				'accessKeySecret' => $setting->accessKeySecret,
+				'region'          => $setting->region ?: 'us-east-1',
+				'endpoint'        => $setting->endpoint ?: null,
+			]);
+
+			return new S3StorageDriver($client, $setting->bucket, $setting->baseUrl);
+		}
+
 		return self::getLocalDriver();
 	}
 
@@ -62,5 +81,19 @@ class StorageDriverFactory {
 			self::$localInstance = new LocalStorageDriver(self::resolveDataRoot());
 		}
 		return self::$localInstance;
+	}
+
+	private static function loadActiveSetting(): ?StorageSetting {
+		require_once ROOT_DIR . '/sys/Storage/StorageSetting.php';
+		$setting = new StorageSetting();
+		$setting->isActive = 1;
+		return $setting->find(true) ? $setting : null;
+	}
+
+	private static function loadSettingById(int $id): ?StorageSetting {
+		require_once ROOT_DIR . '/sys/Storage/StorageSetting.php';
+		$setting = new StorageSetting();
+		$setting->id = $id;
+		return $setting->find(true) ? $setting : null;
 	}
 }

--- a/code/web/sys/Storage/StorageDriverFactory.php
+++ b/code/web/sys/Storage/StorageDriverFactory.php
@@ -49,6 +49,17 @@ class StorageDriverFactory {
 		return $configArray['Site']['dataPath'] ?? '/data/aspen-discovery/' . $serverName;
 	}
 
+	// The storage_settings.id a new write should be recorded against. Null
+	// whenever the active backend is Local Storage, matching the
+	// null-means-local convention getById() relies on.
+	public static function getActiveSettingId(): ?int {
+		$setting = self::loadActiveSetting();
+		if ($setting === null || $setting->driver !== 's3') {
+			return null;
+		}
+		return $setting->id;
+	}
+
 	private static function create(): StorageDriver {
 		$setting = self::loadActiveSetting();
 		return self::buildDriver($setting);

--- a/code/web/sys/Storage/StorageDriverFactory.php
+++ b/code/web/sys/Storage/StorageDriverFactory.php
@@ -74,7 +74,13 @@ class StorageDriverFactory {
 		if ($setting !== null && $setting->driver === 's3' && !empty($setting->bucket)) {
 			require_once ROOT_DIR . '/sys/Storage/S3StorageDriver.php';
 
-			$httpClient = new Symfony\Component\HttpClient\CurlHttpClient();
+			// Short timeouts so an unreachable S3 endpoint fails fast instead
+			// of tying up a PHP-FPM worker for the platform default (which
+			// can run well past a minute).
+			$httpClient = new Symfony\Component\HttpClient\CurlHttpClient([
+				'timeout' => 5,
+				'max_duration' => 15,
+			]);
 			$client = new AsyncAws\S3\S3Client(
 				[
 					'accessKeyId'      => $setting->accessKeyId,

--- a/code/web/sys/Storage/StorageDriverFactory.php
+++ b/code/web/sys/Storage/StorageDriverFactory.php
@@ -106,6 +106,13 @@ class StorageDriverFactory {
 		return self::$localInstance;
 	}
 
+	// Public so callers that need the setting itself (not just a driver
+	// instance) -- e.g. a self-check that wants to re-verify and report on
+	// the active S3 backend's public URL -- don't have to duplicate this query.
+	public static function getActiveSetting(): ?StorageSetting {
+		return self::loadActiveSetting();
+	}
+
 	private static function loadActiveSetting(): ?StorageSetting {
 		require_once ROOT_DIR . '/sys/Storage/StorageSetting.php';
 		$setting = new StorageSetting();

--- a/code/web/sys/Storage/StorageDriverFactory.php
+++ b/code/web/sys/Storage/StorageDriverFactory.php
@@ -63,12 +63,18 @@ class StorageDriverFactory {
 		if ($setting !== null && $setting->driver === 's3' && !empty($setting->bucket)) {
 			require_once ROOT_DIR . '/sys/Storage/S3StorageDriver.php';
 
-			$client = new AsyncAws\S3\S3Client([
-				'accessKeyId'     => $setting->accessKeyId,
-				'accessKeySecret' => $setting->accessKeySecret,
-				'region'          => $setting->region ?: 'us-east-1',
-				'endpoint'        => $setting->endpoint ?: null,
-			]);
+			$httpClient = new Symfony\Component\HttpClient\CurlHttpClient();
+			$client = new AsyncAws\S3\S3Client(
+				[
+					'accessKeyId'      => $setting->accessKeyId,
+					'accessKeySecret'  => $setting->accessKeySecret,
+					'region'           => $setting->region ?: 'us-east-1',
+					'endpoint'         => $setting->endpoint ?: null,
+					'pathStyleEndpoint' => !empty($setting->endpoint),
+				],
+				null,
+				$httpClient
+			);
 
 			return new S3StorageDriver($client, $setting->bucket, $setting->baseUrl);
 		}

--- a/code/web/sys/Storage/StorageSetting.php
+++ b/code/web/sys/Storage/StorageSetting.php
@@ -1,11 +1,20 @@
 <?php
 
+use AsyncAws\S3\S3Client;
+use AsyncAws\S3\Input\HeadBucketRequest;
+
 class StorageSetting extends DataObject {
 	public $__table = 'storage_settings';
 	public $id;
 	public $name;
 	public $driver;
 	public $isActive;
+	public $bucket;
+	public $accessKeyId;
+	public $accessKeySecret;
+	public $region;
+	public $endpoint;
+	public $baseUrl;
 
 	static $_objectStructure = [];
 	static function getObjectStructure(string $context = ''): array {
@@ -33,6 +42,7 @@ class StorageSetting extends DataObject {
 				'type' => 'enum',
 				'values' => [
 					'local' => 'Local Storage',
+					's3'    => 'S3-Compatible Storage',
 				],
 				'label' => 'Storage Driver',
 				'description' => 'The storage backend to use for uploaded files.',
@@ -53,13 +63,76 @@ class StorageSetting extends DataObject {
 				'description' => 'The directory where uploaded files are stored on this server. To change this, update the data path in your server configuration.',
 				'hideInLists' => true,
 			],
+			'bucket' => [
+				'property' => 'bucket',
+				'type' => 'text',
+				'label' => 'Bucket',
+				'description' => 'The S3 bucket name.',
+				'default' => '',
+				'required' => true,
+			],
+			'accessKeyId' => [
+				'property' => 'accessKeyId',
+				'type' => 'text',
+				'label' => 'Access Key ID',
+				'description' => 'The access key ID for S3 authentication.',
+				'default' => '',
+				'required' => true,
+			],
+			'accessKeySecret' => [
+				'property' => 'accessKeySecret',
+				'type' => 'storedPassword',
+				'label' => 'Access Key Secret',
+				'description' => 'The secret access key for S3 authentication.',
+				'default' => '',
+				'required' => true,
+				'hideInLists' => true,
+			],
+			'region' => [
+				'property' => 'region',
+				'type' => 'text',
+				'label' => 'Region',
+				'description' => 'The S3 region (e.g. us-east-1). Required for AWS S3; optional for S3-compatible providers.',
+				'default' => 'us-east-1',
+				'required' => false,
+			],
+			'endpoint' => [
+				'property' => 'endpoint',
+				'type' => 'text',
+				'label' => 'Endpoint URL',
+				'description' => 'Custom endpoint URL for S3-compatible providers (e.g. Cloudflare R2, MinIO). Leave empty for AWS S3.',
+				'default' => '',
+				'required' => false,
+			],
+			'baseUrl' => [
+				'property' => 'baseUrl',
+				'type' => 'text',
+				'label' => 'Public Base URL',
+				'description' => 'The public URL prefix used to serve files (e.g. https://cdn.example.com). Required when using S3.',
+				'default' => '',
+				'required' => false,
+			],
 		];
 
 		self::$_objectStructure[$context] = $structure;
 		return self::$_objectStructure[$context];
 	}
 
+	public function insert(string $context = ''): int|bool {
+		if (!$this->validateS3Credentials()) {
+			return false;
+		}
+		if ($this->isActive) {
+			global $aspen_db;
+			$aspen_db->query('UPDATE storage_settings SET isActive = 0');
+		}
+		return parent::insert($context);
+	}
+
 	public function update(string $context = ''): int|bool {
+		if (!$this->validateS3Credentials()) {
+			return false;
+		}
 		if ($this->isActive) {
 			global $aspen_db;
 			$aspen_db->query('UPDATE storage_settings SET isActive = 0 WHERE id != ' . (int)$this->id);
@@ -67,13 +140,35 @@ class StorageSetting extends DataObject {
 		return parent::update($context);
 	}
 
-	public function insert(string $context = ''): int|bool {
-		// On insert, deactivate all others if this one is set as active.
-		if ($this->isActive) {
-			global $aspen_db;
-			$aspen_db->query('UPDATE storage_settings SET isActive = 0');
+	private function validateS3Credentials(): bool {
+		if ($this->driver !== 's3') {
+			return true;
 		}
-		return parent::insert($context);
+		if (empty($this->bucket) || empty($this->accessKeyId) || empty($this->accessKeySecret)) {
+			$this->validationError = 'Bucket, Access Key ID, and Access Key Secret are required for S3 storage.';
+			return false;
+		}
+		try {
+			$client = new S3Client([
+				'accessKeyId'     => $this->accessKeyId,
+				'accessKeySecret' => $this->accessKeySecret,
+				'region'          => $this->region ?: 'us-east-1',
+				'endpoint'        => $this->endpoint ?: null,
+			]);
+			$result = $client->headBucket(new HeadBucketRequest(['Bucket' => $this->bucket]));
+			$result->resolve();
+			return true;
+		} catch (\Exception $e) {
+			$this->validationError = 'Could not connect to S3 bucket: ' . $e->getMessage();
+			return false;
+		}
+	}
+
+	public function updateStructureForEditingObject($structure): array {
+		if ($this->driver !== 'local') {
+			unset($structure['effectiveDataRoot']);
+		}
+		return $structure;
 	}
 
 	public function __get($name) {

--- a/code/web/sys/Storage/StorageSetting.php
+++ b/code/web/sys/Storage/StorageSetting.php
@@ -1,7 +1,7 @@
 <?php
 
 use AsyncAws\S3\S3Client;
-use AsyncAws\S3\Input\HeadBucketRequest;
+use AsyncAws\S3\Input\ListObjectsV2Request;
 
 class StorageSetting extends DataObject {
 	public $__table = 'storage_settings';
@@ -48,6 +48,17 @@ class StorageSetting extends DataObject {
 				'description' => 'The storage backend to use for uploaded files.',
 				'default' => 'local',
 				'required' => true,
+				'onchange' => 'AspenDiscovery.StorageSettings.toggleS3Fields(this.value)',
+			],
+			's3FieldToggle' => [
+				'property'               => 's3FieldToggle',
+				'type'                   => 'label',
+				'label'                  => '',
+				'description'            => '',
+				'hideInLists'            => true,
+				'suppressNotSetForEmpty' => true,
+				'doNotEscape'            => true,
+				'hiddenByDefault'        => true,
 			],
 			'isActive' => [
 				'property' => 'isActive',
@@ -64,53 +75,59 @@ class StorageSetting extends DataObject {
 				'hideInLists' => true,
 			],
 			'bucket' => [
-				'property' => 'bucket',
-				'type' => 'text',
-				'label' => 'Bucket',
-				'description' => 'The S3 bucket name.',
-				'default' => '',
-				'required' => true,
+				'property'        => 'bucket',
+				'type'            => 'text',
+				'label'           => 'Bucket',
+				'description'     => 'The S3 bucket name. The bucket must already exist on the provider; it is not created automatically.',
+				'default'         => '',
+				'required'        => true,
+				'hiddenByDefault' => true,
 			],
 			'accessKeyId' => [
-				'property' => 'accessKeyId',
-				'type' => 'text',
-				'label' => 'Access Key ID',
-				'description' => 'The access key ID for S3 authentication.',
-				'default' => '',
-				'required' => true,
+				'property'        => 'accessKeyId',
+				'type'            => 'text',
+				'label'           => 'Access Key ID',
+				'description'     => 'The access key ID for S3 authentication.',
+				'default'         => '',
+				'required'        => true,
+				'hiddenByDefault' => true,
 			],
 			'accessKeySecret' => [
-				'property' => 'accessKeySecret',
-				'type' => 'storedPassword',
-				'label' => 'Access Key Secret',
-				'description' => 'The secret access key for S3 authentication.',
-				'default' => '',
-				'required' => true,
-				'hideInLists' => true,
+				'property'        => 'accessKeySecret',
+				'type'            => 'storedPassword',
+				'label'           => 'Access Key Secret',
+				'description'     => 'The secret access key for S3 authentication.',
+				'default'         => '',
+				'required'        => true,
+				'hideInLists'     => true,
+				'hiddenByDefault' => true,
 			],
 			'region' => [
-				'property' => 'region',
-				'type' => 'text',
-				'label' => 'Region',
-				'description' => 'The S3 region (e.g. us-east-1). Required for AWS S3; optional for S3-compatible providers.',
-				'default' => 'us-east-1',
-				'required' => false,
+				'property'        => 'region',
+				'type'            => 'text',
+				'label'           => 'Region',
+				'description'     => 'The S3 region (e.g. us-east-1). Required for AWS S3; optional for S3-compatible providers.',
+				'default'         => 'us-east-1',
+				'required'        => false,
+				'hiddenByDefault' => true,
 			],
 			'endpoint' => [
-				'property' => 'endpoint',
-				'type' => 'text',
-				'label' => 'Endpoint URL',
-				'description' => 'Custom endpoint URL for S3-compatible providers (e.g. Cloudflare R2, MinIO). Leave empty for AWS S3.',
-				'default' => '',
-				'required' => false,
+				'property'        => 'endpoint',
+				'type'            => 'text',
+				'label'           => 'Endpoint URL',
+				'description'     => 'Custom endpoint URL for S3-compatible providers (e.g. Cloudflare R2, MinIO). Leave empty for AWS S3.',
+				'default'         => '',
+				'required'        => false,
+				'hiddenByDefault' => true,
 			],
 			'baseUrl' => [
-				'property' => 'baseUrl',
-				'type' => 'text',
-				'label' => 'Public Base URL',
-				'description' => 'The public URL prefix used to serve files (e.g. https://cdn.example.com). Required when using S3.',
-				'default' => '',
-				'required' => false,
+				'property'        => 'baseUrl',
+				'type'            => 'text',
+				'label'           => 'Public Base URL',
+				'description'     => 'Optional. The public URL that serves the bucket directly (a CDN domain in front of it, or the bucket\'s own public endpoint). When set, the browser is redirected straight there instead of the app proxying every file through itself. Leave empty to have the app proxy file bytes, the same way it does for local storage.',
+				'default'         => '',
+				'required'        => false,
+				'hiddenByDefault' => true,
 			],
 		];
 
@@ -145,21 +162,30 @@ class StorageSetting extends DataObject {
 			return true;
 		}
 		if (empty($this->bucket) || empty($this->accessKeyId) || empty($this->accessKeySecret)) {
-			$this->validationError = 'Bucket, Access Key ID, and Access Key Secret are required for S3 storage.';
+			$this->setLastError('Bucket, Access Key ID, and Access Key Secret are required for S3 storage.');
 			return false;
 		}
 		try {
-			$client = new S3Client([
-				'accessKeyId'     => $this->accessKeyId,
-				'accessKeySecret' => $this->accessKeySecret,
-				'region'          => $this->region ?: 'us-east-1',
-				'endpoint'        => $this->endpoint ?: null,
-			]);
-			$result = $client->headBucket(new HeadBucketRequest(['Bucket' => $this->bucket]));
+			$httpClient = new \Symfony\Component\HttpClient\CurlHttpClient();
+			$client = new S3Client(
+				[
+					'accessKeyId'      => $this->accessKeyId,
+					'accessKeySecret'  => $this->accessKeySecret,
+					'region'           => $this->region ?: 'us-east-1',
+					'endpoint'         => $this->endpoint ?: null,
+					'pathStyleEndpoint' => !empty($this->endpoint),
+				],
+				null,
+				$httpClient
+			);
+			$result = $client->listObjectsV2(new ListObjectsV2Request([
+				'Bucket'  => $this->bucket,
+				'MaxKeys' => 1,
+			]));
 			$result->resolve();
 			return true;
 		} catch (\Exception $e) {
-			$this->validationError = 'Could not connect to S3 bucket: ' . $e->getMessage();
+			$this->setLastError('Could not connect to S3 bucket: ' . $e->getMessage());
 			return false;
 		}
 	}
@@ -174,6 +200,21 @@ class StorageSetting extends DataObject {
 	public function __get($name) {
 		if ($name === 'effectiveDataRoot') {
 			return StorageDriverFactory::resolveDataRoot();
+		}
+		if ($name === 's3FieldToggle') {
+			return '<script>
+AspenDiscovery.StorageSettings = AspenDiscovery.StorageSettings || {};
+AspenDiscovery.StorageSettings.toggleS3Fields = function(driver) {
+	var s3Fields = ["bucket", "accessKeyId", "accessKeySecret", "region", "endpoint", "baseUrl"];
+	var isS3 = driver === "s3";
+	s3Fields.forEach(function(field) {
+		$("#propertyRow" + field).toggle(isS3);
+	});
+};
+$(document).ready(function() {
+	AspenDiscovery.StorageSettings.toggleS3Fields($("#driverSelect").val());
+});
+</script>';
 		}
 		return parent::__get($name);
 	}

--- a/code/web/sys/Storage/StorageSetting.php
+++ b/code/web/sys/Storage/StorageSetting.php
@@ -48,7 +48,7 @@ class StorageSetting extends DataObject {
 				'type' => 'enum',
 				'values' => [
 					'local' => 'Local Storage',
-					's3'    => 'S3-Compatible Storage',
+					's3'    => 'S3-Compatible Storage (CDN Mode)',
 				],
 				'label' => 'Storage Driver',
 				'description' => 'The storage backend to use for uploaded files.',
@@ -121,7 +121,7 @@ class StorageSetting extends DataObject {
 				'property'        => 'endpoint',
 				'type'            => 'text',
 				'label'           => 'Endpoint URL',
-				'description'     => 'Custom endpoint URL for S3-compatible providers (e.g. Cloudflare R2, MinIO). Leave empty for AWS S3.',
+				'description'     => 'Custom endpoint URL for S3-compatible providers. Leave empty for AWS S3.',
 				'default'         => '',
 				'required'        => false,
 				'hiddenByDefault' => true,
@@ -130,9 +130,9 @@ class StorageSetting extends DataObject {
 				'property'        => 'baseUrl',
 				'type'            => 'text',
 				'label'           => 'Public Base URL',
-				'description'     => 'Optional. The public URL that serves the bucket directly (a CDN domain in front of it, or the bucket\'s own public endpoint). When set, the browser is redirected straight there instead of the app proxying every file through itself. Leave empty to have the app proxy file bytes, the same way it does for local storage.',
+				'description'     => 'The public URL that serves the bucket directly (a CDN domain in front of it, or the bucket\'s own public endpoint).',
 				'default'         => '',
-				'required'        => false,
+				'required'        => true,
 				'hiddenByDefault' => true,
 			],
 			'publicUrlStatus' => [
@@ -201,8 +201,8 @@ class StorageSetting extends DataObject {
 		if ($this->driver !== 's3') {
 			return true;
 		}
-		if (empty($this->bucket) || empty($this->accessKeyId) || empty($this->accessKeySecret)) {
-			$this->setLastError('Bucket, Access Key ID, and Access Key Secret are required for S3 storage.');
+		if (empty($this->bucket) || empty($this->accessKeyId) || empty($this->accessKeySecret) || empty($this->baseUrl)) {
+			$this->setLastError('Bucket, Access Key ID, Access Key Secret, and Public Base URL (CDN) are all required for S3 storage.');
 			return false;
 		}
 		try {
@@ -308,7 +308,7 @@ class StorageSetting extends DataObject {
 	// Maps AsyncAws exceptions to a human-readable reason using the standard
 	// S3 API error-code contract (AWS error codes like AccessDenied,
 	// NoSuchBucket, InvalidAccessKeyId), which any S3-compatible provider
-	// implements the same way -- not specific to AWS or MinIO.
+	// implements the same way, not specific to AWS or MinIO.
 	private function describeS3Exception(\Exception $e): string {
 		if ($e instanceof HttpException) {
 			$awsCode = $e->getAwsCode();

--- a/code/web/sys/Storage/StorageSetting.php
+++ b/code/web/sys/Storage/StorageSetting.php
@@ -2,6 +2,10 @@
 
 use AsyncAws\S3\S3Client;
 use AsyncAws\S3\Input\ListObjectsV2Request;
+use AsyncAws\S3\Input\PutObjectRequest;
+use AsyncAws\S3\Input\DeleteObjectRequest;
+use AsyncAws\Core\Exception\Http\HttpException;
+use AsyncAws\Core\Exception\Http\NetworkException;
 
 class StorageSetting extends DataObject {
 	public $__table = 'storage_settings';
@@ -15,6 +19,8 @@ class StorageSetting extends DataObject {
 	public $region;
 	public $endpoint;
 	public $baseUrl;
+	public $verifiedStatus;
+	public $verifiedMessage;
 
 	static $_objectStructure = [];
 	static function getObjectStructure(string $context = ''): array {
@@ -129,6 +135,13 @@ class StorageSetting extends DataObject {
 				'required'        => false,
 				'hiddenByDefault' => true,
 			],
+			'publicUrlStatus' => [
+				'property'        => 'publicUrlStatus',
+				'type'            => 'label',
+				'label'           => 'Public URL Status',
+				'description'     => 'Whether the Public Base URL has been confirmed to serve files anonymously. Re-checked every time this configuration is saved.',
+				'hiddenByDefault' => true,
+			],
 		];
 
 		self::$_objectStructure[$context] = $structure;
@@ -139,6 +152,8 @@ class StorageSetting extends DataObject {
 		if (!$this->validateS3Credentials()) {
 			return false;
 		}
+		$this->refreshPublicUrlStatus();
+		$this->markVerificationFieldsChanged();
 		if ($this->isActive) {
 			global $aspen_db;
 			$aspen_db->query('UPDATE storage_settings SET isActive = 0');
@@ -150,6 +165,8 @@ class StorageSetting extends DataObject {
 		if (!$this->validateS3Credentials()) {
 			return false;
 		}
+		$this->refreshPublicUrlStatus();
+		$this->markVerificationFieldsChanged();
 		if ($this->isActive) {
 			global $aspen_db;
 			$aspen_db->query('UPDATE storage_settings SET isActive = 0 WHERE id != ' . (int)$this->id);
@@ -157,6 +174,29 @@ class StorageSetting extends DataObject {
 		return parent::update($context);
 	}
 
+	// verifiedStatus/verifiedMessage are computed here, not submitted via the
+	// admin form, so DataObjectUtil::updateFromUI() never adds them to
+	// _changedFields. DataObject::update() only persists columns listed in
+	// _changedFields once it's non-empty, so without this they'd silently
+	// keep whatever value was set at the row's original insert().
+	private function markVerificationFieldsChanged(): void {
+		$this->_changedFields[] = 'verifiedStatus';
+		$this->_changedFields[] = 'verifiedMessage';
+	}
+
+	// Re-runs the tier 2 public-URL probe live and persists the result, without
+	// going through the full insert()/update() dance (credential re-validation,
+	// isActive flip). Used by SearchAPI::getIndexStatus() so the CDN Storage
+	// self-check reflects current reality on every status page load / Greenhouse
+	// poll, instead of only whenever an admin happens to re-save the settings form.
+	public function checkAndPersistPublicUrlStatus(): void {
+		$this->refreshPublicUrlStatus();
+		$this->markVerificationFieldsChanged();
+		parent::update();
+	}
+
+	// Tier 1: can we authenticate and see the bucket at all. Required for the
+	// backend to function; blocks save on failure.
 	private function validateS3Credentials(): bool {
 		if ($this->driver !== 's3') {
 			return true;
@@ -166,18 +206,7 @@ class StorageSetting extends DataObject {
 			return false;
 		}
 		try {
-			$httpClient = new \Symfony\Component\HttpClient\CurlHttpClient();
-			$client = new S3Client(
-				[
-					'accessKeyId'      => $this->accessKeyId,
-					'accessKeySecret'  => $this->accessKeySecret,
-					'region'           => $this->region ?: 'us-east-1',
-					'endpoint'         => $this->endpoint ?: null,
-					'pathStyleEndpoint' => !empty($this->endpoint),
-				],
-				null,
-				$httpClient
-			);
+			$client = $this->buildTestClient();
 			$result = $client->listObjectsV2(new ListObjectsV2Request([
 				'Bucket'  => $this->bucket,
 				'MaxKeys' => 1,
@@ -185,9 +214,121 @@ class StorageSetting extends DataObject {
 			$result->resolve();
 			return true;
 		} catch (\Exception $e) {
-			$this->setLastError('Could not connect to S3 bucket: ' . $e->getMessage());
+			$this->setLastError('Could not connect to S3 bucket: ' . $this->describeS3Exception($e));
 			return false;
 		}
+	}
+
+	// Tier 2: can an end user's browser actually fetch a file from the
+	// configured Public Base URL without any Aspen-side authentication. This
+	// is what a CDN redirect relies on, and it can fail (private bucket, wrong
+	// baseUrl) even when tier 1 succeeds, since tier 1 uses authenticated S3
+	// API calls while the redirect is a plain anonymous HTTP request. Never
+	// blocks save; only records verifiedStatus/verifiedMessage so the driver
+	// knows whether it's safe to redirect or must proxy instead.
+	private function refreshPublicUrlStatus(): void {
+		if ($this->driver !== 's3') {
+			$this->verifiedStatus = 'unverified';
+			// '' rather than null: DataObject::update() unconditionally skips
+			// any scalar property whose new value is null, regardless of
+			// _changedFields, so null here would leave a stale message in
+			// the DB instead of clearing it.
+			$this->verifiedMessage = '';
+			return;
+		}
+		if (empty($this->baseUrl)) {
+			$this->verifiedStatus = 'unverified';
+			$this->verifiedMessage = 'No Public Base URL configured; files will be proxied through the application.';
+			return;
+		}
+
+		$probeKey = 'uploads/.aspen-connection-test';
+		try {
+			$client = $this->buildTestClient();
+			$client->putObject(new PutObjectRequest([
+				'Bucket'      => $this->bucket,
+				'Key'         => $probeKey,
+				'Body'        => 'aspen-discovery connection test',
+				'ContentType' => 'text/plain',
+			]));
+		} catch (\Exception $e) {
+			$this->verifiedStatus = 'failed';
+			$this->verifiedMessage = 'Could not write a test file to the bucket: ' . $this->describeS3Exception($e);
+			return;
+		}
+
+		try {
+			$probeUrl = rtrim($this->baseUrl, '/') . '/' . $probeKey;
+			$publicHttpClient = new \Symfony\Component\HttpClient\CurlHttpClient(['timeout' => 5, 'max_duration' => 15]);
+			$response = $publicHttpClient->request('GET', $probeUrl);
+			$statusCode = $response->getStatusCode();
+			if ($statusCode === 200) {
+				$this->verifiedStatus = 'verified';
+				$this->verifiedMessage = ''; // see the null note above
+			} elseif ($statusCode === 403) {
+				$this->verifiedStatus = 'failed';
+				$this->verifiedMessage = "Public Base URL returned 403 Access Denied. The bucket likely doesn't have a public-read policy set.";
+			} elseif ($statusCode === 404) {
+				$this->verifiedStatus = 'failed';
+				$this->verifiedMessage = "Public Base URL returned 404 Not Found. Double check it points at the bucket named \"$this->bucket\".";
+			} else {
+				$this->verifiedStatus = 'failed';
+				$this->verifiedMessage = "Public Base URL returned an unexpected HTTP $statusCode.";
+			}
+		} catch (\Exception $e) {
+			$this->verifiedStatus = 'failed';
+			$this->verifiedMessage = 'Could not reach the Public Base URL: ' . $e->getMessage();
+		} finally {
+			try {
+				$client->deleteObject(new DeleteObjectRequest([
+					'Bucket' => $this->bucket,
+					'Key'    => $probeKey,
+				]));
+			} catch (\Exception $e) {
+				// Best effort cleanup; a leftover probe file isn't worth failing the check over.
+			}
+		}
+	}
+
+	private function buildTestClient(): S3Client {
+		$httpClient = new \Symfony\Component\HttpClient\CurlHttpClient(['timeout' => 5, 'max_duration' => 15]);
+		return new S3Client(
+			[
+				'accessKeyId'      => $this->accessKeyId,
+				'accessKeySecret'  => $this->accessKeySecret,
+				'region'           => $this->region ?: 'us-east-1',
+				'endpoint'         => $this->endpoint ?: null,
+				'pathStyleEndpoint' => !empty($this->endpoint),
+			],
+			null,
+			$httpClient
+		);
+	}
+
+	// Maps AsyncAws exceptions to a human-readable reason using the standard
+	// S3 API error-code contract (AWS error codes like AccessDenied,
+	// NoSuchBucket, InvalidAccessKeyId), which any S3-compatible provider
+	// implements the same way -- not specific to AWS or MinIO.
+	private function describeS3Exception(\Exception $e): string {
+		if ($e instanceof HttpException) {
+			$awsCode = $e->getAwsCode();
+			switch ($awsCode) {
+				case 'InvalidAccessKeyId':
+					return 'The Access Key ID was rejected by the provider.';
+				case 'SignatureDoesNotMatch':
+					return 'The Access Key Secret is incorrect.';
+				case 'NoSuchBucket':
+					return "No bucket named \"$this->bucket\" exists on this provider.";
+				case 'AccessDenied':
+					return 'The credentials are valid but do not have permission to access this bucket.';
+				default:
+					return $awsCode ? "$awsCode: {$e->getAwsMessage()}" : $e->getMessage();
+			}
+		}
+		if ($e instanceof NetworkException) {
+			return "Could not reach the endpoint (" . ($this->endpoint ?: 'default AWS endpoint') . "). Check the Endpoint URL and network connectivity.";
+		}
+		return $e->getMessage();
 	}
 
 	public function updateStructureForEditingObject($structure): array {
@@ -201,11 +342,23 @@ class StorageSetting extends DataObject {
 		if ($name === 'effectiveDataRoot') {
 			return StorageDriverFactory::resolveDataRoot();
 		}
+		if ($name === 'publicUrlStatus') {
+			if ($this->driver !== 's3') {
+				return '';
+			}
+			if ($this->verifiedStatus === 'verified') {
+				return 'Verified — files are served directly from the Public Base URL.';
+			}
+			if ($this->verifiedStatus === 'failed') {
+				return 'Not publicly readable — Aspen proxies file requests through the application instead. ' . $this->verifiedMessage;
+			}
+			return $this->verifiedMessage ?: 'Not yet verified. Save this configuration to check.';
+		}
 		if ($name === 's3FieldToggle') {
 			return '<script>
 AspenDiscovery.StorageSettings = AspenDiscovery.StorageSettings || {};
 AspenDiscovery.StorageSettings.toggleS3Fields = function(driver) {
-	var s3Fields = ["bucket", "accessKeyId", "accessKeySecret", "region", "endpoint", "baseUrl"];
+	var s3Fields = ["bucket", "accessKeyId", "accessKeySecret", "region", "endpoint", "baseUrl", "publicUrlStatus"];
 	var isS3 = driver === "s3";
 	s3Fields.forEach(function(field) {
 		$("#propertyRow" + field).toggle(isS3);

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,8 @@
     "require": {
         "league/oauth2-server": "^9.3",
         "laminas/laminas-diactoros": "^3.8",
-        "lcobucci/clock": "^3.3"
+        "lcobucci/clock": "^3.3",
+        "async-aws/s3": "^3.3"
     },
     "config": {
         "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,145 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "73f1e21a2f8d73462f19ed1eb250eba6",
+    "content-hash": "9e6c60bb0fc3fda7688c5bd55b61d729",
     "packages": [
+        {
+            "name": "async-aws/core",
+            "version": "1.29.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/async-aws/core.git",
+                "reference": "aefe81449ea19f6ed43944bbb29874a0a5e54d18"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/async-aws/core/zipball/aefe81449ea19f6ed43944bbb29874a0a5e54d18",
+                "reference": "aefe81449ea19f6ed43944bbb29874a0a5e54d18",
+                "shasum": ""
+            },
+            "require": {
+                "ext-hash": "*",
+                "ext-simplexml": "*",
+                "php": "^8.2",
+                "psr/cache": "^1.0 || ^2.0 || ^3.0",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
+                "symfony/deprecation-contracts": "^2.1 || ^3.0",
+                "symfony/http-client": "^4.4.16 || ^5.1.7 || ^6.0 || ^7.0 || ^8.0",
+                "symfony/http-client-contracts": "^1.1.8 || ^2.0 || ^3.0",
+                "symfony/service-contracts": "^1.0 || ^2.0 || ^3.0"
+            },
+            "conflict": {
+                "async-aws/s3": "<1.1",
+                "symfony/http-client": "5.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5.42",
+                "symfony/error-handler": "^7.3.2 || ^8.0",
+                "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.29-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "AsyncAws\\Core\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Core package to integrate with AWS. This is a lightweight AWS SDK provider by AsyncAws.",
+            "keywords": [
+                "amazon",
+                "async-aws",
+                "aws",
+                "sdk",
+                "sts"
+            ],
+            "support": {
+                "source": "https://github.com/async-aws/core/tree/1.29.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/jderusse",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nyholm",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-07-29T12:54:05+00:00"
+        },
+        {
+            "name": "async-aws/s3",
+            "version": "3.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/async-aws/s3.git",
+                "reference": "5df1ad51e02f489cf1b78e59890b40632b4a5a42"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/async-aws/s3/zipball/5df1ad51e02f489cf1b78e59890b40632b4a5a42",
+                "reference": "5df1ad51e02f489cf1b78e59890b40632b4a5a42",
+                "shasum": ""
+            },
+            "require": {
+                "async-aws/core": "^1.22",
+                "ext-dom": "*",
+                "ext-filter": "*",
+                "ext-hash": "*",
+                "ext-simplexml": "*",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5.42",
+                "symfony/error-handler": "^7.3.2 || ^8.0",
+                "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "AsyncAws\\S3\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "S3 client, part of the AWS SDK provided by AsyncAws.",
+            "keywords": [
+                "amazon",
+                "async-aws",
+                "aws",
+                "s3",
+                "sdk"
+            ],
+            "support": {
+                "source": "https://github.com/async-aws/s3/tree/3.4.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/jderusse",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nyholm",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-07-29T12:54:05+00:00"
+        },
         {
             "name": "defuse/php-encryption",
             "version": "v2.4.0",
@@ -687,6 +824,55 @@
             "time": "2020-10-15T08:29:30+00:00"
         },
         {
+            "name": "psr/cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/3.0.0"
+            },
+            "time": "2021-02-03T23:26:27+00:00"
+        },
+        {
             "name": "psr/clock",
             "version": "1.0.0",
             "source": {
@@ -733,6 +919,59 @@
                 "source": "https://github.com/php-fig/clock/tree/1.0.0"
             },
             "time": "2022-11-25T14:36:26+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
+            },
+            "time": "2021-11-05T16:47:00+00:00"
         },
         {
             "name": "psr/event-dispatcher",
@@ -1004,6 +1243,477 @@
                 "source": "https://github.com/php-fig/http-server-middleware/tree/1.0.2"
             },
             "time": "2023-04-11T06:14:47+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
+            },
+            "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-05T06:23:12+00:00"
+        },
+        {
+            "name": "symfony/http-client",
+            "version": "v7.4.18",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client.git",
+                "reference": "68d81f78d127984ff2e741f0e0d9cb1078f8f3ea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/68d81f78d127984ff2e741f0e0d9cb1078f8f3ea",
+                "reference": "68d81f78d127984ff2e741f0e0d9cb1078f8f3ea",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/log": "^1|^2|^3",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/http-client-contracts": "~3.4.4|^3.5.2",
+                "symfony/polyfill-php83": "^1.29",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "amphp/amp": "<2.5",
+                "amphp/socket": "<1.1",
+                "php-http/discovery": "<1.15",
+                "symfony/http-foundation": "<6.4"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "*",
+                "php-http/client-implementation": "*",
+                "psr/http-client-implementation": "1.0",
+                "symfony/http-client-implementation": "3.0"
+            },
+            "require-dev": {
+                "amphp/http-client": "^4.2.1|^5.0",
+                "amphp/http-tunnel": "^1.0|^2.0",
+                "guzzlehttp/promises": "^1.4|^2.0",
+                "nyholm/psr7": "^1.0",
+                "php-http/httplug": "^1.0|^2.0",
+                "psr/http-client": "^1.0",
+                "symfony/amphp-http-client-meta": "^1.0|^2.0",
+                "symfony/cache": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/rate-limiter": "^6.4|^7.0|^8.0",
+                "symfony/stopwatch": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpClient\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides powerful methods to fetch HTTP resources synchronously or asynchronously",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "http"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/http-client/tree/v7.4.18"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-08-30T13:49:59+00:00"
+        },
+        {
+            "name": "symfony/http-client-contracts",
+            "version": "v3.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client-contracts.git",
+                "reference": "35be0019e2c2c9fba80f9dc033290a5240f7b44f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/35be0019e2c2c9fba80f9dc033290a5240f7b44f",
+                "reference": "35be0019e2c2c9fba80f9dc033290a5240f7b44f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\HttpClient\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to HTTP clients",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/http-client-contracts/tree/v3.7.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-08-04T08:41:16+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php83",
+            "version": "v1.41.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php83.git",
+                "reference": "5ea99087fb99c273a9b9236ed4c31e78b16103c6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/5ea99087fb99c273a9b9236ed4c31e78b16103c6",
+                "reference": "5ea99087fb99c273a9b9236ed4c31e78b16103c6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php83\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.41.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-01T12:47:55+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v3.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "15e6a07ec2a2c75ceb1b21dd98105ee8456d2257"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/15e6a07ec2a2c75ceb1b21dd98105ee8456d2257",
+                "reference": "15e6a07ec2a2c75ceb1b21dd98105ee8456d2257",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-27T15:39:01+00:00"
         }
     ],
     "packages-dev": [
@@ -1244,11 +1954,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.2.8",
+            "version": "2.2.12",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e285254e60f33c21902efef4a926ca0987c06804",
-                "reference": "e285254e60f33c21902efef4a926ca0987c06804",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/174b0d88710f00a42598886504dd7a146f91ace5",
+                "reference": "174b0d88710f00a42598886504dd7a146f91ace5",
                 "shasum": ""
             },
             "require": {
@@ -1304,7 +2014,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-08-04T22:21:45+00:00"
+            "time": "2026-08-31T19:09:43+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -85,7 +85,7 @@ COPY . /usr/local/aspen-discovery
 
 # Install Composer dependencies
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-	&& cd /usr/local/aspen-discovery/code/web \
+	&& cd /usr/local/aspen-discovery \
 	&& composer install --no-interaction --prefer-dist --no-dev \
 	&& rm /usr/local/bin/composer
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -83,6 +83,12 @@ COPY docker/files/scripts/apache.sh      /apache.sh
 # Add aspen-discovery
 COPY . /usr/local/aspen-discovery
 
+# Install Composer dependencies
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+	&& cd /usr/local/aspen-discovery/code/web \
+	&& composer install --no-interaction --prefer-dist --no-dev \
+	&& rm /usr/local/bin/composer
+
 # Delete sites
 RUN cd /usr/local/aspen-discovery/sites \
 	&& rm -rf *local* \


### PR DESCRIPTION
Adds an S3-compatible storage backend as an alternative to local-disk storage, built behind a generic StorageDriver abstraction (StorageDriverFactory, LocalStorageDriver/S3StorageDriver) rather than hard-coded to one upload type. 

Currently wired up for WebBuilder images and ImageUpload derivatives, so libraries can serve those from a CDN-fronted bucket instead of the app server's local filesystem. The driver interface itself is intentionally object-agnostic, so extending storage-backend support to other uploaded object types later is a matter of routing them through the same abstraction rather than building a second storage layer from scratch.

Includes credential/connectivity validation on save, an admin-facing "Public URL" health check with a status badge, correct per-derivative-size storage-key resolution, MIME-type detection on write, and admin warnings instead of silent failures when an upload can't be written. Templates and API callers now resolve direct CDN URLs at render time instead of always round-tripping through the app's proxy redirect, with a static "image unavailable" placeholder swapped in via onerror on the admin thumbnail list for when a direct link is broken. A migrateLocalFilesToS3.php CLI script is included for existing installs adopting S3 after the fact: it copies previously-uploaded files to the bucket and repoints their storageSettingId, with dry-run and --path-scoped (partial/resumable) modes. 

Backward-compatible: existing installs default to Local Storage untouched, and switching backends doesn't break previously-uploaded files.

Test plan:

  - Fresh install: confirm default is Local Storage, Admin > Storage Settings shows one active "Local Storage" row, existing image upload/view flows work unchanged.
  -  Add an S3 storage setting (Admin > Storage Settings > Add) pointed at a real S3-compatible bucket (MinIO/DO Spaces/etc.):
  - Missing required field (bucket, access key, secret, or Public Base URL) blocks
  save with a clear error.
  - Wrong credentials / unreachable endpoint / nonexistent bucket blocks save via the Tier 1 credential check, with a specific error message per failure type.
 - Valid credentials save successfully; "Public URL Status" badge reflects the Tier 2 unauthenticated-GET probe result (verified/failed) and "Test Connection" re-runs it on demand.
 - Activate the S3 setting, upload an image through WebBuilder > Images with a real (non-trivial) source image:
 - All requested derivative sizes (full/x-large/large/medium/small) land in the bucket under uploads/web_builder_image/<size>/... with correct, non-zero byte content and correct MIME type (not application/octet-stream).
 - Viewing the image renders correctly end to end (ViewImage.php redirect to the CDN URL, or proxy if no Public Base URL is configured) and matches the uploaded bytes exactly.
 - Switch the active backend (S3 → Local, then back to S3) and confirm images uploaded under the previous backend still render correctly (storageSettingId/getById() resolution independent of which backend is currently active).
 - Create a duplicate storage setting (a second Local Storage row, and a second S3 row with identical bucket/credentials to an existing one) and confirm: only one row is ever active at a time regardless of driver type, activating one correctly deactivates all others, and images tied to either duplicate still resolve correctly.
 - Attempt to delete a storage setting that still has linked image_uploads rows and confirm it's blocked with a clear message instead of silently orphaning files.
 - Run migrateLocalFilesToS3.php against a site with existing local uploads: dry-run first, then a real run, then a re-run (should no-op/skip already-migrated files); confirm bytes match pre-migration and storageSettingId is correctly repointed.
 - Force a broken direct link (e.g. point Public Base URL at an unreachable host after uploading) and confirm the WebBuilder Images admin thumbnail list swaps to the "image unavailable" placeholder via onerror instead of showing a broken image icon.
 - Regression: existing Local-Storage-only sites/tests unaffected by any of the above (no S3 setting configured, everything behaves exactly as before this PR).